### PR TITLE
Docs: add "Back to overview"

### DIFF
--- a/api/_patches/html/guide/03 CSS styling.md
+++ b/api/_patches/html/guide/03 CSS styling.md
@@ -166,3 +166,9 @@ The layout model follows closely to the CSS flexbox model (although many propert
 Animations are planned to be implemented with `@keyframes`, but this is not yet supported yet.
 You can create preliminary "animations" by using the dynamic CSS properties, but be aware that
 every repaint with dynamic CSS Ids requires a full re-layout, which can be performance intensive.
+
+
+<br/>
+<br/>
+
+<a href="$$ROOT_RELATIVE$$/guide">Back to overview</a>

--- a/api/_patches/html/guide/04 Images, SVG and charts.md
+++ b/api/_patches/html/guide/04 Images, SVG and charts.md
@@ -1,0 +1,5 @@
+
+<br/>
+<br/>
+
+<a href="$$ROOT_RELATIVE$$/guide">Back to overview</a>

--- a/api/_patches/html/guide/05 Timers, Threads and Animations.md
+++ b/api/_patches/html/guide/05 Timers, Threads and Animations.md
@@ -154,3 +154,8 @@ be prepared for a UI visualization from a non-main thread.
 
 In this chapter you've learned how to use timers, async IO and handle thread-safe and non-thread safe data
 within your data model.
+
+<br/>
+<br/>
+
+<a href="$$ROOT_RELATIVE$$/guide">Back to overview</a>

--- a/api/_patches/html/guide/06 OpenGL.md
+++ b/api/_patches/html/guide/06 OpenGL.md
@@ -282,3 +282,8 @@ to draw your own vector data (for example in order to make a vector graphics edi
 you can build the "SVG layers" yourself (ex. from the SVG data). Each layer is
 batch-rendered, so you can draw many lines or polygons in one draw call, as long as
 they share the same `SvgStyle`.
+
+<br/>
+<br/>
+
+<a href="$$ROOT_RELATIVE$$/guide">Back to overview</a>

--- a/api/_patches/html/guide/07 Unit testing.md
+++ b/api/_patches/html/guide/07 Unit testing.md
@@ -65,3 +65,8 @@ the lifetimes - your callbacks should now look like this:
 ```rust
 fn my_callback(state: State, cb: CbInfo) -> Dom<DataModel> { /* */ }
 ```
+
+<br/>
+<br/>
+
+<a href="$$ROOT_RELATIVE$$/guide">Back to overview</a>

--- a/api/_patches/html/guide/08 XML and azulc.md
+++ b/api/_patches/html/guide/08 XML and azulc.md
@@ -1,1 +1,5 @@
 // TODO
+<br/>
+<br/>
+
+<a href="$$ROOT_RELATIVE$$/guide">Back to overview</a>


### PR DESCRIPTION
There are "Back to overview" links in some pages, but not in others.