### PR TITLE
Support CSS font-weight when shaping variable fonts

### DIFF
--- a/layout/src/callbacks.rs
+++ b/layout/src/callbacks.rs
@@ -2936,26 +2936,33 @@ impl CallbackInfo {
         let Ok(guard) = font_manager.parsed_fonts.lock() else {
             return Vec::new().into();
         };
+        fn describe(font_ref: &FontRef) -> LoadedFont {
+            let parsed = crate::font_ref_to_parsed_font(font_ref);
+            let family_name = parsed
+                .font_name
+                .as_ref()
+                .map(|s| AzString::from(s.clone()))
+                .unwrap_or_default();
+            LoadedFont {
+                font_hash: parsed.hash,
+                family_name,
+                num_glyphs: u32::from(parsed.num_glyphs),
+                has_bytes: parsed.source_bytes_for_subset().is_some(),
+            }
+        }
+
         // BTreeMap-style stable iteration is not guaranteed here (HashMap), so
-        // we collect then sort by font_hash for a deterministic order.
-        let mut out: Vec<LoadedFont> = guard
-            .values()
-            .map(|font_ref| {
-                let parsed = crate::font_ref_to_parsed_font(font_ref);
-                let family_name = parsed
-                    .font_name
-                    .as_ref()
-                    .map(|s| AzString::from(s.clone()))
-                    .unwrap_or_default();
-                LoadedFont {
-                    font_hash: parsed.hash,
-                    family_name,
-                    num_glyphs: u32::from(parsed.num_glyphs),
-                    has_bytes: parsed.source_bytes_for_subset().is_some(),
-                }
-            })
-            .collect();
+        // collect base faces plus their lazy static instances, then sort by
+        // font_hash for a deterministic order.
+        let mut out = Vec::new();
+        for font_ref in guard.values() {
+            let parsed = crate::font_ref_to_parsed_font(font_ref);
+            out.push(describe(font_ref));
+            let instances = parsed.get_variation_instances();
+            out.extend(instances.iter().map(describe));
+        }
         out.sort_by(|a, b| a.font_hash.cmp(&b.font_hash));
+        out.dedup_by_key(|font| font.font_hash);
         out.into()
     }
 

--- a/layout/src/font.rs
+++ b/layout/src/font.rs
@@ -339,13 +339,23 @@ pub mod parsed {
         /// [`crate::text3::cache::FontManager::evict_unused`] to
         /// decide which `LocaGlyfState::Deferred` faces to release.
         pub(crate) last_used: Arc<std::sync::atomic::AtomicU64>,
-        /// `true` if this font is a variable font (carries a `gvar`
-        /// table). Cached at parse time so [`decode_glyph_inner`]
-        /// can short-circuit the variable-context construction for
-        /// the common non-variable case. Variable-glyph delta
-        /// application requires the source bytes to be retained,
-        /// so it only fires on the `LocaGlyfState::Deferred` path.
+        /// `true` if this font has an `fvar` table and variable TrueType
+        /// (`gvar`) or CFF (`CFF2`) outlines. Cached at parse time so both
+        /// instancing and [`decode_glyph_inner`] can short-circuit for the
+        /// common non-variable case.
         pub(crate) is_variable_font: bool,
+        /// Lazily-created static instances of this variable font, keyed by the
+        /// fully resolved (and clamped) user coordinate tuple. CSS exposes only
+        /// nine discrete weights today, so this cache is naturally bounded to
+        /// at most nine entries per face without an eviction policy.
+        pub(crate) variation_instances: Arc<
+            std::sync::Mutex<
+                std::collections::HashMap<
+                    Vec<allsorts::tables::Fixed>,
+                    azul_css::props::basic::FontRef,
+                >,
+            >,
+        >,
         /// Lazy outline cache. Populated on first
         /// [`ParsedFont::get_or_decode_glyph`] call per `gid`; entries
         /// are wrapped in `Arc` so callers can hold them without
@@ -441,6 +451,7 @@ pub mod parsed {
                 // same face.
                 last_used: Arc::clone(&self.last_used),
                 is_variable_font: self.is_variable_font,
+                variation_instances: Arc::clone(&self.variation_instances),
                 glyph_cache: Arc::clone(&self.glyph_cache),
                 // `LocaGlyfState` is `Clone` — for `Loaded` this is an
                 // `Arc::clone`; for `Deferred` it's an `Arc::clone` of
@@ -809,6 +820,46 @@ pub mod parsed {
         }
     }
 
+    /// Convert the static CFF2 table emitted by allsorts instancing into CFF1.
+    /// Azul's outline decoder and PDF bridge already support CFF1, while CFF2
+    /// remains a variable-font-only representation even after its deltas have
+    /// been resolved.
+    fn convert_static_cff2_to_cff1(bytes: &[u8]) -> Option<Vec<u8>> {
+        use allsorts::{
+            binary::read::ReadScope,
+            font_data::FontData,
+            subset::{CmapTarget, SubsetProfile},
+            tables::{FontTableProvider, MaxpTable},
+            tag,
+        };
+
+        let font_data = ReadScope::new(bytes).read::<FontData<'_>>().ok()?;
+        let provider = font_data.table_provider(0).ok()?;
+        let maxp_data = provider.read_table_data(tag::MAXP).ok()?;
+        let maxp = ReadScope::new(&maxp_data).read::<MaxpTable>().ok()?;
+        let glyph_ids = (0..maxp.num_glyphs).collect::<Vec<_>>();
+        let profile = SubsetProfile::Custom(vec![
+            tag::CMAP,
+            tag::HEAD,
+            tag::HHEA,
+            tag::HMTX,
+            tag::MAXP,
+            tag::NAME,
+            tag::OS_2,
+            tag::POST,
+            tag::GPOS,
+            tag::GSUB,
+            tag::GDEF,
+            tag::VHEA,
+            tag::VMTX,
+            tag::CVT,
+            tag::FPGM,
+            tag::PREP,
+        ]);
+
+        allsorts::subset::subset(&provider, &glyph_ids, &profile, CmapTarget::Unicode).ok()
+    }
+
     impl ParsedFont {
         /// Parse a font from bytes using allsorts
         ///
@@ -1158,12 +1209,14 @@ pub mod parsed {
             // into a chain but never actually rasterized (typical
             // for fallback fonts in CSS chains).
             let has_glyf = provider.has_table(tag::GLYF) && provider.has_table(tag::LOCA);
-            // Cache `has_gvar` before `provider` gets moved into
+            // Cache variable-outline table presence before `provider` gets moved into
             // `allsorts::font::Font::new(provider)` further down —
             // it's the cheapest way to detect a variable font and
             // avoids the borrow-after-move that a later
             // `provider.has_table(tag::GVAR)` would incur.
             let has_gvar = provider.has_table(tag::GVAR);
+            let has_cff2 = provider.has_table(tag::CFF2);
+            let is_variable_font = provider.has_table(tag::FVAR) && (has_gvar || has_cff2);
             let loca_glyf_opt: Option<Arc<std::sync::Mutex<LocaGlyf>>> = if has_glyf
                 && !defer_loca_glyf
             {
@@ -1278,7 +1331,10 @@ pub mod parsed {
                 opt_kern_table,
                 cmap_subtable,
                 last_used: Arc::new(std::sync::atomic::AtomicU64::new(0)),
-                is_variable_font: has_gvar,
+                is_variable_font,
+                variation_instances: Arc::new(std::sync::Mutex::new(
+                    std::collections::HashMap::new(),
+                )),
                 glyph_cache: Arc::new(rust_fontconfig::StLock::new(BTreeMap::new())),
                 // Eager path: `from_bytes` loaded LocaGlyf immediately
                 // (or set None if the font has no loca+glyf). Lazy
@@ -1407,6 +1463,112 @@ pub mod parsed {
                 loaded: Arc::new(std::sync::Mutex::new(None)),
             };
             Some(font)
+        }
+
+        /// Return the static font instance for `variations`, creating it on the
+        /// first use. The expensive allsorts instancing and parsing work is paid
+        /// once per resolved coordinate tuple; subsequent shaping runs only take
+        /// a short cache lock and clone a [`FontRef`](azul_css::props::basic::FontRef).
+        pub(crate) fn get_or_create_variation_instance(
+            &self,
+            variations: &[([u8; 4], f32)],
+        ) -> Option<azul_css::props::basic::FontRef> {
+            use std::{
+                collections::hash_map::DefaultHasher,
+                hash::{Hash, Hasher},
+            };
+
+            use allsorts::{
+                binary::read::ReadScope,
+                font_data::FontData,
+                tables::{variable_fonts::fvar::FvarTable, Fixed, FontTableProvider},
+                tag,
+            };
+
+            if !self.is_variable_font {
+                return None;
+            }
+
+            let source = self.original_bytes.as_ref()?;
+            let font_data = ReadScope::new(source.as_slice()).read::<FontData<'_>>().ok()?;
+            let provider = font_data.table_provider(self.original_index).ok()?;
+            let fvar_data = provider.read_table_data(tag::FVAR).ok()?;
+            let fvar = ReadScope::new(&fvar_data).read::<FvarTable<'_>>().ok()?;
+            let source_is_cff2 = provider.has_table(tag::CFF2);
+
+            let coordinates = fvar
+                .axes()
+                .map(|axis| {
+                    let requested = variations
+                        .iter()
+                        .rev()
+                        .find(|(candidate, value)| {
+                            u32::from_be_bytes(*candidate) == axis.axis_tag && value.is_finite()
+                        })
+                        .map(|(_, value)| *value);
+                    requested
+                        .map(Fixed::from)
+                        .unwrap_or(axis.default_value)
+                        .clamp(axis.min_value, axis.max_value)
+                })
+                .collect::<Vec<_>>();
+
+            if let Ok(cache) = self.variation_instances.lock() {
+                if let Some(instance) = cache.get(&coordinates) {
+                    return Some(instance.clone());
+                }
+            }
+
+            let (mut static_bytes, _) =
+                allsorts::variations::instance(&provider, &coordinates).ok()?;
+            if source_is_cff2 {
+                static_bytes = convert_static_cff2_to_cff1(&static_bytes)?;
+            }
+
+            let shared_bytes = Arc::new(rust_fontconfig::FontBytes::Owned(Arc::from(static_bytes)));
+            let mut parsed = Self::from_bytes_shared(shared_bytes, 0, &mut Vec::new())?;
+
+            // The standard ParsedFont hash deliberately samples only the first
+            // and last 4 KiB to avoid faulting huge mmap'd fonts into RAM. Static
+            // instances can differ only in middle tables, so derive their
+            // identity from the base font plus the exact fixed-point tuple.
+            let mut hasher = DefaultHasher::new();
+            b"azul-variable-font-instance".hash(&mut hasher);
+            self.hash.hash(&mut hasher);
+            coordinates.hash(&mut hasher);
+            parsed.hash = hasher.finish();
+
+            let instance = crate::parsed_font_to_font_ref(parsed);
+            let mut cache = self.variation_instances.lock().ok()?;
+            Some(cache
+                .entry(coordinates)
+                .or_insert_with(|| instance.clone())
+                .clone())
+        }
+
+        /// Resolve an already-created variable instance by its shaped-glyph hash.
+        pub(crate) fn get_variation_instance_by_hash(
+            &self,
+            hash: u64,
+        ) -> Option<azul_css::props::basic::FontRef> {
+            let cache = self.variation_instances.lock().ok()?;
+            cache.values().find_map(|instance| {
+                (crate::font_ref_to_parsed_font(instance).hash == hash)
+                    .then(|| instance.clone())
+            })
+        }
+
+        /// Snapshot the static instances created for this variable face.
+        ///
+        /// This is used by callback font introspection so consumers see every
+        /// font hash that can occur in shaped glyph runs.
+        pub(crate) fn get_variation_instances(
+            &self,
+        ) -> Vec<azul_css::props::basic::FontRef> {
+            self.variation_instances
+                .lock()
+                .map(|cache| cache.values().cloned().collect())
+                .unwrap_or_default()
         }
 
         /// Resolve the current face's `LocaGlyf`, loading it lazily
@@ -2377,6 +2539,15 @@ pub mod parsed {
 
         fn get_hash(&self) -> u64 {
             self.hash
+        }
+
+        fn resolve_font_hash(&self, hash: u64) -> Option<Self> {
+            if self.hash == hash {
+                Some(self.clone())
+            } else {
+                self.get_variation_instance_by_hash(hash)
+                    .map(|font_ref| crate::font_ref_to_parsed_font(&font_ref).clone())
+            }
         }
 
         fn get_glyph_size(

--- a/layout/src/font_traits.rs
+++ b/layout/src/font_traits.rs
@@ -64,6 +64,17 @@ pub trait ParsedFontTrait: Send + Clone + ShallowClone {
     /// Hash of the font, necessary for breaking layouted glyphs into glyph runs
     fn get_hash(&self) -> u64;
 
+    /// Resolve either this font or one of its cached variable-font instances
+    /// by the hash stamped onto shaped glyphs.
+    ///
+    /// Non-variable backends only need the default implementation. Variable
+    /// font backends override this so renderers and PDF exporters can retrieve
+    /// the exact static instance that was used for shaping.
+    #[must_use]
+    fn resolve_font_hash(&self, hash: u64) -> Option<Self> {
+        (self.get_hash() == hash).then(|| self.shallow_clone())
+    }
+
     /// Returns the size of a glyph at the given font size, or `None` if the glyph is missing.
     fn get_glyph_size(&self, glyph_id: u16, font_size: f32) -> Option<LogicalSize>;
 

--- a/layout/src/solver3/fc.rs
+++ b/layout/src/solver3/fc.rs
@@ -2998,6 +2998,26 @@ const fn translate_taffy_size(size: LogicalSize) -> TaffySize<Option<f32>> {
     }
 }
 
+/// Resolve a computed CSS `font-weight` to the OpenType `wght` coordinate.
+///
+/// Relative weights currently use the same concrete fallback values as
+/// [`convert_font_weight`]. The CSS cascade preserves `lighter` / `bolder` as
+/// enum values instead of resolving them against the parent, so 300 / 900 are
+/// the closest representation of Azul's existing font-selection behavior.
+#[must_use] pub const fn font_weight_to_wght(weight: StyleFontWeight) -> f32 {
+    match weight {
+        StyleFontWeight::W100 => 100.0,
+        StyleFontWeight::W200 => 200.0,
+        StyleFontWeight::W300 | StyleFontWeight::Lighter => 300.0,
+        StyleFontWeight::Normal => 400.0,
+        StyleFontWeight::W500 => 500.0,
+        StyleFontWeight::W600 => 600.0,
+        StyleFontWeight::Bold => 700.0,
+        StyleFontWeight::W800 => 800.0,
+        StyleFontWeight::W900 | StyleFontWeight::Bolder => 900.0,
+    }
+}
+
 /// Resolves a CSS size metric to pixels.
 ///
 /// - `metric`: The CSS unit (px, pt, em, vw, etc.)

--- a/layout/src/solver3/getters.rs
+++ b/layout/src/solver3/getters.rs
@@ -2994,10 +2994,14 @@ pub fn get_style_properties(
         letter_spacing,
         word_spacing,
         text_decoration,
+        // Keep the computed CSS weight available after fontconfig selection.
+        // Static faces ignore it; variable faces lazily instantiate their
+        // matching `wght` coordinate before shaping.
+        font_variations: vec![(*b"wght", super::fc::font_weight_to_wght(font_weight))],
         tab_size,
         text_transform,
         // These still use defaults - could be extended in future:
-        // font_features, font_variations, writing_mode,
+        // font_features, writing_mode,
         // text_orientation, text_combine_upright, font_variant_*
         ..Default::default()
     }

--- a/layout/src/text3/cache.rs
+++ b/layout/src/text3/cache.rs
@@ -430,6 +430,14 @@ impl<T: ParsedFontTrait> LoadedFonts<T> {
         self.hash_to_id.get(&hash).and_then(|id| self.fonts.get(id))
     }
 
+    /// Get an owned shallow clone of a font by hash, including a variable-font
+    /// instance that may have been created lazily during shaping.
+    #[must_use] pub fn get_owned_by_hash(&self, hash: u64) -> Option<T> {
+        self.get_by_hash(hash)
+            .map(ShallowClone::shallow_clone)
+            .or_else(|| self.fonts.values().find_map(|font| font.resolve_font_hash(hash)))
+    }
+
     /// Get the `FontId` for a hash
     #[must_use] pub fn get_font_id_by_hash(&self, hash: u64) -> Option<&FontId> {
         self.hash_to_id.get(&hash)
@@ -517,6 +525,13 @@ impl<T: ParsedFontTrait> ParsedFontTrait for FontOrRef<T> {
         match self {
             Self::Font(f) => f.get_hash(),
             Self::Ref(r) => r.get_hash(),
+        }
+    }
+
+    fn resolve_font_hash(&self, hash: u64) -> Option<Self> {
+        match self {
+            Self::Font(f) => f.resolve_font_hash(hash).map(Self::Font),
+            Self::Ref(r) => r.resolve_font_hash(hash).map(Self::Ref),
         }
     }
 
@@ -935,11 +950,11 @@ impl<T: ParsedFontTrait> FontManager<T> {
     /// Panics if the internal font-cache mutex is poisoned.
     pub fn get_font_by_hash(&self, font_hash: u64) -> Option<T> {
         let parsed = self.parsed_fonts.lock().unwrap();
-        // Linear search through all cached fonts to find one with matching hash
+        // Linear search through all cached base fonts. A base font can also
+        // resolve a lazily-created variable instance by its synthetic hash.
         let found = parsed
-            .iter()
-            .find(|(_, font)| font.get_hash() == font_hash)
-            .map(|(_, font)| font.clone());
+            .values()
+            .find_map(|font| font.resolve_font_hash(font_hash));
         drop(parsed);
         found
     }
@@ -4164,7 +4179,7 @@ impl ShapedGlyph {
         loaded_fonts: &LoadedFonts<T>,
     ) -> GlyphInstance {
         let size = loaded_fonts
-            .get_by_hash(self.font_hash)
+            .get_owned_by_hash(self.font_hash)
             .and_then(|font| font.get_glyph_size(self.glyph_id, self.style.font_size_px))
             .unwrap_or_default();
 
@@ -4196,7 +4211,7 @@ impl ShapedGlyph {
         loaded_fonts: &LoadedFonts<T>,
     ) -> GlyphInstance {
         let size = loaded_fonts
-            .get_by_hash(self.font_hash)
+            .get_owned_by_hash(self.font_hash)
             .and_then(|font| font.get_glyph_size(self.glyph_id, self.style.font_size_px))
             .unwrap_or_default();
 
@@ -8925,7 +8940,7 @@ pub struct HyphenationBreak {
     let style = last_cluster.style.clone();
 
     // Look up font from hash
-    let font = fonts.get_by_hash(last_glyph.font_hash)?;
+    let font = fonts.get_owned_by_hash(last_glyph.font_hash)?;
     let (hyphen_glyph_id, hyphen_advance) =
         font.get_hyphen_glyph_and_advance(style.font_size_px)?;
 
@@ -9740,9 +9755,9 @@ pub fn justify_kashida_and_rebuild<T: ParsedFontTrait>(
             if let Some(glyph) = c.glyphs.first() {
                 if glyph.script == Script::Arabic {
                     // Look up font from hash
-                    if let Some(font) = fonts.get_by_hash(glyph.font_hash) {
+                    if let Some(font) = fonts.get_owned_by_hash(glyph.font_hash) {
                         return Some((
-                            font.clone(),
+                            font,
                             glyph.font_hash,
                             glyph.font_metrics,
                             glyph.style.clone(),

--- a/layout/src/text3/default.rs
+++ b/layout/src/text3/default.rs
@@ -184,6 +184,15 @@ impl ParsedFontTrait for FontRef {
         crate::font_ref_to_parsed_font(self).hash
     }
 
+    fn resolve_font_hash(&self, hash: u64) -> Option<Self> {
+        let parsed = crate::font_ref_to_parsed_font(self);
+        if parsed.hash == hash {
+            Some(self.clone())
+        } else {
+            parsed.get_variation_instance_by_hash(hash)
+        }
+    }
+
     fn get_glyph_size(&self, glyph_id: u16, font_size: f32) -> Option<LogicalSize> {
         crate::font_ref_to_parsed_font(self).get_glyph_size(glyph_id, font_size)
     }
@@ -733,6 +742,22 @@ fn shape_text_internal(
     direction: BidiDirection,
     style: &StyleProperties,
 ) -> Result<Vec<Glyph>, LayoutError> {
+    // Variable fonts are converted to a static face on first use of a
+    // coordinate tuple. Shaping, outline decoding, CPU rendering, and PDF
+    // embedding then all operate on the same bytes and share the cached face.
+    if let Some(instance) =
+        parsed_font.get_or_create_variation_instance(&style.font_variations)
+    {
+        return shape_text_internal(
+            crate::font_ref_to_parsed_font(&instance),
+            text,
+            script,
+            language,
+            direction,
+            style,
+        );
+    }
+
     let script_tag = to_opentype_script_tag(script);
     #[cfg(feature = "text_layout_hyphenation")]
     let lang_tag = to_opentype_lang_tag(language);

--- a/layout/src/text3/glyphs.rs
+++ b/layout/src/text3/glyphs.rs
@@ -313,8 +313,8 @@ pub struct PdfPositionedGlyph {
             let writing_mode = cluster.style.writing_mode;
 
             // Look up the font from the fonts container
-            let font = match fonts.get_by_hash(font_hash) {
-                Some(f) => f.clone(),
+            let font = match fonts.get_owned_by_hash(font_hash) {
+                Some(f) => f,
                 None => continue, // Skip glyphs with unknown fonts
             };
 

--- a/layout/tests/variable_font_weight.rs
+++ b/layout/tests/variable_font_weight.rs
@@ -1,0 +1,151 @@
+#![cfg(feature = "text_layout")]
+
+use std::sync::Arc;
+
+use allsorts::{binary::read::ReadScope, font_data::FontData, tables::FontTableProvider, tag};
+use azul_core::{
+    dom::{Dom, IdOrClass, NodeId},
+    styled_dom::StyledDom,
+};
+use azul_css::props::basic::{FontRef, PhysicalSize};
+use azul_layout::{
+    font_ref_to_parsed_font,
+    font_traits::ParsedFontTrait,
+    solver3::getters::get_style_properties,
+    text3::{
+        cache::{BidiDirection, FontManager, StyleProperties},
+        default::PathLoader,
+        script::{Language, Script},
+    },
+};
+use rust_fontconfig::{FontBytes, FontId};
+
+const VARIABLE_TTF: &[u8] = include_bytes!("../../doc/fonts/RedHatDisplay-VariableFont_wght.ttf");
+
+fn load_variable_font() -> FontRef {
+    let bytes = Arc::new(FontBytes::Owned(Arc::from(VARIABLE_TTF)));
+    PathLoader::new()
+        .load_font_shared(bytes, 0)
+        .expect("Red Hat Display variable font must parse")
+}
+
+fn style_at_weight(weight: f32) -> StyleProperties {
+    StyleProperties {
+        font_size_px: 24.0,
+        font_variations: vec![(*b"wght", weight)],
+        ..StyleProperties::default()
+    }
+}
+
+#[test]
+fn computed_css_weight_populates_wght_coordinate() {
+    let mut dom =
+        Dom::create_div().with_ids_and_classes(vec![IdOrClass::Class("weighted".into())].into());
+    let (css, errors) = azul_css::parser2::new_from_str(".weighted { font-weight: 800; }");
+    assert!(errors.is_empty(), "CSS should parse: {errors:?}");
+    let styled_dom = StyledDom::create(&mut dom, css);
+
+    let style = get_style_properties(
+        &styled_dom,
+        NodeId::ZERO,
+        None,
+        PhysicalSize::new(800.0, 600.0),
+    );
+
+    assert_eq!(style.font_variations, vec![(*b"wght", 800.0)]);
+}
+
+#[test]
+fn shaping_uses_and_reuses_static_weight_instances() {
+    let font = load_variable_font();
+    let default_style = StyleProperties::default();
+    let light_style = style_at_weight(300.0);
+    let heavy_style = style_at_weight(900.0);
+
+    let default = font
+        .shape_text(
+            "Variable",
+            Script::Latin,
+            Language::EnglishUS,
+            BidiDirection::Ltr,
+            &default_style,
+        )
+        .expect("default instance should shape");
+    let light = font
+        .shape_text(
+            "Variable",
+            Script::Latin,
+            Language::EnglishUS,
+            BidiDirection::Ltr,
+            &light_style,
+        )
+        .expect("light instance should shape");
+    let heavy = font
+        .shape_text(
+            "Variable",
+            Script::Latin,
+            Language::EnglishUS,
+            BidiDirection::Ltr,
+            &heavy_style,
+        )
+        .expect("heavy instance should shape");
+    let light_again = font
+        .shape_text(
+            "Variable",
+            Script::Latin,
+            Language::EnglishUS,
+            BidiDirection::Ltr,
+            &light_style,
+        )
+        .expect("cached light instance should shape");
+
+    let base_hash = font_ref_to_parsed_font(&font).get_hash();
+    let default_hash = default[0].font_hash;
+    let light_hash = light[0].font_hash;
+    let heavy_hash = heavy[0].font_hash;
+    assert_ne!(
+        base_hash, default_hash,
+        "even the default coordinates need an embeddable static resource"
+    );
+    assert_ne!(
+        light_hash, heavy_hash,
+        "weights need distinct font resources"
+    );
+    assert_eq!(
+        light_hash, light_again[0].font_hash,
+        "same tuple must hit the cache"
+    );
+
+    let manager: FontManager<FontRef> =
+        FontManager::new(rust_fontconfig::FcFontCache::default()).unwrap();
+    manager.insert_font(FontId::new(), font);
+
+    let default_font = manager
+        .get_font_by_hash(default_hash)
+        .expect("manager should resolve the cached default instance");
+    let light_font = manager
+        .get_font_by_hash(light_hash)
+        .expect("manager should resolve the cached light instance");
+    let heavy_font = manager
+        .get_font_by_hash(heavy_hash)
+        .expect("manager should resolve the cached heavy instance");
+    let default_parsed = font_ref_to_parsed_font(&default_font);
+    let light_parsed = font_ref_to_parsed_font(&light_font);
+    let heavy_parsed = font_ref_to_parsed_font(&heavy_font);
+
+    assert_eq!(light_parsed.pdf_font_metrics.us_weight_class, 300);
+    assert_eq!(heavy_parsed.pdf_font_metrics.us_weight_class, 900);
+
+    for parsed in [default_parsed, light_parsed, heavy_parsed] {
+        let bytes = parsed
+            .source_bytes_for_subset()
+            .expect("static instance bytes must remain available");
+        let font_data = ReadScope::new(bytes.as_slice())
+            .read::<FontData<'_>>()
+            .unwrap();
+        let provider = font_data.table_provider(0).unwrap();
+        assert!(!provider.has_table(tag::FVAR));
+        assert!(!provider.has_table(tag::GVAR));
+        assert!(provider.has_table(tag::GLYF));
+    }
+}


### PR DESCRIPTION
## Description

`azul-layout` did not translate computed CSS `font-weight` into the OpenType
`wght` axis when shaping variable fonts. Different weights could use the same
default resource, while PDF exporters could receive bytes that did not match
the shaped glyph run.

Related issue: https://github.com/fschutt/printpdf/issues/276

## Describe your solution

- Propagate computed `font-weight` as a `wght` coordinate.
- Lazily instantiate and cache static fonts per resolved axis tuple.
- Use deterministic instance hashes throughout shaping, rendering, and
  font-byte lookup.
- Include generated instances in loaded-font introspection.
- Support TrueType `gvar` and CFF2 fonts, converting static CFF2 to CFF1.

The change is contained in `azul-layout`; `azul-css` already exposes the
required computed weight.

## Are there alternatives or drawbacks?

Downstream exporters could perform instancing, but that duplicates expensive
work and risks shaping and embedding different resources. This implementation
pays the cost once per used tuple and caches the result. Cached instances remain
alive with the base face.

## Is this a breaking change?

No intentional API break. The new trait method has a default implementation.
Variable-font runs now correctly use their static-instance hash.

## Testing

- 2 variable-font tests passed
- 28 shaping tests passed
- 2 font-introspection tests passed
- 140 layout library tests passed
- TrueType and CFF2 instancing verified
