### PR TITLE
Seam audit batch: text editing, scrolling, the native↔headless seam, and the bare-text lint

### DIFF
--- a/api.json
+++ b/api.json
@@ -15229,12 +15229,6 @@
                                 "fn_body": "azul_core::dom::Dom::create_br()"
                             },
                             "create_text_do_not_use_without_block_level_wrapper": {
-                                "fn_args": [
-                                    {
-                                        "value": "String"
-                                    }
-                                ],
-                                "fn_body": "azul_core::dom::Dom::create_text_do_not_use_without_block_level_wrapper(value)",
                                 "doc": [
                                     "Creates a RAW text node - read this before using it.",
                                     "",
@@ -15252,7 +15246,13 @@
                                     "create_span_with_text, ...), which builds that shape for you. The engine",
                                     "also logs a warning after layout when it finds a text node used without",
                                     "a containing block."
-                                ]
+                                ],
+                                "fn_args": [
+                                    {
+                                        "value": "String"
+                                    }
+                                ],
+                                "fn_body": "azul_core::dom::Dom::create_text_do_not_use_without_block_level_wrapper(value)"
                             },
                             "create_image": {
                                 "fn_args": [

--- a/api.json
+++ b/api.json
@@ -15228,13 +15228,31 @@
                                 "fn_args": [],
                                 "fn_body": "azul_core::dom::Dom::create_br()"
                             },
-                            "create_text": {
+                            "create_text_do_not_use_without_block_level_wrapper": {
                                 "fn_args": [
                                     {
                                         "value": "String"
                                     }
                                 ],
-                                "fn_body": "azul_core::dom::Dom::create_text(value)"
+                                "fn_body": "azul_core::dom::Dom::create_text_do_not_use_without_block_level_wrapper(value)",
+                                "doc": [
+                                    "Creates a RAW text node - read this before using it.",
+                                    "",
+                                    "WARNING: azul does NOT auto-wrap raw text in an anonymous block the way",
+                                    "browsers do. A bare text node has NO box of its own: it gets no rect, no",
+                                    "clip and no layout constraints. Every box-model CSS property",
+                                    "(width / height / position / overflow / background / border / padding),",
+                                    "every callback, every tab_index and every dataset attached to a text",
+                                    "node is silently INERT. This has broken shipped widgets before (text",
+                                    "escaping its container, click targets that never fire).",
+                                    "",
+                                    "A raw text node is only correct as the bare leaf INSIDE a block-level",
+                                    "wrapper that carries the styling - p, div, h1... Prefer the",
+                                    "create_*_with_text family (create_p_with_text, create_div_with_text,",
+                                    "create_span_with_text, ...), which builds that shape for you. The engine",
+                                    "also logs a warning after layout when it finds a text node used without",
+                                    "a containing block."
+                                ]
                             },
                             "create_image": {
                                 "fn_args": [
@@ -17628,6 +17646,21 @@
                                 ],
                                 "fn_body": "azul_core::dom::Dom::create_p_with_text(text)"
                             },
+                            "create_div_with_text": {
+                                "doc": [
+                                    "Creates a generic block container (div) with text.",
+                                    "",
+                                    "The div is the box the text lives in: put your styling, callbacks and",
+                                    "tab_index on the DIV, never on the text leaf (a text node has no box of",
+                                    "its own - see create_text_do_not_use_without_block_level_wrapper)."
+                                ],
+                                "fn_args": [
+                                    {
+                                        "text": "String"
+                                    }
+                                ],
+                                "fn_body": "azul_core::dom::Dom::create_div_with_text(text)"
+                            },
                             "create_geolocation_probe": {
                                 "doc": [
                                     "Creates an invisible `NodeType::GeolocationProbe` node that",
@@ -18302,16 +18335,31 @@
                                 "fn_args": [],
                                 "fn_body": "azul_core::dom::NodeData::create_br()"
                             },
-                            "create_text": {
+                            "create_text_do_not_use_without_block_level_wrapper": {
                                 "doc": [
-                                    "Shorthand for `NodeData::create_node(NodeType::Text(value.into()))`."
+                                    "Creates a RAW text node - read this before using it.",
+                                    "",
+                                    "WARNING: azul does NOT auto-wrap raw text in an anonymous block the way",
+                                    "browsers do. A bare text node has NO box of its own: it gets no rect, no",
+                                    "clip and no layout constraints. Every box-model CSS property",
+                                    "(width / height / position / overflow / background / border / padding),",
+                                    "every callback, every tab_index and every dataset attached to a text",
+                                    "node is silently INERT. This has broken shipped widgets before (text",
+                                    "escaping its container, click targets that never fire).",
+                                    "",
+                                    "A raw text node is only correct as the bare leaf INSIDE a block-level",
+                                    "wrapper that carries the styling - p, div, h1... Prefer the",
+                                    "create_*_with_text family (create_p_with_text, create_div_with_text,",
+                                    "create_span_with_text, ...), which builds that shape for you. The engine",
+                                    "also logs a warning after layout when it finds a text node used without",
+                                    "a containing block."
                                 ],
                                 "fn_args": [
                                     {
                                         "value": "String"
                                     }
                                 ],
-                                "fn_body": "azul_core::dom::NodeData::create_text(value)"
+                                "fn_body": "azul_core::dom::NodeData::create_text_do_not_use_without_block_level_wrapper(value)"
                             },
                             "create_image": {
                                 "doc": [

--- a/core/src/compact.rs
+++ b/core/src/compact.rs
@@ -2689,7 +2689,7 @@ mod autotest_generated {
             NodeData::create_node(NodeType::Div),
             NodeData::create_node(NodeType::P),
             NodeData::create_node(NodeType::Br),
-            NodeData::create_text("hello"),
+            NodeData::create_text_do_not_use_without_block_level_wrapper("hello"),
         ];
         for nd in &nodes {
             let mut s = Sink::new();
@@ -2852,7 +2852,7 @@ mod autotest_generated {
 
         let nodes = vec![
             NodeData::create_node(NodeType::Div),
-            NodeData::create_text("hi"),
+            NodeData::create_text_do_not_use_without_block_level_wrapper("hi"),
         ];
         let r = cache.build_compact_cache_with_inheritance(&nodes, &linear_hierarchy(2), &[]);
 

--- a/core/src/diff.rs
+++ b/core/src/diff.rs
@@ -2356,7 +2356,7 @@ mod autotest_generated {
     #[test]
     fn autotest_text_content_round_trips_unicode() {
         for s in UNICODE_SAMPLES {
-            let node = NodeData::create_text(*s);
+            let node = NodeData::create_text_do_not_use_without_block_level_wrapper(*s);
             assert_eq!(
                 get_node_text_content(&node),
                 Some(*s),
@@ -2478,8 +2478,8 @@ mod autotest_generated {
 
     #[test]
     fn autotest_compute_changes_identical_nodes_report_nothing() {
-        let a = NodeData::create_text("same");
-        let b = NodeData::create_text("same");
+        let a = NodeData::create_text_do_not_use_without_block_level_wrapper("same");
+        let b = NodeData::create_text_do_not_use_without_block_level_wrapper("same");
         let changes = compute_node_changes(&a, &b, None, None);
         assert!(
             changes.is_empty(),
@@ -2497,7 +2497,7 @@ mod autotest_generated {
         // sit in different styled states.
         let old = NodeData::create_div();
         let new = with_cb(
-            NodeData::create_text("now a text node")
+            NodeData::create_text_do_not_use_without_block_level_wrapper("now a text node")
                 .with_ids_and_classes(vec![IdOrClass::Class("brand-new".into())].into())
                 .with_css("width: 10px")
                 .with_tab_index(TabIndex::NoKeyboardFocus)
@@ -2525,10 +2525,10 @@ mod autotest_generated {
     #[test]
     fn autotest_compute_changes_text_content_unicode() {
         for (i, s) in UNICODE_SAMPLES.iter().enumerate() {
-            let old = NodeData::create_text(*s);
+            let old = NodeData::create_text_do_not_use_without_block_level_wrapper(*s);
 
             // Same text -> no TEXT_CONTENT flag.
-            let same = NodeData::create_text(*s);
+            let same = NodeData::create_text_do_not_use_without_block_level_wrapper(*s);
             assert!(
                 !compute_node_changes(&old, &same, None, None)
                     .contains(NodeChangeSet::TEXT_CONTENT),
@@ -2540,7 +2540,7 @@ mod autotest_generated {
             if other == *s {
                 continue;
             }
-            let changed = NodeData::create_text(other);
+            let changed = NodeData::create_text_do_not_use_without_block_level_wrapper(other);
             assert!(
                 compute_node_changes(&old, &changed, None, None)
                     .contains(NodeChangeSet::TEXT_CONTENT),
@@ -2712,7 +2712,7 @@ mod autotest_generated {
         let node_data = vec![
             NodeData::create_div(),
             class_node("row"),
-            NodeData::create_text("leaf"),
+            NodeData::create_text_do_not_use_without_block_level_wrapper("leaf"),
             id_node("footer"),
         ];
         let hierarchy = vec![
@@ -2738,7 +2738,7 @@ mod autotest_generated {
         // Priority 1 is absolute: it ignores the CSS ID, the classes, the node
         // type and the position in the tree.
         let bare = NodeData::create_div().with_key(7u32);
-        let decorated = NodeData::create_text("totally different")
+        let decorated = NodeData::create_text_do_not_use_without_block_level_wrapper("totally different")
             .with_key(7u32)
             .with_ids_and_classes(
                 vec![IdOrClass::Id("hero".into()), IdOrClass::Class("x".into())].into(),
@@ -2770,7 +2770,7 @@ mod autotest_generated {
     fn autotest_rec_key_node_type_participates_in_the_structural_key() {
         let div = calculate_reconciliation_key(&[NodeData::create_div()], &[], NodeId::new(0));
         let txt =
-            calculate_reconciliation_key(&[NodeData::create_text("x")], &[], NodeId::new(0));
+            calculate_reconciliation_key(&[NodeData::create_text_do_not_use_without_block_level_wrapper("x")], &[], NodeId::new(0));
         assert_ne!(div, txt, "the node-type discriminant must feed the structural key");
     }
 
@@ -2843,8 +2843,8 @@ mod autotest_generated {
         // siblings must not collide (nth-of-type is folded in).
         let node_data = vec![
             NodeData::create_div(),
-            NodeData::create_text("A"),
-            NodeData::create_text("B"),
+            NodeData::create_text_do_not_use_without_block_level_wrapper("A"),
+            NodeData::create_text_do_not_use_without_block_level_wrapper("B"),
         ];
         let hierarchy = vec![
             hitem(None, None, None, Some(2)),
@@ -2954,11 +2954,11 @@ mod autotest_generated {
         // must NOT fall through to the content/structural tiers, even though
         // the two nodes are otherwise byte-identical.
         let old = vec![with_cb(
-            NodeData::create_text("same content").with_key(1u32),
+            NodeData::create_text_do_not_use_without_block_level_wrapper("same content").with_key(1u32),
             ComponentEventFilter::BeforeUnmount,
         )];
         let new = vec![with_cb(
-            NodeData::create_text("same content").with_key(2u32),
+            NodeData::create_text_do_not_use_without_block_level_wrapper("same content").with_key(2u32),
             ComponentEventFilter::AfterMount,
         )];
 
@@ -2975,9 +2975,9 @@ mod autotest_generated {
     #[test]
     fn autotest_reconcile_update_fires_only_on_rec_key_match_with_changed_content() {
         // Same key, changed text, Updated callback present -> Update event.
-        let old = vec![NodeData::create_text("v1").with_key(1u32)];
+        let old = vec![NodeData::create_text_do_not_use_without_block_level_wrapper("v1").with_key(1u32)];
         let new = vec![with_cb(
-            NodeData::create_text("v2").with_key(1u32),
+            NodeData::create_text_do_not_use_without_block_level_wrapper("v2").with_key(1u32),
             ComponentEventFilter::Updated,
         )];
 
@@ -2990,7 +2990,7 @@ mod autotest_generated {
         // so the Updated handler has to be present on BOTH sides — otherwise the
         // hashes differ for the callback alone and we'd be testing nothing.
         let stable = with_cb(
-            NodeData::create_text("v1").with_key(1u32),
+            NodeData::create_text_do_not_use_without_block_level_wrapper("v1").with_key(1u32),
             ComponentEventFilter::Updated,
         );
         let old = vec![stable.clone()];
@@ -3008,8 +3008,8 @@ mod autotest_generated {
     #[test]
     fn autotest_reconcile_update_requires_the_callback() {
         // Content changed under a stable key, but no Updated callback -> silent.
-        let old = vec![NodeData::create_text("v1").with_key(1u32)];
-        let new = vec![NodeData::create_text("v2").with_key(1u32)];
+        let old = vec![NodeData::create_text_do_not_use_without_block_level_wrapper("v1").with_key(1u32)];
+        let new = vec![NodeData::create_text_do_not_use_without_block_level_wrapper("v2").with_key(1u32)];
         let r = diff_flat(&old, &new);
         assert_eq!(r.node_moves.len(), 1);
         assert!(r.events.is_empty());
@@ -3202,7 +3202,7 @@ mod autotest_generated {
         let old_nd = vec![
             NodeData::create_div(),
             id_node("left"),
-            NodeData::create_text("leaf"),
+            NodeData::create_text_do_not_use_without_block_level_wrapper("leaf"),
         ];
         let old_hier = vec![
             hitem(None, None, None, Some(1)),
@@ -3213,7 +3213,7 @@ mod autotest_generated {
         let new_nd = vec![
             NodeData::create_div(),
             id_node("right"),
-            NodeData::create_text("leaf"),
+            NodeData::create_text_do_not_use_without_block_level_wrapper("leaf"),
         ];
         let new_hier = old_hier.clone();
 
@@ -3713,8 +3713,8 @@ mod autotest_generated {
 
     #[test]
     fn autotest_accumulator_merge_extended_diff_extracts_text_change() {
-        let old_nd = vec![NodeData::create_text("héllo")];
-        let new_nd = vec![NodeData::create_text("héllo wörld")];
+        let old_nd = vec![NodeData::create_text_do_not_use_without_block_level_wrapper("héllo")];
+        let new_nd = vec![NodeData::create_text_do_not_use_without_block_level_wrapper("héllo wörld")];
 
         let extended = ExtendedDiffResult {
             diff: DiffResult {
@@ -3870,8 +3870,8 @@ mod autotest_generated {
 
     #[test]
     fn autotest_reconcile_with_changes_reports_one_entry_per_move() {
-        let old = vec![NodeData::create_text("v1").with_key(1u32)];
-        let new = vec![NodeData::create_text("v2").with_key(1u32)];
+        let old = vec![NodeData::create_text_do_not_use_without_block_level_wrapper("v1").with_key(1u32)];
+        let new = vec![NodeData::create_text_do_not_use_without_block_level_wrapper("v2").with_key(1u32)];
 
         let r = reconcile_dom_with_changes(
             &old,
@@ -3929,8 +3929,8 @@ mod autotest_generated {
     #[test]
     fn autotest_reconcile_with_changes_feeds_the_accumulator() {
         // End-to-end: reconcile -> ExtendedDiffResult -> ChangeAccumulator.
-        let old = vec![NodeData::create_text("before").with_key(1u32)];
-        let new = vec![NodeData::create_text("after").with_key(1u32)];
+        let old = vec![NodeData::create_text_do_not_use_without_block_level_wrapper("before").with_key(1u32)];
+        let new = vec![NodeData::create_text_do_not_use_without_block_level_wrapper("after").with_key(1u32)];
 
         let extended = reconcile_dom_with_changes(
             &old,
@@ -3985,8 +3985,8 @@ mod autotest_generated {
         // identical fingerprint (no address or allocation identity leaking in).
         let state = StyledNodeState::default();
         for s in UNICODE_SAMPLES {
-            let a = NodeDataFingerprint::compute(&NodeData::create_text(*s), Some(&state));
-            let b = NodeDataFingerprint::compute(&NodeData::create_text(*s), Some(&state));
+            let a = NodeDataFingerprint::compute(&NodeData::create_text_do_not_use_without_block_level_wrapper(*s), Some(&state));
+            let b = NodeDataFingerprint::compute(&NodeData::create_text_do_not_use_without_block_level_wrapper(*s), Some(&state));
             assert_eq!(a, b, "fingerprint of {s:?} is not deterministic");
             assert!(a.is_identical(&b));
             assert!(a.diff(&b).is_empty());
@@ -3995,7 +3995,7 @@ mod autotest_generated {
 
     #[test]
     fn autotest_fingerprint_diff_is_symmetric() {
-        let a = NodeDataFingerprint::compute(&NodeData::create_text("a"), None);
+        let a = NodeDataFingerprint::compute(&NodeData::create_text_do_not_use_without_block_level_wrapper("a"), None);
         let b = NodeDataFingerprint::compute(&class_node("x").with_css("width: 1px"), None);
 
         assert_eq!(a.diff(&b), b.diff(&a), "diff must be symmetric");
@@ -4009,8 +4009,8 @@ mod autotest_generated {
 
     #[test]
     fn autotest_fingerprint_text_change_is_layout_and_visual() {
-        let a = NodeDataFingerprint::compute(&NodeData::create_text("one"), None);
-        let b = NodeDataFingerprint::compute(&NodeData::create_text("two"), None);
+        let a = NodeDataFingerprint::compute(&NodeData::create_text_do_not_use_without_block_level_wrapper("one"), None);
+        let b = NodeDataFingerprint::compute(&NodeData::create_text_do_not_use_without_block_level_wrapper("two"), None);
 
         assert!(!a.is_identical(&b));
         let changes = a.diff(&b);
@@ -4107,7 +4107,7 @@ mod autotest_generated {
         let state = StyledNodeState::default();
         let samples = vec![
             NodeData::create_div(),
-            NodeData::create_text("hello 🌍"),
+            NodeData::create_text_do_not_use_without_block_level_wrapper("hello 🌍"),
             class_node("row"),
             id_node("main"),
             NodeData::create_div().with_css("color: red"),
@@ -4361,10 +4361,10 @@ mod dom_fingerprint_tests {
     fn sample_dom() -> Dom {
         Dom::create_node(NodeType::Div)
             .with_class("page".into())
-            .with_child(Dom::create_text("hello"))
+            .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("hello"))
             .with_child(
                 Dom::create_node(NodeType::Div)
-                    .with_child(Dom::create_text("world")),
+                    .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("world")),
             )
     }
 
@@ -4385,10 +4385,10 @@ mod dom_fingerprint_tests {
         let (a, _) = fingerprint_dom(&sample_dom());
         let changed = Dom::create_node(NodeType::Div)
             .with_class("page".into())
-            .with_child(Dom::create_text("hellX"))
+            .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("hellX"))
             .with_child(
                 Dom::create_node(NodeType::Div)
-                    .with_child(Dom::create_text("world")),
+                    .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("world")),
             );
         let (b, _) = fingerprint_dom(&changed);
         assert_ne!(a.structure_root, b.structure_root, "text is structure");
@@ -4429,10 +4429,10 @@ mod dom_fingerprint_tests {
         let (a, _) = fingerprint_dom(&sample_dom());
         let changed = Dom::create_node(NodeType::Div)
             .with_class("pages".into())
-            .with_child(Dom::create_text("hello"))
+            .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("hello"))
             .with_child(
                 Dom::create_node(NodeType::Div)
-                    .with_child(Dom::create_text("world")),
+                    .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("world")),
             );
         let (b, _) = fingerprint_dom(&changed);
         assert_ne!(
@@ -4444,7 +4444,7 @@ mod dom_fingerprint_tests {
     #[test]
     fn added_child_changes_the_parent_and_the_shape() {
         let (a, _) = fingerprint_dom(&sample_dom());
-        let (b, _) = fingerprint_dom(&sample_dom().with_child(Dom::create_text("extra")));
+        let (b, _) = fingerprint_dom(&sample_dom().with_child(Dom::create_text_do_not_use_without_block_level_wrapper("extra")));
         assert_ne!(a.structure_root, b.structure_root);
         assert_ne!(a.structure.len(), b.structure.len());
         // The parent's own hash moved too (child count is folded in), so a

--- a/core/src/dom.rs
+++ b/core/src/dom.rs
@@ -2336,9 +2336,28 @@ impl NodeData {
         Self::create_node(NodeType::Br)
     }
 
+    /// Creates a RAW text node - read this before using it.
+    ///
+    /// **WARNING**: azul does NOT auto-wrap raw text in an anonymous block
+    /// the way browsers do. A bare text node has NO box of its own: it gets
+    /// no rect, no clip, and no layout constraints. Every box-model CSS
+    /// property (width/height/position/overflow/background/border/padding),
+    /// every callback, every `tab_index` and every `dataset` attached to a
+    /// text node is silently INERT. This has broken shipped widgets before
+    /// (text escaping its container, click targets that never fire).
+    ///
+    /// A raw text node is only correct as the bare leaf INSIDE a block-level
+    /// wrapper that carries the styling - `p`, `div`, `h1`... Prefer the
+    /// `create_*_with_text` family (`Dom::create_p_with_text`,
+    /// `Dom::create_div_with_text`, `Dom::create_span_with_text`, ...), which
+    /// builds that shape for you. The engine also logs a warning after layout
+    /// when it finds a text node used without a containing block.
+    ///
     /// Shorthand for `NodeData::create_node(NodeType::Text(value.into()))`.
     #[inline]
-    pub fn create_text<S: Into<AzString>>(value: S) -> Self {
+    pub fn create_text_do_not_use_without_block_level_wrapper<S: Into<AzString>>(
+        value: S,
+    ) -> Self {
         Self::create_node(NodeType::Text(BoxOrStatic::heap(value.into())))
     }
 
@@ -3933,7 +3952,7 @@ impl Dom {
     /// announce the disclosure heading.
     #[inline]
     pub fn create_summary_with_text_no_a11y<S: Into<AzString>>(text: S) -> Self {
-        Self::create_summary_no_a11y().with_child(Self::create_text(text))
+        Self::create_summary_no_a11y().with_child(Self::create_text_do_not_use_without_block_level_wrapper(text))
     }
 
     /// Creates a summary element with text and accessibility information for details.
@@ -3986,8 +4005,26 @@ impl Dom {
             estimated_total_children: 0,
         }
     }
+    /// Creates a RAW text node - read this before using it.
+    ///
+    /// **WARNING**: azul does NOT auto-wrap raw text in an anonymous block
+    /// the way browsers do. A bare text node has NO box of its own: it gets
+    /// no rect, no clip, and no layout constraints. Every box-model CSS
+    /// property (width/height/position/overflow/background/border/padding),
+    /// every callback, every `tab_index` and every `dataset` attached to a
+    /// text node is silently INERT. This has broken shipped widgets before
+    /// (text escaping its container, click targets that never fire).
+    ///
+    /// A raw text node is only correct as the bare leaf INSIDE a block-level
+    /// wrapper that carries the styling - `p`, `div`, `h1`... Prefer the
+    /// `create_*_with_text` family ([`Dom::create_p_with_text`],
+    /// [`Dom::create_div_with_text`], [`Dom::create_span_with_text`], ...),
+    /// which builds that shape for you. The engine also logs a warning after
+    /// layout when it finds a text node used without a containing block.
     #[inline]
-    pub fn create_text<S: Into<AzString>>(value: S) -> Self {
+    pub fn create_text_do_not_use_without_block_level_wrapper<S: Into<AzString>>(
+        value: S,
+    ) -> Self {
         Self::create_node(NodeType::Text(BoxOrStatic::heap(value.into())))
     }
     #[inline]
@@ -4064,7 +4101,7 @@ impl Dom {
     /// - `text`: Heading text
     #[inline]
     pub fn create_h1_with_text<S: Into<AzString>>(text: S) -> Self {
-        Self::create_h1().with_child(Self::create_text(text))
+        Self::create_h1().with_child(Self::create_text_do_not_use_without_block_level_wrapper(text))
     }
 
     /// Creates an empty heading level 2 element.
@@ -4088,7 +4125,7 @@ impl Dom {
     /// - `text`: Heading text
     #[inline]
     pub fn create_h2_with_text<S: Into<AzString>>(text: S) -> Self {
-        Self::create_h2().with_child(Self::create_text(text))
+        Self::create_h2().with_child(Self::create_text_do_not_use_without_block_level_wrapper(text))
     }
 
     /// Creates an empty heading level 3 element.
@@ -4112,7 +4149,7 @@ impl Dom {
     /// - `text`: Heading text
     #[inline]
     pub fn create_h3_with_text<S: Into<AzString>>(text: S) -> Self {
-        Self::create_h3().with_child(Self::create_text(text))
+        Self::create_h3().with_child(Self::create_text_do_not_use_without_block_level_wrapper(text))
     }
 
     /// Creates an empty heading level 4 element.
@@ -4132,7 +4169,7 @@ impl Dom {
     /// - `text`: Heading text
     #[inline]
     pub fn create_h4_with_text<S: Into<AzString>>(text: S) -> Self {
-        Self::create_h4().with_child(Self::create_text(text))
+        Self::create_h4().with_child(Self::create_text_do_not_use_without_block_level_wrapper(text))
     }
 
     /// Creates an empty heading level 5 element.
@@ -4152,7 +4189,7 @@ impl Dom {
     /// - `text`: Heading text
     #[inline]
     pub fn create_h5_with_text<S: Into<AzString>>(text: S) -> Self {
-        Self::create_h5().with_child(Self::create_text(text))
+        Self::create_h5().with_child(Self::create_text_do_not_use_without_block_level_wrapper(text))
     }
 
     /// Creates an empty heading level 6 element.
@@ -4172,7 +4209,7 @@ impl Dom {
     /// - `text`: Heading text
     #[inline]
     pub fn create_h6_with_text<S: Into<AzString>>(text: S) -> Self {
-        Self::create_h6().with_child(Self::create_text(text))
+        Self::create_h6().with_child(Self::create_text_do_not_use_without_block_level_wrapper(text))
     }
 
     /// Creates an empty generic inline container (span).
@@ -4198,7 +4235,7 @@ impl Dom {
     /// - `text`: Span content
     #[inline]
     pub fn create_span_with_text<S: Into<AzString>>(text: S) -> Self {
-        Self::create_span().with_child(Self::create_text(text))
+        Self::create_span().with_child(Self::create_text_do_not_use_without_block_level_wrapper(text))
     }
 
     /// Creates an empty strong importance element.
@@ -4223,7 +4260,7 @@ impl Dom {
     /// - `text`: Text to emphasize
     #[inline]
     pub fn create_strong_with_text<S: Into<AzString>>(text: S) -> Self {
-        Self::create_strong().with_child(Self::create_text(text))
+        Self::create_strong().with_child(Self::create_text_do_not_use_without_block_level_wrapper(text))
     }
 
     /// Creates an empty emphasis element (stress emphasis).
@@ -4248,7 +4285,7 @@ impl Dom {
     /// - `text`: Text to emphasize
     #[inline]
     pub fn create_em_with_text<S: Into<AzString>>(text: S) -> Self {
-        Self::create_em().with_child(Self::create_text(text))
+        Self::create_em().with_child(Self::create_text_do_not_use_without_block_level_wrapper(text))
     }
 
     /// Creates an empty code element.
@@ -4268,7 +4305,7 @@ impl Dom {
     /// - `code`: Code content
     #[inline]
     pub fn create_code_with_text<S: Into<AzString>>(code: S) -> Self {
-        Self::create_code().with_child(Self::create_text(code))
+        Self::create_code().with_child(Self::create_text_do_not_use_without_block_level_wrapper(code))
     }
 
     /// Creates an empty preformatted text element.
@@ -4288,7 +4325,7 @@ impl Dom {
     /// - `text`: Preformatted content
     #[inline]
     pub fn create_pre_with_text<S: Into<AzString>>(text: S) -> Self {
-        Self::create_pre().with_child(Self::create_text(text))
+        Self::create_pre().with_child(Self::create_text_do_not_use_without_block_level_wrapper(text))
     }
 
     /// Creates an empty blockquote element.
@@ -4308,7 +4345,7 @@ impl Dom {
     /// - `text`: Quote content
     #[inline]
     pub fn create_blockquote_with_text<S: Into<AzString>>(text: S) -> Self {
-        Self::create_blockquote().with_child(Self::create_text(text))
+        Self::create_blockquote().with_child(Self::create_text_do_not_use_without_block_level_wrapper(text))
     }
 
     /// Creates an empty citation element.
@@ -4328,7 +4365,7 @@ impl Dom {
     /// - `text`: Citation text
     #[inline]
     pub fn create_cite_with_text<S: Into<AzString>>(text: S) -> Self {
-        Self::create_cite().with_child(Self::create_text(text))
+        Self::create_cite().with_child(Self::create_text_do_not_use_without_block_level_wrapper(text))
     }
 
     /// Creates an empty abbreviation element.
@@ -4352,7 +4389,7 @@ impl Dom {
     #[must_use] pub fn create_abbr_with_title(abbr_text: AzString, title: AzString) -> Self {
         Self::create_node(NodeType::Abbr)
             .with_attribute(AttributeType::Title(title))
-            .with_child(Self::create_text(abbr_text))
+            .with_child(Self::create_text_do_not_use_without_block_level_wrapper(abbr_text))
     }
 
     /// Creates an empty keyboard input element.
@@ -4372,7 +4409,7 @@ impl Dom {
     /// - `text`: Keyboard instruction
     #[inline]
     pub fn create_kbd_with_text<S: Into<AzString>>(text: S) -> Self {
-        Self::create_kbd().with_child(Self::create_text(text))
+        Self::create_kbd().with_child(Self::create_text_do_not_use_without_block_level_wrapper(text))
     }
 
     /// Creates an empty sample output element.
@@ -4391,7 +4428,7 @@ impl Dom {
     /// - `text`: Sample text
     #[inline]
     pub fn create_samp_with_text<S: Into<AzString>>(text: S) -> Self {
-        Self::create_samp().with_child(Self::create_text(text))
+        Self::create_samp().with_child(Self::create_text_do_not_use_without_block_level_wrapper(text))
     }
 
     /// Creates an empty variable element.
@@ -4410,7 +4447,7 @@ impl Dom {
     /// - `text`: Variable name
     #[inline]
     pub fn create_var_with_text<S: Into<AzString>>(text: S) -> Self {
-        Self::create_var().with_child(Self::create_text(text))
+        Self::create_var().with_child(Self::create_text_do_not_use_without_block_level_wrapper(text))
     }
 
     /// Creates an empty subscript element.
@@ -4427,7 +4464,7 @@ impl Dom {
     /// - `text`: Subscript content
     #[inline]
     pub fn create_sub_with_text<S: Into<AzString>>(text: S) -> Self {
-        Self::create_sub().with_child(Self::create_text(text))
+        Self::create_sub().with_child(Self::create_text_do_not_use_without_block_level_wrapper(text))
     }
 
     /// Creates an empty superscript element.
@@ -4444,7 +4481,7 @@ impl Dom {
     /// - `text`: Superscript content
     #[inline]
     pub fn create_sup_with_text<S: Into<AzString>>(text: S) -> Self {
-        Self::create_sup().with_child(Self::create_text(text))
+        Self::create_sup().with_child(Self::create_text_do_not_use_without_block_level_wrapper(text))
     }
 
     /// Creates an empty underline element.
@@ -4459,7 +4496,7 @@ impl Dom {
     /// Use semantic elements when possible (e.g., `<em>` for emphasis).
     #[inline]
     pub fn create_u_with_text<S: Into<AzString>>(text: S) -> Self {
-        Self::create_u().with_child(Self::create_text(text))
+        Self::create_u().with_child(Self::create_text_do_not_use_without_block_level_wrapper(text))
     }
 
     /// Creates an empty strikethrough element.
@@ -4474,7 +4511,7 @@ impl Dom {
     /// Consider using `<del>` for deleted content with datetime attribute.
     #[inline]
     pub fn create_s_with_text<S: Into<AzString>>(text: S) -> Self {
-        Self::create_s().with_child(Self::create_text(text))
+        Self::create_s().with_child(Self::create_text_do_not_use_without_block_level_wrapper(text))
     }
 
     /// Creates an empty mark element.
@@ -4489,7 +4526,7 @@ impl Dom {
     /// Screen readers may announce this as "highlighted".
     #[inline]
     pub fn create_mark_with_text<S: Into<AzString>>(text: S) -> Self {
-        Self::create_mark().with_child(Self::create_text(text))
+        Self::create_mark().with_child(Self::create_text_do_not_use_without_block_level_wrapper(text))
     }
 
     /// Creates an empty deleted text element.
@@ -4504,7 +4541,7 @@ impl Dom {
     /// Use with `datetime` and `cite` attributes for edit tracking.
     #[inline]
     pub fn create_del_with_text<S: Into<AzString>>(text: S) -> Self {
-        Self::create_del().with_child(Self::create_text(text))
+        Self::create_del().with_child(Self::create_text_do_not_use_without_block_level_wrapper(text))
     }
 
     /// Creates an empty inserted text element.
@@ -4519,7 +4556,7 @@ impl Dom {
     /// Use with `datetime` and `cite` attributes for edit tracking.
     #[inline]
     pub fn create_ins_with_text<S: Into<AzString>>(text: S) -> Self {
-        Self::create_ins().with_child(Self::create_text(text))
+        Self::create_ins().with_child(Self::create_text_do_not_use_without_block_level_wrapper(text))
     }
 
     /// Creates an empty definition element.
@@ -4534,7 +4571,7 @@ impl Dom {
     /// Often used within a definition list or with `<abbr>`.
     #[inline]
     pub fn create_dfn_with_text<S: Into<AzString>>(text: S) -> Self {
-        Self::create_dfn().with_child(Self::create_text(text))
+        Self::create_dfn().with_child(Self::create_text_do_not_use_without_block_level_wrapper(text))
     }
 
     /// Creates a time element.
@@ -4547,7 +4584,7 @@ impl Dom {
     /// - `datetime`: Optional machine-readable datetime
     #[inline]
     #[must_use] pub fn create_time(text: AzString, datetime: OptionString) -> Self {
-        let mut element = Self::create_node(NodeType::Time).with_child(Self::create_text(text));
+        let mut element = Self::create_node(NodeType::Time).with_child(Self::create_text_do_not_use_without_block_level_wrapper(text));
         if let OptionString::Some(dt) = datetime {
             element = element.with_attribute(AttributeType::Custom(AttributeNameValue {
                 attr_name: "datetime".into(),
@@ -4570,7 +4607,7 @@ impl Dom {
     /// **Accessibility**: Overrides text direction. Use `dir` attribute (ltr/rtl).
     #[inline]
     pub fn create_bdo_with_text<S: Into<AzString>>(text: S) -> Self {
-        Self::create_bdo().with_child(Self::create_text(text))
+        Self::create_bdo().with_child(Self::create_text_do_not_use_without_block_level_wrapper(text))
     }
 
     // Additional inline / text-level elements
@@ -4591,7 +4628,7 @@ impl Dom {
     /// - `text`: Bold text content
     #[inline]
     pub fn create_b_with_text<S: Into<AzString>>(text: S) -> Self {
-        Self::create_b().with_child(Self::create_text(text))
+        Self::create_b().with_child(Self::create_text_do_not_use_without_block_level_wrapper(text))
     }
 
     /// Creates an empty italic element.
@@ -4610,7 +4647,7 @@ impl Dom {
     /// - `text`: Italic text content
     #[inline]
     pub fn create_i_with_text<S: Into<AzString>>(text: S) -> Self {
-        Self::create_i().with_child(Self::create_text(text))
+        Self::create_i().with_child(Self::create_text_do_not_use_without_block_level_wrapper(text))
     }
 
     /// Creates an empty small text element.
@@ -4627,7 +4664,7 @@ impl Dom {
     /// - `text`: Small text content
     #[inline]
     pub fn create_small_with_text<S: Into<AzString>>(text: S) -> Self {
-        Self::create_small().with_child(Self::create_text(text))
+        Self::create_small().with_child(Self::create_text_do_not_use_without_block_level_wrapper(text))
     }
 
     /// Creates an empty `<big>` element.
@@ -4643,7 +4680,7 @@ impl Dom {
     /// **Note**: Deprecated in HTML5. Prefer CSS `font-size`.
     #[inline]
     pub fn create_big_with_text<S: Into<AzString>>(text: S) -> Self {
-        Self::create_big().with_child(Self::create_text(text))
+        Self::create_big().with_child(Self::create_text_do_not_use_without_block_level_wrapper(text))
     }
 
     /// Creates an empty bi-directional isolate element.
@@ -4661,7 +4698,7 @@ impl Dom {
     /// keeping it from affecting surrounding bidi layout.
     #[inline]
     pub fn create_bdi_with_text<S: Into<AzString>>(text: S) -> Self {
-        Self::create_bdi().with_child(Self::create_text(text))
+        Self::create_bdi().with_child(Self::create_text_do_not_use_without_block_level_wrapper(text))
     }
 
     /// Creates an empty word break opportunity element.
@@ -4696,7 +4733,7 @@ impl Dom {
     /// - `text`: Ruby annotation content
     #[inline]
     pub fn create_rt_with_text<S: Into<AzString>>(text: S) -> Self {
-        Self::create_rt().with_child(Self::create_text(text))
+        Self::create_rt().with_child(Self::create_text_do_not_use_without_block_level_wrapper(text))
     }
 
     /// Creates an empty ruby text container element.
@@ -4721,7 +4758,7 @@ impl Dom {
     /// - `text`: Parenthesis text (typically "(" or ")")
     #[inline]
     pub fn create_rp_with_text<S: Into<AzString>>(text: S) -> Self {
-        Self::create_rp().with_child(Self::create_text(text))
+        Self::create_rp().with_child(Self::create_text_do_not_use_without_block_level_wrapper(text))
     }
 
     /// Creates a `<data>` element binding a machine-readable value to its content.
@@ -4740,7 +4777,7 @@ impl Dom {
     /// - `text`: Human-readable text content.
     #[inline]
     #[must_use] pub fn create_data_with_text(value: AzString, text: AzString) -> Self {
-        Self::create_data(value).with_child(Self::create_text(text))
+        Self::create_data(value).with_child(Self::create_text_do_not_use_without_block_level_wrapper(text))
     }
 
     /// Creates an empty directory list element.
@@ -4770,7 +4807,7 @@ impl Dom {
     #[must_use] pub fn create_a_no_a11y(href: AzString, label: OptionString) -> Self {
         let mut link = Self::create_node(NodeType::A).with_attribute(AttributeType::Href(href));
         if let OptionString::Some(text) = label {
-            link = link.with_child(Self::create_text(text));
+            link = link.with_child(Self::create_text_do_not_use_without_block_level_wrapper(text));
         }
         link
     }
@@ -4784,7 +4821,7 @@ impl Dom {
     /// - `text`: Button label text
     #[inline]
     #[must_use] pub fn create_button_no_a11y(text: AzString) -> Self {
-        Self::create_node(NodeType::Button).with_child(Self::create_text(text))
+        Self::create_node(NodeType::Button).with_child(Self::create_text_do_not_use_without_block_level_wrapper(text))
     }
 
     /// Creates a label element for form controls without accessibility information.
@@ -4801,7 +4838,7 @@ impl Dom {
                 attr_name: "for".into(),
                 value: for_id,
             }))
-            .with_child(Self::create_text(text))
+            .with_child(Self::create_text_do_not_use_without_block_level_wrapper(text))
     }
 
     /// Creates an input element without accessibility information.
@@ -4860,7 +4897,7 @@ impl Dom {
     #[must_use] pub fn create_option_no_a11y(value: AzString, text: AzString) -> Self {
         Self::create_node(NodeType::SelectOption)
             .with_attribute(AttributeType::Value(value))
-            .with_child(Self::create_text(text))
+            .with_child(Self::create_text_do_not_use_without_block_level_wrapper(text))
     }
 
     /// Creates an option element for select dropdowns with accessibility information.
@@ -5180,7 +5217,7 @@ impl Dom {
     /// **Note**: Deprecated in HTML5. Consider using `create_abbr_with_title()` instead.
     #[inline]
     pub fn create_acronym_with_text<S: Into<AzString>>(text: S) -> Self {
-        Self::create_acronym().with_child(Self::create_text(text))
+        Self::create_acronym().with_child(Self::create_text_do_not_use_without_block_level_wrapper(text))
     }
 
     /// Creates a menu element without accessibility information.
@@ -5239,7 +5276,7 @@ impl Dom {
     /// distinct accessible name in addition to the visible text.
     #[inline]
     pub fn create_menuitem_with_text_no_a11y<S: Into<AzString>>(text: S) -> Self {
-        Self::create_menuitem_no_a11y().with_child(Self::create_text(text))
+        Self::create_menuitem_no_a11y().with_child(Self::create_text_do_not_use_without_block_level_wrapper(text))
     }
 
     /// Creates a menu item element with text and accessibility information.
@@ -5615,7 +5652,7 @@ impl Dom {
     /// Should be unique and descriptive. Keep under 60 characters.
     #[inline]
     pub fn create_title_with_text<S: Into<AzString>>(text: S) -> Self {
-        Self::create_title().with_child(Self::create_text(text))
+        Self::create_title().with_child(Self::create_text_do_not_use_without_block_level_wrapper(text))
     }
 
     /// Creates a meta element.
@@ -5679,7 +5716,7 @@ impl Dom {
     /// This creates a `<style>` HTML element for embedded stylesheets.
     #[inline]
     pub fn create_style_with_text<S: Into<AzString>>(text: S) -> Self {
-        Self::create_style().with_child(Self::create_text(text))
+        Self::create_style().with_child(Self::create_text_do_not_use_without_block_level_wrapper(text))
     }
 
     /// Creates a base element for document base URL.
@@ -5704,7 +5741,7 @@ impl Dom {
     #[must_use] pub fn create_th_with_scope(scope: AzString, text: AzString) -> Self {
         Self::create_node(NodeType::Th)
             .with_attribute(AttributeType::Scope(scope))
-            .with_child(Self::create_text(text))
+            .with_child(Self::create_text_do_not_use_without_block_level_wrapper(text))
     }
 
     /// Creates a table data cell with text.
@@ -5713,7 +5750,7 @@ impl Dom {
     /// - `text`: Cell content
     #[inline]
     pub fn create_td_with_text<S: Into<AzString>>(text: S) -> Self {
-        Self::create_td().with_child(Self::create_text(text))
+        Self::create_td().with_child(Self::create_text_do_not_use_without_block_level_wrapper(text))
     }
 
     /// Creates a table header cell with text.
@@ -5722,7 +5759,7 @@ impl Dom {
     /// - `text`: Header text
     #[inline]
     pub fn create_th_with_text<S: Into<AzString>>(text: S) -> Self {
-        Self::create_th().with_child(Self::create_text(text))
+        Self::create_th().with_child(Self::create_text_do_not_use_without_block_level_wrapper(text))
     }
 
     /// Creates a list item with text.
@@ -5731,7 +5768,7 @@ impl Dom {
     /// - `text`: List item content
     #[inline]
     pub fn create_li_with_text<S: Into<AzString>>(text: S) -> Self {
-        Self::create_li().with_child(Self::create_text(text))
+        Self::create_li().with_child(Self::create_text_do_not_use_without_block_level_wrapper(text))
     }
 
     /// Creates a paragraph with text.
@@ -5740,7 +5777,23 @@ impl Dom {
     /// - `text`: Paragraph content
     #[inline]
     pub fn create_p_with_text<S: Into<AzString>>(text: S) -> Self {
-        Self::create_p().with_child(Self::create_text(text))
+        Self::create_p()
+            .with_child(Self::create_text_do_not_use_without_block_level_wrapper(text))
+    }
+
+    /// Creates a generic block container (div) with text.
+    ///
+    /// The div is the box the text lives in: put your styling, callbacks and
+    /// `tab_index` on the DIV, never on the text leaf (a text node has no box
+    /// of its own - see
+    /// [`Dom::create_text_do_not_use_without_block_level_wrapper`]).
+    ///
+    /// **Parameters:**
+    /// - `text`: Div content
+    #[inline]
+    pub fn create_div_with_text<S: Into<AzString>>(text: S) -> Self {
+        Self::create_div()
+            .with_child(Self::create_text_do_not_use_without_block_level_wrapper(text))
     }
 
     // Accessibility-Aware Constructors
@@ -5857,7 +5910,7 @@ impl Dom {
     #[allow(clippy::needless_pass_by_value)] // owned azul C-ABI value taken by value (FFI ownership-transfer convention)
     pub fn create_table<S: Into<AzString>>(caption: S, aria: SmallAriaInfo) -> Self {
         let mut table = Self::create_table_no_a11y()
-            .with_child(Self::create_caption().with_child(Self::create_text(caption)));
+            .with_child(Self::create_caption().with_child(Self::create_text_do_not_use_without_block_level_wrapper(caption)));
         table.root.set_accessibility_info(aria.to_full_info());
         table
     }
@@ -5891,7 +5944,7 @@ impl Dom {
     pub fn from_xml<S: AsRef<str>>(xml_str: S) -> Self {
         // TODO: Implement full XML parsing
         // For now, just create a text node showing that XML was loaded
-        Self::create_text(format!(
+        Self::create_text_do_not_use_without_block_level_wrapper(format!(
             "XML content loaded ({} bytes)",
             xml_str.as_ref().len()
         ))
@@ -5900,7 +5953,7 @@ impl Dom {
     /// Parse XML/XHTML string into a DOM (fallback without xml feature)
     #[cfg(not(feature = "xml"))]
     pub fn from_xml<S: AsRef<str>>(xml_str: S) -> Self {
-        Self::create_text(format!(
+        Self::create_text_do_not_use_without_block_level_wrapper(format!(
             "XML parsing requires 'xml' feature ({} bytes)",
             xml_str.as_ref().len()
         ))
@@ -6407,7 +6460,7 @@ mod audit_tests {
     // Miri can validate the raw write / box ownership transfer for UB.
     #[test]
     fn copy_special_moving_complex_moves_text_node_type() {
-        let mut nd = NodeData::create_text("hello").with_css("color: red;");
+        let mut nd = NodeData::create_text_do_not_use_without_block_level_wrapper("hello").with_css("color: red;");
         assert!(!nd.style.rules.is_empty(), "precondition: style set");
 
         let copy = nd.copy_special_moving_complex();
@@ -7480,12 +7533,12 @@ mod autotest_generated {
     #[test]
     fn create_text_accepts_empty_unicode_and_huge_input() {
         for s in ["", "x", "日本語 🎉"] {
-            let nd = NodeData::create_text(s);
+            let nd = NodeData::create_text_do_not_use_without_block_level_wrapper(s);
             assert!(nd.is_text_node());
             assert_eq!(nd.get_node_type().format(), Some(s.to_string()));
         }
         let big = huge_unicode_string();
-        let nd = NodeData::create_text(big.clone());
+        let nd = NodeData::create_text_do_not_use_without_block_level_wrapper(big.clone());
         assert!(nd.is_text_node());
         assert_eq!(nd.get_node_type().format(), Some(big));
     }
@@ -7615,7 +7668,7 @@ mod autotest_generated {
 
     #[test]
     fn is_node_type_is_content_sensitive_for_text() {
-        let nd = NodeData::create_text("a");
+        let nd = NodeData::create_text_do_not_use_without_block_level_wrapper("a");
         assert!(nd.is_node_type(NodeType::Text(BoxOrStatic::heap(AzString::from("a")))));
         assert!(
             !nd.is_node_type(NodeType::Text(BoxOrStatic::heap(AzString::from("b")))),
@@ -7626,7 +7679,7 @@ mod autotest_generated {
 
     #[test]
     fn is_text_node_and_is_virtual_view_node() {
-        assert!(NodeData::create_text("x").is_text_node());
+        assert!(NodeData::create_text_do_not_use_without_block_level_wrapper("x").is_text_node());
         assert!(!NodeData::create_div().is_text_node());
 
         let vv = NodeData::create_virtual_view(RefAny::new(1u32), virtual_view_callback());
@@ -8081,8 +8134,8 @@ mod autotest_generated {
     fn structural_hash_ignores_text_content_but_data_hash_does_not() {
         // Documented behaviour: Text("Hello") must match Text("Hello World") during
         // reconciliation so the cursor survives an edit.
-        let a = NodeData::create_text("Hello");
-        let b = NodeData::create_text("Hello World");
+        let a = NodeData::create_text_do_not_use_without_block_level_wrapper("Hello");
+        let b = NodeData::create_text_do_not_use_without_block_level_wrapper("Hello World");
 
         assert_eq!(
             a.calculate_structural_hash(),
@@ -8195,7 +8248,7 @@ mod autotest_generated {
 
     #[test]
     fn node_data_display_wraps_text_content_in_a_tag_pair() {
-        let s = format!("{}", NodeData::create_text("hello"));
+        let s = format!("{}", NodeData::create_text_do_not_use_without_block_level_wrapper("hello"));
         assert!(s.starts_with('<'));
         assert!(s.ends_with('>'));
         assert!(s.contains("hello"), "{s}");
@@ -8214,7 +8267,7 @@ mod autotest_generated {
             "日本語 🎉",
             "line\nbreak\ttab",
         ] {
-            let s = format!("{}", NodeData::create_text(text));
+            let s = format!("{}", NodeData::create_text_do_not_use_without_block_level_wrapper(text));
             assert!(s.contains(text), "Display dropped content for {text:?}");
         }
     }
@@ -8222,7 +8275,7 @@ mod autotest_generated {
     #[test]
     fn node_data_display_survives_a_huge_text_payload() {
         let big = huge_unicode_string();
-        let s = format!("{}", NodeData::create_text(big.clone()));
+        let s = format!("{}", NodeData::create_text_do_not_use_without_block_level_wrapper(big.clone()));
         assert!(s.len() > big.len());
     }
 
@@ -8343,7 +8396,7 @@ mod autotest_generated {
 
     #[test]
     fn swap_with_default_returns_the_original_and_leaves_a_div() {
-        let mut nd = NodeData::create_text("payload");
+        let mut nd = NodeData::create_text_do_not_use_without_block_level_wrapper("payload");
         let taken = nd.swap_with_default();
         assert!(taken.is_text_node());
         assert!(nd.is_node_type(NodeType::Div), "the slot becomes a fresh div");
@@ -8380,7 +8433,7 @@ mod autotest_generated {
         let mut v: NodeDataVec = vec![
             NodeData::create_div(),
             NodeData::create_br(),
-            NodeData::create_text("t"),
+            NodeData::create_text_do_not_use_without_block_level_wrapper("t"),
         ]
         .into();
         assert_eq!(v.as_container().internal.len(), 3);
@@ -8602,8 +8655,8 @@ mod autotest_generated {
     fn dom_clone_and_eq_agree_on_a_nested_tree() {
         let d = Dom::create_div()
             .with_id("r".into())
-            .with_child(Dom::create_text("a"))
-            .with_child(Dom::create_div().with_child(Dom::create_text("b")));
+            .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("a"))
+            .with_child(Dom::create_div().with_child(Dom::create_text_do_not_use_without_block_level_wrapper("b")));
         let c = d.clone();
         assert_eq!(d, c);
         assert_eq!(hash_of(&d), hash_of(&c));
@@ -8615,7 +8668,7 @@ mod autotest_generated {
     #[test]
     fn dom_debug_does_not_panic_on_a_nested_tree() {
         let d = Dom::create_div()
-            .with_child(Dom::create_text("日本語 🎉"))
+            .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("日本語 🎉"))
             .with_child(Dom::create_div().with_child(Dom::create_br()));
         let s = format!("{d:?}");
         assert!(s.contains("Dom"));

--- a/core/src/events.rs
+++ b/core/src/events.rs
@@ -1064,6 +1064,15 @@ pub enum DefaultAction {
     },
     /// No default action for this event
     None,
+    /// Enter in a PLAIN-TEXT editing context (the editing host's computed
+    /// `white-space` preserves newlines: pre / pre-wrap / break-spaces /
+    /// pre-line), and Shift+Enter in ANY contenteditable host: insert a
+    /// literal `"\n"` through the standard text-input pipeline (which brings
+    /// veto, undo, and caret-follow along) instead of recording a structural
+    /// block split. APPENDED at the enum tail for ABI stability.
+    InsertLineBreakAtCursor {
+        target: DomNodeId,
+    },
 }
 
 /// Amount to scroll for keyboard-based scrolling
@@ -3665,7 +3674,7 @@ fn handle_mouse_down(
 /// Handle `MouseOver` event - detect drag selection
 fn handle_mouse_over(
     event: &SyntheticEvent,
-    hit_test: Option<&FullHitTest>,
+    _hit_test: Option<&FullHitTest>,
     mouse_state: &crate::window::MouseState,
     drag_start_position: Option<LogicalPosition>,
 ) -> Option<InternalEventAction> {
@@ -3675,7 +3684,13 @@ fn handle_mouse_over(
 
     let start_position = drag_start_position?;
 
-    let _target = get_first_hovered_node(hit_test)?;
+    // Deliberately NOT gated on a hovered hit node. A drag that leaves the
+    // text — into the container's padding, over a gap, past the last line —
+    // still extends the selection in every native editor, and the endpoint is
+    // resolved from the pointer position against the ANCHOR block's layout
+    // (`process_mouse_drag_for_selection`), not from whatever happens to be
+    // under the cursor. Requiring a hit node froze the selection exactly where
+    // the user was reaching for more of it.
     let current_position = get_mouse_position_with_fallback(event, mouse_state);
 
     Some(InternalEventAction::AddAndPass(
@@ -6336,9 +6351,12 @@ mod autotest_generated {
         let down = MouseState { left_down: true, ..MouseState::default() };
         assert!(handle_mouse_over(&ev, Some(&ht), &down, None).is_none());
 
-        // Button down + origin but nothing under the cursor -> no drag.
-        assert!(handle_mouse_over(&ev, None, &down, Some(start)).is_none());
-        assert!(handle_mouse_over(&ev, Some(&empty_hit_test()), &down, Some(start)).is_none());
+        // Button down + origin but nothing under the cursor -> STILL a drag:
+        // reaching past the text (into padding, past the last line) is how a
+        // selection gets extended, and the endpoint resolves against the
+        // anchor block, not against whatever is under the pointer.
+        assert!(handle_mouse_over(&ev, None, &down, Some(start)).is_some());
+        assert!(handle_mouse_over(&ev, Some(&empty_hit_test()), &down, Some(start)).is_some());
 
         // All three present -> a drag selection from origin to the current point.
         match handle_mouse_over(&ev, Some(&ht), &down, Some(start)) {

--- a/core/src/hit_test.rs
+++ b/core/src/hit_test.rs
@@ -125,13 +125,25 @@ impl Default for OverflowingScrollNode {
 /// All pipelines still share the same `IdNamespace` and `DocumentId`.
 pub type PipelineSourceId = u32;
 
-/// Information about a scroll frame, given to the user by the framework
+/// Information about a scroll frame, given to the user by the framework.
+///
+/// The two rects are NOT in the same coordinate space — never subtract one
+/// origin from the other. That silent ambiguity put the scrollbar thumb
+/// partway down the track for every container not at the window origin.
+/// See `ScrollManager::get_scroll_states_for_dom` for the producer.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd)]
 pub struct ScrollPosition {
-    /// How big is the parent container
-    /// (so that things like "scroll to left edge" can be implemented)?
+    /// The scroll container's border box in ABSOLUTE window coordinates.
+    /// `size` is the scrollport ("how big is the parent container", so
+    /// "scroll to left edge" can be implemented); `origin` is where that
+    /// container sits on screen and is only meaningful to scroll-into-view.
     pub parent_rect: LogicalRect,
-    /// How big is the scroll rect (i.e. the union of all children)?
+    /// `size` = the scrollable content ("the union of all children", or the
+    /// `VirtualView` virtual size when one was reported).
+    /// `origin` = the SCROLL OFFSET ITSELF — distance already scrolled from
+    /// the scroll origin, normally clamped to `[0, content − container]`.
+    /// It is NOT an absolute position and NOT relative to
+    /// `parent_rect.origin`; content paints at `position − origin`.
     pub children_rect: LogicalRect,
 }
 

--- a/core/src/icon.rs
+++ b/core/src/icon.rs
@@ -1968,7 +1968,7 @@ mod autotest_generated {
     #[test]
     fn resolve_icons_in_styled_dom_is_a_no_op_without_icons() {
         let shared = SharedIconProvider::from_handle(IconProviderHandle::with_resolver(div_resolver));
-        let mut sd = StyledDom::create_from_dom(Dom::create_body().with_child(Dom::create_text("hi")));
+        let mut sd = StyledDom::create_from_dom(Dom::create_body().with_child(Dom::create_text_do_not_use_without_block_level_wrapper("hi")));
         let before_len = sd.node_data.as_ref().len();
         let before_root = node_type_at(&sd, 0);
 
@@ -2227,7 +2227,7 @@ mod icon_cache_tests {
         PARITY_CALLS.fetch_add(1, AtomicOrdering::SeqCst);
         // A realistic replacement: styled text (what a font-icon resolver
         // produces), reading nothing but producing node type + props + a11y.
-        let mut dom = Dom::create_text("\u{e88a}");
+        let mut dom = Dom::create_text_do_not_use_without_block_level_wrapper("\u{e88a}");
         dom.root.set_css_props(
             vec![CssPropertyWithConditions::simple(CssProperty::width(LayoutWidth::px(16.0)))]
                 .into(),
@@ -2309,7 +2309,7 @@ mod icon_cache_tests {
         StyledDom::create_from_dom(
             Dom::create_body()
                 .with_child(Dom::create_div())
-                .with_child(Dom::create_text("x")),
+                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("x")),
         )
     }
 

--- a/core/src/prop_cache.rs
+++ b/core/src/prop_cache.rs
@@ -3556,9 +3556,15 @@ impl CssPropertyCache {
             }
         }
 
-        // All UA property types that get_ua_property() may return Some for
+        // All UA property types that get_ua_property() may return Some for.
+        // MUST stay in sync with compact.rs::UA_PROPERTY_TYPES: a UA property
+        // present in one list but not the other makes the two cascade paths
+        // disagree about the computed value (this bit the VirtualView
+        // overflow default).
         let property_types = [
             CssPropertyType::Display,
+            CssPropertyType::OverflowX,
+            CssPropertyType::OverflowY,
             CssPropertyType::Width,
             CssPropertyType::Height,
             CssPropertyType::FontSize,

--- a/core/src/selection.rs
+++ b/core/src/selection.rs
@@ -486,9 +486,31 @@ impl MultiCursorState {
     /// `move_fn` takes a `TextCursor` and returns the new `TextCursor` after movement.
     /// If `extend_selection` is true, the anchor stays and only the focus moves,
     /// creating or extending a range.
+    ///
+    /// A bare (non-extending) move over an active range COLLAPSES to the range
+    /// boundary — the arrow-key rule. Use [`Self::move_all_cursors_with`] for
+    /// steps where that is wrong (Home/End, document jumps).
     pub fn move_all_cursors(
         &mut self,
         extend_selection: bool,
+        move_fn: impl Fn(&TextCursor) -> TextCursor,
+    ) {
+        self.move_all_cursors_with(extend_selection, true, move_fn);
+    }
+
+    /// [`Self::move_all_cursors`], with control over what a bare move does to
+    /// an active range.
+    ///
+    /// `collapse_range_to_boundary` is the arrow-key rule: Left/Right with a
+    /// selection put the caret on the selection's edge and go no further.
+    /// Every OTHER step — Home/End, Ctrl+Home/End, a visual line, a word — is a
+    /// MOVEMENT and must be performed: collapsing them to the nearest edge is
+    /// how pressing End with text selected used to leave the caret sitting at
+    /// the end of the selection instead of the end of the line.
+    pub fn move_all_cursors_with(
+        &mut self,
+        extend_selection: bool,
+        collapse_range_to_boundary: bool,
         move_fn: impl Fn(&TextCursor) -> TextCursor,
     ) {
         for sel in &mut self.selections {
@@ -517,7 +539,7 @@ impl MultiCursorState {
                                 end: new_end,
                             });
                         }
-                    } else {
+                    } else if collapse_range_to_boundary {
                         // Bare arrow with an active selection collapses the caret
                         // to the selection boundary in the arrow's direction WITHOUT
                         // advancing a character (standard editor behavior). Running
@@ -534,6 +556,12 @@ impl MultiCursorState {
                         let probe = move_fn(&r.end);
                         let collapsed = if probe >= r.end { hi } else { lo };
                         sel.selection = Selection::Cursor(collapsed);
+                    } else {
+                        // Home / End / Ctrl+Home / Ctrl+End / a visual line step:
+                        // the caret goes where the step points, measured from the
+                        // focus. The boundary collapse above would strand it on
+                        // the selection's edge instead.
+                        sel.selection = Selection::Cursor(move_fn(&r.end));
                     }
                 }
             }

--- a/core/src/style.rs
+++ b/core/src/style.rs
@@ -476,7 +476,7 @@ fn match_single_selector(
         // inherited from its `p { color: red }` parent. The one exception is
         // a rule scoped to EXACTLY this node (`node_scoped_to_self`) — that
         // is a bare-declaration `with_css` ON the text node itself, i.e.
-        // inline-style semantics: `create_text("x").with_css("color: white")`
+        // inline-style semantics: `create_text_do_not_use_without_block_level_wrapper("x").with_css("color: white")`
         // must apply. Subtree-scoped and unscoped `*` rules keep refusing
         // text nodes.
         Global => !node_data.is_text_node() || node_scoped_to_self,
@@ -754,7 +754,7 @@ mod autotest_generated {
         vec![
             NodeData::create_body(),
             div_with(Some("first"), Some("a")),
-            NodeData::create_text("hello"),
+            NodeData::create_text_do_not_use_without_block_level_wrapper("hello"),
             div_with(None, Some("b")),
             p,
             div_with(None, Some("c")),
@@ -1555,7 +1555,7 @@ mod autotest_generated {
     #[test]
     fn match_single_selector_global_matches_elements_but_never_text_nodes() {
         let div = NodeData::create_div();
-        let text = NodeData::create_text("hello");
+        let text = NodeData::create_text_do_not_use_without_block_level_wrapper("hello");
         assert!(match_single_selector(
             &CssPathSelector::Global,
             info(0, false),
@@ -1580,10 +1580,10 @@ mod autotest_generated {
     #[test]
     fn global_matches_a_text_node_only_when_the_rule_is_scoped_to_exactly_it() {
         // Inline-style semantics (miniword ENGINE-ISSUE 4):
-        // `create_text("x").with_css("color: white")` produces
+        // `create_text_do_not_use_without_block_level_wrapper("x").with_css("color: white")` produces
         // `[Root(n..=n), Global]` — the author addressed THIS node, so the
         // universal selector must match despite it being a text node.
-        let text = NodeData::create_text("hello");
+        let text = NodeData::create_text_do_not_use_without_block_level_wrapper("hello");
         let nid = NodeId::new(7);
         let self_scope = CssPathSelector::Root(CssScopeRange { start: 7, end: 7 });
         let global = CssPathSelector::Global;
@@ -1949,8 +1949,8 @@ mod autotest_generated {
         let data = vec![
             NodeData::create_body(),
             NodeData::create_div(),
-            NodeData::create_text("a"),
-            NodeData::create_text("b"),
+            NodeData::create_text_do_not_use_without_block_level_wrapper("a"),
+            NodeData::create_text_do_not_use_without_block_level_wrapper("b"),
         ];
         let hierarchy_ref = NodeHierarchyRef::from_slice(&hierarchy);
         let data_ref = NodeDataContainerRef::from_slice(&data);

--- a/core/src/styled_dom.rs
+++ b/core/src/styled_dom.rs
@@ -3632,7 +3632,7 @@ mod autotest_generated {
         assert!(sd.get_styled_node_state(&NodeId::ZERO).is_normal());
     }
 
-    /// miniword ENGINE-ISSUE 4: `Dom::create_text(..).with_css(..)` silently
+    /// miniword ENGINE-ISSUE 4: `Dom::create_text_do_not_use_without_block_level_wrapper(..).with_css(..)` silently
     /// dropped EVERY declaration — the bare-decl wrapper parses to
     /// `* { .. }`, and the `Global` matcher refused text nodes even for
     /// rules scoped to exactly that node. All four reported strings now
@@ -3652,7 +3652,7 @@ mod autotest_generated {
             let dom = crate::dom::Dom::create_body().with_child(
                 crate::dom::Dom::create_div()
                     .with_css("color: #444444; font-size: 10px;")
-                    .with_child(crate::dom::Dom::create_text("X").with_css(css_str)),
+                    .with_child(crate::dom::Dom::create_text_do_not_use_without_block_level_wrapper("X").with_css(css_str)),
             );
             // create_from_dom is the production path (scope_inline_css +
             // collect_css_from_dom); plain create() ignores dom.css.
@@ -3694,7 +3694,7 @@ mod autotest_generated {
         let dom = crate::dom::Dom::create_body().with_child(
             crate::dom::Dom::create_div()
                 .with_css("color: #444444;")
-                .with_child(crate::dom::Dom::create_text("X")),
+                .with_child(crate::dom::Dom::create_text_do_not_use_without_block_level_wrapper("X")),
         );
         let styled = StyledDom::create_from_dom(dom);
         let cache = styled.get_css_property_cache();

--- a/core/src/ua_css.rs
+++ b/core/src/ua_css.rs
@@ -89,6 +89,12 @@ static HEIGHT_100_PERCENT: CssProperty = CssProperty::Height(CssPropertyValue::E
 /// display: block
 static DISPLAY_BLOCK: CssProperty =
     CssProperty::Display(CssPropertyValue::Exact(LayoutDisplay::Block));
+static OVERFLOW_X_AUTO: CssProperty = CssProperty::OverflowX(CssPropertyValue::Exact(
+    azul_css::props::layout::LayoutOverflow::Auto,
+));
+static OVERFLOW_Y_AUTO: CssProperty = CssProperty::OverflowY(CssPropertyValue::Exact(
+    azul_css::props::layout::LayoutOverflow::Auto,
+));
 
 /// display: inline
 static DISPLAY_INLINE: CssProperty =
@@ -776,6 +782,14 @@ static BUTTON_BORDER_RIGHT_WIDTH: CssProperty =
         // VirtualView is a block-level replaced element (like div) — must be block
         // so it participates in flex layout (flex-grow, etc.)
         (NT::VirtualView, PT::Display) => Some(&DISPLAY_BLOCK),
+        // A VirtualView exists to virtualize scrollable content, so scrolling
+        // is its DEFAULT: `auto` gets it a scroll id (wheel target) and — via
+        // the virtual-size-aware necessity rule — a scrollbar exactly when
+        // the published `virtual_scroll_size` overflows the viewport. A VV
+        // that must NOT wheel-scroll (the map pans+zooms, the video widget)
+        // opts out explicitly with `overflow: hidden`, which both already do.
+        (NT::VirtualView, PT::OverflowX) => Some(&OVERFLOW_X_AUTO),
+        (NT::VirtualView, PT::OverflowY) => Some(&OVERFLOW_Y_AUTO),
 
         // Icon Elements - inline-block so they have width/height but flow inline
         (NT::Icon(_), PT::Display) => Some(&DISPLAY_INLINE_BLOCK),
@@ -1179,6 +1193,36 @@ mod autotest_generated {
 
     fn text_node(s: &str) -> NodeType {
         NodeType::Text(BoxOrStatic::heap(AzString::from(s)))
+    }
+
+    /// A VirtualView is a scroll container BY DEFAULT: `overflow: auto` on
+    /// both axes from the UA sheet, so app CSS no longer has to opt in (the
+    /// virtual-size-aware necessity rule keeps bars away until the published
+    /// `virtual_scroll_size` actually overflows). Opt-outs stay explicit
+    /// (`overflow: hidden` — map/video); invisible-but-scrollable composes
+    /// via `scrollbar-width: none`.
+    #[test]
+    fn virtual_view_defaults_to_overflow_auto_on_both_axes() {
+        use azul_css::props::layout::LayoutOverflow;
+        for pt in [CssPropertyType::OverflowX, CssPropertyType::OverflowY] {
+            let got = get_ua_property(&NodeType::VirtualView, pt)
+                .unwrap_or_else(|| panic!("no UA default for VirtualView {pt:?}"));
+            let ok = matches!(
+                got,
+                CssProperty::OverflowX(CssPropertyValue::Exact(LayoutOverflow::Auto))
+                    | CssProperty::OverflowY(CssPropertyValue::Exact(LayoutOverflow::Auto))
+            );
+            assert!(ok, "VirtualView {pt:?} UA default is not overflow:auto: {got:?}");
+        }
+        // And the axis-correct variant is returned for each request.
+        assert!(matches!(
+            get_ua_property(&NodeType::VirtualView, CssPropertyType::OverflowX),
+            Some(CssProperty::OverflowX(_))
+        ));
+        assert!(matches!(
+            get_ua_property(&NodeType::VirtualView, CssPropertyType::OverflowY),
+            Some(CssProperty::OverflowY(_))
+        ));
     }
 
     fn icon_node(s: &str) -> NodeType {

--- a/core/src/xml.rs
+++ b/core/src/xml.rs
@@ -2832,7 +2832,7 @@ fn builtin_render_fn(
     if let Some(text_str) = data.get_default_string("text") {
         let prepared = prepare_string(text_str);
         if !prepared.is_empty() {
-            dom = dom.with_children(alloc::vec![Dom::create_text(prepared)].into());
+            dom = dom.with_children(alloc::vec![Dom::create_text_do_not_use_without_block_level_wrapper(prepared)].into());
         }
     }
     let r: Result<StyledDom, RenderDomError> = Ok(StyledDom::create(&mut dom, Css::empty()));
@@ -2854,7 +2854,7 @@ fn builtin_compile_fn(
     let r: Result<AzString, CompileError> = match target {
         CompileTarget::Rust => {
             text.map_or_else(|| Ok(format!("Dom::create_node(NodeType::{type_name})").into()), |text_str| Ok(format!(
-                    "Dom::create_node(NodeType::{}).with_children(vec![Dom::create_text(\"{}\")])",
+                    "Dom::create_node(NodeType::{}).with_children(vec![Dom::create_text_do_not_use_without_block_level_wrapper(\"{}\")])",
                     type_name,
                     text_str.as_str().replace('\\', "\\\\").replace('"', "\\\"")
                 ).into()))
@@ -2880,7 +2880,7 @@ fn push_scalar_field(children: &mut Vec<Dom>, field_name: &str, value: &dyn fmt:
     use crate::dom::{Dom, NodeType};
     let text = alloc::format!("{field_name}: {value}");
     children.push(
-        Dom::create_node(NodeType::Div).with_children(alloc::vec![Dom::create_text(text)].into()),
+        Dom::create_node(NodeType::Div).with_children(alloc::vec![Dom::create_text_do_not_use_without_block_level_wrapper(text)].into()),
     );
 }
 
@@ -2920,7 +2920,7 @@ fn push_scalar_field(children: &mut Vec<Dom>, field_name: &str, value: &dyn fmt:
                         let text = s.as_str().trim();
                         if !text.is_empty() {
                             let label_dom = Dom::create_node(NodeType::Div).with_children(
-                                alloc::vec![Dom::create_text(text.to_string())].into(),
+                                alloc::vec![Dom::create_text_do_not_use_without_block_level_wrapper(text.to_string())].into(),
                             );
                             children.push(label_dom);
                         }
@@ -2960,7 +2960,7 @@ fn push_scalar_field(children: &mut Vec<Dom>, field_name: &str, value: &dyn fmt:
                         );
                         children.push(
                             Dom::create_node(NodeType::Div)
-                                .with_children(alloc::vec![Dom::create_text(text)].into()),
+                                .with_children(alloc::vec![Dom::create_text_do_not_use_without_block_level_wrapper(text)].into()),
                         );
                     }
                     ComponentDefaultValue::ComponentInstance(ci) => {
@@ -2980,7 +2980,7 @@ fn push_scalar_field(children: &mut Vec<Dom>, field_name: &str, value: &dyn fmt:
                                     );
                                     children.push(
                                         Dom::create_node(NodeType::Div).with_children(
-                                            alloc::vec![Dom::create_text(text)].into(),
+                                            alloc::vec![Dom::create_text_do_not_use_without_block_level_wrapper(text)].into(),
                                         ),
                                     );
                                 }
@@ -2993,7 +2993,7 @@ fn push_scalar_field(children: &mut Vec<Dom>, field_name: &str, value: &dyn fmt:
                                     );
                                     children.push(
                                         Dom::create_node(NodeType::Div).with_children(
-                                            alloc::vec![Dom::create_text(text)].into(),
+                                            alloc::vec![Dom::create_text_do_not_use_without_block_level_wrapper(text)].into(),
                                         ),
                                     );
                                 }
@@ -3006,7 +3006,7 @@ fn push_scalar_field(children: &mut Vec<Dom>, field_name: &str, value: &dyn fmt:
                             );
                             children.push(
                                 Dom::create_node(NodeType::Div)
-                                    .with_children(alloc::vec![Dom::create_text(text)].into()),
+                                    .with_children(alloc::vec![Dom::create_text_do_not_use_without_block_level_wrapper(text)].into()),
                             );
                         }
                     }
@@ -3015,14 +3015,14 @@ fn push_scalar_field(children: &mut Vec<Dom>, field_name: &str, value: &dyn fmt:
                         let text = alloc::format!("{}: fn({})", field_name, name.as_str());
                         children.push(
                             Dom::create_node(NodeType::Div)
-                                .with_children(alloc::vec![Dom::create_text(text)].into()),
+                                .with_children(alloc::vec![Dom::create_text_do_not_use_without_block_level_wrapper(text)].into()),
                         );
                     }
                     ComponentDefaultValue::Json(json_str) => {
                         let text = alloc::format!("{}: {}", field_name, json_str.as_str());
                         children.push(
                             Dom::create_node(NodeType::Div)
-                                .with_children(alloc::vec![Dom::create_text(text)].into()),
+                                .with_children(alloc::vec![Dom::create_text_do_not_use_without_block_level_wrapper(text)].into()),
                         );
                     }
                     ComponentDefaultValue::None => {
@@ -3082,12 +3082,12 @@ fn push_scalar_field(children: &mut Vec<Dom>, field_name: &str, value: &dyn fmt:
                     OptionComponentDefaultValue::Some(ComponentDefaultValue::String(s)) => {
                         let escaped = s.as_str().replace('\\', "\\\\").replace('"', "\\\"");
                         lines.push(alloc::format!(
-                            "{inner_indent}children.push(Dom::create_text(\"{escaped}\"));"
+                            "{inner_indent}children.push(Dom::create_text_do_not_use_without_block_level_wrapper(\"{escaped}\"));"
                         ));
                     }
                     OptionComponentDefaultValue::Some(ComponentDefaultValue::Bool(b)) => {
                         lines.push(alloc::format!(
-                            "{inner_indent}children.push(Dom::create_text(format!(\"{{}}: {{}}\", \"{fname}\", {b}).as_str()));"
+                            "{inner_indent}children.push(Dom::create_text_do_not_use_without_block_level_wrapper(format!(\"{{}}: {{}}\", \"{fname}\", {b}).as_str()));"
                         ));
                     }
                     OptionComponentDefaultValue::Some(
@@ -3167,7 +3167,7 @@ fn push_scalar_field(children: &mut Vec<Dom>, field_name: &str, value: &dyn fmt:
                     OptionComponentDefaultValue::Some(ComponentDefaultValue::String(s)) => {
                         let escaped = s.as_str().replace('\\', "\\\\").replace('"', "\\\"");
                         lines.push(alloc::format!(
-                            "{inner_indent}root.add_child(Dom::create_text(String(\"{escaped}\")));"
+                            "{inner_indent}root.add_child(Dom::create_text_do_not_use_without_block_level_wrapper(String(\"{escaped}\")));"
                         ));
                     }
                     OptionComponentDefaultValue::Some(
@@ -3203,7 +3203,7 @@ fn push_scalar_field(children: &mut Vec<Dom>, field_name: &str, value: &dyn fmt:
                             .replace('"', "\\\"")
                             .replace('\'', "\\'");
                         lines.push(alloc::format!(
-                            "{inner_indent}root = root.with_child(Dom.create_text(\"{escaped}\"))"
+                            "{inner_indent}root = root.with_child(Dom.create_text_do_not_use_without_block_level_wrapper(\"{escaped}\"))"
                         ));
                     }
                     OptionComponentDefaultValue::Some(
@@ -4152,7 +4152,7 @@ fn builtin_if_render_fn(
         "if: false (else branch)"
     };
     let mut dom =
-        Dom::create_node(NodeType::Div).with_children(alloc::vec![Dom::create_text(label)].into());
+        Dom::create_node(NodeType::Div).with_children(alloc::vec![Dom::create_text_do_not_use_without_block_level_wrapper(label)].into());
     let css = Css::empty();
     ResultStyledDomRenderDomError::Ok(StyledDom::create(&mut dom, css))
 }
@@ -4227,7 +4227,7 @@ fn builtin_for_render_fn(
     for i in 0..count {
         items.push(
             Dom::create_node(NodeType::Div)
-                .with_children(alloc::vec![Dom::create_text(alloc::format!("Item {i}"))].into()),
+                .with_children(alloc::vec![Dom::create_text_do_not_use_without_block_level_wrapper(alloc::format!("Item {i}"))].into()),
         );
     }
     let mut dom = Dom::create_node(NodeType::Div).with_children(items.into());
@@ -4308,7 +4308,7 @@ fn builtin_map_render_fn(
 
     let label = alloc::format!("map: data_json={data_str}");
     let mut dom =
-        Dom::create_node(NodeType::Div).with_children(alloc::vec![Dom::create_text(label)].into());
+        Dom::create_node(NodeType::Div).with_children(alloc::vec![Dom::create_text_do_not_use_without_block_level_wrapper(label)].into());
     let css = Css::empty();
     ResultStyledDomRenderDomError::Ok(StyledDom::create(&mut dom, css))
 }
@@ -5824,7 +5824,7 @@ fn xml_node_to_dom_fast<'a>(
                 children.push(child_dom);
             }
             XmlNodeChild::Text(text) => {
-                let text_dom = Dom::create_text(AzString::from(text.as_str()));
+                let text_dom = Dom::create_text_do_not_use_without_block_level_wrapper(AzString::from(text.as_str()));
                 children.push(text_dom);
             }
         }
@@ -5993,7 +5993,7 @@ fn xml_node_to_fast_dom<'a>(
                     )?;
                 }
                 XmlNodeChild::Text(text) => {
-                    builder.add_leaf(NodeData::create_text(AzString::from(text.as_str())));
+                    builder.add_leaf(NodeData::create_text_do_not_use_without_block_level_wrapper(AzString::from(text.as_str())));
                 }
             }
         }
@@ -6713,7 +6713,7 @@ pub fn compile_body_node_to_rust_code<'a>(
                     if !text.is_empty() {
                         let escaped = text.replace('\\', "\\\\").replace('"', "\\\"");
                         let _ = write!(dom_string,
-                            "{t}Dom::create_text(\"{escaped}\"),\r\n"
+                            "{t}Dom::create_text_do_not_use_without_block_level_wrapper(\"{escaped}\"),\r\n"
                         );
                     }
                 }
@@ -6985,7 +6985,7 @@ fn compile_node_to_rust_code_inner(
                     let t2 = String::from("    ").repeat(tabs);
                     let escaped = text.replace('\\', "\\\\").replace('"', "\\\"");
                     Some(Ok(format!(
-                        "{t2}Dom::create_text(\"{escaped}\")"
+                        "{t2}Dom::create_text_do_not_use_without_block_level_wrapper(\"{escaped}\")"
                     )))
                 }
             }
@@ -7480,7 +7480,7 @@ const CPP_SYNTAX: FluentSyntax = FluentSyntax {
     // — `NodeType` is a tagged union, so `create_node` would need union
     // construction; the per-tag creators exist for every common HTML element.
     create_node: |tag| alloc::format!("Dom::create_{}()", tag.to_lowercase()),
-    create_text: |s| alloc::format!("Dom::create_text(String(\"{s}\"))"),
+    create_text: |s| alloc::format!("Dom::create_text_do_not_use_without_block_level_wrapper(String(\"{s}\"))"),
     with_css: |s| alloc::format!(".with_css(String(\"{s}\"))"),
     with_class: |s| alloc::format!(".with_class(String(\"{s}\"))"),
     with_id: |s| alloc::format!(".with_id(String(\"{s}\"))"),
@@ -7491,7 +7491,7 @@ const PYTHON_SYNTAX: FluentSyntax = FluentSyntax {
     target: CompileTarget::Python,
     // Per-tag creators (azul.Dom.create_div(), …) — see CPP_SYNTAX note.
     create_node: |tag| alloc::format!("azul.Dom.create_{}()", tag.to_lowercase()),
-    create_text: |s| alloc::format!("azul.Dom.create_text(\"{s}\")"),
+    create_text: |s| alloc::format!("azul.Dom.create_text_do_not_use_without_block_level_wrapper(\"{s}\")"),
     with_css: |s| alloc::format!(".with_css(\"{s}\")"),
     with_class: |s| alloc::format!(".with_class(\"{s}\")"),
     with_id: |s| alloc::format!(".with_id(\"{s}\")"),
@@ -7921,10 +7921,10 @@ mod tests {
         // since we're testing the parsing logic
         let expected_dom = Dom::create_p().with_children(
             vec![
-                Dom::create_text("Text before "),
+                Dom::create_text_do_not_use_without_block_level_wrapper("Text before "),
                 Dom::create_node(NodeType::Span)
-                    .with_children(vec![Dom::create_text("inline text")].into()),
-                Dom::create_text(" text after."),
+                    .with_children(vec![Dom::create_text_do_not_use_without_block_level_wrapper("inline text")].into()),
+                Dom::create_text_do_not_use_without_block_level_wrapper(" text after."),
             ]
             .into(),
         );
@@ -10586,8 +10586,8 @@ mod autotest_generated {
     fn compact_dom_builder_keeps_hierarchy_and_data_parallel() {
         let mut b = CompactDomBuilder::new();
         b.open_node(NodeData::create_node(NodeType::Html));
-        b.add_leaf(NodeData::create_text("a"));
-        b.add_leaf(NodeData::create_text("b"));
+        b.add_leaf(NodeData::create_text_do_not_use_without_block_level_wrapper("a"));
+        b.add_leaf(NodeData::create_text_do_not_use_without_block_level_wrapper("b"));
         b.close_node();
         let fd = b.finish();
         assert_eq!(fd.node_data.as_ref().len(), 3);

--- a/core/src/xml.rs
+++ b/core/src/xml.rs
@@ -2861,7 +2861,7 @@ fn builtin_compile_fn(
         }
         CompileTarget::C => {
             text.map_or_else(|| Ok(format!("AzDom_create{type_name}()").into()), |text_str| Ok(format!(
-                    "AzDom_createText(AZ_STR(\"{}\"))",
+                    "AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AZ_STR(\"{}\"))",
                     text_str
                         .as_str()
                         .replace('\\', "\\\\")
@@ -3133,7 +3133,7 @@ fn push_scalar_field(children: &mut Vec<Dom>, field_name: &str, value: &dyn fmt:
                     OptionComponentDefaultValue::Some(ComponentDefaultValue::String(s)) => {
                         let escaped = s.as_str().replace('\\', "\\\\").replace('"', "\\\"");
                         lines.push(alloc::format!(
-                            "{inner_indent}AzDom_addChild(&root, AzDom_createText(AZ_STR(\"{escaped}\")));"
+                            "{inner_indent}AzDom_addChild(&root, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AZ_STR(\"{escaped}\")));"
                         ));
                     }
                     OptionComponentDefaultValue::Some(
@@ -7816,7 +7816,7 @@ fn compile_node_c(
                 if !text.is_empty() {
                     let esc = text.replace('\\', "\\\\").replace('"', "\\\"");
                     let _ = writeln!(out,
-                        "    AzDom_addChild(&{var}, AzDom_createText(AZ_STR(\"{esc}\")));"
+                        "    AzDom_addChild(&{var}, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AZ_STR(\"{esc}\")));"
                     );
                 }
             }
@@ -7872,7 +7872,7 @@ pub fn str_to_c_code<'a>(
                 if !text.is_empty() {
                     let esc = text.replace('\\', "\\\\").replace('"', "\\\"");
                     let _ = writeln!(body,
-                        "    AzDom_addChild(&{root}, AzDom_createText(AZ_STR(\"{esc}\")));"
+                        "    AzDom_addChild(&{root}, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AZ_STR(\"{esc}\")));"
                     );
                 }
             }

--- a/core/tests/compact_cache.rs
+++ b/core/tests/compact_cache.rs
@@ -42,7 +42,7 @@ fn test_h1_display_block_from_ua() {
     // H1 should get display:block from UA CSS even without any author CSS
     let dom = Dom::create_html().with_child(
         Dom::create_body().with_child(
-            Dom::create_node(NodeType::H1).with_child(Dom::create_text("heading"))
+            Dom::create_node(NodeType::H1).with_child(Dom::create_text_do_not_use_without_block_level_wrapper("heading"))
         )
     );
     let s = styled(dom, "");
@@ -57,8 +57,8 @@ fn test_h1_display_block_from_ua() {
 fn test_div_block_span_inline_from_ua() {
     let dom = Dom::create_html().with_child(
         Dom::create_body()
-            .with_child(Dom::create_div().with_child(Dom::create_text("div")))
-            .with_child(Dom::create_node(NodeType::Span).with_child(Dom::create_text("span")))
+            .with_child(Dom::create_div().with_child(Dom::create_text_do_not_use_without_block_level_wrapper("div")))
+            .with_child(Dom::create_node(NodeType::Span).with_child(Dom::create_text_do_not_use_without_block_level_wrapper("span")))
     );
     let s = styled(dom, "");
     // 0=Html, 1=Body, 2=Div, 3=text, 4=Span, 5=text
@@ -70,7 +70,7 @@ fn test_div_block_span_inline_from_ua() {
 fn test_h1_bold_from_ua() {
     let dom = Dom::create_html().with_child(
         Dom::create_body().with_child(
-            Dom::create_node(NodeType::H1).with_child(Dom::create_text("h"))
+            Dom::create_node(NodeType::H1).with_child(Dom::create_text_do_not_use_without_block_level_wrapper("h"))
         )
     );
     let s = styled(dom, "");
@@ -84,7 +84,7 @@ fn test_h1_font_size_from_ua() {
     // H1 should get font-size: 2em from UA CSS
     let dom = Dom::create_html().with_child(
         Dom::create_body().with_child(
-            Dom::create_node(NodeType::H1).with_child(Dom::create_text("h"))
+            Dom::create_node(NodeType::H1).with_child(Dom::create_text_do_not_use_without_block_level_wrapper("h"))
         )
     );
     let s = styled(dom, "");
@@ -113,7 +113,7 @@ fn test_h1_font_size_from_ua() {
 fn test_author_css_display_flex_overrides_ua_block() {
     let dom = Dom::create_html().with_child(
         Dom::create_body().with_child(
-            Dom::create_div().with_child(Dom::create_text("flex"))
+            Dom::create_div().with_child(Dom::create_text_do_not_use_without_block_level_wrapper("flex"))
         )
     );
     let s = styled(dom, "div { display: flex; }");
@@ -126,7 +126,7 @@ fn test_global_star_doesnt_override_ua_display() {
     // `* { margin: 0; }` should NOT change display (it doesn't set display)
     let dom = Dom::create_html().with_child(
         Dom::create_body().with_child(
-            Dom::create_node(NodeType::H1).with_child(Dom::create_text("h1"))
+            Dom::create_node(NodeType::H1).with_child(Dom::create_text_do_not_use_without_block_level_wrapper("h1"))
         )
     );
     let s = styled(dom, "* { margin: 0; padding: 0; }");
@@ -151,7 +151,7 @@ fn test_font_weight_inherits_from_parent() {
                     CssProperty::font_weight(StyleFontWeight::Bold)
                 )
             ].into())
-            .with_child(Dom::create_div().with_child(Dom::create_text("child")))
+            .with_child(Dom::create_div().with_child(Dom::create_text_do_not_use_without_block_level_wrapper("child")))
     );
     let s = styled(dom, "");
     // 0=Html, 1=Body (bold), 2=Div, 3=text
@@ -166,7 +166,7 @@ fn test_display_does_not_inherit() {
     // Body is display:block, but a Span child should NOT inherit block
     let dom = Dom::create_html().with_child(
         Dom::create_body().with_child(
-            Dom::create_node(NodeType::Span).with_child(Dom::create_text("span"))
+            Dom::create_node(NodeType::Span).with_child(Dom::create_text_do_not_use_without_block_level_wrapper("span"))
         )
     );
     let s = styled(dom, "");
@@ -194,7 +194,7 @@ fn test_inline_css_overrides_stylesheet() {
                         CssProperty::width(azul_css::props::layout::LayoutWidth::Px(PixelValue::px(200.0)))
                     )
                 ].into())
-                .with_child(Dom::create_text("wide"))
+                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("wide"))
         )
     );
     let s = styled(dom, "div { width: 100px; }");
@@ -217,7 +217,7 @@ fn test_background_color_via_class_selector() {
         Dom::create_body().with_child(
             Dom::create_div()
                 .with_ids_and_classes(vec![IdOrClass::Class("red".into())].into())
-                .with_child(Dom::create_text("red bg"))
+                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("red bg"))
         )
     );
     let s = styled(dom, ".red { background-color: #ff0000; }");
@@ -491,7 +491,7 @@ fn test_text_color_inherits_from_parent_div() {
         Dom::create_body().with_child(
             Dom::create_div()
                 .with_ids_and_classes(vec![IdOrClass::Class("c".into())].into())
-                .with_child(Dom::create_text("hello"))
+                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("hello"))
         )
     );
     let s = styled(dom, ".c { color: #ff0000; }");
@@ -517,7 +517,7 @@ fn test_text_color_white_on_red_background() {
         Dom::create_body().with_child(
             Dom::create_div()
                 .with_ids_and_classes(vec![IdOrClass::Class("box".into())].into())
-                .with_child(Dom::create_text("visible"))
+                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("visible"))
         )
     );
     let s = styled(dom, ".box { background-color: #ff0000; color: #ffffff; }");
@@ -555,19 +555,19 @@ fn test_dom_node_id_mapping_with_whitespace_text() {
     // HTML: <body>\n  <div class="a">text</div>\n  <div class="b">text</div>\n</body>
     let dom = Dom::create_html().with_child(
         Dom::create_body()
-            .with_child(Dom::create_text("\n  "))
+            .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("\n  "))
             .with_child(
                 Dom::create_div()
                     .with_ids_and_classes(vec![azul_core::dom::IdOrClass::Class("a".into())].into())
-                    .with_child(Dom::create_text("first"))
+                    .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("first"))
             )
-            .with_child(Dom::create_text("\n  "))
+            .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("\n  "))
             .with_child(
                 Dom::create_div()
                     .with_ids_and_classes(vec![azul_core::dom::IdOrClass::Class("b".into())].into())
-                    .with_child(Dom::create_text("second"))
+                    .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("second"))
             )
-            .with_child(Dom::create_text("\n"))
+            .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("\n"))
     );
     let s = styled(dom, ".a { color: #ff0000; padding: 10px; } .b { color: #0000ff; padding: 20px; }");
 
@@ -624,12 +624,12 @@ fn test_multiple_text_children_with_different_parent_styles() {
             .with_child(
                 Dom::create_div()
                     .with_ids_and_classes(vec![IdOrClass::Class("red".into())].into())
-                    .with_child(Dom::create_text("red text"))
+                    .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("red text"))
             )
             .with_child(
                 Dom::create_div()
                     .with_ids_and_classes(vec![IdOrClass::Class("blue".into())].into())
-                    .with_child(Dom::create_text("blue text"))
+                    .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("blue text"))
             )
     );
     let s = styled(dom, ".red { color: #ff0000; background: #ffcccc; } .blue { color: #0000ff; background: #ccccff; }");
@@ -658,7 +658,7 @@ fn test_font_family_inherits_from_body() {
         Dom::create_body().with_child(
             Dom::create_div()
                 .with_ids_and_classes(vec![IdOrClass::Class("box".into())].into())
-                .with_child(Dom::create_text("hello"))
+                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("hello"))
         )
     );
     let s = styled(dom, "body { font-family: sans-serif; } .box { background: red; }");
@@ -681,7 +681,7 @@ fn test_font_hash_to_families_populated() {
         Dom::create_body().with_child(
             Dom::create_div()
                 .with_ids_and_classes(vec![IdOrClass::Class("box".into())].into())
-                .with_child(Dom::create_text("hello"))
+                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("hello"))
         )
     );
     let s = styled(dom, "body { font-family: sans-serif; }");
@@ -712,7 +712,7 @@ fn test_font_hash_to_families_text_node_inherits() {
         Dom::create_body().with_child(
             Dom::create_div()
                 .with_ids_and_classes(vec![IdOrClass::Class("box".into())].into())
-                .with_child(Dom::create_text("hello"))
+                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("hello"))
         )
     );
     let s = styled(dom, "body { font-family: sans-serif; }");

--- a/core/tests/css_inheritance.rs
+++ b/core/tests/css_inheritance.rs
@@ -65,7 +65,7 @@ fn test_font_size_inheritance_single_level() {
             ))]
             .into(),
         )
-        .with_child(Dom::create_node(NodeType::P).with_child(Dom::create_text("Text")));
+        .with_child(Dom::create_node(NodeType::P).with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Text")));
 
     let (styled_dom, mut cache) = setup_test!(dom);
 
@@ -127,7 +127,7 @@ fn test_font_size_override_not_inherited() {
                     ))]
                     .into(),
                 )
-                .with_child(Dom::create_text("Text")),
+                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Text")),
         );
 
     let (styled_dom, mut cache) = setup_test!(dom);
@@ -181,7 +181,7 @@ fn test_font_weight_inheritance_multi_level() {
         )
         .with_child(
             Dom::create_node(NodeType::P)
-                .with_child(Dom::create_node(NodeType::Span).with_child(Dom::create_text("Text"))),
+                .with_child(Dom::create_node(NodeType::Span).with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Text"))),
         );
 
     let (styled_dom, mut cache) = setup_test!(dom);
@@ -248,7 +248,7 @@ fn test_mixed_inherited_and_explicit_properties() {
                     ))]
                     .into(),
                 )
-                .with_child(Dom::create_text("Text")),
+                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Text")),
         );
 
     let (styled_dom, mut cache) = setup_test!(dom);
@@ -311,7 +311,7 @@ fn test_non_inheritable_property_not_inherited() {
             ))]
             .into(),
         )
-        .with_child(Dom::create_node(NodeType::P).with_child(Dom::create_text("Text")));
+        .with_child(Dom::create_node(NodeType::P).with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Text")));
 
     let (styled_dom, mut cache) = setup_test!(dom);
     let node_hierarchy = styled_dom.node_hierarchy.as_container().internal;
@@ -353,8 +353,8 @@ fn test_update_invalidation() {
         )
         .with_children(
             vec![
-                Dom::create_node(NodeType::P).with_child(Dom::create_text("Child 1")),
-                Dom::create_node(NodeType::P).with_child(Dom::create_text("Child 2")),
+                Dom::create_node(NodeType::P).with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Child 1")),
+                Dom::create_node(NodeType::P).with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Child 2")),
             ]
             .into(),
         );
@@ -411,7 +411,7 @@ fn test_deeply_nested_inheritance() {
         .with_child(Dom::create_node(NodeType::Section).with_child(
             Dom::create_node(NodeType::Article).with_child(
                 Dom::create_node(NodeType::P).with_child(
-                    Dom::create_node(NodeType::Span).with_child(Dom::create_text("Deep text")),
+                    Dom::create_node(NodeType::Span).with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Deep text")),
                 ),
             ),
         ));
@@ -473,7 +473,7 @@ fn test_em_unit_inheritance_basic() {
                     ))]
                     .into(),
                 )
-                .with_child(Dom::create_text("Text")),
+                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Text")),
         );
 
     let (styled_dom, mut cache) = setup_test!(dom);
@@ -542,7 +542,7 @@ fn test_em_unit_cascading_multiplication() {
                             ))]
                             .into(),
                         )
-                        .with_child(Dom::create_text("Text")),
+                        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Text")),
                 ),
         );
 
@@ -641,7 +641,7 @@ fn test_em_on_font_size_refers_to_parent() {
                             ))]
                             .into(),
                         )
-                        .with_child(Dom::create_text("Text")),
+                        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Text")),
                 ),
         );
 
@@ -760,7 +760,7 @@ fn test_em_without_ancestor_absolute_unit() {
             ))]
             .into(),
         )
-        .with_child(Dom::create_node(NodeType::P).with_child(Dom::create_text("Text")));
+        .with_child(Dom::create_node(NodeType::P).with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Text")));
 
     // NOTE: setup_test! already calls StyledDom::new which calls compute_inherited_values
     let (_styled_dom, cache) = setup_test!(dom);
@@ -856,7 +856,7 @@ fn test_percentage_font_size_inheritance() {
                             ))]
                             .into(),
                         )
-                        .with_child(Dom::create_text("Text")),
+                        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Text")),
                 ),
         );
 

--- a/core/tests/diff.rs
+++ b/core/tests/diff.rs
@@ -660,9 +660,9 @@ fn test_different_node_types() {
 fn test_text_nodes() {
     use azul_css::AzString;
     
-    let text_a = NodeData::create_text(AzString::from("Hello"));
-    let text_b = NodeData::create_text(AzString::from("World"));
-    let text_a_copy = NodeData::create_text(AzString::from("Hello"));
+    let text_a = NodeData::create_text_do_not_use_without_block_level_wrapper(AzString::from("Hello"));
+    let text_b = NodeData::create_text_do_not_use_without_block_level_wrapper(AzString::from("World"));
+    let text_a_copy = NodeData::create_text_do_not_use_without_block_level_wrapper(AzString::from("Hello"));
     
     // Old: ["Hello", "World"], New: ["World", "Hello"]
     let old_data = vec![text_a.clone(), text_b.clone()];
@@ -1305,8 +1305,8 @@ fn test_structural_hash_text_nodes_match() {
     use azul_css::AzString;
     
     // Two text nodes with different content should have same structural hash
-    let text_a = NodeData::create_text(AzString::from("Hello"));
-    let text_b = NodeData::create_text(AzString::from("Hello World"));
+    let text_a = NodeData::create_text_do_not_use_without_block_level_wrapper(AzString::from("Hello"));
+    let text_b = NodeData::create_text_do_not_use_without_block_level_wrapper(AzString::from("Hello World"));
     
     // Content hash should be different
     assert_ne!(text_a.calculate_node_data_hash(), text_b.calculate_node_data_hash());
@@ -1321,7 +1321,7 @@ fn test_structural_hash_different_types() {
     
     // Div and Text should have different structural hashes
     let div = NodeData::create_div();
-    let text = NodeData::create_text(AzString::from("Hello"));
+    let text = NodeData::create_text_do_not_use_without_block_level_wrapper(AzString::from("Hello"));
     
     assert_ne!(div.calculate_structural_hash(), text.calculate_structural_hash());
 }
@@ -1332,8 +1332,8 @@ fn test_text_nodes_match_by_structural_hash() {
     
     // Old DOM has Text("Hello"), new DOM has Text("Hello World")
     // They should match by structural hash
-    let old_data = vec![NodeData::create_text(AzString::from("Hello"))];
-    let new_data = vec![NodeData::create_text(AzString::from("Hello World"))];
+    let old_data = vec![NodeData::create_text_do_not_use_without_block_level_wrapper(AzString::from("Hello"))];
+    let new_data = vec![NodeData::create_text_do_not_use_without_block_level_wrapper(AzString::from("Hello World"))];
     
     let mut old_layout = OrderedMap::default();
     old_layout.insert(NodeId::new(0), LogicalRect::zero());

--- a/core/tests/dom_constructor.rs
+++ b/core/tests/dom_constructor.rs
@@ -216,7 +216,7 @@ fn _coverage_with_text_ruby() {
 
 fn _coverage_args() {
     let s = AzString::from("");
-    let _ = Dom::create_text(s.clone());
+    let _ = Dom::create_text_do_not_use_without_block_level_wrapper(s.clone());
     let _ = Dom::create_icon(s.clone());
     let _ = Dom::create_abbr_with_title(s.clone(), s.clone());
     let _ = Dom::create_time(s.clone(), OptionString::None);

--- a/core/tests/dom_manipulation.rs
+++ b/core/tests/dom_manipulation.rs
@@ -21,22 +21,22 @@ fn test_dom_body_creation() {
 
 #[test]
 fn test_dom_text_creation() {
-    let dom = Dom::create_text("Hello World");
+    let dom = Dom::create_text_do_not_use_without_block_level_wrapper("Hello World");
     assert!(matches!(dom.root.node_type, NodeType::Text(_)));
 }
 
 #[test]
 fn test_dom_with_child() {
-    let dom = Dom::create_div().with_child(Dom::create_text("Child"));
+    let dom = Dom::create_div().with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Child"));
     assert_eq!(dom.children.len(), 1);
 }
 
 #[test]
 fn test_dom_with_multiple_children() {
     let dom = Dom::create_div()
-        .with_child(Dom::create_text("First"))
-        .with_child(Dom::create_text("Second"))
-        .with_child(Dom::create_text("Third"));
+        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("First"))
+        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Second"))
+        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Third"));
     assert_eq!(dom.children.len(), 3);
 }
 
@@ -44,9 +44,9 @@ fn test_dom_with_multiple_children() {
 fn test_dom_with_children_vec() {
     let dom = Dom::create_div().with_children(
         vec![
-            Dom::create_text("One"),
-            Dom::create_text("Two"),
-            Dom::create_text("Three"),
+            Dom::create_text_do_not_use_without_block_level_wrapper("One"),
+            Dom::create_text_do_not_use_without_block_level_wrapper("Two"),
+            Dom::create_text_do_not_use_without_block_level_wrapper("Three"),
         ]
         .into(),
     );
@@ -56,14 +56,14 @@ fn test_dom_with_children_vec() {
 #[test]
 fn test_dom_nested_structure() {
     let dom =
-        Dom::create_div().with_child(Dom::create_div().with_child(Dom::create_text("Nested")));
+        Dom::create_div().with_child(Dom::create_div().with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Nested")));
     assert_eq!(dom.children.len(), 1);
 }
 
 #[test]
 fn test_dom_deeply_nested() {
     let dom = Dom::create_div().with_child(Dom::create_div().with_child(
-        Dom::create_div().with_child(Dom::create_div().with_child(Dom::create_text("Deep"))),
+        Dom::create_div().with_child(Dom::create_div().with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Deep"))),
     ));
     assert_eq!(dom.children.len(), 1);
 }
@@ -121,16 +121,16 @@ fn test_dom_with_empty_children_vec() {
 #[test]
 fn test_dom_mixed_node_types() {
     let dom = Dom::create_div()
-        .with_child(Dom::create_node(NodeType::P).with_child(Dom::create_text("Paragraph")))
-        .with_child(Dom::create_node(NodeType::Span).with_child(Dom::create_text("Span")))
-        .with_child(Dom::create_node(NodeType::H1).with_child(Dom::create_text("Heading")));
+        .with_child(Dom::create_node(NodeType::P).with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Paragraph")))
+        .with_child(Dom::create_node(NodeType::Span).with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Span")))
+        .with_child(Dom::create_node(NodeType::H1).with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Heading")));
     assert_eq!(dom.children.len(), 3);
 }
 
 #[test]
 fn test_dom_text_content() {
     let text = "Test content";
-    let dom = Dom::create_text(text);
+    let dom = Dom::create_text_do_not_use_without_block_level_wrapper(text);
     if let NodeType::Text(content) = &dom.root.node_type {
         assert_eq!(content.as_str(), text);
     } else {
@@ -141,7 +141,7 @@ fn test_dom_text_content() {
 #[test]
 fn test_dom_unicode_text() {
     let text = "日本語テスト 🎉 مرحبا";
-    let dom = Dom::create_text(text);
+    let dom = Dom::create_text_do_not_use_without_block_level_wrapper(text);
     if let NodeType::Text(content) = &dom.root.node_type {
         assert_eq!(content.as_str(), text);
     } else {
@@ -151,7 +151,7 @@ fn test_dom_unicode_text() {
 
 #[test]
 fn test_dom_empty_text() {
-    let dom = Dom::create_text("");
+    let dom = Dom::create_text_do_not_use_without_block_level_wrapper("");
     if let NodeType::Text(content) = &dom.root.node_type {
         assert!(content.as_str().is_empty());
     } else {
@@ -162,7 +162,7 @@ fn test_dom_empty_text() {
 #[test]
 fn test_dom_very_long_text() {
     let text = "a".repeat(10000);
-    let dom = Dom::create_text(text.clone());
+    let dom = Dom::create_text_do_not_use_without_block_level_wrapper(text.clone());
     if let NodeType::Text(content) = &dom.root.node_type {
         assert_eq!(content.as_str().len(), 10000);
     } else {
@@ -173,7 +173,7 @@ fn test_dom_very_long_text() {
 #[test]
 fn test_dom_whitespace_text() {
     let text = "   \n\t\r\n   ";
-    let dom = Dom::create_text(text);
+    let dom = Dom::create_text_do_not_use_without_block_level_wrapper(text);
     if let NodeType::Text(content) = &dom.root.node_type {
         assert_eq!(content.as_str(), text);
     } else {
@@ -186,13 +186,13 @@ fn test_dom_table_structure() {
     let dom = Dom::create_node(NodeType::Table)
         .with_child(
             Dom::create_node(NodeType::Tr)
-                .with_child(Dom::create_node(NodeType::Td).with_child(Dom::create_text("Cell 1")))
-                .with_child(Dom::create_node(NodeType::Td).with_child(Dom::create_text("Cell 2"))),
+                .with_child(Dom::create_node(NodeType::Td).with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Cell 1")))
+                .with_child(Dom::create_node(NodeType::Td).with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Cell 2"))),
         )
         .with_child(
             Dom::create_node(NodeType::Tr)
-                .with_child(Dom::create_node(NodeType::Td).with_child(Dom::create_text("Cell 3")))
-                .with_child(Dom::create_node(NodeType::Td).with_child(Dom::create_text("Cell 4"))),
+                .with_child(Dom::create_node(NodeType::Td).with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Cell 3")))
+                .with_child(Dom::create_node(NodeType::Td).with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Cell 4"))),
         );
     assert_eq!(dom.children.len(), 2);
 }
@@ -200,9 +200,9 @@ fn test_dom_table_structure() {
 #[test]
 fn test_dom_list_structure() {
     let dom = Dom::create_node(NodeType::Ul)
-        .with_child(Dom::create_node(NodeType::Li).with_child(Dom::create_text("Item 1")))
-        .with_child(Dom::create_node(NodeType::Li).with_child(Dom::create_text("Item 2")))
-        .with_child(Dom::create_node(NodeType::Li).with_child(Dom::create_text("Item 3")));
+        .with_child(Dom::create_node(NodeType::Li).with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Item 1")))
+        .with_child(Dom::create_node(NodeType::Li).with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Item 2")))
+        .with_child(Dom::create_node(NodeType::Li).with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Item 3")));
     assert_eq!(dom.children.len(), 3);
 }
 
@@ -210,46 +210,46 @@ fn test_dom_list_structure() {
 fn test_dom_form_structure() {
     let dom = Dom::create_node(NodeType::Form)
         .with_child(Dom::create_node(NodeType::Input))
-        .with_child(Dom::create_node(NodeType::Button).with_child(Dom::create_text("Submit")));
+        .with_child(Dom::create_node(NodeType::Button).with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Submit")));
     assert_eq!(dom.children.len(), 2);
 }
 
 #[test]
 fn test_dom_semantic_elements() {
     let dom = Dom::create_node(NodeType::Article)
-        .with_child(Dom::create_node(NodeType::Header).with_child(Dom::create_text("Title")))
-        .with_child(Dom::create_node(NodeType::Section).with_child(Dom::create_text("Content")))
-        .with_child(Dom::create_node(NodeType::Footer).with_child(Dom::create_text("Footer")));
+        .with_child(Dom::create_node(NodeType::Header).with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Title")))
+        .with_child(Dom::create_node(NodeType::Section).with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Content")))
+        .with_child(Dom::create_node(NodeType::Footer).with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Footer")));
     assert_eq!(dom.children.len(), 3);
 }
 
 #[test]
 fn test_dom_all_heading_levels() {
     let dom = Dom::create_div()
-        .with_child(Dom::create_node(NodeType::H1).with_child(Dom::create_text("H1")))
-        .with_child(Dom::create_node(NodeType::H2).with_child(Dom::create_text("H2")))
-        .with_child(Dom::create_node(NodeType::H3).with_child(Dom::create_text("H3")))
-        .with_child(Dom::create_node(NodeType::H4).with_child(Dom::create_text("H4")))
-        .with_child(Dom::create_node(NodeType::H5).with_child(Dom::create_text("H5")))
-        .with_child(Dom::create_node(NodeType::H6).with_child(Dom::create_text("H6")));
+        .with_child(Dom::create_node(NodeType::H1).with_child(Dom::create_text_do_not_use_without_block_level_wrapper("H1")))
+        .with_child(Dom::create_node(NodeType::H2).with_child(Dom::create_text_do_not_use_without_block_level_wrapper("H2")))
+        .with_child(Dom::create_node(NodeType::H3).with_child(Dom::create_text_do_not_use_without_block_level_wrapper("H3")))
+        .with_child(Dom::create_node(NodeType::H4).with_child(Dom::create_text_do_not_use_without_block_level_wrapper("H4")))
+        .with_child(Dom::create_node(NodeType::H5).with_child(Dom::create_text_do_not_use_without_block_level_wrapper("H5")))
+        .with_child(Dom::create_node(NodeType::H6).with_child(Dom::create_text_do_not_use_without_block_level_wrapper("H6")));
     assert_eq!(dom.children.len(), 6);
 }
 
 #[test]
 fn test_dom_inline_elements() {
     let dom = Dom::create_node(NodeType::P)
-        .with_child(Dom::create_text("Normal "))
-        .with_child(Dom::create_node(NodeType::Strong).with_child(Dom::create_text("bold")))
-        .with_child(Dom::create_text(" and "))
-        .with_child(Dom::create_node(NodeType::Em).with_child(Dom::create_text("italic")))
-        .with_child(Dom::create_text(" text"));
+        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Normal "))
+        .with_child(Dom::create_node(NodeType::Strong).with_child(Dom::create_text_do_not_use_without_block_level_wrapper("bold")))
+        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper(" and "))
+        .with_child(Dom::create_node(NodeType::Em).with_child(Dom::create_text_do_not_use_without_block_level_wrapper("italic")))
+        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper(" text"));
     assert_eq!(dom.children.len(), 5);
 }
 
 #[test]
 fn test_dom_many_children() {
     let children: Vec<Dom> = (0..100)
-        .map(|i| Dom::create_text(format!("Child {i}")))
+        .map(|i| Dom::create_text_do_not_use_without_block_level_wrapper(format!("Child {i}")))
         .collect();
     let dom = Dom::create_div().with_children(children.into());
     assert_eq!(dom.children.len(), 100);
@@ -277,7 +277,7 @@ fn test_dom_deep_tree() {
     // Test a deep but narrow tree
     fn create_deep(depth: usize) -> Dom {
         if depth == 0 {
-            Dom::create_text("Leaf")
+            Dom::create_text_do_not_use_without_block_level_wrapper("Leaf")
         } else {
             Dom::create_div().with_child(create_deep(depth - 1))
         }

--- a/core/tests/prop_cache.rs
+++ b/core/tests/prop_cache.rs
@@ -58,7 +58,7 @@ macro_rules! setup_styled_dom {
 #[test]
 fn test_computed_values_exist_for_all_nodes() {
     let dom = Dom::create_div()
-        .with_child(Dom::create_node(NodeType::P).with_child(Dom::create_text("Text")));
+        .with_child(Dom::create_node(NodeType::P).with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Text")));
 
     let (_styled_dom, cache) = setup_styled_dom!(dom);
 
@@ -116,7 +116,7 @@ fn test_inline_css_takes_precedence() {
 #[test]
 fn test_css_stylesheet_applies() {
     let dom = Dom::create_div()
-        .with_child(Dom::create_node(NodeType::P).with_child(Dom::create_text("Text")));
+        .with_child(Dom::create_node(NodeType::P).with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Text")));
 
     let css = "p { font-size: 18px; }";
     let (_styled_dom, cache) = setup_styled_dom!(dom, css);
@@ -145,7 +145,7 @@ fn test_inherited_property_has_correct_origin() {
             ))]
             .into(),
         )
-        .with_child(Dom::create_node(NodeType::P).with_child(Dom::create_text("Text")));
+        .with_child(Dom::create_node(NodeType::P).with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Text")));
 
     let (_styled_dom, cache) = setup_styled_dom!(dom);
 
@@ -192,7 +192,7 @@ fn test_own_property_overrides_inherited() {
                     ))]
                     .into(),
                 )
-                .with_child(Dom::create_text("Text")),
+                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Text")),
         );
 
     let (_styled_dom, cache) = setup_styled_dom!(dom);
@@ -236,7 +236,7 @@ fn test_em_resolved_to_px_in_computed() {
                     ))]
                     .into(),
                 )
-                .with_child(Dom::create_text("Text")),
+                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Text")),
         );
 
     let (_styled_dom, cache) = setup_styled_dom!(dom);
@@ -280,7 +280,7 @@ fn test_deeply_nested_inheritance() {
             .into(),
         )
         .with_child(Dom::create_div().with_child(
-            Dom::create_div().with_child(Dom::create_div().with_child(Dom::create_text("Deep"))),
+            Dom::create_div().with_child(Dom::create_div().with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Deep"))),
         ));
 
     let (_styled_dom, cache) = setup_styled_dom!(dom);
@@ -303,7 +303,7 @@ fn test_deeply_nested_inheritance() {
 
 #[test]
 fn test_ua_css_for_headings() {
-    let dom = Dom::create_node(NodeType::H1).with_child(Dom::create_text("Heading"));
+    let dom = Dom::create_node(NodeType::H1).with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Heading"));
 
     let (_styled_dom, cache) = setup_styled_dom!(dom);
 
@@ -374,7 +374,7 @@ fn test_font_weight_inheritance() {
             ))]
             .into(),
         )
-        .with_child(Dom::create_node(NodeType::Span).with_child(Dom::create_text("Bold text")));
+        .with_child(Dom::create_node(NodeType::Span).with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Bold text")));
 
     let (_styled_dom, cache) = setup_styled_dom!(dom);
 
@@ -416,7 +416,7 @@ fn test_color_inheritance() {
             ))]
             .into(),
         )
-        .with_child(Dom::create_node(NodeType::P).with_child(Dom::create_text("Red text")));
+        .with_child(Dom::create_node(NodeType::P).with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Red text")));
 
     let (_styled_dom, cache) = setup_styled_dom!(dom);
 
@@ -447,7 +447,7 @@ fn test_non_inheritable_property_not_inherited() {
     // display is not inheritable
     let css = "div { display: flex; }";
     let dom = Dom::create_div()
-        .with_child(Dom::create_node(NodeType::P).with_child(Dom::create_text("Text")));
+        .with_child(Dom::create_node(NodeType::P).with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Text")));
 
     let (_styled_dom, cache) = setup_styled_dom!(dom, css);
 
@@ -474,7 +474,7 @@ fn test_non_inheritable_property_not_inherited() {
 
 #[test]
 fn test_empty_css_produces_only_ua_styles() {
-    let dom = Dom::create_node(NodeType::P).with_child(Dom::create_text("Paragraph"));
+    let dom = Dom::create_node(NodeType::P).with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Paragraph"));
 
     let (styled_dom, _cache) = setup_styled_dom!(dom);
 
@@ -496,7 +496,7 @@ fn test_text_node_inherits_from_parent() {
             ))]
             .into(),
         )
-        .with_child(Dom::create_text("Text inherits"));
+        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Text inherits"));
 
     let (_styled_dom, cache) = setup_styled_dom!(dom);
 

--- a/core/tests/reconciliation/deep_reconciliation.rs
+++ b/core/tests/reconciliation/deep_reconciliation.rs
@@ -85,8 +85,8 @@ fn deep_nested_mount_produces_mount_events_for_each_new_node() {
 
     let mount_cb = lifecycle_cb(ComponentEventFilter::AfterMount);
     let new_dom = Dom::create_from_data(NodeData::create_div())
-        .with_child(Dom::create_from_data(mount_cb(NodeData::create_text("inner1"))))
-        .with_child(Dom::create_from_data(mount_cb(NodeData::create_text("inner2"))));
+        .with_child(Dom::create_from_data(mount_cb(NodeData::create_text_do_not_use_without_block_level_wrapper("inner1"))))
+        .with_child(Dom::create_from_data(mount_cb(NodeData::create_text_do_not_use_without_block_level_wrapper("inner2"))));
 
     let (old_nd, old_hier) = flatten(old_dom);
     let (new_nd, new_hier) = flatten(new_dom);
@@ -130,7 +130,7 @@ fn deep_nested_unmount_fires_for_removed_subtree_root_only() {
     let unmount_cb = lifecycle_cb(ComponentEventFilter::BeforeUnmount);
     let old_dom = Dom::create_from_data(NodeData::create_div()).with_child(
         Dom::create_from_data(unmount_cb(NodeData::create_div()))
-            .with_child(Dom::create_from_data(NodeData::create_text("leaf"))),
+            .with_child(Dom::create_from_data(NodeData::create_text_do_not_use_without_block_level_wrapper("leaf"))),
     );
     let new_dom = Dom::create_from_data(NodeData::create_div());
 
@@ -245,12 +245,12 @@ fn identical_leaves_under_different_parents_do_not_match() {
             .with_child(
                 Dom::create_from_data(NodeData::create_div())
                     .with_class("X".into())
-                    .with_child(Dom::create_from_data(mount_cb(NodeData::create_text("leaf")))),
+                    .with_child(Dom::create_from_data(mount_cb(NodeData::create_text_do_not_use_without_block_level_wrapper("leaf")))),
             )
             .with_child(
                 Dom::create_from_data(NodeData::create_div())
                     .with_class("Y".into())
-                    .with_child(Dom::create_from_data(mount_cb(NodeData::create_text("leaf")))),
+                    .with_child(Dom::create_from_data(mount_cb(NodeData::create_text_do_not_use_without_block_level_wrapper("leaf")))),
             )
     };
 
@@ -303,7 +303,7 @@ fn deep_resize_event_fires_when_bounds_change_on_matched_node() {
 
     let build = |label: &str| -> Dom {
         Dom::create_from_data(NodeData::create_div())
-            .with_child(Dom::create_from_data(resize_cb(NodeData::create_text(label))))
+            .with_child(Dom::create_from_data(resize_cb(NodeData::create_text_do_not_use_without_block_level_wrapper(label))))
     };
 
     let (old_nd, old_hier) = flatten(build("content"));
@@ -372,7 +372,7 @@ fn keyed_update_fires_on_content_change() {
     let make = |text: &str| -> Dom {
         Dom::create_from_data(NodeData::create_div()).with_child(Dom::create_from_data(
             lifecycle_cb(ComponentEventFilter::Updated)(
-                NodeData::create_text(text).with_key(42u64),
+                NodeData::create_text_do_not_use_without_block_level_wrapper(text).with_key(42u64),
             ),
         ))
     };

--- a/core/tests/reconciliation/dom_reconciliation.rs
+++ b/core/tests/reconciliation/dom_reconciliation.rs
@@ -64,7 +64,7 @@ fn reconcile_dom_with_changes_flat(
 fn identical_dom_no_changes() {
     let data = vec![
         NodeData::create_div(),
-        NodeData::create_text("Hello"),
+        NodeData::create_text_do_not_use_without_block_level_wrapper("Hello"),
     ];
     let layout = make_layout(data.len());
     
@@ -84,7 +84,7 @@ fn identical_dom_no_changes() {
 
 #[test]
 fn identical_dom_accumulator_empty() {
-    let data = vec![NodeData::create_div(), NodeData::create_text("Hi")];
+    let data = vec![NodeData::create_div(), NodeData::create_text_do_not_use_without_block_level_wrapper("Hi")];
     let layout = make_layout(data.len());
     
     let extended = reconcile_dom_with_changes_flat(
@@ -106,8 +106,8 @@ fn identical_dom_accumulator_empty() {
 
 #[test]
 fn text_edit_detected() {
-    let old = vec![NodeData::create_text("Hello")];
-    let new = vec![NodeData::create_text("World")];
+    let old = vec![NodeData::create_text_do_not_use_without_block_level_wrapper("Hello")];
+    let new = vec![NodeData::create_text_do_not_use_without_block_level_wrapper("World")];
     
     let old_layout = make_layout(1);
     let new_layout = make_layout(1);
@@ -127,8 +127,8 @@ fn text_edit_detected() {
 
 #[test]
 fn text_edit_accumulator_shows_ifc_scope() {
-    let old = vec![NodeData::create_text("Hello")];
-    let new = vec![NodeData::create_text("World")];
+    let old = vec![NodeData::create_text_do_not_use_without_block_level_wrapper("Hello")];
+    let new = vec![NodeData::create_text_do_not_use_without_block_level_wrapper("World")];
     
     let old_layout = make_layout(1);
     let new_layout = make_layout(1);
@@ -261,7 +261,7 @@ fn node_added_detected_as_mount() {
     let old = vec![NodeData::create_div()];
     let new = vec![
         NodeData::create_div(),
-        NodeData::create_text("new"),
+        NodeData::create_text_do_not_use_without_block_level_wrapper("new"),
     ];
     
     let old_layout = make_layout(1);
@@ -290,7 +290,7 @@ fn node_added_detected_as_mount() {
 fn node_removed_detected_as_unmount() {
     let old = vec![
         NodeData::create_div(),
-        NodeData::create_text("old"),
+        NodeData::create_text_do_not_use_without_block_level_wrapper("old"),
     ];
     let new = vec![NodeData::create_div()];
     
@@ -342,14 +342,14 @@ fn node_type_change_full_scope() {
 #[test]
 fn only_changed_node_flagged() {
     let old = vec![
-        NodeData::create_text("Line 1"),
-        NodeData::create_text("Line 2"),
-        NodeData::create_text("Line 3"),
+        NodeData::create_text_do_not_use_without_block_level_wrapper("Line 1"),
+        NodeData::create_text_do_not_use_without_block_level_wrapper("Line 2"),
+        NodeData::create_text_do_not_use_without_block_level_wrapper("Line 3"),
     ];
     let new = vec![
-        NodeData::create_text("Line 1"),         // same
-        NodeData::create_text("Line 2 edited"),  // changed
-        NodeData::create_text("Line 3"),          // same
+        NodeData::create_text_do_not_use_without_block_level_wrapper("Line 1"),         // same
+        NodeData::create_text_do_not_use_without_block_level_wrapper("Line 2 edited"),  // changed
+        NodeData::create_text_do_not_use_without_block_level_wrapper("Line 3"),          // same
     ];
     
     let old_layout = make_layout(3);
@@ -416,13 +416,13 @@ fn keyed_reorder_no_content_change() {
 #[test]
 fn insert_at_beginning() {
     let old = vec![
-        NodeData::create_text("Item 1"),
-        NodeData::create_text("Item 2"),
+        NodeData::create_text_do_not_use_without_block_level_wrapper("Item 1"),
+        NodeData::create_text_do_not_use_without_block_level_wrapper("Item 2"),
     ];
     let new = vec![
-        NodeData::create_text("Item 0"),  // new
-        NodeData::create_text("Item 1"),  // old[0]
-        NodeData::create_text("Item 2"),  // old[1]
+        NodeData::create_text_do_not_use_without_block_level_wrapper("Item 0"),  // new
+        NodeData::create_text_do_not_use_without_block_level_wrapper("Item 1"),  // old[0]
+        NodeData::create_text_do_not_use_without_block_level_wrapper("Item 2"),  // old[1]
     ];
     
     let old_layout = make_layout(2);
@@ -449,13 +449,13 @@ fn insert_at_beginning() {
 #[test]
 fn delete_from_middle() {
     let old = vec![
-        NodeData::create_text("A"),
-        NodeData::create_text("B"),
-        NodeData::create_text("C"),
+        NodeData::create_text_do_not_use_without_block_level_wrapper("A"),
+        NodeData::create_text_do_not_use_without_block_level_wrapper("B"),
+        NodeData::create_text_do_not_use_without_block_level_wrapper("C"),
     ];
     let new = vec![
-        NodeData::create_text("A"),
-        NodeData::create_text("C"),
+        NodeData::create_text_do_not_use_without_block_level_wrapper("A"),
+        NodeData::create_text_do_not_use_without_block_level_wrapper("C"),
     ];
     
     let old_layout = make_layout(3);
@@ -515,7 +515,7 @@ fn realistic_todo_list_update() {
     // Simulate a todo list: user marks item 2 as complete (class change)
     // and edits item 3's text
     let make_todo = |text: &str, done: bool| -> NodeData {
-        let mut nd = NodeData::create_text(text);
+        let mut nd = NodeData::create_text_do_not_use_without_block_level_wrapper(text);
         if done {
             nd.add_class(AzString::from("done"));
         }
@@ -577,7 +577,7 @@ fn empty_to_empty_no_changes() {
 #[test]
 fn empty_to_populated() {
     let old: Vec<NodeData> = vec![];
-    let new = vec![NodeData::create_div(), NodeData::create_text("hello")];
+    let new = vec![NodeData::create_div(), NodeData::create_text_do_not_use_without_block_level_wrapper("hello")];
     
     let old_layout = OrderedMap::default();
     let new_layout = make_layout(2);
@@ -599,7 +599,7 @@ fn empty_to_populated() {
 
 #[test]
 fn populated_to_empty() {
-    let old = vec![NodeData::create_div(), NodeData::create_text("hello")];
+    let old = vec![NodeData::create_div(), NodeData::create_text_do_not_use_without_block_level_wrapper("hello")];
     let new: Vec<NodeData> = vec![];
     
     let old_layout = make_layout(2);

--- a/core/tests/reconciliation/fingerprint.rs
+++ b/core/tests/reconciliation/fingerprint.rs
@@ -23,8 +23,8 @@ fn identical_divs_have_identical_fingerprint() {
 
 #[test]
 fn identical_text_nodes_have_identical_fingerprint() {
-    let a = NodeData::create_text("Hello World");
-    let b = NodeData::create_text("Hello World");
+    let a = NodeData::create_text_do_not_use_without_block_level_wrapper("Hello World");
+    let b = NodeData::create_text_do_not_use_without_block_level_wrapper("Hello World");
     let fa = NodeDataFingerprint::compute(&a, None);
     let fb = NodeDataFingerprint::compute(&b, None);
     assert!(fa.is_identical(&fb));
@@ -54,8 +54,8 @@ fn identical_fingerprint_with_styled_state() {
 
 #[test]
 fn text_change_detected_by_fingerprint() {
-    let a = NodeData::create_text("Hello");
-    let b = NodeData::create_text("World");
+    let a = NodeData::create_text_do_not_use_without_block_level_wrapper("Hello");
+    let b = NodeData::create_text_do_not_use_without_block_level_wrapper("World");
     let fa = NodeDataFingerprint::compute(&a, None);
     let fb = NodeDataFingerprint::compute(&b, None);
     assert!(!fa.is_identical(&fb));
@@ -76,7 +76,7 @@ fn node_type_change_detected_by_fingerprint() {
 #[test]
 fn div_to_text_changes_content_hash() {
     let a = NodeData::create_div();
-    let b = NodeData::create_text("hello");
+    let b = NodeData::create_text_do_not_use_without_block_level_wrapper("hello");
     let fa = NodeDataFingerprint::compute(&a, None);
     let fb = NodeDataFingerprint::compute(&b, None);
     assert_ne!(fa.content_hash, fb.content_hash);
@@ -235,8 +235,8 @@ fn tab_index_change_detected_by_attrs_hash() {
 
 #[test]
 fn might_affect_layout_text_change() {
-    let a = NodeData::create_text("Hello");
-    let b = NodeData::create_text("World");
+    let a = NodeData::create_text_do_not_use_without_block_level_wrapper("Hello");
+    let b = NodeData::create_text_do_not_use_without_block_level_wrapper("World");
     let fa = NodeDataFingerprint::compute(&a, None);
     let fb = NodeDataFingerprint::compute(&b, None);
     assert!(fa.might_affect_layout(&fb));
@@ -292,8 +292,8 @@ fn tier1_identical_skips_tier2() {
 
 #[test]
 fn tier1_mismatch_tier2_confirms_text_change() {
-    let a = NodeData::create_text("Hello");
-    let b = NodeData::create_text("World");
+    let a = NodeData::create_text_do_not_use_without_block_level_wrapper("Hello");
+    let b = NodeData::create_text_do_not_use_without_block_level_wrapper("World");
     let fa = NodeDataFingerprint::compute(&a, None);
     let fb = NodeDataFingerprint::compute(&b, None);
 
@@ -311,8 +311,8 @@ fn tier1_mismatch_tier2_confirms_text_change() {
 fn tier1_conservative_content_hash_refined_by_tier2() {
     // Fingerprint diff is conservative: content_hash mismatch sets both
     // TEXT_CONTENT and IMAGE_CHANGED. Tier 2 should be more precise.
-    let a = NodeData::create_text("Hello");
-    let b = NodeData::create_text("World");
+    let a = NodeData::create_text_do_not_use_without_block_level_wrapper("Hello");
+    let b = NodeData::create_text_do_not_use_without_block_level_wrapper("World");
     let fa = NodeDataFingerprint::compute(&a, None);
     let fb = NodeDataFingerprint::compute(&b, None);
 
@@ -361,7 +361,7 @@ fn computed_fingerprint_non_zero_for_div() {
 
 #[test]
 fn fingerprint_deterministic() {
-    let a = NodeData::create_text("test");
+    let a = NodeData::create_text_do_not_use_without_block_level_wrapper("test");
     let mut b = NodeData::create_div();
     b.add_class(AzString::from("my-class"));
     b.set_contenteditable(true);
@@ -381,8 +381,8 @@ fn fingerprint_deterministic() {
 
 #[test]
 fn text_change_only_affects_content_hash() {
-    let a = NodeData::create_text("Hello");
-    let b = NodeData::create_text("World");
+    let a = NodeData::create_text_do_not_use_without_block_level_wrapper("Hello");
+    let b = NodeData::create_text_do_not_use_without_block_level_wrapper("World");
     // Same ids/classes, same CSS, same attrs
     let fa = NodeDataFingerprint::compute(&a, None);
     let fb = NodeDataFingerprint::compute(&b, None);

--- a/core/tests/reconciliation/node_change_set.rs
+++ b/core/tests/reconciliation/node_change_set.rs
@@ -27,8 +27,8 @@ fn identical_divs_produce_empty_changeset() {
 
 #[test]
 fn identical_text_nodes_produce_empty_changeset() {
-    let a = NodeData::create_text("Hello");
-    let b = NodeData::create_text("Hello");
+    let a = NodeData::create_text_do_not_use_without_block_level_wrapper("Hello");
+    let b = NodeData::create_text_do_not_use_without_block_level_wrapper("Hello");
     let cs = compute_node_changes(&a, &b, None, None);
     assert!(cs.is_empty(), "identical text nodes should have empty changeset");
 }
@@ -47,8 +47,8 @@ fn empty_changeset_is_visually_unchanged() {
 
 #[test]
 fn text_change_sets_text_content_flag() {
-    let a = NodeData::create_text("Hello");
-    let b = NodeData::create_text("World");
+    let a = NodeData::create_text_do_not_use_without_block_level_wrapper("Hello");
+    let b = NodeData::create_text_do_not_use_without_block_level_wrapper("World");
     let cs = compute_node_changes(&a, &b, None, None);
     assert!(cs.contains(NodeChangeSet::TEXT_CONTENT),
         "changing text content should set TEXT_CONTENT flag");
@@ -56,16 +56,16 @@ fn text_change_sets_text_content_flag() {
 
 #[test]
 fn text_change_needs_layout() {
-    let a = NodeData::create_text("short");
-    let b = NodeData::create_text("a much longer text that changes layout");
+    let a = NodeData::create_text_do_not_use_without_block_level_wrapper("short");
+    let b = NodeData::create_text_do_not_use_without_block_level_wrapper("a much longer text that changes layout");
     let cs = compute_node_changes(&a, &b, None, None);
     assert!(cs.needs_layout(), "text change should need layout");
 }
 
 #[test]
 fn text_same_length_different_content_sets_flag() {
-    let a = NodeData::create_text("AAAA");
-    let b = NodeData::create_text("BBBB");
+    let a = NodeData::create_text_do_not_use_without_block_level_wrapper("AAAA");
+    let b = NodeData::create_text_do_not_use_without_block_level_wrapper("BBBB");
     let cs = compute_node_changes(&a, &b, None, None);
     assert!(cs.contains(NodeChangeSet::TEXT_CONTENT),
         "same-length different text should still set TEXT_CONTENT");
@@ -73,16 +73,16 @@ fn text_same_length_different_content_sets_flag() {
 
 #[test]
 fn text_empty_to_nonempty_sets_flag() {
-    let a = NodeData::create_text("");
-    let b = NodeData::create_text("content");
+    let a = NodeData::create_text_do_not_use_without_block_level_wrapper("");
+    let b = NodeData::create_text_do_not_use_without_block_level_wrapper("content");
     let cs = compute_node_changes(&a, &b, None, None);
     assert!(cs.contains(NodeChangeSet::TEXT_CONTENT));
 }
 
 #[test]
 fn text_nonempty_to_empty_sets_flag() {
-    let a = NodeData::create_text("content");
-    let b = NodeData::create_text("");
+    let a = NodeData::create_text_do_not_use_without_block_level_wrapper("content");
+    let b = NodeData::create_text_do_not_use_without_block_level_wrapper("");
     let cs = compute_node_changes(&a, &b, None, None);
     assert!(cs.contains(NodeChangeSet::TEXT_CONTENT));
 }
@@ -103,14 +103,14 @@ fn div_to_span_sets_node_type_changed() {
 #[test]
 fn div_to_text_sets_node_type_changed() {
     let a = NodeData::create_div();
-    let b = NodeData::create_text("text");
+    let b = NodeData::create_text_do_not_use_without_block_level_wrapper("text");
     let cs = compute_node_changes(&a, &b, None, None);
     assert!(cs.contains(NodeChangeSet::NODE_TYPE_CHANGED));
 }
 
 #[test]
 fn text_to_div_sets_node_type_changed() {
-    let a = NodeData::create_text("text");
+    let a = NodeData::create_text_do_not_use_without_block_level_wrapper("text");
     let b = NodeData::create_div();
     let cs = compute_node_changes(&a, &b, None, None);
     assert!(cs.contains(NodeChangeSet::NODE_TYPE_CHANGED));
@@ -322,8 +322,8 @@ fn combined_flags_bitwise_or() {
 
 #[test]
 fn multiple_changes_combined() {
-    let a = NodeData::create_text("Hello");
-    let mut b = NodeData::create_text("World");
+    let a = NodeData::create_text_do_not_use_without_block_level_wrapper("Hello");
+    let mut b = NodeData::create_text_do_not_use_without_block_level_wrapper("World");
     b.add_class(AzString::from("changed"));
     let cs = compute_node_changes(&a, &b, None, None);
     assert!(cs.contains(NodeChangeSet::TEXT_CONTENT), "text changed");
@@ -332,8 +332,8 @@ fn multiple_changes_combined() {
 
 #[test]
 fn text_and_style_change_combined() {
-    let a = NodeData::create_text("old");
-    let b = NodeData::create_text("new").with_css("width: 50px;");
+    let a = NodeData::create_text_do_not_use_without_block_level_wrapper("old");
+    let b = NodeData::create_text_do_not_use_without_block_level_wrapper("new").with_css("width: 50px;");
     let cs = compute_node_changes(&a, &b, None, None);
     assert!(cs.contains(NodeChangeSet::TEXT_CONTENT));
     assert!(

--- a/core/tests/reconciliation/state_preservation.rs
+++ b/core/tests/reconciliation/state_preservation.rs
@@ -63,7 +63,7 @@ fn migration_map_reorder() {
     // new: [B-text, A-div-with-key]
     let mut a = NodeData::create_div();
     a.add_id(AzString::from("a"));
-    let b = NodeData::create_text("B");
+    let b = NodeData::create_text_do_not_use_without_block_level_wrapper("B");
     
     let old = vec![a.clone(), b.clone()];
     let new = vec![b.clone(), a.clone()];
@@ -161,7 +161,7 @@ fn keyed_node_survives_siblings_changing() {
     // Node with key survives even when siblings are added
     let mut keyed = NodeData::create_div();
     keyed.add_id(AzString::from("persist"));
-    let extra = NodeData::create_text("new");
+    let extra = NodeData::create_text_do_not_use_without_block_level_wrapper("new");
     
     let old = vec![keyed.clone()];
     let new = vec![extra, keyed.clone()]; // keyed node moved to position 1
@@ -192,7 +192,7 @@ fn identical_unkeyed_nodes_match_by_hash() {
 #[test]
 fn different_unkeyed_nodes_may_not_match() {
     let div = NodeData::create_div();
-    let text = NodeData::create_text("hello");
+    let text = NodeData::create_text_do_not_use_without_block_level_wrapper("hello");
     
     let old = vec![div.clone()];
     let new = vec![text.clone()];
@@ -210,8 +210,8 @@ fn different_unkeyed_nodes_may_not_match() {
 #[test]
 fn text_node_edit_preserves_match() {
     // Editing text content: the node should still match by position/structure
-    let old = vec![NodeData::create_text("Hello")];
-    let new = vec![NodeData::create_text("World")];
+    let old = vec![NodeData::create_text_do_not_use_without_block_level_wrapper("Hello")];
+    let new = vec![NodeData::create_text_do_not_use_without_block_level_wrapper("World")];
     
     let result = reconcile(&old, &new);
     // Even though content changed, structural matching should pair them
@@ -271,7 +271,7 @@ fn accumulator_tracks_mount_unmount_from_diff() {
 fn repeated_identical_rebuild_stable() {
     let data = vec![
         NodeData::create_div(),
-        NodeData::create_text("hello"),
+        NodeData::create_text_do_not_use_without_block_level_wrapper("hello"),
         NodeData::create_div(),
     ];
     
@@ -288,16 +288,16 @@ fn repeated_identical_rebuild_stable() {
 fn incremental_changes_produce_correct_migration() {
     // Simulating incremental edits to a document
     let v1 = vec![
-        NodeData::create_text("Line 1"),
-        NodeData::create_text("Line 2"),
-        NodeData::create_text("Line 3"),
+        NodeData::create_text_do_not_use_without_block_level_wrapper("Line 1"),
+        NodeData::create_text_do_not_use_without_block_level_wrapper("Line 2"),
+        NodeData::create_text_do_not_use_without_block_level_wrapper("Line 3"),
     ];
     
     // Edit: change line 2
     let v2 = vec![
-        NodeData::create_text("Line 1"),
-        NodeData::create_text("Line 2 modified"),
-        NodeData::create_text("Line 3"),
+        NodeData::create_text_do_not_use_without_block_level_wrapper("Line 1"),
+        NodeData::create_text_do_not_use_without_block_level_wrapper("Line 2 modified"),
+        NodeData::create_text_do_not_use_without_block_level_wrapper("Line 3"),
     ];
     
     let result = reconcile(&v1, &v2);

--- a/core/tests/reconciliation/text_reconciliation.rs
+++ b/core/tests/reconciliation/text_reconciliation.rs
@@ -18,7 +18,7 @@ use azul_core::id::NodeId;
 
 #[test]
 fn get_text_content_from_text_node() {
-    let node = NodeData::create_text("Hello World");
+    let node = NodeData::create_text_do_not_use_without_block_level_wrapper("Hello World");
     assert_eq!(get_node_text_content(&node), Some("Hello World"));
 }
 
@@ -30,7 +30,7 @@ fn get_text_content_from_div_returns_none() {
 
 #[test]
 fn get_text_content_from_empty_text() {
-    let node = NodeData::create_text("");
+    let node = NodeData::create_text_do_not_use_without_block_level_wrapper("");
     assert_eq!(get_node_text_content(&node), Some(""));
 }
 
@@ -40,16 +40,16 @@ fn get_text_content_from_empty_text() {
 
 #[test]
 fn detect_text_change_via_compute() {
-    let a = NodeData::create_text("Hello");
-    let b = NodeData::create_text("World");
+    let a = NodeData::create_text_do_not_use_without_block_level_wrapper("Hello");
+    let b = NodeData::create_text_do_not_use_without_block_level_wrapper("World");
     let cs = compute_node_changes(&a, &b, None, None);
     assert!(cs.contains(NodeChangeSet::TEXT_CONTENT));
 }
 
 #[test]
 fn no_text_change_same_content() {
-    let a = NodeData::create_text("Same");
-    let b = NodeData::create_text("Same");
+    let a = NodeData::create_text_do_not_use_without_block_level_wrapper("Same");
+    let b = NodeData::create_text_do_not_use_without_block_level_wrapper("Same");
     let cs = compute_node_changes(&a, &b, None, None);
     assert!(!cs.contains(NodeChangeSet::TEXT_CONTENT));
 }

--- a/core/tests/styled_dom_append.rs
+++ b/core/tests/styled_dom_append.rs
@@ -23,11 +23,11 @@ fn style_dom(mut dom: Dom) -> StyledDom {
 #[test]
 fn test_append_single_child() {
     let parent = style_dom(Dom::create_div()
-        .with_child(Dom::create_text("existing")));
+        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("existing")));
 
     let initial_len = parent.node_hierarchy.as_ref().len();
 
-    let child = style_dom(Dom::create_text("appended"));
+    let child = style_dom(Dom::create_text_do_not_use_without_block_level_wrapper("appended"));
     let child_len = child.node_hierarchy.as_ref().len();
 
     let mut combined = parent;
@@ -44,9 +44,9 @@ fn test_append_single_child() {
 fn test_append_multiple_children() {
     let mut parent = style_dom(Dom::create_div());
 
-    parent.append_child(style_dom(Dom::create_text("first")));
-    parent.append_child(style_dom(Dom::create_text("second")));
-    parent.append_child(style_dom(Dom::create_text("third")));
+    parent.append_child(style_dom(Dom::create_text_do_not_use_without_block_level_wrapper("first")));
+    parent.append_child(style_dom(Dom::create_text_do_not_use_without_block_level_wrapper("second")));
+    parent.append_child(style_dom(Dom::create_text_do_not_use_without_block_level_wrapper("third")));
 
     assert_eq!(parent.node_hierarchy.as_ref().len(), 4);
 }
@@ -56,7 +56,7 @@ fn test_append_nested_child() {
     let parent = style_dom(Dom::create_div());
 
     let nested = style_dom(Dom::create_div()
-        .with_child(Dom::create_div().with_child(Dom::create_text("deeply nested"))));
+        .with_child(Dom::create_div().with_child(Dom::create_text_do_not_use_without_block_level_wrapper("deeply nested"))));
 
     let mut combined = parent;
     combined.append_child(nested);
@@ -98,7 +98,7 @@ fn test_append_nested_child() {
 #[test]
 fn test_no_underflow_on_empty_parent() {
     let parent = style_dom(Dom::create_div());
-    let child = style_dom(Dom::create_text("child"));
+    let child = style_dom(Dom::create_text_do_not_use_without_block_level_wrapper("child"));
 
     let mut combined = parent;
     combined.append_child(child);
@@ -117,7 +117,7 @@ fn test_no_underflow_on_empty_parent() {
 #[test]
 fn test_hierarchy_fields_use_one_based_encoding() {
     let parent = style_dom(Dom::create_div()
-        .with_child(Dom::create_text("child")));
+        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("child")));
 
     let root = parent.root.into_crate_internal().expect("should have root");
     let root_node = &parent.node_hierarchy.as_ref()[root.index()];
@@ -135,7 +135,7 @@ fn test_hierarchy_fields_use_one_based_encoding() {
 
 #[test]
 fn test_none_fields_are_zero() {
-    let leaf = style_dom(Dom::create_text("leaf"));
+    let leaf = style_dom(Dom::create_text_do_not_use_without_block_level_wrapper("leaf"));
 
     let root = leaf.root.into_crate_internal().expect("should have root");
     let root_node = &leaf.node_hierarchy.as_ref()[root.index()];
@@ -149,11 +149,11 @@ fn test_none_fields_are_zero() {
 #[test]
 fn test_regression_index_2_with_len_2() {
     let parent = style_dom(Dom::create_div()
-        .with_child(Dom::create_text("child")));
+        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("child")));
 
     assert_eq!(parent.node_hierarchy.as_ref().len(), 2);
 
-    let child2 = style_dom(Dom::create_text("child2"));
+    let child2 = style_dom(Dom::create_text_do_not_use_without_block_level_wrapper("child2"));
 
     let mut combined = parent;
     combined.append_child(child2);
@@ -177,7 +177,7 @@ fn test_xml_like_append_sequence() {
 
     for i in 0..5 {
         let child = style_dom(Dom::create_div()
-            .with_child(Dom::create_text(format!("text {i}"))));
+            .with_child(Dom::create_text_do_not_use_without_block_level_wrapper(format!("text {i}"))));
         body.append_child(child);
     }
 

--- a/dll/src/desktop/extra/pdf/mod.rs
+++ b/dll/src/desktop/extra/pdf/mod.rs
@@ -829,7 +829,7 @@ mod tests {
     #[test]
     fn dom_to_pdf_embeds_text_fonts() {
         let dom = Dom::create_body()
-            .with_child(Dom::create_text("Hello PDF text — glyphs must embed"));
+            .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Hello PDF text — glyphs must embed"));
         let bytes = dom_to_pdf(dom, 595.0, 842.0);
         assert!(!bytes.as_ref().is_empty(), "PDF generation produced no bytes");
 
@@ -891,7 +891,7 @@ mod tests {
     #[test]
     fn pdf_roundtrips_to_svg_pages_and_dom() {
         let dom = Dom::create_body()
-            .with_child(Dom::create_text("Reverse-path text for SVG extraction"));
+            .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Reverse-path text for SVG extraction"));
         let bytes = dom_to_pdf(dom, 595.0, 842.0);
         let pages = pdf_to_svg_pages(bytes.as_ref());
         assert_eq!(pages.len(), 1, "expected exactly one SVG page");

--- a/dll/src/desktop/menu_renderer.rs
+++ b/dll/src/desktop/menu_renderer.rs
@@ -312,7 +312,7 @@ fn create_string_menu_item_dom(
         .with_ids_and_classes(IdOrClassVec::from_vec(vec![IdOrClass::Class(
             "menu-item-label".into(),
         )]))
-        .with_child(Dom::create_text(item.label.clone()));
+        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper(item.label.clone()));
     item_dom = item_dom.with_child(label_dom);
 
     // Keyboard shortcut (if present)
@@ -322,7 +322,7 @@ fn create_string_menu_item_dom(
             .with_ids_and_classes(IdOrClassVec::from_vec(vec![IdOrClass::Class(
                 "menu-item-shortcut".into(),
             )]))
-            .with_child(Dom::create_text(shortcut_text));
+            .with_child(Dom::create_text_do_not_use_without_block_level_wrapper(shortcut_text));
         item_dom = item_dom.with_child(shortcut_dom);
     }
 
@@ -332,7 +332,7 @@ fn create_string_menu_item_dom(
             .with_ids_and_classes(IdOrClassVec::from_vec(vec![IdOrClass::Class(
                 "menu-item-arrow".into(),
             )]))
-            .with_child(Dom::create_text("▶"));
+            .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("▶"));
         item_dom = item_dom.with_child(arrow_dom);
     }
 
@@ -398,7 +398,7 @@ fn create_icon_dom(icon: &OptionMenuItemIcon) -> Dom {
                 // Add checkmark if checked
                 if *checked {
                     icon_dom =
-                        Dom::create_text("✓").with_ids_and_classes(IdOrClassVec::from_vec(vec![
+                        Dom::create_text_do_not_use_without_block_level_wrapper("✓").with_ids_and_classes(IdOrClassVec::from_vec(vec![
                             IdOrClass::Class("menu-item-icon".into()),
                             IdOrClass::Class("menu-item-checkbox".into()),
                             IdOrClass::Class("menu-item-checkbox-checked".into()),

--- a/dll/src/desktop/shell2/android/mod.rs
+++ b/dll/src/desktop/shell2/android/mod.rs
@@ -82,6 +82,13 @@ pub struct AndroidWindow {
     pub backend: RenderBackend,
     /// `false` once `MainEvent::Destroy` arrives; breaks the outer loop.
     pub is_open: bool,
+    /// Theme change queued by the Java-UI-thread JNI hook
+    /// (`nativeOnUiModeChanged`), drained on the LOOP thread each iteration.
+    /// Encoding matches the JNI contract: 0 = none pending, 1 = light,
+    /// 2 = dark. The Java thread must never mutate window state or run a
+    /// pass itself — that is what left a live delta for the validation check
+    /// and raced the loop's own reads.
+    pub pending_theme: std::sync::atomic::AtomicI32,
     /// Shared icon provider — needed by `regenerate_layout()` so widgets
     /// (notably button/icon containers) can resolve `IconReference`s.
     pub icon_provider: SharedIconProvider,
@@ -128,6 +135,7 @@ impl AndroidWindow {
                 layout_window: Some(layout_window),
                 current_window_state: full_window_state,
                 previous_window_state: None,
+                os_synced_state: None,
                 renderer_resources: RendererResources::default(),
                 fc_cache,
                 gl_context_ptr: azul_core::gl::OptionGlContextPtr::None,
@@ -152,6 +160,7 @@ impl AndroidWindow {
             native_window: None,
             backend: RenderBackend::Cpu,
             is_open: true,
+            pending_theme: std::sync::atomic::AtomicI32::new(0),
             icon_provider,
             font_registry,
             accessibility_adapter: accessibility::AndroidAccessibilityAdapter::new(),
@@ -420,6 +429,8 @@ impl PlatformWindow for AndroidWindow {
 
     fn hide_tooltip_from_callback(&mut self) {}
 
+    /// The activity owns the window geometry outright, so there is nothing to
+    /// push and no OS-sync baseline to diff (`os_synced_state` stays `None`).
     fn sync_window_state(&mut self) {}
 }
 
@@ -514,6 +525,10 @@ pub fn android_main(app: AndroidApp) {
 
         // Regenerate layout when something invalidated the frame (init,
         // resize, input). Populates cpu_backend.last_frame.
+        // Drain the Java-thread theme queue on the loop thread: snapshot →
+        // mutate → pass, like every other OS-state change.
+        drain_pending_theme(&mut window);
+
         let mut frame_dirty = false;
         if window.common.regeneration_pending() {
             match window.regenerate_layout() {
@@ -554,6 +569,28 @@ pub fn android_main(app: AndroidApp) {
 /// already queued as `Initial` and the user's layout callback must see THAT,
 /// so return the implicit `RefreshDom` (which `request_regeneration` never
 /// lets overwrite a more specific queued reason) while it is still pending.
+/// Apply a theme change queued by the Java UI thread (see `pending_theme`).
+/// Runs on the loop thread: contract shape (snapshot → mutate → pass), so
+/// `ThemeChanged` dispatches and no live delta is left behind.
+#[cfg(all(target_os = "android", feature = "android-activity"))]
+fn drain_pending_theme(window: &mut AndroidWindow) {
+    let raw = window
+        .pending_theme
+        .swap(0, std::sync::atomic::Ordering::AcqRel);
+    let theme = match raw {
+        1 => azul_core::window::WindowTheme::LightMode,
+        2 => azul_core::window::WindowTheme::DarkMode,
+        _ => return,
+    };
+    if window.common.current_window_state.theme == theme {
+        return;
+    }
+    window.common.previous_window_state = Some(window.common.current_window_state.clone());
+    window.common.current_window_state.theme = theme;
+    window.common.request_regeneration(RelayoutReason::ThemeChange);
+    let _ = window.process_window_events(0);
+}
+
 #[cfg(all(target_os = "android", feature = "android-activity"))]
 fn resize_reason(window: &AndroidWindow) -> RelayoutReason {
     if window.common.regeneration_pending()
@@ -570,6 +607,12 @@ fn handle_poll_event(app: &AndroidApp, window: &mut AndroidWindow, event: PollEv
     match event {
         PollEvent::Main(main_event) => match main_event {
             MainEvent::InitWindow { .. } => {
+                // Contract shape (snapshot → mutate → pass): Android never
+                // dispatched WindowResize/WindowDpiChanged — these arms wrote
+                // geometry with no snapshot and no pass, so the diff either
+                // never existed or tripped the validation check later.
+                window.common.previous_window_state =
+                    Some(window.common.current_window_state.clone());
                 // Sync the framework's window state to the native
                 // surface: physical dimensions + DPI. azul-layout uses
                 // 96 as the "1x" baseline (CSS pixel = 1/96 inch), so
@@ -606,6 +649,7 @@ fn handle_poll_event(app: &AndroidApp, window: &mut AndroidWindow, event: PollEv
                         window.common.request_regeneration(reason);
                     }
                 }
+                let _ = window.process_window_events(0);
             }
             MainEvent::TerminateWindow { .. } => {
                 log_debug!(LogCategory::Window, "[Android] TerminateWindow");
@@ -613,6 +657,9 @@ fn handle_poll_event(app: &AndroidApp, window: &mut AndroidWindow, event: PollEv
                 { window.native_window = None; }
             }
             MainEvent::WindowResized { .. } => {
+                // Contract shape (snapshot → mutate → pass) — see InitWindow.
+                window.common.previous_window_state =
+                    Some(window.common.current_window_state.clone());
                 #[cfg(feature = "ndk")]
                 {
                     if let Some(nw) = window.native_window.as_ref() {
@@ -626,6 +673,7 @@ fn handle_poll_event(app: &AndroidApp, window: &mut AndroidWindow, event: PollEv
                 }
                 let reason = resize_reason(window);
                 window.common.request_regeneration(reason);
+                let _ = window.process_window_events(0);
             }
             MainEvent::ConfigChanged { .. } => {
                 // Density can change while running: fold/unfold, moving the
@@ -637,6 +685,10 @@ fn handle_poll_event(app: &AndroidApp, window: &mut AndroidWindow, event: PollEv
                 let density = app.config().density().filter(|&d| d > 0).unwrap_or(160);
                 let dpi = (((density as f32) * 96.0 / 160.0).round() as u32).max(1);
                 if window.common.current_window_state.size.dpi != dpi {
+                    // Contract shape (snapshot → mutate → pass) — the dpi
+                    // diff is what dispatches WindowDpiChanged.
+                    window.common.previous_window_state =
+                        Some(window.common.current_window_state.clone());
                     let reason = resize_reason(window);
                     window.common.current_window_state.size.dpi = dpi;
                     #[cfg(feature = "ndk")]
@@ -648,6 +700,7 @@ fn handle_poll_event(app: &AndroidApp, window: &mut AndroidWindow, event: PollEv
                             (nw.height() as f32) / android_scale;
                     }
                     window.common.request_regeneration(reason);
+                    let _ = window.process_window_events(0);
                 }
             }
             MainEvent::InputAvailable => {
@@ -1242,16 +1295,14 @@ mod jni_bridge {
             // whatever the window already carries.
             _ => return,
         };
+        // Queue only — the LOOP thread drains this (drain_pending_theme),
+        // snapshots the event-diff baseline, applies the theme and runs the
+        // pass there. Mutating window state from the Java thread raced the
+        // loop and left a live delta the validation check rightly flags.
+        let _ = theme;
         with_window(native_ptr, |w| {
-            if w.common.current_window_state.theme == theme {
-                return;
-            }
-            // previous_window_state is what the diff pipeline compares against
-            // to decide a ThemeChanged event fired; without it no callback runs.
-            w.common.previous_window_state = Some(w.common.current_window_state.clone());
-            w.common.current_window_state.theme = theme;
-            w.common
-                .request_regeneration(RelayoutReason::ThemeChange);
+            w.pending_theme
+                .store(night_mode, std::sync::atomic::Ordering::Release);
         });
     }
 

--- a/dll/src/desktop/shell2/common/event.rs
+++ b/dll/src/desktop/shell2/common/event.rs
@@ -169,11 +169,19 @@ use azul_layout::{
 use rust_fontconfig::FcFontCache;
 
 use crate::desktop::wr_translate2::{self, AsyncHitTester, WrRenderApi};
-use crate::{log_debug, log_warn};
+use crate::{log_debug, log_error, log_warn};
 
 const AUTO_SCROLL_EDGE_THRESHOLD: f32 = 30.0;
 const AUTO_SCROLL_MAX_SPEED: f32 = 15.0;
-const KEYBOARD_SCROLL_LINE_PX: f32 = 20.0;
+/// One wheel detent / one scroll "line", in logical pixels — the engine's
+/// canonical unit for DISCRETE scroll input. Every backend converts its
+/// native tick to this (X11 button-4/5 ticks, Win32 WHEEL_DELTA notches
+/// scaled by the wheel-lines setting, macOS non-precise line deltas, Wayland
+/// axis_discrete detents, keyboard arrow scrolling). Trackpad/precise deltas
+/// stay raw. Tune HERE, never per-backend — four independent `20.0`s
+/// drifting apart is exactly how macOS wheels ended up ~20x slower than X11.
+pub const WHEEL_SCROLL_PIXELS_PER_LINE: f32 = 20.0;
+const KEYBOARD_SCROLL_LINE_PX: f32 = WHEEL_SCROLL_PIXELS_PER_LINE;
 const KEYBOARD_SCROLL_DOCUMENT_MAX: f32 = 100_000.0;
 const DEFAULT_VIEWPORT_HEIGHT: f32 = 600.0;
 
@@ -451,6 +459,71 @@ extern "C" fn auto_scroll_timer_callback(
     }
 }
 
+/// Record ONE undoable entry for a multi-cursor edit that neither recording
+/// site covers.
+///
+/// `apply_text_changeset` records typing (changeset ids counting UP from 0)
+/// and `delete_selection` records deletions (ids counting DOWN from
+/// `usize::MAX`). A smart paste distributes N clipboard lines over N cursors
+/// through `edit_text_multi` and reaches neither, so Ctrl+Z after one used to
+/// undo whatever edit came before it.
+///
+/// The restore itself runs off the styled pre/post content snapshots keyed by
+/// changeset id, so the operation kind and range recorded here are
+/// informational — they are what the C-API `inspect_*` fns read. Ids come
+/// from `LayoutWindow::record_text_edit_undo`'s single monotonic counter
+/// (shared with typing and deletion).
+fn record_multi_edit_undo(
+    lw: &mut LayoutWindow,
+    target: azul_core::dom::DomNodeId,
+    node_id: NodeId,
+    pre_content: &[azul_layout::text3::cache::InlineContent],
+    post_content: &[azul_layout::text3::cache::InlineContent],
+    pre_selections: &[azul_core::selection::Selection],
+) {
+    use azul_core::{selection::Selection, window::CursorPosition};
+    use azul_layout::managers::{
+        changeset::{TextOpPaste, TextOperation},
+        undo_redo::NodeStateSnapshot,
+    };
+
+    let pre_text = lw.extract_text_from_inline_content(pre_content);
+    let old_cursor = pre_selections.first().and_then(|sel| match sel {
+        Selection::Cursor(c) => Some(*c),
+        Selection::Range(_) => None,
+    });
+    let old_range = pre_selections.first().and_then(|sel| match sel {
+        Selection::Range(r) => Some(*r),
+        Selection::Cursor(_) => None,
+    });
+    let timestamp = azul_core::task::Instant::now();
+
+    let pre_state = NodeStateSnapshot {
+        node_id,
+        text_content: pre_text.into(),
+        cursor_position: old_cursor.into(),
+        selection_range: old_range.into(),
+        timestamp,
+    };
+    // A smart paste bypasses the text-input record pipeline, so the commit
+    // queues the host's Input notification.
+    lw.record_text_edit_undo(
+        target,
+        pre_state,
+        pre_content.to_vec(),
+        post_content.to_vec(),
+        TextOperation::Paste(TextOpPaste {
+            content: ClipboardContent {
+                plain_text: lw.extract_text_from_inline_content(post_content).into(),
+                styled_runs: StyledTextRunVec::from_const_slice(&[]),
+            },
+            position: CursorPosition::Uninitialized,
+            new_cursor: CursorPosition::Uninitialized,
+        }),
+        azul_layout::window::TextEditNotify::QueueInput,
+    );
+}
+
 // Focus Restyle Helper
 
 /// Apply focus change restyle and determine the ProcessEventResult.
@@ -691,7 +764,7 @@ pub struct InvokeSingleCallbackBorrows<'a> {
 /// Where a window-state mutation originated. This is the event-source tracking
 /// the window-state sync relies on (see [`CommonWindowState::update_window_state`]).
 ///
-/// `sync_window_state()` pushes the diff between `previous_window_state` (the
+/// `sync_window_state()` pushes the diff between `os_synced_state` (the
 /// baseline = "what the OS already has") and `current_window_state` (what we
 /// want) to the OS via `XMoveWindow`/`XResizeWindow`/`SetWindowPos`/…. Tagging
 /// the source decides whether a change is echoed:
@@ -707,6 +780,142 @@ pub enum WindowStateSource {
     App,
     /// OS reported the change (already applied) → never echoed back.
     Os,
+}
+
+// Input-delta validation (R2)
+
+/// Is the window-state validation gate on?
+///
+/// Diagnostics here are runtime env / atomics, never cargo features (the same
+/// ruling `AZ_LOG` / `AZ_PROFILE` / `AZ_BACKEND` / `AZ_E2E_TEST` follow), read
+/// once. A debug build validates unconditionally; a release build — which is
+/// what the battery and every shipped binary are — has to opt in with
+/// `AZ_VALIDATE=1`.
+#[must_use]
+pub fn validation_enabled() -> bool {
+    if cfg!(debug_assertions) {
+        return true;
+    }
+    #[cfg(feature = "std")]
+    {
+        static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+        return *ON.get_or_init(|| {
+            std::env::var("AZ_VALIDATE")
+                .map(|v| {
+                    let v = v.trim().to_ascii_lowercase();
+                    !matches!(v.as_str(), "" | "0" | "off" | "false" | "no" | "none")
+                })
+                .unwrap_or(false)
+        });
+    }
+    #[cfg(not(feature = "std"))]
+    false
+}
+
+/// The first event-bearing field on which two window states disagree, for the
+/// validation message. Only the fields `event_determination` actually reads —
+/// naming `platform_specific_options` would not help anybody debug a lost
+/// `Resized`.
+fn first_differing_state_field(
+    a: &FullWindowState,
+    b: &FullWindowState,
+) -> Option<&'static str> {
+    if a.size.dimensions != b.size.dimensions {
+        return Some("size.dimensions");
+    }
+    if a.size.dpi != b.size.dpi {
+        return Some("size.dpi");
+    }
+    if a.position != b.position {
+        return Some("position");
+    }
+    if a.flags.frame != b.flags.frame {
+        return Some("flags.frame");
+    }
+    if a.flags.is_visible != b.flags.is_visible {
+        return Some("flags.is_visible");
+    }
+    if a.flags.has_focus != b.flags.has_focus {
+        return Some("flags.has_focus");
+    }
+    if a.flags.close_requested != b.flags.close_requested {
+        return Some("flags.close_requested");
+    }
+    if a.flags.decorations != b.flags.decorations {
+        return Some("flags.decorations");
+    }
+    if a.window_focused != b.window_focused {
+        return Some("window_focused");
+    }
+    if a.theme != b.theme {
+        return Some("theme");
+    }
+    if a.monitor_id != b.monitor_id {
+        return Some("monitor_id");
+    }
+    if a.title != b.title {
+        return Some("title");
+    }
+    if a.mouse_state != b.mouse_state {
+        return Some("mouse_state");
+    }
+    if a.keyboard_state != b.keyboard_state {
+        return Some("keyboard_state");
+    }
+    if a.touch_state != b.touch_state {
+        return Some("touch_state");
+    }
+    if a == b {
+        None
+    } else {
+        Some("(a field event determination does not read)")
+    }
+}
+
+/// Catch an UNCONSUMED INPUT DELTA before it is silently overwritten.
+///
+/// The invariant: whenever a platform handler is about to snapshot the
+/// event-diff baseline, `previous_window_state` already equals
+/// `current_window_state` — every completed `process_window_events` pass
+/// leaves it that way (it consumes its own delta), and every injection site
+/// snapshots immediately before mutating and runs its pass immediately after.
+///
+/// A non-zero diff here means an earlier handler mutated
+/// `current_window_state` and returned WITHOUT running a pass. The snapshot
+/// about to happen overwrites the baseline with the already-mutated state, and
+/// the event that delta encoded — a resize, a DPI change, a maximize — is gone
+/// for good. Nothing crashes and nothing logs; the callback simply never
+/// fires, which is exactly how it stayed unnoticed on four backends.
+///
+/// Gated on [`validation_enabled`]; panics rather than logs, because a
+/// diagnostic that only logs in a loop of 60 frames per second is a diagnostic
+/// nobody reads.
+pub fn check_input_delta_consumed(
+    previous: Option<&FullWindowState>,
+    current: &FullWindowState,
+    site: &str,
+) {
+    if !validation_enabled() {
+        return;
+    }
+    let Some(previous) = previous else {
+        return; // no baseline yet: the first frame has nothing to consume
+    };
+    if let Some(field) = first_differing_state_field(previous, current) {
+        log_error!(
+            super::debug_server::LogCategory::Window,
+            "[AZ_VALIDATE] unconsumed input delta at {}: previous_window_state.{} != \
+             current_window_state.{} — a handler mutated the current state without running \
+             process_window_events(), and this snapshot is about to delete that event",
+            site,
+            field,
+            field
+        );
+        panic!(
+            "[AZ_VALIDATE] unconsumed input delta at {site}: previous_window_state.{field} != \
+             current_window_state.{field}"
+        );
+    }
 }
 
 /// App-global undo/redo manager handle, shared (Arc) between the App and every
@@ -940,8 +1149,33 @@ pub struct CommonWindowState {
     pub layout_window: Option<LayoutWindow>,
     /// Current window state
     pub current_window_state: FullWindowState,
-    /// Window state from previous frame (for diff detection)
+    /// The EVENT-DIFF baseline: the state the last completed
+    /// [`PlatformWindow::process_window_events`] pass consumed.
+    ///
+    /// `determine_all_events` derives WindowResize / WindowMove / DpiChanged /
+    /// every flag transition purely from `previous` vs `current`, so this field
+    /// has exactly ONE writer — the end of a pass (plus the pre-mutation
+    /// snapshot every injection site takes). It is NOT the OS sync baseline;
+    /// see [`Self::os_synced_state`].
     pub previous_window_state: Option<FullWindowState>,
+    /// The OS-SYNC baseline: what the window system last confirmed it has.
+    ///
+    /// `sync_window_state()` pushes the diff between this and
+    /// `current_window_state` to the OS (`XMoveWindow` / `SetWindowPos` /
+    /// `setFrameTopLeftPoint` / …) and then advances it — see
+    /// [`Self::take_os_sync_diff`].
+    ///
+    /// It exists because `previous_window_state` cannot serve both roles:
+    /// suppressing an OS echo means "make the diff zero", and event
+    /// determination reads the same diff to decide whether a `Resized` /
+    /// `DpiChanged` / maximize transition happened. One field could satisfy
+    /// only one of the two, and the echo-suppression writer won — which is
+    /// why OS-reported resizes, DPI changes and frame-flag changes never
+    /// reached a single user callback on any backend.
+    ///
+    /// `None` until the window has been shown and the baseline seeded
+    /// (`mark_os_synced()`), which is also what makes the first frame a no-op.
+    pub os_synced_state: Option<FullWindowState>,
     // NOTE: there is deliberately NO `image_cache` here. The css-id image map
     // has a single owner — `LayoutWindow::image_cache` — and a single writer,
     // `LayoutWindow::apply_content_change` (the shell copy used to be mirrored
@@ -1222,13 +1456,23 @@ impl CommonWindowState {
     /// This is the single entry point for changing `current_window_state` in a
     /// way `sync_window_state()` is aware of:
     ///   * [`App`](WindowStateSource::App) — mutates `current` only, so the
-    ///     `current` vs `previous` diff makes `sync_window_state()` push it to
-    ///     the OS (`XMoveWindow`/`SetWindowPos`/…).
+    ///     `current` vs `os_synced_state` diff makes `sync_window_state()` push
+    ///     it to the OS (`XMoveWindow`/`SetWindowPos`/…).
     ///   * [`Os`](WindowStateSource::Os) — the change is *already applied* by the
-    ///     OS, so this mutates `current` AND advances the sync baseline
-    ///     (`previous`) in lockstep, leaving a zero diff so it is never echoed.
-    ///     Echoing OS-reported geometry is what drifted the window on reparenting
-    ///     WMs (F4).
+    ///     OS, so this mutates `current` AND advances the OS-sync baseline
+    ///     (`os_synced_state`) in lockstep, leaving a zero diff so it is never
+    ///     echoed. Echoing OS-reported geometry is what drifted the window on
+    ///     reparenting WMs (F4).
+    ///
+    /// It NEVER writes `previous_window_state`. It used to, back when one field
+    /// was both baselines, and that is precisely what killed the events: the
+    /// OS reports a resize, the echo suppression zeroes the previous→current
+    /// diff, and `determine_all_events` — which derives WindowResize /
+    /// WindowMove / DpiChanged / the frame-flag transitions from exactly that
+    /// diff — sees nothing to report. `Resized` was dead on all four backends,
+    /// `DpiChanged` on Windows and Wayland, maximize/fullscreen/miniaturize on
+    /// Wayland and macOS. Advancing the event baseline is the sole business of
+    /// `process_window_events`.
     ///
     /// `apply` may run against both states, so pass a pure field assignment with
     /// no side effects.
@@ -1239,10 +1483,46 @@ impl CommonWindowState {
     ) {
         apply(&mut self.current_window_state);
         if source == WindowStateSource::Os {
-            if let Some(prev) = self.previous_window_state.as_mut() {
-                apply(prev);
+            if let Some(synced) = self.os_synced_state.as_mut() {
+                apply(synced);
             }
         }
+    }
+
+    /// Seed / advance the OS-sync baseline to the current state.
+    ///
+    /// Call it once the window exists and its state is known to match what the
+    /// window system has (right after creation, or after a sync that pushed
+    /// everything). Until it has been called at least once,
+    /// [`Self::take_os_sync_diff`] answers `None` and no geometry is pushed —
+    /// which is what makes the first frame a no-op instead of a burst of
+    /// redundant `SetWindowPos` calls.
+    pub fn mark_os_synced(&mut self) {
+        self.os_synced_state = Some(self.current_window_state.clone());
+    }
+
+    /// The OS-sync baseline, without advancing it.
+    #[must_use]
+    pub fn os_sync_baseline(&self) -> Option<&FullWindowState> {
+        self.os_synced_state.as_ref()
+    }
+
+    /// THE accessor every `sync_window_state()` opens with: `(baseline,
+    /// current)` to diff, with the baseline advanced to `current` in the same
+    /// call.
+    ///
+    /// Advancing here rather than at the end of each backend's sync is
+    /// deliberate — a baseline that some backend forgets to advance re-pushes
+    /// the same geometry every single frame, and that failure is invisible
+    /// until a WM answers the redundant push with a configure event. Returns
+    /// `None` before the baseline is seeded (see [`Self::mark_os_synced`]), so
+    /// the classic `None => return, // first frame, nothing to sync` arm still
+    /// reads the same.
+    pub fn take_os_sync_diff(&mut self) -> Option<(FullWindowState, FullWindowState)> {
+        let baseline = self.os_synced_state.take()?;
+        let current = self.current_window_state.clone();
+        self.os_synced_state = Some(current.clone());
+        Some((baseline, current))
     }
 
     /// Perform a hit test using whichever backend is available (GPU or CPU).
@@ -1472,6 +1752,40 @@ pub trait PlatformWindow {
 
     /// Set the previous window state
     fn set_previous_window_state(&mut self, state: FullWindowState);
+
+    /// Snapshot the EVENT-DIFF baseline, then mutate `current_window_state`,
+    /// then run `process_window_events` — in that order. THE call every
+    /// platform event handler opens with.
+    ///
+    /// It exists so the three-step protocol has one name instead of a
+    /// copy-pasted `let s = self.get_current_window_state().clone();
+    /// self.set_previous_window_state(s);` in every handler on four backends,
+    /// and so the R2 check below has one place to live.
+    ///
+    /// Only for TOP-LEVEL handlers (a platform event just arrived). Do not
+    /// call it from inside a pass: mid-pass the previous→current delta is the
+    /// live input being consumed, and the check would rightly object.
+    fn snapshot_window_state_baseline(&mut self, site: &str) {
+        check_input_delta_consumed(
+            self.get_previous_window_state().as_ref(),
+            self.get_current_window_state(),
+            site,
+        );
+        let current = self.get_current_window_state().clone();
+        self.set_previous_window_state(current);
+    }
+
+    /// SANCTIONED SWALLOW: a handler consumed an input itself and the delta
+    /// must NOT become an event — the scrollbar-thumb drag (routed around the
+    /// event system by design) and a key eaten by an open popup are the two
+    /// legitimate cases. Advances the event-diff baseline so
+    /// [`check_input_delta_consumed`] does not read the mutation as a lost
+    /// event. Greppable by name; every call site is an explicit, audited
+    /// exception to the snapshot→mutate→pass contract.
+    fn discard_input_delta(&mut self, _site: &str) {
+        let current = self.get_current_window_state().clone();
+        self.set_previous_window_state(current);
+    }
 
     // Resource Access
 
@@ -1959,6 +2273,38 @@ pub trait PlatformWindow {
 
     // PROVIDED: Exhaustive Callback Change Processing (Cross-Platform)
 
+    /// The C-API `DeleteBackward` / `DeleteForward` arms, routed onto the SAME
+    /// path Backspace and Delete take.
+    ///
+    /// They used to call `text3::edit::delete_backward` / `delete_forward`
+    /// against the primary CURSOR only. A Range selection was therefore
+    /// invisible to them — the C API could not delete a selection at all, it
+    /// deleted one grapheme next to the selection's cursor — nothing was
+    /// recorded for undo (the keyboard path records a `DeleteText` operation
+    /// with styled pre/post snapshots), and the caret kept blinking through
+    /// the edit. `delete_selection` is that keyboard path.
+    fn apply_capi_delete(
+        &mut self,
+        dom_id: DomId,
+        node_id: NodeId,
+        forward: bool,
+    ) -> ProcessEventResult {
+        let target = azul_core::dom::DomNodeId {
+            dom: dom_id,
+            node: NodeHierarchyItemId::from_crate_internal(Some(node_id)),
+        };
+        let now = azul_core::task::Instant::now();
+        let Some(lw) = self.get_layout_window_mut() else {
+            return ProcessEventResult::DoNothing;
+        };
+        if lw.delete_selection(target, forward).is_none() {
+            return ProcessEventResult::DoNothing;
+        }
+        // Editing keeps the caret solid while it happens, same as typing.
+        lw.text_edit_manager.blink.reset_blink_on_input(now);
+        ProcessEventResult::ShouldUpdateDisplayListCurrentWindow
+    }
+
     /// Process a single user-initiated callback change.
     ///
     /// This is the SINGLE place where all `CallbackChange` variants are handled.
@@ -2254,63 +2600,71 @@ pub trait PlatformWindow {
             // === Focus ===
 
             CallbackChange::SetFocusTarget { target } => {
-                // Resolve focus target to actual node. A failed resolution
-                // must be AUDIBLE: `.ok().flatten()` used to swallow both
-                // the Err(warning) and the matched-nothing case, and a
-                // dropped programmatic focus is indistinguishable from a
-                // working no-op (the 2026-08-11 caret hunt burned a day on
-                // exactly this silence).
-                let resolved = if let Some(lw) = self.get_layout_window() {
-                    let current_focus = lw.focus_manager.get_focused_node().copied();
-                    match azul_layout::managers::focus_cursor::resolve_focus_target(
+                // Resolve ONCE, and distinguish "matched nothing" from "there
+                // is no layout to match against yet". A failed resolution must
+                // also be AUDIBLE: `.ok().flatten()` used to swallow both the
+                // Err(warning) and the matched-nothing case, and a dropped
+                // programmatic focus is indistinguishable from a working no-op
+                // (the 2026-08-11 caret hunt burned a day on exactly this
+                // silence).
+                //
+                // The two-call version this replaces asked the same question
+                // twice and read `Ok(None)` as "clear focus" — which, before
+                // the first layout, is what silently swallowed every
+                // `set_focus` issued from a create callback.
+                use azul_layout::managers::focus_cursor::FocusResolution;
+
+                let resolution = if let Some(lw) = self.get_layout_window_mut() {
+                    azul_layout::managers::focus_cursor::resolve_focus_target_or_defer(
+                        &mut lw.focus_manager,
                         target,
                         &lw.layout_results,
-                        current_focus,
-                    ) {
-                        Ok(Some(n)) => {
-                            crate::log_debug!(
-                                crate::desktop::shell2::common::debug_server::LogCategory::Window,
-                                "[SetFocusTarget] resolved {:?} -> node {:?}",
-                                target, n
-                            );
-                            Some(n)
-                        }
-                        Ok(None) => {
-                            crate::log_warn!(
-                                crate::desktop::shell2::common::debug_server::LogCategory::Window,
-                                "[SetFocusTarget] target resolved to NO node \
-                                 (path matched nothing focusable, or layout_results empty): {:?}",
-                                target
-                            );
-                            None
-                        }
-                        Err(w) => {
-                            crate::log_warn!(
-                                crate::desktop::shell2::common::debug_server::LogCategory::Window,
-                                "[SetFocusTarget] resolution FAILED: {:?} (target {:?})",
-                                w, target
-                            );
-                            None
-                        }
-                    }
-                } else {
-                    None
-                };
-
-                // Clear focus case: target resolves to None
-                let is_clear = if let Some(lw) = self.get_layout_window() {
-                    let current_focus = lw.focus_manager.get_focused_node().copied();
-                    matches!(
-                        azul_layout::managers::focus_cursor::resolve_focus_target(
-                            target, &lw.layout_results, current_focus,
-                        ),
-                        Ok(None)
                     )
                 } else {
-                    false
+                    return ProcessEventResult::DoNothing;
                 };
 
-                if let Some(new_focus) = resolved {
+                let new_focus = match resolution {
+                    Ok(FocusResolution::Resolved(Some(n))) => {
+                        crate::log_debug!(
+                            crate::desktop::shell2::common::debug_server::LogCategory::Window,
+                            "[SetFocusTarget] resolved {:?} -> node {:?}",
+                            target, n
+                        );
+                        Some(n)
+                    }
+                    Ok(FocusResolution::Resolved(None)) => {
+                        crate::log_debug!(
+                            crate::desktop::shell2::common::debug_server::LogCategory::Window,
+                            "[SetFocusTarget] target resolved to NO node — clearing focus: {:?}",
+                            target
+                        );
+                        None
+                    }
+                    Ok(FocusResolution::Deferred) => {
+                        // No layout yet: the target is queued on the focus
+                        // manager and re-resolved by the next
+                        // finalize_pending_focus_changes(). Touching focus here
+                        // — in either direction — is what made a create-callback
+                        // set_focus vanish.
+                        crate::log_debug!(
+                            crate::desktop::shell2::common::debug_server::LogCategory::Window,
+                            "[SetFocusTarget] focus target queued until first layout: {:?}",
+                            target
+                        );
+                        return ProcessEventResult::DoNothing;
+                    }
+                    Err(w) => {
+                        crate::log_warn!(
+                            crate::desktop::shell2::common::debug_server::LogCategory::Window,
+                            "[SetFocusTarget] resolution FAILED: {:?} (target {:?})",
+                            w, target
+                        );
+                        return ProcessEventResult::DoNothing;
+                    }
+                };
+
+                if let Some(new_focus) = new_focus {
                     // Focus a specific node
                     let timer_action = if let Some(lw) = self.get_layout_window_mut() {
                         lw.focus_manager.set_focused_node(Some(new_focus));
@@ -2346,7 +2700,7 @@ pub trait PlatformWindow {
                         }
                     }
                     ProcessEventResult::ShouldReRenderCurrentWindow
-                } else if is_clear {
+                } else {
                     // Clear focus
                     let timer_action = if let Some(lw) = self.get_layout_window_mut() {
                         lw.focus_manager.set_focused_node(None);
@@ -2369,8 +2723,6 @@ pub trait PlatformWindow {
                         }
                     }
                     ProcessEventResult::ShouldReRenderCurrentWindow
-                } else {
-                    ProcessEventResult::DoNothing
                 }
             }
 
@@ -2805,36 +3157,22 @@ pub trait PlatformWindow {
             }
 
             CallbackChange::DeleteBackward { dom_id, node_id } => {
-                if let Some(lw) = self.get_layout_window_mut() {
-                    if let Some(cursor) = lw.text_edit_manager.get_primary_cursor() {
-                        let content = lw.get_text_before_textinput(*dom_id, *node_id);
-                        use azul_layout::text3::edit::delete_backward;
-                        let mut new_content = content.clone();
-                        let (updated_content, new_cursor) = delete_backward(&new_content, &cursor);
-                        if let Some(ref mut mc) = lw.text_edit_manager.multi_cursor { mc.set_single_cursor(new_cursor); }
-                        lw.update_text_cache_after_edit(*dom_id, *node_id, updated_content);
-                    } 
-                } 
-                ProcessEventResult::ShouldUpdateDisplayListCurrentWindow
+                self.apply_capi_delete(*dom_id, *node_id, false)
             }
 
             CallbackChange::DeleteForward { dom_id, node_id } => {
-                if let Some(lw) = self.get_layout_window_mut() {
-                    if let Some(cursor) = lw.text_edit_manager.get_primary_cursor() {
-                        let content = lw.get_text_before_textinput(*dom_id, *node_id);
-                        use azul_layout::text3::edit::delete_forward;
-                        let mut new_content = content.clone();
-                        let (updated_content, new_cursor) = delete_forward(&new_content, &cursor);
-                        if let Some(ref mut mc) = lw.text_edit_manager.multi_cursor { mc.set_single_cursor(new_cursor); }
-                        lw.update_text_cache_after_edit(*dom_id, *node_id, updated_content);
-                    }
-                }
-                ProcessEventResult::ShouldUpdateDisplayListCurrentWindow
+                self.apply_capi_delete(*dom_id, *node_id, true)
             }
 
-            CallbackChange::MoveCursor { dom_id: _, node_id: _, cursor } => {
+            CallbackChange::MoveCursor { dom_id, node_id, cursor } => {
+                // Same route as every MoveCursor{Left,Right,…} arm. Setting the
+                // cursor straight on the multi-cursor state skipped the display
+                // list rebuild `handle_cursor_movement` does, so a programmatic
+                // move repainted the OLD caret position. `extend_selection` is
+                // false because this variant carries an absolute cursor, not a
+                // movement.
                 if let Some(lw) = self.get_layout_window_mut() {
-                    if let Some(ref mut mc) = lw.text_edit_manager.multi_cursor { mc.set_single_cursor(*cursor); }
+                    lw.handle_cursor_movement(*dom_id, *node_id, *cursor, false);
                 }
                 ProcessEventResult::ShouldReRenderCurrentWindow
             }
@@ -3166,13 +3504,26 @@ pub trait PlatformWindow {
                 }).collect();
 
                 let mut result = ProcessEventResult::DoNothing;
+                let mut text_prevented = false;
 
                 if !text_events.is_empty() {
-                    let (text_changes_result, text_update, _) = self.dispatch_events_propagated(&text_events);
+                    let (text_changes_result, text_update, text_prevent_default) =
+                        self.dispatch_events_propagated(&text_events);
+                    text_prevented = text_prevent_default;
                     result = result.max_self(text_changes_result);
                     if matches!(text_update, Update::RefreshDom | Update::RefreshDomAllWindows) {
                         result = result.max_self(ProcessEventResult::ShouldRegenerateDomCurrentWindow);
                     }
+                }
+
+                // A callback veto (preventDefault / TextInputValid::No) kills
+                // the recorded edit — clearing it also stops the NEXT pass's
+                // unconditional apply from landing it late.
+                if text_prevented {
+                    if let Some(lw) = self.get_layout_window_mut() {
+                        lw.text_input_manager.clear_changeset();
+                    }
+                    return result;
                 }
 
                 // Apply text changeset
@@ -3736,11 +4087,22 @@ pub trait PlatformWindow {
                             // N lines → N cursors: use edit_text_multi
                             if let Some(ref mc) = layout_window.text_edit_manager.multi_cursor {
                                 let dom_id = mc.node_id.dom;
+                                let target = mc.node_id;
                                 if let Some(node_id) = mc.node_id.node.into_crate_internal() {
                                     let content = layout_window.get_text_before_textinput(dom_id, node_id);
                                     let selections = mc.to_selections();
                                     let (new_content, new_sels) = azul_layout::text3::edit::edit_text_multi(
                                         &content, &selections, &lines,
+                                    );
+                                    // Smart paste is an EDIT and has to be
+                                    // undoable: it bypasses both recording
+                                    // sites (apply_text_changeset for typing,
+                                    // delete_selection for deletions), so
+                                    // Ctrl+Z after a multi-cursor paste used
+                                    // to undo whatever came before it instead.
+                                    record_multi_edit_undo(
+                                        layout_window, target, node_id,
+                                        &content, &new_content, &selections,
                                     );
                                     if let Some(ref mut mc) = layout_window.text_edit_manager.multi_cursor {
                                         mc.update_from_edit_result(&new_sels);
@@ -3763,43 +4125,151 @@ pub trait PlatformWindow {
             }
 
             SystemChange::SelectAllText => {
-                // Select all text in the focused contenteditable node
-                if let Some(layout_window) = self.get_layout_window_mut() {
-                    if let Some(focused_node) = layout_window.focus_manager.focused_node {
-                        let dom_id = focused_node.dom;
-                        if let Some(node_id) = focused_node.node.into_crate_internal() {
-                            let range = layout_window.get_inline_layout_for_node(dom_id, node_id)
-                                .and_then(|layout| {
-                                    let start = layout.get_first_cluster_cursor()?;
-                                    let end = layout.get_last_cluster_cursor()?;
-                                    Some(azul_core::selection::SelectionRange { start, end })
-                                });
+                // Ctrl+A over a MULTI-BLOCK editable, not just the one IFC the
+                // focus happens to sit on. The old arm built its range from
+                // `get_inline_layout_for_node(focused_node)` alone, so a
+                // container whose children are paragraphs has no inline layout
+                // of its own and select-all did NOTHING at all — while the
+                // engine has carried cross-block selection (the same machinery
+                // drag-select and Cut/Copy use) the whole time.
+                let Some(focused_node) = self
+                    .get_layout_window()
+                    .and_then(|lw| lw.focus_manager.focused_node)
+                else {
+                    return ProcessEventResult::DoNothing;
+                };
+                let dom_id = focused_node.dom;
+                let Some(node_id) = focused_node.node.into_crate_internal() else {
+                    return ProcessEventResult::DoNothing;
+                };
 
-                            if let Some(range) = range {
-                                let did_set = if let Some(ref mut mc) = layout_window.text_edit_manager.multi_cursor {
-                                    // Select the whole content as ONE range. The caret
-                                    // sits at range.end (last cluster) implicitly. Do NOT
-                                    // follow with set_single_cursor — that collapsed the
-                                    // selection, turning Ctrl+A into a no-op "move caret to
-                                    // end" instead of select-all.
-                                    mc.set_single_range(range);
-                                    true
-                                } else {
-                                    false
-                                };
-                                if did_set {
-                                    // Rebuild the display list so the selection HIGHLIGHT is
-                                    // actually drawn (build_text_selections_map runs inside).
-                                    // Without this, ShouldUpdateDisplayListCurrentWindow only
-                                    // re-renders the stale display list, so the range is set
-                                    // functionally but stays invisible. Mirrors
-                                    // apply_selection_op (Shift+Arrow), which regenerates for
-                                    // exactly this reason.
-                                    layout_window.regenerate_display_list_for_dom(dom_id);
-                                    return ProcessEventResult::ShouldUpdateDisplayListCurrentWindow;
-                                }
+                // The blocks to cover, rooted at the editing HOST: with focus
+                // on one paragraph INSIDE a multi-paragraph contenteditable,
+                // Ctrl+A must still cover the whole editable — so walk up to
+                // the outermost node whose contenteditable-ness the focus
+                // inherits, and select from there. A non-editable focus keeps
+                // the focused node as its root (unchanged behavior).
+                //
+                // Root's own IFC (a text input / a single paragraph) → that
+                // one block; otherwise its ELEMENT children that are IFC
+                // roots — the paragraph chain of a contenteditable container.
+                // Text children are skipped: XML pretty-printing whitespace
+                // is not a block, and a raw text run cannot anchor a
+                // cross-block selection.
+                let blocks: Vec<NodeId> = {
+                    let Some(lw) = self.get_layout_window() else {
+                        return ProcessEventResult::DoNothing;
+                    };
+                    let sel_root = lw
+                        .find_contenteditable_host(dom_id, node_id)
+                        .unwrap_or(node_id);
+                    if lw.get_inline_layout_for_node(dom_id, sel_root).is_some() {
+                        vec![sel_root]
+                    } else {
+                        let Some(lr) = lw.layout_results.get(&dom_id) else {
+                            return ProcessEventResult::DoNothing;
+                        };
+                        let hierarchy = lr.styled_dom.node_hierarchy.as_container();
+                        let node_data = lr.styled_dom.node_data.as_container();
+                        let mut out = Vec::new();
+                        let mut child = hierarchy[sel_root].first_child_id(sel_root);
+                        while let Some(c) = child {
+                            let is_text = matches!(
+                                node_data[c].get_node_type(),
+                                azul_core::dom::NodeType::Text(_)
+                            );
+                            if !is_text && lw.get_inline_layout_for_node(dom_id, c).is_some() {
+                                out.push(c);
                             }
+                            child = hierarchy[c].next_sibling_id();
                         }
+                        out
+                    }
+                };
+
+                let (Some(&first), Some(&last)) = (blocks.first(), blocks.last()) else {
+                    return ProcessEventResult::DoNothing;
+                };
+
+                // Endpoint cursors come from the LAYOUT (real grapheme
+                // clusters); a byte-length synthetic end cursor resolves to
+                // nothing in get_selection_rects and the block silently loses
+                // its highlight.
+                let cursors = self.get_layout_window().and_then(|lw| {
+                    let start = lw
+                        .get_inline_layout_for_node(dom_id, first)?
+                        .get_first_cluster_cursor()?;
+                    let end = lw
+                        .get_inline_layout_for_node(dom_id, last)?
+                        .get_last_cluster_cursor()?;
+                    Some((start, end))
+                });
+                let Some((start_cursor, end_cursor)) = cursors else {
+                    return ProcessEventResult::DoNothing;
+                };
+
+                if first != last {
+                    // Cross-block: the engine precomputes the per-IFC ranges
+                    // (anchor tail, full middles, focus head) and stores them
+                    // render-ready, where the display-list pass picks them up
+                    // through build_text_selections_map.
+                    let set = self
+                        .get_layout_window_mut()
+                        .is_some_and(|lw| {
+                            lw.set_cross_block_selection(
+                                dom_id, first, start_cursor, last, end_cursor,
+                            )
+                        });
+                    if set {
+                        if let Some(lw) = self.get_layout_window_mut() {
+                            lw.regenerate_display_list_for_dom(dom_id);
+                        }
+                        return ProcessEventResult::ShouldUpdateDisplayListCurrentWindow;
+                    }
+                    // Not a sibling chain (nested / mixed containers): fall
+                    // through to selecting the first block rather than nothing.
+                }
+
+                let range = azul_core::selection::SelectionRange {
+                    start: start_cursor,
+                    end: if first == last {
+                        end_cursor
+                    } else {
+                        // Single-block fallback: end at the FIRST block's end.
+                        match self
+                            .get_layout_window()
+                            .and_then(|lw| lw.get_inline_layout_for_node(dom_id, first))
+                            .and_then(|l| l.get_last_cluster_cursor())
+                        {
+                            Some(c) => c,
+                            None => return ProcessEventResult::DoNothing,
+                        }
+                    },
+                };
+
+                if let Some(lw) = self.get_layout_window_mut() {
+                    lw.text_edit_manager.clear_cross_block_selection();
+                    let did_set = if let Some(ref mut mc) = lw.text_edit_manager.multi_cursor {
+                        // Select the whole content as ONE range. The caret
+                        // sits at range.end (last cluster) implicitly. Do NOT
+                        // follow with set_single_cursor — that collapsed the
+                        // selection, turning Ctrl+A into a no-op "move caret to
+                        // end" instead of select-all.
+                        mc.set_single_range(range);
+                        true
+                    } else {
+                        false
+                    };
+                    if did_set {
+                        // Rebuild the display list so the selection HIGHLIGHT is
+                        // actually drawn (build_text_selections_map runs inside).
+                        // Without this, ShouldUpdateDisplayListCurrentWindow only
+                        // re-renders the stale display list, so the range is set
+                        // functionally but stays invisible. Mirrors
+                        // apply_selection_op (Shift+Arrow), which regenerates for
+                        // exactly this reason.
+                        lw.regenerate_display_list_for_dom(dom_id);
+                        return ProcessEventResult::ShouldUpdateDisplayListCurrentWindow;
                     }
                 }
                 ProcessEventResult::DoNothing
@@ -4219,6 +4689,26 @@ pub trait PlatformWindow {
             }
 
             SystemChange::FinalizePendingFocusChanges => {
+                // A `set_focus` issued before the first layout (a create
+                // callback, most commonly) is parked on the focus manager and
+                // recovered here. It is drained BEFORE the gate below, not
+                // inside `finalize_pending_focus_changes`, for two reasons:
+                // that call only happens when `needs_cursor_initialization()`
+                // is already set — which a deferred target does not set — and
+                // only the shell can arm a real OS blink timer. The engine can
+                // put the `Timer` in its own map, which is all a headless / E2E
+                // host needs and nothing a desktop shell does.
+                let deferred_blink = self
+                    .get_layout_window_mut()
+                    .and_then(azul_layout::window::LayoutWindow::drain_deferred_focus_target);
+                if let Some(timer) = deferred_blink {
+                    if let Some(lw) = self.get_layout_window_mut() {
+                        lw.timers
+                            .insert(azul_core::task::CURSOR_BLINK_TIMER_ID, timer.clone());
+                    }
+                    self.start_timer(azul_core::task::CURSOR_BLINK_TIMER_ID.id, timer);
+                }
+
                 let timer_creation_needed = if let Some(layout_window) = self.get_layout_window_mut() {
                     let needs_init = layout_window.focus_manager.needs_cursor_initialization();
                     if needs_init {
@@ -4291,57 +4781,19 @@ pub trait PlatformWindow {
             }
 
             SystemChange::ScrollCursorIntoViewAfterTextInput => {
-                if let Some(layout_window) = self.get_layout_window() {
-                    if let Some(cursor_rect) = layout_window.get_focused_cursor_rect() {
-                        if let Some(focused_node_id) = layout_window.focus_manager.focused_node {
-                            if let Some(scroll_container) = layout_window.find_scrollable_ancestor(focused_node_id) {
-                                let scroll_node_id = scroll_container.node.into_crate_internal();
-                                if let Some(scroll_node_id) = scroll_node_id {
-                                    if let Some(scroll_state) = layout_window.scroll_manager
-                                        .get_scroll_state(scroll_container.dom, scroll_node_id) {
-                                        if let Some(container_rect) = layout_window.get_node_layout_rect(scroll_container) {
-                                            let visible_area = azul_core::geom::LogicalRect::new(
-                                                azul_core::geom::LogicalPosition::new(
-                                                    container_rect.origin.x + scroll_state.current_offset.x,
-                                                    container_rect.origin.y + scroll_state.current_offset.y,
-                                                ),
-                                                container_rect.size,
-                                            );
-
-                                            const SCROLL_PADDING: f32 = 5.0;
-                                            let mut scroll_delta = azul_core::geom::LogicalPosition::zero();
-
-                                            if cursor_rect.origin.x < visible_area.origin.x + SCROLL_PADDING {
-                                                scroll_delta.x = cursor_rect.origin.x - (visible_area.origin.x + SCROLL_PADDING);
-                                            } else if cursor_rect.origin.x + cursor_rect.size.width > visible_area.origin.x + visible_area.size.width - SCROLL_PADDING {
-                                                scroll_delta.x = (cursor_rect.origin.x + cursor_rect.size.width) - (visible_area.origin.x + visible_area.size.width - SCROLL_PADDING);
-                                            }
-
-                                            if cursor_rect.origin.y < visible_area.origin.y + SCROLL_PADDING {
-                                                scroll_delta.y = cursor_rect.origin.y - (visible_area.origin.y + SCROLL_PADDING);
-                                            } else if cursor_rect.origin.y + cursor_rect.size.height > visible_area.origin.y + visible_area.size.height - SCROLL_PADDING {
-                                                scroll_delta.y = (cursor_rect.origin.y + cursor_rect.size.height) - (visible_area.origin.y + visible_area.size.height - SCROLL_PADDING);
-                                            }
-
-                                            if scroll_delta.x != 0.0 || scroll_delta.y != 0.0 {
-                                                let external = ExternalSystemCallbacks::rust_internal();
-                                                let now = (external.get_system_time_fn.cb)();
-
-                                                if let Some(layout_window_mut) = self.get_layout_window_mut() {
-                                                    layout_window_mut.scroll_manager.scroll_by(
-                                                        scroll_container.dom, scroll_node_id, scroll_delta,
-                                                        std::time::Duration::from_millis(0).into(),
-                                                        azul_core::events::EasingFunction::Linear,
-                                                        now,
-                                                    );
-                                                    return ProcessEventResult::ShouldReRenderCurrentWindow;
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
+                // The canonical reveal, not a second one. This arm used to
+                // carry its own inline copy — 5px padding, an INSTANT
+                // `scroll_manager.scroll_by`, blind to `caret_scroll_glide` —
+                // while `CreateTextInput` already called
+                // `scroll_selection_into_view` for the same keystroke. Typing
+                // therefore issued TWO reveals per pass with different
+                // semantics, and the one the user saw was whichever ran last.
+                if let Some(layout_window) = self.get_layout_window_mut() {
+                    if layout_window.scroll_selection_into_view(
+                        azul_layout::window::SelectionScrollType::Cursor,
+                        azul_layout::window::ScrollMode::Instant,
+                    ) {
+                        return ProcessEventResult::ShouldReRenderCurrentWindow;
                     }
                 }
                 ProcessEventResult::DoNothing
@@ -6100,6 +6552,14 @@ pub trait PlatformWindow {
             if r >= ProcessEventResult::ShouldReRenderCurrentWindow {
                 should_recurse = true;
             }
+        } else if prevent_default {
+            // A vetoed edit must DIE, not wait: the pending record would
+            // otherwise survive into the next pass, whose unconditional apply
+            // would land the vetoed character late (e.g. on the next mouse
+            // move). `clear_changeset`'s doc always promised this call.
+            if let Some(lw) = self.get_layout_window_mut() {
+                lw.text_input_manager.clear_changeset();
+            }
         }
 
         // MOUSE CLICK-TO-FOCUS (W3C default behavior)
@@ -6221,6 +6681,43 @@ pub trait PlatformWindow {
                                 synthetic_click_target = Some(*target);
                             }
 
+                            DefaultAction::InsertLineBreakAtCursor { target } => {
+                                // Plain-text Enter / Shift+Enter: a literal
+                                // "\n" through the standard text pipeline.
+                                // The apply tail already ran this pass, so
+                                // record + apply directly (same two system
+                                // changes the tail uses). Runs only under
+                                // !prevent_default, so the veto is honored;
+                                // undo + caret-follow come from the changeset
+                                // path itself.
+                                if let Some(lw) = self.get_layout_window_mut() {
+                                    if let Some(node_id) = target.node.into_crate_internal() {
+                                        let old_inline = lw.get_text_before_textinput(target.dom, node_id);
+                                        let old_text = lw.extract_text_from_inline_content(&old_inline);
+                                        use azul_layout::managers::text_input::TextInputSource;
+                                        lw.text_input_manager.record_input(
+                                            *target,
+                                            "\n".to_string(),
+                                            old_text,
+                                            TextInputSource::Keyboard,
+                                        );
+                                    }
+                                }
+                                let r = self.apply_system_change(&SystemChange::ApplyTextChangeset);
+                                result = result.max(r);
+                                let r = self.apply_system_change(
+                                    &SystemChange::ScrollCursorIntoViewAfterTextInput,
+                                );
+                                result = result.max(r);
+                                // Applied outside the record pipeline's event
+                                // window — owe the host its Input dispatch.
+                                if let Some(lw) = self.get_layout_window_mut() {
+                                    lw.text_edit_manager
+                                        .pending_edit_notifications
+                                        .push(*target);
+                                }
+                            }
+
                             DefaultAction::SplitBlockAtCursor { .. }
                             | DefaultAction::MergeWithPrevious { .. }
                             | DefaultAction::MergeWithNext { .. } => {
@@ -6308,6 +6805,41 @@ pub trait PlatformWindow {
                             }
                         }
                     }
+                }
+            }
+        }
+
+        // TEXT-EDIT NOTIFICATIONS: edits committed OUTSIDE the text-input
+        // record pipeline this pass (deletions, multi-cursor paste, the Enter
+        // line break) dispatch their Input event here, so widget mirrors
+        // observe every committed edit, not only insertions.
+        {
+            let pending = self
+                .get_layout_window_mut()
+                .map(azul_layout::window::LayoutWindow::take_text_edit_notifications)
+                .unwrap_or_default();
+            if !pending.is_empty() {
+                let now = azul_core::task::Instant::now();
+                let edit_events: Vec<_> = pending
+                    .into_iter()
+                    .map(|host| {
+                        azul_core::events::SyntheticEvent::new(
+                            azul_core::events::EventType::Input,
+                            azul_core::events::EventSource::User,
+                            host,
+                            now.clone(),
+                            azul_core::events::EventData::None,
+                        )
+                    })
+                    .collect();
+                let (edit_result, edit_update, _) = self.dispatch_events_propagated(&edit_events);
+                result = result.max(edit_result);
+                if matches!(
+                    edit_update,
+                    azul_core::callbacks::Update::RefreshDom
+                        | azul_core::callbacks::Update::RefreshDomAllWindows
+                ) {
+                    result = result.max(ProcessEventResult::ShouldRegenerateDomCurrentWindow);
                 }
             }
         }
@@ -6514,6 +7046,16 @@ pub trait PlatformWindow {
     /// ```
     fn process_timers_and_threads(&mut self) -> bool {
         use azul_core::callbacks::Update;
+
+        // R2: every backend calls this from its frame loop at TOP level, never
+        // from inside a pass — which makes it the one shared point where a
+        // delta some platform handler left unconsumed is still observable
+        // before the next handler's snapshot erases it.
+        check_input_delta_consumed(
+            self.get_previous_window_state().as_ref(),
+            self.get_current_window_state(),
+            "process_timers_and_threads",
+        );
 
         let (timer_changes_result, timer_results) = self.invoke_expired_timers();
         let mut max_changes_result = timer_changes_result;
@@ -6892,6 +7434,19 @@ pub trait PlatformWindow {
                 || *t == azul_core::task::LONG_PRESS_TIMER_ID
         });
 
+        // MWA-B8b: a drag-autoscroll frame moves the VIEW; the selection
+        // endpoint has to travel with it, which is what every native editor
+        // does. Extension used to ride on `MouseOver` alone — which needs
+        // pointer MOTION *and* a hovered hit node — so holding the pointer
+        // still past the window edge scrolled the container with the
+        // selection frozen at wherever it was when the pointer stopped.
+        // It happens here, not in `auto_scroll_timer_callback`, because a
+        // timer callback only has an immutable `CallbackInfo` and there is no
+        // `CallbackChange` that carries a drag extension.
+        let drag_autoscroll_fired = expired_timer_ids
+            .iter()
+            .any(|t| *t == azul_core::task::DRAG_AUTOSCROLL_TIMER_ID);
+
         let mut all_results = Vec::new();
         let mut changes_result = ProcessEventResult::DoNothing;
 
@@ -6929,6 +7484,34 @@ pub trait PlatformWindow {
             }
 
             all_results.push(update);
+        }
+
+        if drag_autoscroll_fired {
+            // The pointer is the drag focus wherever it is — OutOfWindow
+            // coordinates are valid input here for the same reason the timer
+            // itself accepts them (dragging past the edge is the whole point).
+            let pointer = match &self.get_current_window_state().mouse_state.cursor_position {
+                azul_core::window::CursorPosition::InWindow(p)
+                | azul_core::window::CursorPosition::OutOfWindow(p) => Some(*p),
+                azul_core::window::CursorPosition::Uninitialized => None,
+            };
+            let held = self.get_current_window_state().mouse_state.left_down;
+            // A node drag suppresses text selection — the same gate
+            // SystemChange::TextSelectionDrag applies.
+            let node_dragging = self
+                .get_layout_window()
+                .is_some_and(|lw| lw.gesture_drag_manager.is_node_drag_active());
+            if held && !node_dragging {
+                if let (Some(pointer), Some(lw)) = (pointer, self.get_layout_window_mut()) {
+                    // The anchor lives on the multi-cursor state, so the start
+                    // argument is unused; a missing editing session makes this
+                    // a no-op, which is what a node/file drag wants.
+                    if lw.process_mouse_drag_for_selection(pointer, pointer).is_some() {
+                        changes_result = changes_result
+                            .max(ProcessEventResult::ShouldUpdateDisplayListCurrentWindow);
+                    }
+                }
+            }
         }
 
         if capability_pump_fired {

--- a/dll/src/desktop/shell2/common/layout.rs
+++ b/dll/src/desktop/shell2/common/layout.rs
@@ -39,68 +39,107 @@ const SCROLLBAR_FADE_DURATION_MS: u64 = 200;
 
 fn register_scroll_nodes(layout_window: &mut LayoutWindow) {
     let now: azul_core::task::Instant = std::time::Instant::now().into();
-    for (dom_id, layout_result) in &layout_window.layout_results {
-        for (node_idx, node) in layout_result.layout_tree.nodes.iter().enumerate() {
-            let scrollbar_info = layout_result.layout_tree.warm(node_idx)
-                .and_then(|w| w.scrollbar_info.as_ref());
-            if let Some(scrollbar_info) = scrollbar_info {
-                if scrollbar_info.needs_vertical || scrollbar_info.needs_horizontal {
-                    if let Some(dom_node_id) = node.dom_node_id {
-                        // CSS spec: scrolling occurs within the padding box, so the
-                        // viewport for scroll clamp must be padding-box, not content-box.
-                        // This must match compute_scrollbar_geometry() which also uses
-                        // padding-box (inner_rect = paint_rect - borders).
-                        let border_box_size = node.used_size.unwrap_or_default();
-                        let resolved = node.box_props.unpack();
-                        let border = &resolved.border;
-                        let container_size = azul_core::geom::LogicalSize {
-                            width: (border_box_size.width
-                                    - border.left - border.right).max(0.0),
-                            height: (border_box_size.height
-                                     - border.top - border.bottom).max(0.0),
-                        };
+    for (dom_id, layout_result) in &mut layout_window.layout_results {
+        // What the VirtualView callbacks published for this DOM, read the way
+        // `display_list::paint_scrollbars` reads it — same producer, same
+        // `children_rect.size`, so the two cannot disagree about the extent.
+        // Snapshotted before the registration loop mutates the manager;
+        // registration never touches `virtual_scroll_size`.
+        let scroll_states = layout_window.scroll_manager.get_scroll_states_for_dom(*dom_id);
 
-                        // container_rect must use absolute window coordinates,
-                        // not (0,0), so scroll_into_view calculations are correct.
-                        let container_origin = layout_result
-                            .calculated_positions
-                            .get(node_idx)
-                            .copied()
-                            .unwrap_or_else(azul_core::geom::LogicalPosition::zero);
+        for node_idx in 0..layout_result.layout_tree.nodes.len() {
+            let node = &layout_result.layout_tree.nodes[node_idx];
+            let Some(dom_node_id) = node.dom_node_id else {
+                continue;
+            };
 
-                        let container_rect = azul_core::geom::LogicalRect {
-                            origin: container_origin,
-                            size: container_size,
-                        };
+            // CSS spec: scrolling occurs within the padding box, so the
+            // viewport for scroll clamp must be padding-box, not content-box.
+            // This must match compute_scrollbar_geometry() which also uses
+            // padding-box (inner_rect = paint_rect - borders).
+            let border_box_size = node.used_size.unwrap_or_default();
+            let resolved = node.box_props.unpack();
+            let border = &resolved.border;
+            let container_size = azul_core::geom::LogicalSize {
+                width: (border_box_size.width
+                        - border.left - border.right).max(0.0),
+                height: (border_box_size.height
+                         - border.top - border.bottom).max(0.0),
+            };
 
-                        let content_size = layout_result.layout_tree.get_content_size(node_idx);
+            // container_rect must use absolute window coordinates,
+            // not (0,0), so scroll_into_view calculations are correct.
+            let container_origin = layout_result
+                .calculated_positions
+                .get(node_idx)
+                .copied()
+                .unwrap_or_else(azul_core::geom::LogicalPosition::zero);
 
-                        // Use the layout-computed scrollbar width, not the
-                        // hardcoded default. On macOS with overlay scrollbars,
-                        // scrollbar_width is 0.0 (no layout space reserved).
-                        // The scroll_manager falls back to DEFAULT_SCROLLBAR_WIDTH_PX
-                        // when thickness is 0 for hit-test geometry.
-                        let scrollbar_thickness = scrollbar_info.scrollbar_width
-                            .max(scrollbar_info.scrollbar_height);
+            let Some(mut scrollbar_info) = layout_result
+                .layout_tree
+                .warm(node_idx)
+                .and_then(|w| w.scrollbar_info)
+            else {
+                continue;
+            };
 
-                        layout_window.scroll_manager.register_or_update_scroll_node(
-                            *dom_id,
-                            dom_node_id,
-                            container_rect,
-                            content_size,
-                            now.clone(),
-                            scrollbar_thickness,
-                            scrollbar_info.visual_width_px,
-                            scrollbar_info.needs_horizontal,
-                            scrollbar_info.needs_vertical,
-                        );
-
-                        log_debug!(LogCategory::Layout,
-                            "[register_scroll_nodes] Registered scroll node: dom={:?} node={:?} container={:?} content={:?}",
-                            dom_id, dom_node_id, container_size, content_size);
+            // A VirtualView's scrollable extent does not exist during layout —
+            // it is whatever its callback just published. Amend the flags here,
+            // where both the tree and the ScrollManager are in reach, and store
+            // the answer back so every later consumer (the GPU thumb updater
+            // `update_scrollbar_transforms`, the registration below, the
+            // hit-test scrollbar states) reads one decision rather than
+            // re-deriving it. `paint_scrollbars` calls the same function while
+            // building the display list, which is why the numbers agree.
+            if let Some(pos) = scroll_states.get(&dom_node_id) {
+                let raised = azul_layout::solver3::cache::apply_virtual_scroll_necessity(
+                    &layout_result.styled_dom,
+                    dom_node_id,
+                    pos.children_rect.size,
+                    container_size,
+                    &mut scrollbar_info,
+                );
+                if raised {
+                    if let Some(warm) = layout_result.layout_tree.warm_mut(node_idx) {
+                        warm.scrollbar_info = Some(scrollbar_info);
                     }
                 }
             }
+
+            if !(scrollbar_info.needs_vertical || scrollbar_info.needs_horizontal) {
+                continue;
+            }
+
+            let container_rect = azul_core::geom::LogicalRect {
+                origin: container_origin,
+                size: container_size,
+            };
+
+            let content_size = layout_result.layout_tree.get_content_size(node_idx);
+
+            // Use the layout-computed scrollbar width, not the
+            // hardcoded default. On macOS with overlay scrollbars,
+            // scrollbar_width is 0.0 (no layout space reserved).
+            // The scroll_manager falls back to DEFAULT_SCROLLBAR_WIDTH_PX
+            // when thickness is 0 for hit-test geometry.
+            let scrollbar_thickness = scrollbar_info.scrollbar_width
+                .max(scrollbar_info.scrollbar_height);
+
+            layout_window.scroll_manager.register_or_update_scroll_node(
+                *dom_id,
+                dom_node_id,
+                container_rect,
+                content_size,
+                now.clone(),
+                scrollbar_thickness,
+                scrollbar_info.visual_width_px,
+                scrollbar_info.needs_horizontal,
+                scrollbar_info.needs_vertical,
+            );
+
+            log_debug!(LogCategory::Layout,
+                "[register_scroll_nodes] Registered scroll node: dom={:?} node={:?} container={:?} content={:?}",
+                dom_id, dom_node_id, container_size, content_size);
         }
     }
     layout_window.scroll_manager.calculate_scrollbar_states();
@@ -1279,6 +1318,17 @@ phases.mark("after_layout_and_dl");
     azul_layout::probe::emit_phase_heap("end");
 phases.mark("end");
     phases.report();
+
+    // A focus parked before the FIRST layout (a create callback, most
+    // commonly) is applied right after the layout that made it resolvable,
+    // so the caret is seeded in this very frame instead of one event pass
+    // later. The blink Timer lands in the engine's timer map; the OS blink
+    // timer is armed by the next pass's FinalizePendingFocusChanges arm,
+    // which on a desktop shell arrives with the window's first real event.
+    // The e2e runner performs the same call at its layout tail (parity).
+    if layout_window.focus_manager.has_deferred_focus_target() {
+        layout_window.finalize_pending_focus_changes();
+    }
 
     Ok(LayoutRegenerateResult::LayoutChanged)
 }

--- a/dll/src/desktop/shell2/common/layout.rs
+++ b/dll/src/desktop/shell2/common/layout.rs
@@ -6,6 +6,7 @@
 //! The regenerate_layout function takes direct field references instead of using trait methods
 //! to avoid borrow checker issues (similar to invoke_callbacks pattern).
 
+use azul_layout::solver3::LayoutNodeId;
 use std::{cell::RefCell, sync::Arc};
 
 use azul_core::{
@@ -77,7 +78,7 @@ fn register_scroll_nodes(layout_window: &mut LayoutWindow) {
 
             let Some(mut scrollbar_info) = layout_result
                 .layout_tree
-                .warm(node_idx)
+                .warm(LayoutNodeId::new(node_idx))
                 .and_then(|w| w.scrollbar_info)
             else {
                 continue;
@@ -100,7 +101,7 @@ fn register_scroll_nodes(layout_window: &mut LayoutWindow) {
                     &mut scrollbar_info,
                 );
                 if raised {
-                    if let Some(warm) = layout_result.layout_tree.warm_mut(node_idx) {
+                    if let Some(warm) = layout_result.layout_tree.warm_mut(LayoutNodeId::new(node_idx)) {
                         warm.scrollbar_info = Some(scrollbar_info);
                     }
                 }
@@ -115,7 +116,7 @@ fn register_scroll_nodes(layout_window: &mut LayoutWindow) {
                 size: container_size,
             };
 
-            let content_size = layout_result.layout_tree.get_content_size(node_idx);
+            let content_size = layout_result.layout_tree.get_content_size(LayoutNodeId::new(node_idx));
 
             // Use the layout-computed scrollbar width, not the
             // hardcoded default. On macOS with overlay scrollbars,

--- a/dll/src/desktop/shell2/headless/mod.rs
+++ b/dll/src/desktop/shell2/headless/mod.rs
@@ -2779,7 +2779,7 @@ mod tests {
             .map(|s| s.label.clone())
             .unwrap_or_default();
         Dom::create_body()
-            .with_child(Dom::create_div().with_child(Dom::create_text(label.as_str())))
+            .with_child(Dom::create_div().with_child(Dom::create_text_do_not_use_without_block_level_wrapper(label.as_str())))
     }
 
     /// One embedded font for the whole harness. Using a bundled font instead of
@@ -2952,7 +2952,7 @@ mod tests {
                     ]
                     .into(),
                 )
-                .with_child(Dom::create_text(text))
+                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper(text))
         };
         let spacer = Dom::create_div().with_css_props(
             vec![C::simple(CssProperty::flex_grow(LayoutFlexGrow::const_new(1)))].into(),
@@ -2973,7 +2973,7 @@ mod tests {
             .with_css_props(
                 vec![C::simple(CssProperty::text_align(StyleTextAlign::Center))].into(),
             )
-            .with_child(Dom::create_text(label.as_str()));
+            .with_child(Dom::create_text_do_not_use_without_block_level_wrapper(label.as_str()));
         Dom::create_body().with_child(row).with_child(centered)
     }
 
@@ -3701,7 +3701,7 @@ mod tests {
             // stays on the incremental path — see the note on the test.
             let div = Dom::create_div()
                 .with_css_props(props.into())
-                .with_child(Dom::create_text("one two three"));
+                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("one two three"));
             Dom::create_body().with_child(div)
         }
 
@@ -3796,7 +3796,7 @@ mod tests {
                     ]
                     .into(),
                 )
-                .with_child(Dom::create_text("native backbuffer"));
+                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("native backbuffer"));
             Dom::create_body().with_child(div)
         }
 
@@ -3891,7 +3891,7 @@ mod tests {
         fn doc_dom() -> Dom {
             let mut body = Dom::create_body();
             for i in 0..14usize {
-                body = body.with_child(Dom::create_text(match i % 3 {
+                body = body.with_child(Dom::create_text_do_not_use_without_block_level_wrapper(match i % 3 {
                     0 => "alpha beta gamma delta epsilon zeta eta theta iota kappa",
                     1 => "the quick brown fox jumps over the lazy dog again and again",
                     _ => "lorem ipsum dolor sit amet consectetur adipiscing elit sed do",
@@ -5284,7 +5284,7 @@ mod tests {
                     ))]
                     .into(),
                 )
-                .with_child(Dom::create_text("Label"))
+                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Label"))
         };
         Dom::create_body()
             .with_child(label(255, 0, 0))

--- a/dll/src/desktop/shell2/headless/mod.rs
+++ b/dll/src/desktop/shell2/headless/mod.rs
@@ -476,7 +476,7 @@ impl CpuBackend {
         // further down.
         let scroll_offsets = layout_window
             .scroll_manager
-            .build_scroll_offset_map(dom_id, &result.scroll_ids);
+            .build_scroll_offset_map(dom_id, &result.scroll_id_to_node_id);
 
         // GPU-value diff: thumb position / fade opacity / drag & CSS
         // transforms change WITHOUT any display-list item changing (items
@@ -1334,6 +1334,7 @@ impl HeadlessWindow {
                 layout_window: Some(layout_window),
                 current_window_state: full_window_state,
                 previous_window_state: None,
+                os_synced_state: None,
                 renderer_resources: RendererResources::default(),
                 fc_cache,
                 gl_context_ptr: OptionGlContextPtr::None,
@@ -1775,8 +1776,13 @@ impl HeadlessWindow {
     /// re-invoke `layout()` exactly the way the real platform handlers do.
     pub fn simulate_resize(&mut self, width: f32, height: f32) {
         use azul_core::geom::LogicalSize;
+        // Contract shape (snapshot → mutate → pass): the size diff dispatches
+        // `WindowResize` exactly as a native configure does, and no live delta
+        // is left behind for the validation check to flag.
+        self.common.previous_window_state = Some(self.common.current_window_state.clone());
         self.common.current_window_state.size.dimensions = LogicalSize { width, height };
         self.common.request_regeneration(azul_core::callbacks::RelayoutReason::Resize);
+        let _ = self.process_window_events(0);
     }
 
     /// Read the queued reason for the next `regenerate_layout()` call.
@@ -1802,10 +1808,14 @@ impl HeadlessWindow {
 
     /// Replace the active touch point list. Updates `num_touches` to match.
     pub fn inject_touch_points(&mut self, points: impl IntoIterator<Item = TouchPoint>) {
+        // Contract shape (snapshot → mutate → pass): the touch_state diff is
+        // what dispatches TouchStart/Move/End, same as the native shells.
+        self.common.previous_window_state = Some(self.common.current_window_state.clone());
         let vec: TouchPointVec = points.into_iter().collect::<Vec<_>>().into();
         let touch_state = &mut self.common.current_window_state.touch_state;
         touch_state.num_touches = vec.len();
         touch_state.touch_points = vec;
+        let _ = self.process_window_events(0);
         self.wake();
     }
 
@@ -2157,6 +2167,14 @@ impl HeadlessWindow {
                             if !matches!(r, azul_core::events::ProcessEventResult::DoNothing) {
                                 events_need_redraw = true;
                             }
+                            // SANCTIONED SWALLOW: the thumb drag consumed this
+                            // motion; the cursor delta must not surface as a
+                            // MouseMove event later. Same exception as the
+                            // desktop shells.
+                            PlatformWindow::discard_input_delta(
+                                &mut self,
+                                "headless.mouse_move.scrollbar_drag",
+                            );
                         } else {
                             self.update_hit_test_at(pos);
                             record_headless_input(&mut self, false, false); // MWA-A4
@@ -2298,6 +2316,17 @@ impl HeadlessWindow {
                         // relayout depending on which API drove the resize.
                         self.common
                             .request_regeneration(azul_core::callbacks::RelayoutReason::Resize);
+                        // Same shape as the ten sibling arms: run the pass so
+                        // the size diff dispatches `WindowResize` — the one
+                        // backend CI runs used to be the one backend that
+                        // never fired it (the F4 class), and the un-passed
+                        // delta tripped the AZ_VALIDATE assertion at the next
+                        // `process_timers_and_threads()`.
+                        let r = self.process_window_events(0);
+                        events_result = events_result.max(r);
+                        if !matches!(r, azul_core::events::ProcessEventResult::DoNothing) {
+                            events_need_redraw = true;
+                        }
                         events_need_redraw = true;
                     }
                     HeadlessEvent::Scroll { delta_x, delta_y } => {
@@ -2684,7 +2713,8 @@ impl PlatformWindow for HeadlessWindow {
     }
 
     fn sync_window_state(&mut self) {
-        // No native window to synchronise
+        // No native window to synchronise, so there is no OS-sync baseline to
+        // diff either (`os_synced_state` stays `None`).
     }
 }
 
@@ -6157,7 +6187,9 @@ mod tests {
         let lw = w.common.layout_window.as_ref().unwrap();
         let dom = DomId { inner: 0 };
         let result = lw.layout_results.get(&dom).unwrap();
-        let offsets = lw.scroll_manager.build_scroll_offset_map(dom, &result.scroll_ids);
+        let offsets = lw
+            .scroll_manager
+            .build_scroll_offset_map(dom, &result.scroll_id_to_node_id);
         let rs = azul_layout::cpurender::CpuRenderState::new(offsets)
             .with_system_style(lw.system_style.clone());
         let full_clip = LogicalRect {

--- a/dll/src/desktop/shell2/ios/mod.rs
+++ b/dll/src/desktop/shell2/ios/mod.rs
@@ -1318,6 +1318,7 @@ impl IOSWindow {
                 layout_window: Some(layout_window),
                 current_window_state: full_window_state,
                 previous_window_state: None,
+                os_synced_state: None,
                 renderer_resources: RendererResources::default(),
                 fc_cache,
                 gl_context_ptr: OptionGlContextPtr::None,
@@ -1621,5 +1622,7 @@ impl PlatformWindow for IOSWindow {
 
     fn hide_tooltip_from_callback(&mut self) {}
 
+    /// UIKit owns the window geometry outright, so there is nothing to push and
+    /// no OS-sync baseline to diff (`os_synced_state` stays `None`).
     fn sync_window_state(&mut self) {}
 }

--- a/dll/src/desktop/shell2/linux/mod.rs
+++ b/dll/src/desktop/shell2/linux/mod.rs
@@ -55,12 +55,12 @@ impl LinuxWindow {
         }
     }
 
-    pub fn present(&mut self) -> Result<(), WindowError> {
-        match self {
-            LinuxWindow::X11(w) => w.present(),
-            LinuxWindow::Wayland(w) => w.present(),
-        }
-    }
+    // NOTE: there is deliberately no `present()` here. Both backends present
+    // through their own frame machinery (X11 `render_and_present`, Wayland
+    // `generate_frame_if_needed`); a generic present entry invited callers to
+    // bypass the frame-callback latch / damage tracking and shipped three
+    // latent traps before it was removed (see git history of
+    // `WaylandWindow::present`).
 
     pub fn is_open(&self) -> bool {
         match self {

--- a/dll/src/desktop/shell2/linux/timer.rs
+++ b/dll/src/desktop/shell2/linux/timer.rs
@@ -21,8 +21,15 @@ pub fn start_timerfd(
             libc::TFD_NONBLOCK | libc::TFD_CLOEXEC,
         );
         if fd >= 0 {
-            let secs = (interval_ms / 1000) as libc::time_t;
-            let nsecs = ((interval_ms % 1000) * 1_000_000) as libc::c_long;
+            // A timerfd with it_value == {0, 0} is DISARMED, not "fire
+            // immediately and repeatedly". `Timer::tick_millis` legitimately
+            // returns 0 for sub-millisecond / "as fast as possible" timers, and
+            // those silently never fired on Linux while working everywhere else.
+            // One nanosecond is the smallest armed value the kernel accepts; it
+            // still coalesces to the actual timer resolution.
+            let interval_ns = (interval_ms as u128 * 1_000_000).max(1);
+            let secs = (interval_ns / 1_000_000_000) as libc::time_t;
+            let nsecs = (interval_ns % 1_000_000_000) as libc::c_long;
             let spec = libc::itimerspec {
                 it_interval: libc::timespec {
                     tv_sec: secs,

--- a/dll/src/desktop/shell2/linux/wayland/events.rs
+++ b/dll/src/desktop/shell2/linux/wayland/events.rs
@@ -251,22 +251,44 @@ pub(super) extern "C" fn wl_surface_enter_handler(
             old_dpi,
             new_dpi
         );
-        window.common.current_window_state.size.dpi = new_dpi;
-        window.common.request_regeneration(azul_core::callbacks::RelayoutReason::RefreshDom);
-        // Recreate the shm buffers at the new scale (physical = logical ×
-        // scale) — the old buffers are sized for the previous scale and the
-        // copy clamp would truncate every frame.
-        let (w, h) = {
-            let d = &window.common.current_window_state.size.dimensions;
-            (d.width as i32, d.height as i32)
-        };
-        window.resize_surface(w, h);
-        // Schedule the frame NOW. Setting the flag alone renders nothing:
-        // Wayland gets no spurious expose/configure events, so an idle window
-        // dragged to another monitor kept its old-DPI frame until the next
-        // input event.
-        window.request_redraw();
+        apply_os_dpi_change(window, new_dpi);
     }
+}
+
+/// Publish an OS-driven DPI change: snapshot the diff baseline, write
+/// `size.dpi`, recreate the shm buffers at the new physical size, schedule the
+/// frame and run the shared pass.
+///
+/// The pass is not optional. `WindowDpiChanged` is derived from the `size.dpi`
+/// delta between previous and current, so writing `current` alone left the next
+/// handler's snapshot to erase the change and the app never heard about it.
+fn apply_os_dpi_change(window: &mut WaylandWindow, new_dpi: u32) {
+    window.common.previous_window_state = Some(window.common.current_window_state.clone());
+    // Source = Os: the compositor already applied the scale, so the write lands
+    // in `current` AND the OS-sync baseline, and never in `previous_window_state`
+    // (the event delta the pass at the bottom consumes).
+    window.common.update_window_state(
+        crate::desktop::shell2::common::event::WindowStateSource::Os,
+        |ws| {
+            ws.size.dpi = new_dpi;
+        },
+    );
+    window.common.request_regeneration(azul_core::callbacks::RelayoutReason::RefreshDom);
+    // Recreate the shm buffers at the new scale (physical = logical × scale) —
+    // the old buffers are sized for the previous scale and the copy clamp would
+    // truncate every frame.
+    let (w, h) = {
+        let d = &window.common.current_window_state.size.dimensions;
+        (d.width as i32, d.height as i32)
+    };
+    window.resize_surface(w, h);
+    // Schedule the frame NOW. Setting the flag alone renders nothing: Wayland
+    // gets no spurious expose/configure events, so an idle window dragged to
+    // another monitor kept its old-DPI frame until the next input event.
+    window.request_redraw();
+
+    let result = window.process_window_events(0);
+    window.handle_process_event_result(result);
 }
 
 pub(super) extern "C" fn wl_surface_leave_handler(
@@ -297,17 +319,7 @@ pub(super) extern "C" fn wl_surface_leave_handler(
             old_dpi,
             new_dpi
         );
-        window.common.current_window_state.size.dpi = new_dpi;
-        window.common.request_regeneration(azul_core::callbacks::RelayoutReason::RefreshDom);
-        // Same as the enter handler: recreate buffers at the new scale +
-        // schedule the frame now (no spurious events on Wayland to mask a
-        // missing redraw request).
-        let (w, h) = {
-            let d = &window.common.current_window_state.size.dimensions;
-            (d.width as i32, d.height as i32)
-        };
-        window.resize_surface(w, h);
-        window.request_redraw();
+        apply_os_dpi_change(window, new_dpi);
     }
 }
 
@@ -343,17 +355,7 @@ pub(super) extern "C" fn wp_fractional_scale_preferred_scale_handler(
         new_dpi,
         scale_120
     );
-    window.common.current_window_state.size.dpi = new_dpi;
-    window.common.request_regeneration(azul_core::callbacks::RelayoutReason::RefreshDom);
-    // Recreate the shm buffers at the new physical size (same rationale as the
-    // wl_output enter/leave handlers) and schedule the frame NOW — Wayland
-    // sends no spurious expose/configure to mask a missing redraw request.
-    let (w, h) = {
-        let d = &window.common.current_window_state.size.dimensions;
-        (d.width as i32, d.height as i32)
-    };
-    window.resize_surface(w, h);
-    window.request_redraw();
+    apply_os_dpi_change(window, new_dpi);
 }
 
 extern "C" fn xdg_wm_base_ping_handler(data: *mut c_void, shell: *mut xdg_wm_base, serial: u32) {
@@ -452,15 +454,17 @@ pub(super) extern "C" fn registry_global_handler(
             window.track_listener(window.xdg_wm_base);
         }
         "wl_seat" => {
+            let seat_version = version.min(7);
             let seat = unsafe {
                 (window.wayland.wl_registry_bind)(
                     registry,
                     name,
                     &window.wayland.wl_seat_interface,
-                    version.min(7),
+                    seat_version,
                 ) as *mut wl_seat
             };
             window.seat = seat;
+            window.seat_version = seat_version;
             unsafe { (window.wayland.wl_seat_add_listener)(seat, &WL_SEAT_LISTENER, data) };
             window.track_listener(seat);
             unsafe { try_init_tablet(window, data) };
@@ -960,10 +964,19 @@ pub struct WaylandDragState {
     pub offer: *mut wl_data_offer,
     /// Serial from the most recent `enter` — required to `accept` the offer.
     pub enter_serial: u32,
-    /// Whether the current offer advertised `text/uri-list` (i.e. droppable files).
+    /// Whether the current DRAG offer advertised `text/uri-list` (i.e. droppable
+    /// files). Only `data_device.enter` may set this, from
+    /// [`Self::pending_has_uri_list`].
     pub has_uri_list: bool,
     /// Last drag position (window-local pixels), updated on enter/motion.
     pub position: azul_core::geom::LogicalPosition,
+    /// The offer whose `wl_data_offer.offer` mime advertisements are currently
+    /// arriving. An offer's mime list is announced BEFORE the `enter` or
+    /// `selection` that reveals what the offer is FOR, so the advertisements
+    /// have to be accumulated against the offer itself.
+    pub pending_offer: *mut wl_data_offer,
+    /// Whether [`Self::pending_offer`] advertised `text/uri-list`.
+    pub pending_has_uri_list: bool,
 }
 
 /// Create the wl_data_device once both the manager and the seat are bound
@@ -989,7 +1002,7 @@ pub(super) unsafe fn try_init_data_device(window: &mut WaylandWindow, data: *mut
 // --- wl_data_offer events ---
 extern "C" fn data_offer_offer(
     data: *mut c_void,
-    _offer: *mut wl_data_offer,
+    offer: *mut wl_data_offer,
     mime_type: *const c_char,
 ) {
     if mime_type.is_null() {
@@ -997,8 +1010,10 @@ extern "C" fn data_offer_offer(
     }
     let window = unsafe { &mut *(data as *mut WaylandWindow) };
     let mime = unsafe { CStr::from_ptr(mime_type).to_str().unwrap_or_default() };
-    if mime == URI_LIST_MIME {
-        window.drag.has_uri_list = true;
+    // Record against the OFFER, not the drag. Whether this offer is a drag or a
+    // clipboard selection is not known until `enter` / `selection` arrives.
+    if mime == URI_LIST_MIME && offer == window.drag.pending_offer {
+        window.drag.pending_has_uri_list = true;
     }
 }
 extern "C" fn data_offer_source_actions(
@@ -1023,8 +1038,13 @@ extern "C" fn data_device_data_offer(
     id: *mut wl_data_offer,
 ) {
     let window = unsafe { &mut *(data as *mut WaylandWindow) };
-    // Reset per-offer flags; the `offer` events for this offer follow immediately.
-    window.drag.has_uri_list = false;
+    // Start accumulating THIS offer's mime advertisements; they follow
+    // immediately. `drag.has_uri_list` is deliberately untouched: every clipboard
+    // change in any other app also delivers an offer here, and resetting the drag
+    // flag from it made a mid-drag clipboard change stop `data_device_motion`
+    // from accepting — the drop was then refused.
+    window.drag.pending_offer = id;
+    window.drag.pending_has_uri_list = false;
     unsafe { (window.wayland.wl_data_offer_add_listener)(id, &WL_DATA_OFFER_LISTENER, data) };
 }
 
@@ -1116,6 +1136,11 @@ extern "C" fn data_device_enter(
     let window = unsafe { &mut *(data as *mut WaylandWindow) };
     window.drag.offer = id;
     window.drag.enter_serial = serial;
+    // This is the event that says "that offer is a DRAG" — promote its
+    // accumulated mime advertisement now.
+    window.drag.has_uri_list = !id.is_null()
+        && id == window.drag.pending_offer
+        && window.drag.pending_has_uri_list;
     // wl_fixed (24.8) -> logical pixels.
     let pos = azul_core::geom::LogicalPosition::new(x as f32 / 256.0, y as f32 / 256.0);
     window.drag.position = pos;
@@ -1214,6 +1239,11 @@ unsafe fn receive_uri_list(window: &WaylandWindow, offer: *mut wl_data_offer) ->
     parse_uri_list(&text)
 }
 
+/// Deadline for a `wl_data_offer` pipe transfer. Matches the XWayland
+/// fallback's `CLIPBOARD_READ_TIMEOUT` — the peer is another process and may
+/// never write or close.
+const OFFER_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
+
 /// MWA-B3: receive an arbitrary mime payload from a `wl_data_offer` through a
 /// pipe — the generalization of the DnD uri-list receive, shared with the
 /// clipboard paste path (`read_wayland_selection`).
@@ -1239,21 +1269,70 @@ pub(super) unsafe fn receive_offer_bytes(
     (window.wayland.wl_display_flush)(window.display);
     libc::close(write_fd);
 
-    // Read the read end to EOF.
+    // The fd on the other end belongs to a FOREIGN process. A source that hangs,
+    // is stopped, or dies without closing its write end used to freeze the whole
+    // UI thread in `read()` forever — blocking calls on the UI thread are
+    // forbidden, and this one was reachable from an ordinary Ctrl+V. Non-blocking
+    // read end (the write end keeps its blocking semantics — it is the source's
+    // fd and O_NONBLOCK there would truncate large payloads) plus a poll deadline,
+    // matching the XWayland fallback's CLIPBOARD_READ_TIMEOUT.
+    let flags = libc::fcntl(read_fd, libc::F_GETFL, 0);
+    if flags >= 0 {
+        libc::fcntl(read_fd, libc::F_SETFL, flags | libc::O_NONBLOCK);
+    }
+
+    let deadline = std::time::Instant::now() + OFFER_READ_TIMEOUT;
     let mut buf = Vec::new();
     let mut chunk = [0u8; 4096];
-    loop {
-        let n = libc::read(read_fd, chunk.as_mut_ptr() as *mut c_void, chunk.len());
-        if n > 0 {
-            buf.extend_from_slice(&chunk[..n as usize]);
-        } else if n == 0 {
+    'transfer: loop {
+        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+        if remaining.is_zero() {
+            log_warn!(
+                LogCategory::Platform,
+                "[Wayland] '{}' transfer timed out after {:?} ({} bytes read) — abandoning the \
+                 pipe rather than blocking the UI thread",
+                mime_type,
+                OFFER_READ_TIMEOUT,
+                buf.len()
+            );
             break;
-        } else {
-            let err = *libc::__errno_location();
-            if err == libc::EINTR {
+        }
+
+        let mut pfd = libc::pollfd {
+            fd: read_fd,
+            events: libc::POLLIN,
+            revents: 0,
+        };
+        // .max(1): a sub-millisecond remainder must still WAIT, not spin.
+        let timeout_ms = remaining.as_millis().clamp(1, i32::MAX as u128) as i32;
+        let ready = libc::poll(&mut pfd, 1, timeout_ms);
+        if ready < 0 {
+            if *libc::__errno_location() == libc::EINTR {
                 continue;
             }
             break;
+        }
+        if ready == 0 {
+            continue; // deadline check above turns this into the timeout branch
+        }
+
+        // POLLHUP with no data pending still needs the read() to observe EOF.
+        loop {
+            let n = libc::read(read_fd, chunk.as_mut_ptr() as *mut c_void, chunk.len());
+            if n > 0 {
+                buf.extend_from_slice(&chunk[..n as usize]);
+            } else if n == 0 {
+                break 'transfer;
+            } else {
+                let err = *libc::__errno_location();
+                if err == libc::EINTR {
+                    continue;
+                }
+                if err == libc::EAGAIN || err == libc::EWOULDBLOCK {
+                    continue 'transfer; // drained for now — wait for more
+                }
+                break 'transfer;
+            }
         }
     }
     libc::close(read_fd);
@@ -1631,7 +1710,9 @@ pub(super) extern "C" fn xdg_toplevel_configure_handler(
     let window = unsafe { &mut *(data as *mut WaylandWindow) };
 
     // Parse states array to determine window state (maximized, fullscreen, etc.)
-    if !states.is_null() {
+    let new_frame = if states.is_null() {
+        None
+    } else {
         let array = unsafe { &*states };
         let states_data = array.data as *const u32;
         let states_count = array.size / std::mem::size_of::<u32>();
@@ -1651,14 +1732,48 @@ pub(super) extern "C" fn xdg_toplevel_configure_handler(
             }
         }
 
-        window.common.current_window_state.flags.frame = if is_fullscreen {
+        let _ = is_activated; // Can be used for focus indication if needed
+        Some(if is_fullscreen {
             WindowFrame::Fullscreen
         } else if is_maximized {
             WindowFrame::Maximized
         } else {
             WindowFrame::Normal
-        };
-        let _ = is_activated; // Can be used for focus indication if needed
+        })
+    };
+
+    // A configure carries OS-driven window-state changes (size, maximize,
+    // fullscreen) and every one of them has to reach the app through the shared
+    // pass: snapshot the diff baseline BEFORE mutating, run the pass after.
+    // Writing `current` with no snapshot and no pass is what made native
+    // drag-resize / maximize fire no WindowResize at all — the NEXT handler's
+    // snapshot re-based `previous` onto the already-changed state and the delta
+    // was gone.
+    //
+    // Both conditions are decided before anything is written so the repeated
+    // no-op configures (a drag-resize delivers one PER PIXEL, and the compositor
+    // re-sends the current size on every state-only change) cost neither a full
+    // window-state clone nor an event pass.
+    let frame_changed =
+        new_frame.is_some_and(|f| window.common.current_window_state.flags.frame != f);
+    let size_changed = width > 0
+        && height > 0
+        && (width != window.common.current_window_state.size.dimensions.width as i32
+            || height != window.common.current_window_state.size.dimensions.height as i32);
+
+    if frame_changed || size_changed {
+        window.common.previous_window_state = Some(window.common.current_window_state.clone());
+    }
+    if let Some(frame) = new_frame {
+        // Source = Os: the compositor has already applied the frame state, so
+        // the OS-sync baseline advances with it and the next sync_window_state()
+        // does not send xdg_toplevel_set_maximized straight back.
+        window.common.update_window_state(
+            crate::desktop::shell2::common::event::WindowStateSource::Os,
+            |ws| {
+                ws.flags.frame = frame;
+            },
+        );
     }
 
     // Configure census. A mouse drag-resize delivers one of these PER FRAME;
@@ -1698,8 +1813,13 @@ pub(super) extern "C" fn xdg_toplevel_configure_handler(
                 current_height as f32,
             );
 
-            window.common.current_window_state.size.dimensions.width = width as f32;
-            window.common.current_window_state.size.dimensions.height = height as f32;
+            window.common.update_window_state(
+                crate::desktop::shell2::common::event::WindowStateSource::Os,
+                |ws| {
+                    ws.size.dimensions.width = width as f32;
+                    ws.size.dimensions.height = height as f32;
+                },
+            );
             // RESIZE POLICY (user ruling 2026-08-08): a drag delivers one
             // configure PER PIXEL (373 measured in a 5 s drag), and each full
             // regeneration costs 654-942 ms — so a resize NEVER re-invokes the
@@ -1750,6 +1870,14 @@ pub(super) extern "C" fn xdg_toplevel_configure_handler(
             window.resize_surface(width, height);
         }
     }
+
+    // Relayout is already scheduled above (request_regeneration_for_resize keeps
+    // the per-pixel drag off the full-regeneration path); this pass exists purely
+    // so the app's WindowResize / frame-change callbacks actually run.
+    if frame_changed || size_changed {
+        let result = window.process_window_events(0);
+        window.handle_process_event_result(result);
+    }
 }
 
 pub(super) extern "C" fn xdg_toplevel_close_handler(
@@ -1757,7 +1885,27 @@ pub(super) extern "C" fn xdg_toplevel_close_handler(
     _xdg_toplevel: *mut xdg_toplevel,
 ) {
     let window = unsafe { &mut *(data as *mut WaylandWindow) };
-    window.is_open = false;
+
+    // xdg_toplevel.close is a REQUEST, not an order. Clearing `is_open` here made
+    // the run loop drop the window without the app's close callback ever running,
+    // so Alt+F4 / the titlebar X discarded unsaved work silently and no callback
+    // could veto it. Same protocol as Win32 WM_CLOSE: flip `close_requested`
+    // false -> true and run a pass so EventType::WindowClose fires; a callback
+    // that clears the flag cancels the close.
+    window.common.previous_window_state = Some(window.common.current_window_state.clone());
+    window.common.current_window_state.flags.close_requested = true;
+
+    let result = window.process_window_events(0);
+    window.handle_process_event_result(result);
+
+    if window.common.current_window_state.flags.close_requested {
+        window.is_open = false;
+    } else {
+        log_debug!(
+            LogCategory::Window,
+            "[Wayland] xdg_toplevel.close cancelled by callback"
+        );
+    }
 }
 
 pub(super) extern "C" fn xdg_toplevel_configure_bounds_handler(
@@ -1847,7 +1995,14 @@ pub(super) extern "C" fn pointer_axis_handler(
     window.handle_pointer_axis(axis, value as f64 / 256.0);
 }
 
-extern "C" fn pointer_frame_handler(_data: *mut c_void, _pointer: *mut wl_pointer) {}
+/// `wl_pointer.frame` closes an atomic group of pointer events. The axis events
+/// of a frame are accumulated, not dispatched, so this is where a scroll
+/// actually happens — one dispatch for a diagonal scroll instead of two — and
+/// where the frame-scoped `axis_source` is dropped.
+extern "C" fn pointer_frame_handler(data: *mut c_void, _pointer: *mut wl_pointer) {
+    let window = unsafe { &mut *(data as *mut WaylandWindow) };
+    window.handle_pointer_frame();
+}
 // MWA-C-scroll: axis_source/axis_stop were empty stubs, so every Wayland
 // scroll was WheelDiscrete (touchpad deltas became velocity impulses) and
 // rubber-band spring-back never triggered. axis_source arrives before the
@@ -1869,12 +2024,17 @@ extern "C" fn pointer_axis_stop_handler(
     let window = unsafe { &mut *(data as *mut WaylandWindow) };
     window.handle_pointer_axis_stop();
 }
+/// `wl_pointer.axis_discrete` — the detent count behind the frame's axis value.
+/// It is the only compositor-independent scroll quantity available here, so the
+/// frame flush uses it to hit the same per-notch distance as X11 / Win32.
 extern "C" fn pointer_axis_discrete_handler(
-    _data: *mut c_void,
+    data: *mut c_void,
     _pointer: *mut wl_pointer,
-    _axis: u32,
-    _discrete: i32,
+    axis: u32,
+    discrete: i32,
 ) {
+    let window = unsafe { &mut *(data as *mut WaylandWindow) };
+    window.handle_pointer_axis_discrete(axis, discrete);
 }
 
 extern "C" fn keyboard_enter_handler(
@@ -1882,10 +2042,29 @@ extern "C" fn keyboard_enter_handler(
     _keyboard: *mut wl_keyboard,
     _serial: u32,
     _surface: *mut wl_surface,
-    _keys: *mut c_void,
+    keys: *mut c_void,
 ) {
     let window = unsafe { &mut *(data as *mut WaylandWindow) };
-    window.handle_keyboard_enter();
+
+    // `keys` is a wl_array of the evdev keycodes held down AT THE MOMENT focus
+    // arrives — the compositor never replays their press events. Dropping it
+    // meant a key held across the focus change (Ctrl during Alt-Tab) was invisible
+    // to us until its release, which then removed something we never added.
+    // The listener types it as *mut c_void; the protocol type is wl_array.
+    let held: Vec<u32> = if keys.is_null() {
+        Vec::new()
+    } else {
+        let array = unsafe { &*(keys as *const wl_array) };
+        if array.data.is_null() {
+            Vec::new()
+        } else {
+            let count = array.size / std::mem::size_of::<u32>();
+            let keycodes = array.data as *const u32;
+            (0..count).map(|i| unsafe { *keycodes.add(i) }).collect()
+        }
+    };
+
+    window.handle_keyboard_enter(&held);
 }
 extern "C" fn keyboard_leave_handler(
     data: *mut c_void,

--- a/dll/src/desktop/shell2/linux/wayland/mod.rs
+++ b/dll/src/desktop/shell2/linux/wayland/mod.rs
@@ -425,9 +425,32 @@ pub struct WaylandWindow {
     /// axis events classify as TrackpadContinuous so the physics timer
     /// applies deltas directly (OS/compositor momentum) instead of wheel
     /// impulses; axis_stop then emits TrackpadEnd for rubber-band
-    /// spring-back. Sticky across frames — compositors resend the source
-    /// with every scroll frame from a given device.
+    /// spring-back.
+    ///
+    /// Reset to `wheel` by `handle_pointer_frame`. The protocol scopes
+    /// axis_source to ONE frame ("carries the source information for all events
+    /// within that frame"); when it was sticky instead, the first wheel tick
+    /// after any trackpad scroll inherited TrackpadContinuous and scrolled with
+    /// touchpad physics.
     current_axis_source: u32,
+    /// Axis deltas accumulated within the current wl_pointer frame, in the
+    /// engine's raw-delta convention (sign already flipped).
+    ///
+    /// A wl_pointer frame is the atomic unit: a diagonal trackpad scroll carries
+    /// X and Y in ONE frame and must produce ONE scroll, not two full event
+    /// passes with two synthetic Scroll dispatches.
+    pending_axis_value: (f32, f32),
+    /// `wl_pointer.axis_discrete` detents accumulated in the current frame, same
+    /// sign convention as `pending_axis_value`. Non-zero only for ratcheting
+    /// wheels; it is what lets the flush convert to the shared 20px-per-detent
+    /// magnitude instead of the compositor's raw ~10-15px axis value.
+    pending_axis_discrete: (f32, f32),
+    /// Whether the current frame carries any axis input to flush.
+    pending_axis: bool,
+    /// Bound `wl_seat` version. `wl_pointer.frame` and `.axis_discrete` are v5+;
+    /// on an older seat no frame event ever arrives, so the axis accumulator has
+    /// to flush itself per event instead of waiting forever.
+    seat_version: u32,
     data_device_version: u32,
     data_device_initialized: bool,
     drag: events::WaylandDragState,
@@ -706,6 +729,40 @@ pub struct WaylandPopup {
 }
 
 // Event Handler Types
+
+/// `wl_pointer.axis` axis values.
+const WL_POINTER_AXIS_VERTICAL_SCROLL: u32 = 0;
+const WL_POINTER_AXIS_HORIZONTAL_SCROLL: u32 = 1;
+
+/// `wl_pointer.axis_source` values.
+const WL_AXIS_SOURCE_WHEEL: u32 = 0;
+const WL_AXIS_SOURCE_FINGER: u32 = 1;
+const WL_AXIS_SOURCE_CONTINUOUS: u32 = 2;
+
+/// Pixels per discrete wheel detent — the shared cross-backend constant.
+const WHEEL_TICK_PIXELS: f32 =
+    crate::desktop::shell2::common::event::WHEEL_SCROLL_PIXELS_PER_LINE;
+
+/// `wl_pointer.frame` and `.axis_discrete` were both added in wl_seat v5.
+const WL_POINTER_FRAME_SINCE_VERSION: u32 = 5;
+
+/// Write the down-flag of exactly ONE mouse button, leaving the others untouched.
+///
+/// Every button transition — press and release alike — must go through here.
+/// Broadcasting `button == X` across all three flags is what turned "press Right
+/// while Left is held" into a phantom LeftMouseUp in the state diff.
+fn set_mouse_button_down(
+    mouse_state: &mut azul_core::window::MouseState,
+    button: MouseButton,
+    down: bool,
+) {
+    match button {
+        MouseButton::Left => mouse_state.left_down = down,
+        MouseButton::Right => mouse_state.right_down = down,
+        MouseButton::Middle => mouse_state.middle_down = down,
+        MouseButton::Other(_) => {}
+    }
+}
 
 // XKB Keyboard Translation
 
@@ -1049,81 +1106,11 @@ impl WaylandWindow {
         format!(" [protocol error: {name}@{id} code {code}]")
     }
 
-    pub fn present(&mut self) -> Result<(), WindowError> {
-        let fractional = self.fractional_scale_active();
-        let (logical_w, logical_h) = {
-            let d = &self.common.current_window_state.size.dimensions;
-            (d.width as i32, d.height as i32)
-        };
-        let result = match &mut self.render_mode {
-            RenderMode::Gpu(gl_context, _) => gl_context.swap_buffers(),
-            RenderMode::Cpu(Some(cpu_state)) => {
-                // Buffer already rendered by render_frame_if_ready — just submit
-                unsafe {
-                    (self.wayland.wl_surface_attach)(self.surface, cpu_state.active_buffer(), 0, 0);
-                    *cpu_state.slots[cpu_state.active].busy = true;
-                    // Per-rect damage from the last render pass (buffer px);
-                    // empty = the frame is unchanged (nothing to recomposite).
-                    let surface_version =
-                        (self.wayland.wl_proxy_get_version)(self.surface as *mut defines::wl_proxy);
-                    let scale = cpu_state.scale.max(1);
-                    if fractional {
-                        // Viewport fractional scaling: buffer scale MUST be 1
-                        // (reset any stale integer value) and the viewport
-                        // maps the physical buffer to the logical size.
-                        if surface_version >= 3 {
-                            (self.wayland.wl_surface_set_buffer_scale)(self.surface, 1);
-                        }
-                        if let Some(vp) = self.viewport {
-                            wp_viewport_set_destination(
-                                &self.wayland, vp, logical_w, logical_h,
-                            );
-                        }
-                    } else if surface_version >= 3 && scale > 1 {
-                        (self.wayland.wl_surface_set_buffer_scale)(self.surface, scale);
-                    }
-                    for (dx, dy, dw, dh) in cpu_state.damage_rects.drain(..) {
-                        if surface_version >= 4 {
-                            (self.wayland.wl_surface_damage_buffer)(self.surface, dx, dy, dw, dh);
-                        } else {
-                            let x0 = dx.div_euclid(scale);
-                            let y0 = dy.div_euclid(scale);
-                            let x1 = (dx + dw + scale - 1).div_euclid(scale);
-                            let y1 = (dy + dh + scale - 1).div_euclid(scale);
-                            (self.wayland.wl_surface_damage)(self.surface, x0, y0, x1 - x0, y1 - y0);
-                        }
-                    }
-                    (self.wayland.wl_surface_commit)(self.surface);
-                }
-                Ok(())
-            }
-            RenderMode::Cpu(None) => {
-                // CPU fallback not yet initialized - wait for wl_shm from registry
-                Ok(())
-            }
-        };
-
-        // Clean up old textures from previous epochs to prevent memory leak
-        // This must happen AFTER render() and buffer swap when WebRender no longer needs the textures
-        if let Some(ref layout_window) = self.common.layout_window {
-            crate::desktop::gl_texture_integration::remove_old_gl_textures(
-                &layout_window.document_id,
-                layout_window.epoch,
-            );
-        }
-
-        // CI-only escape hatch: exit after first successful frame render.
-        // Intentionally uses process::exit() to skip Drop impls for fast CI shutdown.
-        if result.is_ok() && std::env::var("AZ_EXIT_SUCCESS_AFTER_FRAME_RENDER").is_ok() {
-            log_info!(
-                LogCategory::Platform,
-                "[CI] AZ_EXIT_SUCCESS_AFTER_FRAME_RENDER set - exiting with success"
-            );
-            std::process::exit(0);
-        }
-
-        result
-    }
+    // NOTE: `WaylandWindow::present` is deliberately GONE (with its sole
+    // caller `LinuxWindow::present`). The real present path is
+    // `generate_frame_if_needed` → `render_and_present`; the deleted body
+    // attached buffers without a busy check, bypassed the frame-callback
+    // latch, and hard-exited on AZ_EXIT_SUCCESS_AFTER_FRAME_RENDER.
 
     pub fn is_open(&self) -> bool {
         self.is_open
@@ -1665,6 +1652,7 @@ impl WaylandWindow {
                     active_route: azul_core::resources::OptionRouteMatch::None,
                 },
                 previous_window_state: None,
+                os_synced_state: None,
                 layout_window: Some(layout_window),
                 render_api: None,
                 renderer: None,
@@ -1701,6 +1689,10 @@ impl WaylandWindow {
             clipboard_source: std::ptr::null_mut(),
             last_input_serial: 0,
             current_axis_source: 0,
+            pending_axis_value: (0.0, 0.0),
+            pending_axis_discrete: (0.0, 0.0),
+            pending_axis: false,
+            seat_version: 0,
             data_device_version: 0,
             data_device_initialized: false,
             drag: events::WaylandDragState::default(),
@@ -2852,6 +2844,11 @@ impl WaylandWindow {
             self.common.current_window_state
                 .keyboard_state
                 .current_virtual_keycode = OptionVirtualKeyCode::None;
+            // SANCTIONED SWALLOW: no translation possible, no event owed.
+            {
+                use crate::desktop::shell2::common::event::PlatformWindow as _;
+                self.discard_input_delta("wayland.handle_key.xkb_null");
+            }
             return;
         }
 
@@ -2862,24 +2859,41 @@ impl WaylandWindow {
         let virtual_keycode = translate_keysym_to_virtual_keycode(keysym);
 
         // Client-side key repeat: arm on press of a repeatable key, disarm
-        // when THAT key is released. Modifiers don't repeat.
+        // when THAT key is released. The keymap decides what repeats — modifiers,
+        // Compose, dead keys and level-switch keys are all non-repeating there,
+        // and only the keymap knows which of them a given layout defines.
         {
-            use azul_core::window::VirtualKeyCode as VK;
-            let is_modifier = matches!(
-                virtual_keycode,
-                VK::LShift
-                    | VK::RShift
-                    | VK::LControl
-                    | VK::RControl
-                    | VK::LAlt
-                    | VK::RAlt
-                    | VK::LWin
-                    | VK::RWin
-                    | VK::Capital
-                    | VK::Numlock
-                    | VK::Scroll
-            );
-            if is_pressed && !is_modifier {
+            // The shared `Xkb` binding (one dlopen path per library — the
+            // codebase convention) resolves the symbol; the fallback below
+            // only covers a still-missing keymap.
+            let repeats = match (
+                Some(self.xkb.xkb_keymap_key_repeats),
+                self.keyboard_state.keymap.is_null(),
+            ) {
+                (Some(key_repeats), false) => unsafe {
+                    key_repeats(self.keyboard_state.keymap, xkb_keycode) != 0
+                },
+                // No keymap / symbol unavailable: fall back to "everything except
+                // the modifiers we can name repeats".
+                _ => {
+                    use azul_core::window::VirtualKeyCode as VK;
+                    !matches!(
+                        virtual_keycode,
+                        VK::LShift
+                            | VK::RShift
+                            | VK::LControl
+                            | VK::RControl
+                            | VK::LAlt
+                            | VK::RAlt
+                            | VK::LWin
+                            | VK::RWin
+                            | VK::Capital
+                            | VK::Numlock
+                            | VK::Scroll
+                    )
+                }
+            };
+            if is_pressed && repeats {
                 self.arm_key_repeat(key);
             } else if !is_pressed && self.key_repeat_keycode == Some(key) {
                 self.disarm_key_repeat();
@@ -2893,6 +2907,11 @@ impl WaylandWindow {
             && self.active_popup.is_some()
         {
             self.dismiss_active_popup();
+            // SANCTIONED SWALLOW: the popup consumed the key.
+            {
+                use crate::desktop::shell2::common::event::PlatformWindow as _;
+                self.discard_input_delta("wayland.handle_key.popup_escape");
+            }
             return;
         }
 
@@ -2919,15 +2938,24 @@ impl WaylandWindow {
                     }
                 }
             }
+            // SANCTIONED SWALLOW: the popup consumed the key.
+            {
+                use crate::desktop::shell2::common::event::PlatformWindow as _;
+                self.discard_input_delta("wayland.handle_key.popup_route");
+            }
             return;
         }
 
-        self.common.current_window_state
-            .keyboard_state
-            .current_virtual_keycode = OptionVirtualKeyCode::Some(virtual_keycode);
-
-        // Update pressed_virtual_keycodes and pressed_scancodes lists
+        // Update current_virtual_keycode + the pressed_virtual_keycodes /
+        // pressed_scancodes lists. current_virtual_keycode MUST be cleared on
+        // release: the shared diff derives VirtualKeyUp from
+        // `previous.is_some() && current.is_none()`, and a leftover Some(vk) also
+        // swallows the next discrete press of the SAME key (no Some → Some delta),
+        // which is why Backspace/Enter/arrows only registered every other tap.
         if is_pressed {
+            self.common.current_window_state
+                .keyboard_state
+                .current_virtual_keycode = OptionVirtualKeyCode::Some(virtual_keycode);
             // Add key to pressed lists
             self.common.current_window_state
                 .keyboard_state
@@ -2938,6 +2966,9 @@ impl WaylandWindow {
                 .pressed_scancodes
                 .insert_hm_item(key);
         } else {
+            self.common.current_window_state
+                .keyboard_state
+                .current_virtual_keycode = OptionVirtualKeyCode::None;
             // Remove key from pressed lists
             self.common.current_window_state
                 .keyboard_state
@@ -3055,6 +3086,47 @@ impl WaylandWindow {
             }
             ProcessEventResult::DoNothing => {}
         }
+
+        self.sync_ime_after_input();
+    }
+
+    /// Keep the IME in step with the FOCUS and the CARET, not with DOM
+    /// regeneration.
+    ///
+    /// `sync_text_input_v3_focus_state` / `update_ime_position_from_cursor` used
+    /// to run only from `regenerate_layout_inner`. Clicking into a
+    /// contenteditable normally produces a re-render, not a regeneration, so
+    /// `zwp_text_input_v3.enable()` was deferred until some unrelated DOM rebuild
+    /// happened to occur — CJK composition had nothing to attach to — and the
+    /// cursor rectangle went stale while typing. This runs at the end of every
+    /// input pass instead, after any incremental relayout above has refreshed
+    /// the caret geometry.
+    ///
+    /// The early-out keeps it off the mouse-motion hot path, and the rectangle
+    /// only goes on the wire when it actually moved: `sync_ime_position_to_os`
+    /// marshals + commits + flushes on every call.
+    fn sync_ime_after_input(&mut self) {
+        let editing = self
+            .common
+            .layout_window
+            .as_ref()
+            .map(|lw| lw.text_edit_manager.has_active_editing())
+            .unwrap_or(false);
+        if !editing && !self.text_input_enabled {
+            return;
+        }
+
+        let was_enabled = self.text_input_enabled;
+        let old_position = self.common.current_window_state.ime_position;
+
+        self.update_ime_position_from_cursor();
+        self.sync_text_input_v3_focus_state();
+
+        if self.text_input_enabled
+            && (!was_enabled || self.common.current_window_state.ime_position != old_position)
+        {
+            self.sync_ime_position_to_os();
+        }
     }
 
     /// Handle pointer motion event
@@ -3125,6 +3197,7 @@ impl WaylandWindow {
     /// Clear all touch points (cancel — compositor took over the sequence).
     pub fn handle_touch_cancel(&mut self) {
         use azul_core::window::TouchPointVec;
+        self.common.previous_window_state = Some(self.common.current_window_state.clone());
         let ts = &mut self.common.current_window_state.touch_state;
         ts.touch_points = TouchPointVec::from_vec(Vec::new());
         ts.num_touches = 0;
@@ -3132,6 +3205,12 @@ impl WaylandWindow {
         if let Some(lw) = self.common.layout_window.as_mut() {
             lw.gesture_drag_manager.touch_cancel_all();
         }
+        // Same contract as handle_touch_point / handle_touch_up: without the pass
+        // the cancel's own touch_state delta was erased by the next handler's
+        // snapshot, so a compositor-stolen gesture left the app mid-drag (and the
+        // repaint that routing the result brings never happened either).
+        let result = self.process_window_events(0);
+        self.handle_process_event_result(result);
     }
 
     /// Feed the accumulated tablet pen state on the tool's `frame` event.
@@ -3191,6 +3270,10 @@ impl WaylandWindow {
             // no-op and the redraw-only variants still request_redraw, so plain
             // scrollbar drags behave exactly as before.
             self.handle_process_event_result(result);
+            // SANCTIONED SWALLOW: the thumb drag consumed this motion; the
+            // cursor delta must not surface as a MouseMove event later.
+            use crate::desktop::shell2::common::event::PlatformWindow as _;
+            self.discard_input_delta("wayland.pointer_motion.scrollbar_drag");
             return;
         }
 
@@ -3352,22 +3435,16 @@ impl WaylandWindow {
             }
         }
 
-        if is_down {
-            // Button pressed
-            self.common.current_window_state.mouse_state.left_down = mouse_button == MouseButton::Left;
-            self.common.current_window_state.mouse_state.right_down = mouse_button == MouseButton::Right;
-            self.common.current_window_state.mouse_state.middle_down = mouse_button == MouseButton::Middle;
-            self.pointer_state.button_down = Some(mouse_button);
-        } else {
-            // Button released — only clear the button that was actually released
-            match mouse_button {
-                MouseButton::Left => self.common.current_window_state.mouse_state.left_down = false,
-                MouseButton::Right => self.common.current_window_state.mouse_state.right_down = false,
-                MouseButton::Middle => self.common.current_window_state.mouse_state.middle_down = false,
-                _ => {}
-            }
-            self.pointer_state.button_down = None;
-        }
+        // Only the button that actually changed may be written. Assigning all
+        // three from `mouse_button == …` cleared the OTHER buttons, so pressing
+        // Right while Left was held made the state diff synthesize a phantom
+        // LeftMouseUp — drags and text selections died mid-gesture.
+        set_mouse_button_down(
+            &mut self.common.current_window_state.mouse_state,
+            mouse_button,
+            is_down,
+        );
+        self.pointer_state.button_down = if is_down { Some(mouse_button) } else { None };
 
         // Record input sample for gesture detection
         let button_state = match mouse_button {
@@ -3383,17 +3460,11 @@ impl WaylandWindow {
         self.handle_process_event_result(result);
     }
 
-    /// Handle pointer axis (scroll) event
+    /// Accumulate one `wl_pointer.axis` event into the current pointer frame.
+    ///
+    /// Nothing is dispatched here — `handle_pointer_frame` flushes the frame as a
+    /// single scroll. See [`Self::pending_axis_value`].
     pub fn handle_pointer_axis(&mut self, axis: u32, value: f64) {
-        use azul_css::OptionF32;
-
-        const WL_POINTER_AXIS_VERTICAL_SCROLL: u32 = 0;
-        const WL_POINTER_AXIS_HORIZONTAL_SCROLL: u32 = 1;
-
-        // Save previous state BEFORE making changes
-        self.common.previous_window_state = Some(self.common.current_window_state.clone());
-
-        // Determine scroll delta based on axis.
         // MWA-B13: wl_pointer.axis is POSITIVE toward bottom/right (the
         // "natural" content direction), but azul's raw-delta chokepoint uses
         // the X11 convention (button 4 / up = +1, button 5 / down = −1) —
@@ -3401,11 +3472,91 @@ impl WaylandWindow {
         // value through unsigned inverted every wheel/trackpad scroll on
         // Wayland. NEEDS-RUNTIME-VERIFY: direction on a real compositor
         // (with and without natural-scroll enabled).
-        let (delta_x, delta_y) = match axis {
-            WL_POINTER_AXIS_HORIZONTAL_SCROLL => (-(value as f32), 0.0),
-            WL_POINTER_AXIS_VERTICAL_SCROLL => (0.0, -(value as f32)),
-            _ => (0.0, 0.0),
+        match axis {
+            WL_POINTER_AXIS_HORIZONTAL_SCROLL => {
+                self.pending_axis_value.0 -= value as f32;
+            }
+            WL_POINTER_AXIS_VERTICAL_SCROLL => {
+                self.pending_axis_value.1 -= value as f32;
+            }
+            _ => return,
+        }
+        self.pending_axis = true;
+        // No wl_pointer.frame on a pre-v5 seat — nothing would ever flush this.
+        if self.seat_version < WL_POINTER_FRAME_SINCE_VERSION {
+            self.flush_pending_axis();
+        }
+    }
+
+    /// Accumulate one `wl_pointer.axis_discrete` (detent count) into the frame.
+    pub fn handle_pointer_axis_discrete(&mut self, axis: u32, discrete: i32) {
+        match axis {
+            WL_POINTER_AXIS_HORIZONTAL_SCROLL => {
+                self.pending_axis_discrete.0 -= discrete as f32;
+            }
+            WL_POINTER_AXIS_VERTICAL_SCROLL => {
+                self.pending_axis_discrete.1 -= discrete as f32;
+            }
+            _ => return,
+        }
+        self.pending_axis = true;
+    }
+
+    /// `wl_pointer.frame` — the frame is complete. Flush its accumulated axis
+    /// input and drop the frame-scoped axis source.
+    pub fn handle_pointer_frame(&mut self) {
+        self.flush_pending_axis();
+        self.current_axis_source = WL_AXIS_SOURCE_WHEEL;
+    }
+
+    /// Dispatch the axis input accumulated in the current pointer frame as ONE
+    /// scroll, then run a single event pass.
+    fn flush_pending_axis(&mut self) {
+        if !self.pending_axis {
+            return;
+        }
+        self.pending_axis = false;
+        let (raw_x, raw_y) = std::mem::replace(&mut self.pending_axis_value, (0.0, 0.0));
+        let (disc_x, disc_y) = std::mem::replace(&mut self.pending_axis_discrete, (0.0, 0.0));
+
+        let is_trackpad = self.current_axis_source == WL_AXIS_SOURCE_FINGER
+            || self.current_axis_source == WL_AXIS_SOURCE_CONTINUOUS;
+
+        // MAGNITUDE: a ratcheting wheel detent is worth WHEEL_TICK_PIXELS
+        // everywhere else (X11 button 4/5 = ±1 × 20, Win32 = WHEEL_DELTA/120 ×
+        // 20). The raw wl axis value for one detent is compositor-defined
+        // (~10-15 px), so the same wheel scrolled a different distance on
+        // Wayland than on X11. axis_discrete carries the detent count, which is
+        // the only compositor-independent quantity available here; without it
+        // (older compositor, or a continuous source) fall back to the raw value.
+        let (delta_x, delta_y) = if !is_trackpad && (disc_x != 0.0 || disc_y != 0.0) {
+            (
+                disc_x * WHEEL_TICK_PIXELS,
+                disc_y * WHEEL_TICK_PIXELS,
+            )
+        } else {
+            // Trackpad deltas are already pixel distances — pass them through.
+            (raw_x, raw_y)
         };
+
+        if delta_x == 0.0 && delta_y == 0.0 {
+            return;
+        }
+
+        // Save previous state BEFORE making changes
+        self.common.previous_window_state = Some(self.common.current_window_state.clone());
+
+        // The scroll target is whatever is under the cursor NOW. Reusing the
+        // hover manager's last hit test meant a stationary cursor over content
+        // that had scrolled/relaid-out beneath it kept scrolling the node that
+        // used to be there (X11 re-runs the hit test for exactly this reason).
+        let hover_pos = match self.common.current_window_state.mouse_state.cursor_position {
+            CursorPosition::InWindow(pos) => Some(pos),
+            _ => None,
+        };
+        if let Some(pos) = hover_pos {
+            self.update_hit_test(pos);
+        }
 
         // Queue scroll input for the physics timer instead of directly setting offsets.
         {
@@ -3423,14 +3574,16 @@ impl WaylandWindow {
                 // scrolling) deltas are position deltas, not wheel ticks;
                 // treating them as WheelDiscrete stacked velocity impulses
                 // and made touchpad scrolling fly. axis_stop → TrackpadEnd.
-                const WL_AXIS_SOURCE_FINGER: u32 = 1;
-                const WL_AXIS_SOURCE_CONTINUOUS: u32 = 2;
-                let source = if self.current_axis_source == WL_AXIS_SOURCE_FINGER
-                    || self.current_axis_source == WL_AXIS_SOURCE_CONTINUOUS
-                {
-                    ScrollInputSource::TrackpadContinuous
+                let (source, device) = if is_trackpad {
+                    (
+                        ScrollInputSource::TrackpadContinuous,
+                        azul_layout::managers::scroll_state::ScrollInputDevice::Touchpad,
+                    )
                 } else {
-                    ScrollInputSource::WheelDiscrete
+                    (
+                        ScrollInputSource::WheelDiscrete,
+                        azul_layout::managers::scroll_state::ScrollInputDevice::MouseWheel,
+                    )
                 };
 
                 if let Some((_dom_id, _node_id, start_timer)) =
@@ -3439,15 +3592,7 @@ impl WaylandWindow {
                         delta_x,
                         delta_y,
                         source,
-                        // Provenance mirrors the wl_pointer.axis_source
-                        // classification above.
-                        if self.current_axis_source == WL_AXIS_SOURCE_FINGER
-                            || self.current_axis_source == WL_AXIS_SOURCE_CONTINUOUS
-                        {
-                            azul_layout::managers::scroll_state::ScrollInputDevice::Touchpad
-                        } else {
-                            azul_layout::managers::scroll_state::ScrollInputDevice::MouseWheel
-                        },
+                        device,
                         &layout_window.hover_manager,
                         &InputPointId::Mouse,
                         now,
@@ -3504,8 +3649,10 @@ impl WaylandWindow {
         use azul_layout::managers::hover::InputPointId;
         use azul_layout::managers::scroll_state::ScrollInputSource;
 
-        const WL_AXIS_SOURCE_FINGER: u32 = 1;
-        const WL_AXIS_SOURCE_CONTINUOUS: u32 = 2;
+        // axis_stop rides in the same frame as any axis events that preceded it,
+        // and TrackpadEnd is only meaningful AFTER them.
+        self.flush_pending_axis();
+
         if self.current_axis_source != WL_AXIS_SOURCE_FINGER
             && self.current_axis_source != WL_AXIS_SOURCE_CONTINUOUS
         {
@@ -3578,6 +3725,17 @@ impl WaylandWindow {
         self.common.previous_window_state = Some(self.common.current_window_state.clone());
         self.common.current_window_state.window_focused = false;
         self.dynamic_selector_context.window_focused = false;
+        // Every held key is released somewhere we will never hear about, so drop
+        // them all now. Engine modifiers are DERIVED from pressed_virtual_keycodes
+        // (core/src/window.rs, KeyboardState::*_down) — leaving Ctrl in the list
+        // made the whole app behave as if Ctrl were held forever after an
+        // Alt-Tab away with a modifier down.
+        self.common.current_window_state.keyboard_state.pressed_virtual_keycodes =
+            azul_core::window::VirtualKeyCodeVec::new();
+        self.common.current_window_state.keyboard_state.pressed_scancodes =
+            azul_core::window::ScanCodeVec::new();
+        self.common.current_window_state.keyboard_state.current_virtual_keycode =
+            azul_core::window::OptionVirtualKeyCode::None;
         // MWA-A3b: forward to AT-SPI — accesskit_unix never learns window
         // focus on its own (Orca got no focus events on Wayland).
         #[cfg(feature = "a11y")]
@@ -3791,10 +3949,34 @@ impl WaylandWindow {
         Some(String::from_utf8_lossy(&bytes).into_owned())
     }
 
-    pub fn handle_keyboard_enter(&mut self) {
+    /// Handle keyboard enter event (window gained focus).
+    ///
+    /// `held_scancodes` are the evdev keycodes the compositor reports as already
+    /// down at focus time (the `wl_keyboard.enter` keys array). They get no press
+    /// events, so they must be seeded here or the engine's derived modifier set
+    /// stays wrong until each of them is released.
+    pub fn handle_keyboard_enter(&mut self, held_scancodes: &[u32]) {
         self.common.previous_window_state = Some(self.common.current_window_state.clone());
         self.common.current_window_state.window_focused = true;
         self.dynamic_selector_context.window_focused = true;
+
+        let xkb_state = self.keyboard_state.state;
+        for &scancode in held_scancodes {
+            self.common.current_window_state
+                .keyboard_state
+                .pressed_scancodes
+                .insert_hm_item(scancode);
+            if xkb_state.is_null() {
+                continue;
+            }
+            // XKB keycode = evdev keycode + 8 (same offset as handle_key).
+            let keysym =
+                unsafe { (self.xkb.xkb_state_key_get_one_sym)(xkb_state, scancode + 8) };
+            self.common.current_window_state
+                .keyboard_state
+                .pressed_virtual_keycodes
+                .insert_hm_item(translate_keysym_to_virtual_keycode(keysym));
+        }
         // MWA-A3b: mirror of handle_keyboard_leave — forward focus to AT-SPI.
         #[cfg(feature = "a11y")]
         self.accessibility_adapter.set_focus(true);
@@ -4139,8 +4321,9 @@ impl WaylandWindow {
     /// - size (via GL context / CPU buffer)
     /// - background_material (via apply_background_material)
     ///
-    /// This method applies the remaining fields and sets previous_window_state
-    /// so that sync_window_state() works correctly for future changes.
+    /// This method applies the remaining fields and seeds both baselines
+    /// (event-diff and OS-sync) so that sync_window_state() works correctly for
+    /// future changes.
     fn apply_initial_window_state(&mut self) {
         use azul_core::geom::OptionLogicalSize;
         use azul_core::window::WindowFrame;
@@ -4214,8 +4397,13 @@ impl WaylandWindow {
             }
         }
 
-        // CRITICAL: Set previous_window_state so sync_window_state() works for future changes
+        // Seed BOTH baselines: the event-diff one (so the first pass has
+        // something to diff against) and the OS-sync one — everything above is
+        // now applied on the toplevel, so sync_window_state() must not re-push
+        // it. Until mark_os_synced() has run, take_os_sync_diff() answers None
+        // and nothing is pushed at the compositor.
         self.common.previous_window_state = Some(self.common.current_window_state.clone());
+        self.common.mark_os_synced();
     }
 
     /// Synchronize window state with Wayland compositor
@@ -4224,146 +4412,122 @@ impl WaylandWindow {
     pub fn sync_window_state(&mut self) {
         use azul_core::window::WindowFrame;
 
+        // Diff against the OS-SYNC baseline, not the event baseline:
+        // `previous_window_state` is advanced by every completed event pass and
+        // is free to hold a live delta, so diffing it here would push (and echo)
+        // state the compositor itself just reported in a configure.
+        // `take_os_sync_diff` hands over (baseline, current) and advances the
+        // baseline in the same call.
+        let (previous, current) = match self.common.take_os_sync_diff() {
+            Some(pair) => pair,
+            None => return, // First frame, nothing to sync
+        };
+
         // Note: Wayland state changes must be committed
         let mut needs_commit = false;
 
         // Sync title
-        if let Some(prev) = &self.common.previous_window_state {
-            if prev.title != self.common.current_window_state.title {
-                let c_title = match std::ffi::CString::new(self.common.current_window_state.title.as_str())
-                {
-                    Ok(s) => s,
-                    Err(_) => return,
-                };
-                unsafe {
-                    (self.wayland.xdg_toplevel_set_title)(self.xdg_toplevel, c_title.as_ptr());
-                }
-                needs_commit = true;
+        if previous.title != current.title {
+            let c_title = match std::ffi::CString::new(current.title.as_str()) {
+                Ok(s) => s,
+                Err(_) => return,
+            };
+            unsafe {
+                (self.wayland.xdg_toplevel_set_title)(self.xdg_toplevel, c_title.as_ptr());
             }
-
-            // Window frame state changed? (Minimize/Maximize/Normal/Fullscreen)
-            if prev.flags.frame != self.common.current_window_state.flags.frame {
-                match self.common.current_window_state.flags.frame {
-                    WindowFrame::Minimized => {
-                        unsafe {
-                            (self.wayland.xdg_toplevel_set_minimized)(self.xdg_toplevel);
-                        }
-                    }
-                    WindowFrame::Maximized => {
-                        // If previously fullscreen, unset fullscreen first
-                        if prev.flags.frame == WindowFrame::Fullscreen {
-                            unsafe {
-                                (self.wayland.xdg_toplevel_unset_fullscreen)(self.xdg_toplevel);
-                            }
-                        }
-                        unsafe {
-                            (self.wayland.xdg_toplevel_set_maximized)(self.xdg_toplevel);
-                        }
-                    }
-                    WindowFrame::Fullscreen => {
-                        // If previously maximized, unset maximized first
-                        if prev.flags.frame == WindowFrame::Maximized {
-                            unsafe {
-                                (self.wayland.xdg_toplevel_unset_maximized)(self.xdg_toplevel);
-                            }
-                        }
-                        unsafe {
-                            (self.wayland.xdg_toplevel_set_fullscreen)(
-                                self.xdg_toplevel,
-                                std::ptr::null_mut(), // NULL = current output
-                            );
-                        }
-                    }
-                    WindowFrame::Normal => {
-                        if prev.flags.frame == WindowFrame::Maximized {
-                            unsafe {
-                                (self.wayland.xdg_toplevel_unset_maximized)(self.xdg_toplevel);
-                            }
-                        }
-                        if prev.flags.frame == WindowFrame::Fullscreen {
-                            unsafe {
-                                (self.wayland.xdg_toplevel_unset_fullscreen)(self.xdg_toplevel);
-                            }
-                        }
-                        // Note: Wayland has no explicit "unminimize" — the compositor handles it
-                    }
-                }
-                needs_commit = true;
-            }
-
-            // Min dimensions changed?
-            if prev.size.min_dimensions != self.common.current_window_state.size.min_dimensions {
-                use azul_core::geom::OptionLogicalSize;
-                let (w, h) = match self.common.current_window_state.size.min_dimensions {
-                    OptionLogicalSize::Some(dims) => (dims.width as i32, dims.height as i32),
-                    OptionLogicalSize::None => (0, 0), // 0 = no minimum
-                };
-                unsafe {
-                    (self.wayland.xdg_toplevel_set_min_size)(self.xdg_toplevel, w, h);
-                }
-                needs_commit = true;
-            }
-
-            // Max dimensions changed?
-            if prev.size.max_dimensions != self.common.current_window_state.size.max_dimensions {
-                use azul_core::geom::OptionLogicalSize;
-                let (w, h) = match self.common.current_window_state.size.max_dimensions {
-                    OptionLogicalSize::Some(dims) => (dims.width as i32, dims.height as i32),
-                    OptionLogicalSize::None => (0, 0), // 0 = no maximum
-                };
-                unsafe {
-                    (self.wayland.xdg_toplevel_set_max_size)(self.xdg_toplevel, w, h);
-                }
-                needs_commit = true;
-            }
+            needs_commit = true;
         }
 
-        // Check window flags for is_top_level and other changes
-        // We extract all values first to avoid borrow conflicts
-        let flag_changes = self.common.previous_window_state.as_ref().map(|prev| {
-            let is_top_level_changed =
-                prev.flags.is_top_level != self.common.current_window_state.flags.is_top_level;
-            let prevent_sleep_changed = prev.flags.prevent_system_sleep
-                != self.common.current_window_state.flags.prevent_system_sleep;
-            let background_material_changed = prev.flags.background_material
-                != self.common.current_window_state.flags.background_material;
-            let new_is_top_level = self.common.current_window_state.flags.is_top_level;
-            let new_prevent_sleep = self.common.current_window_state.flags.prevent_system_sleep;
-            let new_background_material = self.common.current_window_state.flags.background_material;
-
-            (
-                is_top_level_changed,
-                new_is_top_level,
-                prevent_sleep_changed,
-                new_prevent_sleep,
-                background_material_changed,
-                new_background_material,
-            )
-        });
-
-        if let Some((
-            is_top_level_changed,
-            new_is_top_level,
-            prevent_sleep_changed,
-            new_prevent_sleep,
-            background_material_changed,
-            new_background_material,
-        )) = flag_changes
-        {
-            if is_top_level_changed {
-                self.set_is_top_level(new_is_top_level);
+        // Window frame state changed? (Minimize/Maximize/Normal/Fullscreen)
+        if previous.flags.frame != current.flags.frame {
+            match current.flags.frame {
+                WindowFrame::Minimized => {
+                    unsafe {
+                        (self.wayland.xdg_toplevel_set_minimized)(self.xdg_toplevel);
+                    }
+                }
+                WindowFrame::Maximized => {
+                    // If previously fullscreen, unset fullscreen first
+                    if previous.flags.frame == WindowFrame::Fullscreen {
+                        unsafe {
+                            (self.wayland.xdg_toplevel_unset_fullscreen)(self.xdg_toplevel);
+                        }
+                    }
+                    unsafe {
+                        (self.wayland.xdg_toplevel_set_maximized)(self.xdg_toplevel);
+                    }
+                }
+                WindowFrame::Fullscreen => {
+                    // If previously maximized, unset maximized first
+                    if previous.flags.frame == WindowFrame::Maximized {
+                        unsafe {
+                            (self.wayland.xdg_toplevel_unset_maximized)(self.xdg_toplevel);
+                        }
+                    }
+                    unsafe {
+                        (self.wayland.xdg_toplevel_set_fullscreen)(
+                            self.xdg_toplevel,
+                            std::ptr::null_mut(), // NULL = current output
+                        );
+                    }
+                }
+                WindowFrame::Normal => {
+                    if previous.flags.frame == WindowFrame::Maximized {
+                        unsafe {
+                            (self.wayland.xdg_toplevel_unset_maximized)(self.xdg_toplevel);
+                        }
+                    }
+                    if previous.flags.frame == WindowFrame::Fullscreen {
+                        unsafe {
+                            (self.wayland.xdg_toplevel_unset_fullscreen)(self.xdg_toplevel);
+                        }
+                    }
+                    // Note: Wayland has no explicit "unminimize" — the compositor handles it
+                }
             }
+            needs_commit = true;
+        }
 
-            // Check window flags for prevent_system_sleep
-            if prevent_sleep_changed {
-                self.set_prevent_system_sleep(new_prevent_sleep);
+        // Min dimensions changed?
+        if previous.size.min_dimensions != current.size.min_dimensions {
+            use azul_core::geom::OptionLogicalSize;
+            let (w, h) = match current.size.min_dimensions {
+                OptionLogicalSize::Some(dims) => (dims.width as i32, dims.height as i32),
+                OptionLogicalSize::None => (0, 0), // 0 = no minimum
+            };
+            unsafe {
+                (self.wayland.xdg_toplevel_set_min_size)(self.xdg_toplevel, w, h);
             }
+            needs_commit = true;
+        }
 
-            // Background material changed? (transparency/blur effects)
-            if background_material_changed {
-                self.apply_background_material(new_background_material);
-                needs_commit = true;
+        // Max dimensions changed?
+        if previous.size.max_dimensions != current.size.max_dimensions {
+            use azul_core::geom::OptionLogicalSize;
+            let (w, h) = match current.size.max_dimensions {
+                OptionLogicalSize::Some(dims) => (dims.width as i32, dims.height as i32),
+                OptionLogicalSize::None => (0, 0), // 0 = no maximum
+            };
+            unsafe {
+                (self.wayland.xdg_toplevel_set_max_size)(self.xdg_toplevel, w, h);
             }
+            needs_commit = true;
+        }
+
+        // Check window flags for is_top_level
+        if previous.flags.is_top_level != current.flags.is_top_level {
+            self.set_is_top_level(current.flags.is_top_level);
+        }
+
+        // Check window flags for prevent_system_sleep
+        if previous.flags.prevent_system_sleep != current.flags.prevent_system_sleep {
+            self.set_prevent_system_sleep(current.flags.prevent_system_sleep);
+        }
+
+        // Background material changed? (transparency/blur effects)
+        if previous.flags.background_material != current.flags.background_material {
+            self.apply_background_material(current.flags.background_material);
+            needs_commit = true;
         }
 
         // Note: Wayland doesn't support direct position control

--- a/dll/src/desktop/shell2/linux/x11/clipboard.rs
+++ b/dll/src/desktop/shell2/linux/x11/clipboard.rs
@@ -3,6 +3,7 @@
 //! This module provides clipboard synchronization between azul-layout's ClipboardManager
 //! and the X11 system clipboard (both PRIMARY and CLIPBOARD selections).
 
+use std::sync::mpsc::{self, Sender, SyncSender};
 use std::sync::{Mutex, MutexGuard, OnceLock};
 use std::time::Duration;
 
@@ -10,7 +11,23 @@ use azul_layout::managers::clipboard::ClipboardManager;
 use x11_clipboard::Clipboard;
 
 use super::super::super::common::debug_server::LogCategory;
-use crate::log_error;
+use crate::{log_error, log_warn};
+
+/// How long the UI thread waits for a selection read before giving up.
+///
+/// An X11 selection read is a round trip to ANOTHER process: when the owner is
+/// gone or wedged — routine after the owning app exits — it blocks for the full
+/// timeout. That used to happen ON THE UI THREAD, twice, at 3 s each, so Ctrl+V
+/// could freeze the event loop for 6 s (caret blink, tweens and rendering all
+/// stall). Blocking calls on the UI thread are forbidden: the read now runs on
+/// a worker thread and the UI thread waits only this long — long enough for any
+/// owner that is actually alive (a real transfer is a few milliseconds), short
+/// enough that a dead one costs a hitch instead of a freeze.
+const PASTE_UI_DEADLINE: Duration = Duration::from_millis(400);
+
+/// Per-selection deadline INSIDE the worker thread. Bounded so the worker
+/// cannot hold the clipboard mutex (shared with `write_to_clipboard`) for long.
+const SELECTION_LOAD_TIMEOUT: Duration = Duration::from_millis(600);
 
 /// Process-wide persistent X11 clipboard owner.
 ///
@@ -86,39 +103,118 @@ pub fn write_to_clipboard(text: &str) -> Result<(), ClipboardError> {
     Ok(())
 }
 
-/// Read content from X11 system clipboard
+/// Claim ONLY the PRIMARY selection (the X11 select/middle-click-paste idiom).
 ///
-/// Attempts to read from CLIPBOARD selection first, falls back to PRIMARY.
-/// Returns the clipboard text content if available.
+/// Selecting text claims PRIMARY without touching CLIPBOARD — an explicit copy
+/// is what owns CLIPBOARD, and clobbering it on every selection would destroy
+/// whatever the user copied.
 ///
-/// Note: Each selection read uses a 3-second timeout, so this function may
-/// block for up to 6 seconds in the worst case (both selections time out).
-pub fn get_clipboard_content() -> Option<String> {
+/// Handed to the worker rather than performed inline: this runs on every mouse
+/// release that ends a selection, and the clipboard mutex can be held by an
+/// in-flight read. `Ok` therefore means "queued", not "owned".
+pub fn write_to_primary(text: &str) -> Result<(), ClipboardError> {
+    let sender = worker().ok_or(ClipboardError::InitFailed)?;
+    sender
+        .send(ClipboardJob::ClaimPrimary(text.to_string()))
+        .map_err(|_| ClipboardError::WriteFailed)
+}
+
+/// Which selection a read targets.
+#[derive(Debug, Copy, Clone)]
+enum SelectionKind {
+    /// CLIPBOARD (Ctrl+C/V), falling back to PRIMARY when it is empty.
+    Clipboard,
+    /// PRIMARY only (middle-click paste).
+    Primary,
+}
+
+/// Work handed to the clipboard thread.
+enum ClipboardJob {
+    /// Read a selection and answer on `reply`.
+    Load {
+        kind: SelectionKind,
+        reply: SyncSender<Option<String>>,
+    },
+    /// Take ownership of PRIMARY with this text (fire and forget).
+    ClaimPrimary(String),
+}
+
+/// Handle to the (lazily spawned) clipboard worker thread.
+///
+/// One long-lived thread rather than one per paste: a slow owner must not be
+/// able to pile up threads, and serializing the reads keeps the clipboard mutex
+/// held by at most one of them.
+fn worker() -> Option<MutexGuard<'static, Sender<ClipboardJob>>> {
+    static WORKER: OnceLock<Mutex<Sender<ClipboardJob>>> = OnceLock::new();
+    let m = WORKER.get_or_init(|| {
+        let (tx, rx) = mpsc::channel::<ClipboardJob>();
+        let _ = std::thread::Builder::new()
+            .name("azul-x11-clipboard".to_string())
+            .spawn(move || {
+                while let Ok(job) = rx.recv() {
+                    match job {
+                        // A reply nobody is waiting for any more (the UI thread
+                        // hit its deadline and dropped the receiver) is
+                        // discarded, not an error.
+                        ClipboardJob::Load { kind, reply } => {
+                            let _ = reply.try_send(load_selection(kind));
+                        }
+                        ClipboardJob::ClaimPrimary(text) => claim_primary(&text),
+                    }
+                }
+            });
+        Mutex::new(tx)
+    });
+    m.lock().ok()
+}
+
+/// Worker-thread side of a PRIMARY claim.
+fn claim_primary(text: &str) {
+    let Some(guard) = clipboard() else {
+        return;
+    };
+    let Some(clipboard) = guard.as_ref() else {
+        return;
+    };
+    if clipboard
+        .store(
+            clipboard.setter.atoms.primary,
+            clipboard.setter.atoms.utf8_string,
+            text.as_bytes(),
+        )
+        .is_err()
+    {
+        log_warn!(
+            LogCategory::Resources,
+            "[X11] failed to claim the PRIMARY selection"
+        );
+    }
+}
+
+/// Worker-thread side of a read. Blocking — never call this on the UI thread.
+fn load_selection(kind: SelectionKind) -> Option<String> {
     let guard = clipboard()?;
     let clipboard = guard.as_ref()?;
-    let timeout = Duration::from_secs(3);
 
-    // Try CLIPBOARD first (Ctrl+C/V)
-    if let Ok(data) = clipboard.load(
-        clipboard.getter.atoms.clipboard,
-        clipboard.getter.atoms.utf8_string,
-        clipboard.getter.atoms.property,
-        timeout,
-    ) {
-        if let Ok(s) = String::from_utf8(data) {
-            if !s.is_empty() {
-                return Some(s);
-            }
-        }
-    }
+    // CLIPBOARD first, PRIMARY as the fallback — both inside ONE request, so
+    // the UI thread's single deadline covers the whole chain.
+    let targets = match kind {
+        SelectionKind::Clipboard => vec![
+            clipboard.getter.atoms.clipboard,
+            clipboard.getter.atoms.primary,
+        ],
+        SelectionKind::Primary => vec![clipboard.getter.atoms.primary],
+    };
 
-    // Fall back to PRIMARY (middle-click)
-    if let Ok(data) = clipboard.load(
-        clipboard.getter.atoms.primary,
-        clipboard.getter.atoms.utf8_string,
-        clipboard.getter.atoms.property,
-        timeout,
-    ) {
+    for selection in targets {
+        let Ok(data) = clipboard.load(
+            selection,
+            clipboard.getter.atoms.utf8_string,
+            clipboard.getter.atoms.property,
+            SELECTION_LOAD_TIMEOUT,
+        ) else {
+            continue;
+        };
         if let Ok(s) = String::from_utf8(data) {
             if !s.is_empty() {
                 return Some(s);
@@ -127,6 +223,43 @@ pub fn get_clipboard_content() -> Option<String> {
     }
 
     None
+}
+
+/// Hand a read to the worker and wait at most [`PASTE_UI_DEADLINE`] for it.
+fn request(kind: SelectionKind) -> Option<String> {
+    let (reply, answer) = mpsc::sync_channel(1);
+    {
+        let sender = worker()?;
+        sender.send(ClipboardJob::Load { kind, reply }).ok()?;
+    }
+    match answer.recv_timeout(PASTE_UI_DEADLINE) {
+        Ok(text) => text,
+        Err(_) => {
+            log_warn!(
+                LogCategory::Resources,
+                "[X11] selection owner did not answer within {:?} — pasting nothing",
+                PASTE_UI_DEADLINE
+            );
+            None
+        }
+    }
+}
+
+/// Read content from X11 system clipboard
+///
+/// Attempts to read from CLIPBOARD selection first, falls back to PRIMARY.
+/// Returns the clipboard text content if available.
+///
+/// Non-blocking by UI-thread standards: the actual selection transfer runs on
+/// the clipboard worker thread and this call gives up after
+/// [`PASTE_UI_DEADLINE`] with an empty result.
+pub fn get_clipboard_content() -> Option<String> {
+    request(SelectionKind::Clipboard)
+}
+
+/// Read the PRIMARY selection only — the middle-click paste source.
+pub fn get_primary_content() -> Option<String> {
+    request(SelectionKind::Primary)
 }
 
 #[derive(Debug, Copy, Clone)]

--- a/dll/src/desktop/shell2/linux/x11/defines.rs
+++ b/dll/src/desktop/shell2/linux/x11/defines.rs
@@ -35,6 +35,8 @@ pub union XEvent {
     pub configure: XConfigureEvent,
     pub client_message: XClientMessageEvent,
     pub selection: XSelectionEvent,
+    pub keymap: XKeymapEvent,
+    pub mapping: XMappingEvent,
     pub xcookie: XGenericEventCookie,
     pad: [c_long; 24],
 }
@@ -136,6 +138,36 @@ pub struct XFocusChangeEvent {
     pub window: Window,
     pub mode: c_int,
     pub detail: c_int,
+}
+/// `KeymapNotify`: the server reports the FULL keyboard state right after every
+/// `FocusIn` (when `KeymapStateMask` is selected). `key_vector` is a bit vector
+/// indexed by keycode (`key_vector[kc >> 3] & (1 << (kc & 7))`), which is the
+/// X11-designed remedy for keys released while another window held focus.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct XKeymapEvent {
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: c_int,
+    pub display: *mut Display,
+    pub window: Window,
+    pub key_vector: [c_char; 32],
+}
+/// `MappingNotify`: the keycode → keysym table or the modifier mapping changed
+/// (keyboard layout switch, `xmodmap`). Delivered to every client regardless of
+/// the selected event mask; the client-side table is only refreshed by passing
+/// this event to `XRefreshKeyboardMapping`.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct XMappingEvent {
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: c_int,
+    pub display: *mut Display,
+    pub window: Window,
+    pub request: c_int,
+    pub first_keycode: c_int,
+    pub count: c_int,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -251,6 +283,9 @@ pub const ButtonReleaseMask: c_long = 1 << 3;
 pub const EnterWindowMask: c_long = 1 << 4;
 pub const LeaveWindowMask: c_long = 1 << 5;
 pub const PointerMotionMask: c_long = 1 << 6;
+/// Ask for `KeymapNotify` after every `FocusIn` — without it the client has no
+/// way to learn which keys were released while another window had focus.
+pub const KeymapStateMask: c_long = 1 << 14;
 pub const ExposureMask: c_long = 1 << 15;
 pub const StructureNotifyMask: c_long = 1 << 17;
 pub const FocusChangeMask: c_long = 1 << 21;
@@ -276,12 +311,29 @@ pub const EnterNotify: c_int = 7;
 pub const LeaveNotify: c_int = 8;
 pub const FocusIn: c_int = 9;
 pub const FocusOut: c_int = 10;
+pub const KeymapNotify: c_int = 11;
 pub const Expose: c_int = 12;
 pub const UnmapNotify: c_int = 18;
 pub const MapNotify: c_int = 19;
 pub const ConfigureNotify: c_int = 22;
 pub const SelectionNotify: c_int = 31;
 pub const ClientMessage: c_int = 33;
+pub const MappingNotify: c_int = 34;
+
+// Focus/crossing `mode` values (X.h). A grab activating or releasing — including
+// this app's OWN menu pointer grab — synthesizes FocusIn/FocusOut and
+// EnterNotify/LeaveNotify pairs that do NOT mean the user changed windows.
+pub const NotifyNormal: c_int = 0;
+pub const NotifyGrab: c_int = 1;
+pub const NotifyUngrab: c_int = 2;
+pub const NotifyWhileGrabbed: c_int = 3;
+/// Focus `detail`: the focus followed the POINTER, not the window.
+pub const NotifyPointer: c_int = 5;
+
+// `XMappingEvent.request` values (X.h).
+pub const MappingModifier: c_int = 0;
+pub const MappingKeyboard: c_int = 1;
+pub const MappingPointer: c_int = 2;
 
 // Window classes and attributes
 pub const InputOutput: c_uint = 1;
@@ -402,6 +454,86 @@ pub const XK_Alt_L: u32 = 0xFFE9;
 pub const XK_Alt_R: u32 = 0xFFEA;
 pub const XK_Super_L: u32 = 0xFFEB;
 pub const XK_Super_R: u32 = 0xFFEC;
+pub const XK_Meta_L: u32 = 0xFFE7;
+pub const XK_Meta_R: u32 = 0xFFE8;
+pub const XK_Hyper_L: u32 = 0xFFED;
+pub const XK_Hyper_R: u32 = 0xFFEE;
+pub const XK_Caps_Lock: u32 = 0xFFE5;
+pub const XK_Shift_Lock: u32 = 0xFFE6;
+pub const XK_Num_Lock: u32 = 0xFF7F;
+pub const XK_Menu: u32 = 0xFF67;
+pub const XK_Print: u32 = 0xFF61;
+pub const XK_Sys_Req: u32 = 0xFF15;
+/// AltGr (third-level shift). Missing from the table, so every AltGr-composed
+/// accelerator was dead on X11.
+pub const XK_ISO_Level3_Shift: u32 = 0xFE03;
+pub const XK_Mode_switch: u32 = 0xFF7E;
+
+// Punctuation / OEM keys. `Ctrl+-` / `Ctrl+=` (zoom out/in) live here.
+pub const XK_minus: u32 = 0x002D;
+pub const XK_underscore: u32 = 0x005F;
+pub const XK_equal: u32 = 0x003D;
+pub const XK_plus: u32 = 0x002B;
+pub const XK_comma: u32 = 0x002C;
+pub const XK_less: u32 = 0x003C;
+pub const XK_period: u32 = 0x002E;
+pub const XK_greater: u32 = 0x003E;
+pub const XK_semicolon: u32 = 0x003B;
+pub const XK_colon: u32 = 0x003A;
+pub const XK_apostrophe: u32 = 0x0027;
+pub const XK_quotedbl: u32 = 0x0022;
+pub const XK_grave: u32 = 0x0060;
+pub const XK_asciitilde: u32 = 0x007E;
+pub const XK_bracketleft: u32 = 0x005B;
+pub const XK_braceleft: u32 = 0x007B;
+pub const XK_bracketright: u32 = 0x005D;
+pub const XK_braceright: u32 = 0x007D;
+pub const XK_backslash: u32 = 0x005C;
+pub const XK_bar: u32 = 0x007C;
+pub const XK_slash: u32 = 0x002F;
+pub const XK_question: u32 = 0x003F;
+
+// Keypad.
+pub const XK_KP_Space: u32 = 0xFF80;
+pub const XK_KP_Tab: u32 = 0xFF89;
+pub const XK_KP_Enter: u32 = 0xFF8D;
+pub const XK_KP_Home: u32 = 0xFF95;
+pub const XK_KP_Left: u32 = 0xFF96;
+pub const XK_KP_Up: u32 = 0xFF97;
+pub const XK_KP_Right: u32 = 0xFF98;
+pub const XK_KP_Down: u32 = 0xFF99;
+pub const XK_KP_Page_Up: u32 = 0xFF9A;
+pub const XK_KP_Page_Down: u32 = 0xFF9B;
+pub const XK_KP_End: u32 = 0xFF9C;
+pub const XK_KP_Begin: u32 = 0xFF9D;
+pub const XK_KP_Insert: u32 = 0xFF9E;
+pub const XK_KP_Delete: u32 = 0xFF9F;
+pub const XK_KP_Equal: u32 = 0xFFBD;
+pub const XK_KP_Multiply: u32 = 0xFFAA;
+pub const XK_KP_Add: u32 = 0xFFAB;
+pub const XK_KP_Separator: u32 = 0xFFAC;
+pub const XK_KP_Subtract: u32 = 0xFFAD;
+pub const XK_KP_Decimal: u32 = 0xFFAE;
+pub const XK_KP_Divide: u32 = 0xFFAF;
+pub const XK_KP_0: u32 = 0xFFB0;
+pub const XK_KP_1: u32 = 0xFFB1;
+pub const XK_KP_2: u32 = 0xFFB2;
+pub const XK_KP_3: u32 = 0xFFB3;
+pub const XK_KP_4: u32 = 0xFFB4;
+pub const XK_KP_5: u32 = 0xFFB5;
+pub const XK_KP_6: u32 = 0xFFB6;
+pub const XK_KP_7: u32 = 0xFFB7;
+pub const XK_KP_8: u32 = 0xFFB8;
+pub const XK_KP_9: u32 = 0xFFB9;
+
+// `Status` values returned through the last out-param of the
+// Xmb/Xutf8/XwcLookupString family (Xlib.h). `XBufferOverflow` means NOTHING
+// was written and the return value is the required buffer size in bytes.
+pub const XBufferOverflow: c_int = -1;
+pub const XLookupNone: c_int = 1;
+pub const XLookupChars: c_int = 2;
+pub const XLookupKeySym: c_int = 3;
+pub const XLookupBoth: c_int = 4;
 
 // EGL types
 pub type EGLDisplay = *mut c_void;
@@ -538,8 +670,17 @@ pub const XI_TouchEnd: c_int = 20;
 pub const XIAllDevices: c_int = 0;
 pub const XIAllMasterDevices: c_int = 1;
 pub const XIValuatorClass: c_int = 2;
+pub const XIScrollClass: c_int = 3;
 pub const XITouchClass: c_int = 8;
 pub const XIModeAbsolute: c_int = 1;
+pub const XIScrollTypeVertical: c_int = 1;
+pub const XIScrollTypeHorizontal: c_int = 2;
+/// `XIScrollClassInfo.flags`: the driver does NOT emit emulated button 4-7
+/// presses for this axis, so the valuator is the only scroll delivery.
+pub const XIScrollFlagNoEmulation: c_int = 1;
+/// `XIDeviceEvent.flags`: this button event is the legacy wheel emulation of a
+/// smooth-scroll valuator. Handling both is what double-scrolls a touchpad.
+pub const XIPointerEmulated: c_int = 1 << 16;
 
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -588,6 +729,20 @@ pub struct XIValuatorClassInfo {
     pub value: f64,
     pub resolution: c_int,
     pub mode: c_int,
+}
+/// Smooth-scroll axis of a device (XI2.1). `increment` is the valuator delta
+/// that equals one legacy wheel detent; the valuator itself carries an
+/// ACCUMULATING absolute value, so a scroll delta is
+/// `(new - last) / increment` — fractional for touchpads.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct XIScrollClassInfo {
+    pub type_: c_int,
+    pub sourceid: c_int,
+    pub number: c_int,
+    pub scroll_type: c_int,
+    pub increment: f64,
+    pub flags: c_int,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -765,6 +920,27 @@ pub type XFreeCursor = unsafe extern "C" fn(*mut Display, Cursor) -> c_int;
 pub type XUndefineCursor = unsafe extern "C" fn(*mut Display, Window) -> c_int;
 pub type XkbSetDetectableAutoRepeat =
     unsafe extern "C" fn(*mut Display, c_int, *mut c_int) -> c_int;
+/// X11 keycode. 8 bits on Linux (`NeedWidePrototypes == 0`).
+pub type KeyCode = c_uchar;
+/// The 8 × `max_keypermod` table returned by `XGetModifierMapping`: row `i`
+/// (Shift, Lock, Control, Mod1..Mod5) lists the keycodes bound to that modifier.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct XModifierKeymap {
+    pub max_keypermod: c_int,
+    pub modifiermap: *mut KeyCode,
+}
+pub type XGetModifierMapping = unsafe extern "C" fn(*mut Display) -> *mut XModifierKeymap;
+pub type XFreeModifiermap = unsafe extern "C" fn(*mut XModifierKeymap) -> c_int;
+/// Refresh the CLIENT-side keycode → keysym table after a `MappingNotify`.
+/// Without it every translation stays on the layout that was active at connect.
+pub type XRefreshKeyboardMapping = unsafe extern "C" fn(*mut XMappingEvent) -> c_int;
+/// Full keyboard state as a 32-byte keycode bit vector (`keys_return`).
+pub type XQueryKeymap = unsafe extern "C" fn(*mut Display, *mut c_char) -> c_int;
+/// XKB keycode → keysym for a given group/level. Used to identify which
+/// `ModN` bit actually carries Alt / Super / AltGr on THIS keyboard.
+pub type XkbKeycodeToKeysym =
+    unsafe extern "C" fn(*mut Display, KeyCode, c_int, c_int) -> KeySym;
 /// XTranslateCoordinates(display, src_w, dest_w, src_x, src_y,
 ///   dest_x_return, dest_y_return, child_return) -> Bool (0 = different screens).
 pub type XTranslateCoordinates = unsafe extern "C" fn(

--- a/dll/src/desktop/shell2/linux/x11/dlopen.rs
+++ b/dll/src/desktop/shell2/linux/x11/dlopen.rs
@@ -149,6 +149,19 @@ pub struct Xlib {
     /// reliable absolute window position under a reparenting WM (ConfigureNotify
     /// x/y are parent-relative for non-synthetic events).
     pub XTranslateCoordinates: Option<XTranslateCoordinates>,
+    /// Optional (lenient): refresh the client-side keycode → keysym table after
+    /// a `MappingNotify`. Without it a keyboard-layout switch leaves every
+    /// translation on the layout that was active when the connection opened.
+    pub XRefreshKeyboardMapping: Option<XRefreshKeyboardMapping>,
+    /// Optional (lenient): full keyboard state as a keycode bit vector, used to
+    /// resync `pressed_*` on focus change (the KeymapNotify fallback).
+    pub XQueryKeymap: Option<XQueryKeymap>,
+    /// Optional (lenient): keycode → keysym, needed to learn which `ModN` bit
+    /// carries Alt / Super / AltGr on the CURRENT keyboard instead of assuming
+    /// the Mod1/Mod4 defaults.
+    pub XkbKeycodeToKeysym: Option<XkbKeycodeToKeysym>,
+    pub XGetModifierMapping: Option<XGetModifierMapping>,
+    pub XFreeModifiermap: Option<XFreeModifiermap>,
     pub XUnmapWindow: XUnmapWindow,
     pub XCreateFontCursor: XCreateFontCursor,
     pub XDefineCursor: XDefineCursor,
@@ -238,6 +251,19 @@ impl Xlib {
             },
             XTranslateCoordinates: unsafe {
                 lib.get_symbol::<XTranslateCoordinates>("XTranslateCoordinates").ok()
+            },
+            XRefreshKeyboardMapping: unsafe {
+                lib.get_symbol::<XRefreshKeyboardMapping>("XRefreshKeyboardMapping").ok()
+            },
+            XQueryKeymap: unsafe { lib.get_symbol::<XQueryKeymap>("XQueryKeymap").ok() },
+            XkbKeycodeToKeysym: unsafe {
+                lib.get_symbol::<XkbKeycodeToKeysym>("XkbKeycodeToKeysym").ok()
+            },
+            XGetModifierMapping: unsafe {
+                lib.get_symbol::<XGetModifierMapping>("XGetModifierMapping").ok()
+            },
+            XFreeModifiermap: unsafe {
+                lib.get_symbol::<XFreeModifiermap>("XFreeModifiermap").ok()
             },
             XUnmapWindow: load_symbol!(lib, _, "XUnmapWindow"),
             XCreateFontCursor: load_symbol!(lib, _, "XCreateFontCursor"),
@@ -350,6 +376,10 @@ pub struct Xkb {
         unsafe extern "C" fn(*mut xkb_state, u32, u32, u32, u32, u32, u32) -> u32,
     pub xkb_state_key_get_one_sym: unsafe extern "C" fn(*mut xkb_state, u32) -> u32,
     pub xkb_state_key_get_utf8: unsafe extern "C" fn(*mut xkb_state, u32, *mut i8, usize) -> i32,
+    /// Does this key auto-repeat? The keymap knows (modifiers, locks and
+    /// several function keys do not), which is strictly better than a
+    /// hand-rolled list of "keys that should not repeat".
+    pub xkb_keymap_key_repeats: unsafe extern "C" fn(*mut xkb_keymap, xkb_keycode_t) -> i32,
 }
 
 impl Xkb {
@@ -366,6 +396,7 @@ impl Xkb {
             xkb_state_update_mask: load_symbol!(lib, _, "xkb_state_update_mask"),
             xkb_state_key_get_one_sym: load_symbol!(lib, _, "xkb_state_key_get_one_sym"),
             xkb_state_key_get_utf8: load_symbol!(lib, _, "xkb_state_key_get_utf8"),
+            xkb_keymap_key_repeats: load_symbol!(lib, _, "xkb_keymap_key_repeats"),
             _lib: lib,
         }))
     }

--- a/dll/src/desktop/shell2/linux/x11/events.rs
+++ b/dll/src/desktop/shell2/linux/x11/events.rs
@@ -41,7 +41,8 @@ use crate::{log_debug, log_error, log_info, log_trace, log_warn};
 /// Pixels per discrete X11 scroll tick (button 4/5). X11 scroll events are
 /// unitless discrete steps; this constant converts them to pixel deltas for
 /// the scroll physics system.
-const X11_SCROLL_TICK_PIXELS: f32 = 20.0;
+pub(super) const X11_SCROLL_TICK_PIXELS: f32 =
+    crate::desktop::shell2::common::event::WHEEL_SCROLL_PIXELS_PER_LINE;
 
 // IME Support (X Input Method)
 
@@ -303,9 +304,9 @@ impl ImeManager {
     pub(super) fn lookup_string(&self, event: &mut XKeyEvent) -> (Option<String>, Option<KeySym>) {
         let mut keysym: KeySym = 0;
         let mut status: i32 = 0;
-        let mut buffer: [c_char; 32] = [0; 32];
+        let mut stack: [c_char; 32] = [0; 32];
 
-        let count = unsafe {
+        let mut count = unsafe {
             // Xutf8LookupString (not XmbLookupString): the committed bytes are
             // guaranteed UTF-8 regardless of the locale codeset, so accented and
             // CJK commit strings decode correctly even under a non-UTF-8 locale.
@@ -313,17 +314,44 @@ impl ImeManager {
             (self.xlib.Xutf8LookupString)(
                 self.xic,
                 event,
-                buffer.as_mut_ptr(),
-                buffer.len() as i32,
+                stack.as_mut_ptr(),
+                stack.len() as i32,
                 &mut keysym,
                 &mut status,
             )
         };
 
-        let chars = if count > 0 {
+        // XBufferOverflow: NOTHING was written and the return value is the
+        // buffer size the commit needs. The fixed 32-byte buffer overflows on
+        // any commit past ~11 CJK characters — an ordinary phrase — and the
+        // untested status left the caller seeing count <= 0, so the whole
+        // composed sentence vanished. Re-run into a heap buffer of the
+        // requested size.
+        let mut heap: Vec<c_char> = Vec::new();
+        if status == XBufferOverflow && count > 0 {
+            heap = vec![0; count as usize];
+            count = unsafe {
+                (self.xlib.Xutf8LookupString)(
+                    self.xic,
+                    event,
+                    heap.as_mut_ptr(),
+                    heap.len() as i32,
+                    &mut keysym,
+                    &mut status,
+                )
+            };
+        }
+
+        // XLookupNone / XLookupKeySym leave the buffer untouched (count == 0);
+        // a second overflow would mean the IM lied about the size.
+        let has_text =
+            count > 0 && !matches!(status, XBufferOverflow | XLookupNone | XLookupKeySym);
+        let chars = if has_text {
             // Use count to slice the buffer rather than CStr::from_ptr, which would
-            // read past the buffer if X11 fills all 32 bytes with no null terminator.
-            let bytes: Vec<u8> = buffer[..count as usize].iter().map(|b| *b as u8).collect();
+            // read past the buffer if X11 fills it with no null terminator.
+            let src: &[c_char] = if heap.is_empty() { &stack } else { &heap };
+            let end = (count as usize).min(src.len());
+            let bytes: Vec<u8> = src[..end].iter().map(|b| *b as u8).collect();
             Some(String::from_utf8_lossy(&bytes).into_owned())
         } else {
             None
@@ -599,17 +627,86 @@ impl X11Window {
         // Update hit test
         self.update_hit_test(position);
 
-        // Check for right-click context menu (before event processing)
+        // Check for right-click context menu (before event processing).
+        // The pass below runs EITHER WAY: returning early here left
+        // `right_down: true -> false` sitting in the un-consumed delta, so
+        // RightMouseUp / Hover(RightMouseUp) never fired for that click and
+        // the next handler's snapshot destroyed the transition.
         if !is_down && button == MouseButton::Right {
             if let Some(hit_node) = self.get_first_hovered_node() {
-                if self.try_show_context_menu(hit_node, position) {
-                    return ProcessEventResult::DoNothing;
+                self.try_show_context_menu(hit_node, position);
+            }
+        }
+
+        // X11 middle-click paste: the PRIMARY selection is inserted at the
+        // caret, which the button-2 PRESS already moved to the click point.
+        // Recorded before the pass so the changeset is applied by it, exactly
+        // like typed text. (The other half of the idiom — claiming PRIMARY on
+        // selection — is below.)
+        //
+        // Only asked for when something editable actually has focus: the read
+        // waits on the selection OWNER, so a middle click anywhere else must
+        // not pay for it (and `record_text_input` would drop the text anyway).
+        if !is_down
+            && button == MouseButton::Middle
+            && self
+                .common
+                .layout_window
+                .as_ref()
+                .is_some_and(|lw| lw.text_edit_manager.has_active_editing())
+        {
+            if let Some(text) = super::clipboard::get_primary_content() {
+                if !text.is_empty() {
+                    if let Some(ref mut layout_window) = self.common.layout_window {
+                        layout_window.record_text_input(&text);
+                    }
                 }
             }
         }
 
         // V2 system will automatically detect MouseDown/MouseUp and dispatch callbacks
-        self.process_window_events(0)
+        let result = self.process_window_events(0);
+
+        // The release that ends a selection gesture claims PRIMARY (run after
+        // the pass, which is what finalizes the selection).
+        if !is_down && button == MouseButton::Left {
+            self.publish_primary_selection();
+        }
+
+        result
+    }
+
+    /// Claim the X11 PRIMARY selection for the current text selection.
+    ///
+    /// On X11, *selecting* text is itself a PRIMARY claim — no copy involved —
+    /// and middle-click pastes it. PRIMARY was only ever written by an explicit
+    /// Ctrl+C, so both halves of the idiom were missing.
+    fn publish_primary_selection(&mut self) {
+        let text = {
+            let Some(lw) = self.common.layout_window.as_ref() else {
+                return;
+            };
+            if !lw.text_edit_manager.has_active_editing() {
+                return;
+            }
+            let dom_id = lw
+                .text_edit_manager
+                .get_editing_dom_id()
+                .unwrap_or(DomId { inner: 0 });
+            match lw.get_selected_content_for_clipboard(&dom_id) {
+                Some(content) => content.plain_text.as_str().to_string(),
+                None => return,
+            }
+        };
+        if text.is_empty() {
+            return;
+        }
+        if let Err(e) = super::clipboard::write_to_primary(&text) {
+            log_warn!(
+                LogCategory::Resources,
+                "[X11] failed to claim the PRIMARY selection: {e}"
+            );
+        }
     }
 
     /// Handle mouse motion events
@@ -664,6 +761,15 @@ impl X11Window {
 
     /// Handle mouse entering/leaving window
     pub fn handle_mouse_crossing(&mut self, event: &XCrossingEvent) -> ProcessEventResult {
+        // A grab activating or releasing synthesizes a Leave/Enter pair that
+        // does NOT mean the pointer moved — and this app grabs the pointer for
+        // its own menus. Acting on it pushed an EMPTY hit test and
+        // OutOfWindow, so opening a context menu wiped the parent's hover
+        // state (and the matching ungrab crossing re-ran the whole pass).
+        if event.mode == NotifyGrab || event.mode == NotifyUngrab {
+            return ProcessEventResult::DoNothing;
+        }
+
         // Physical (X11 wire) → logical.
         let position = self.to_logical_pos(event.x as f32, event.y as f32);
 
@@ -693,12 +799,37 @@ impl X11Window {
         self.process_window_events(0)
     }
 
-    /// Handle scroll wheel events (X11 button 4/5)
+    /// Handle a discrete wheel detent (core / XI2-emulated buttons 4-7).
+    ///
+    /// `delta_x` / `delta_y` are ratcheting tick counts in the engine's
+    /// canonical X11 sign convention (up = +1, left = +1).
     fn handle_scroll(
         &mut self,
         delta_x: f32,
         delta_y: f32,
         position: LogicalPosition,
+    ) -> ProcessEventResult {
+        self.handle_scroll_input(
+            delta_x * X11_SCROLL_TICK_PIXELS,
+            delta_y * X11_SCROLL_TICK_PIXELS,
+            position,
+            false,
+        )
+    }
+
+    /// Shared scroll ingress, in PIXELS, in the canonical X11 sign convention.
+    ///
+    /// `continuous` marks an XI2 smooth-scroll valuator delta (touchpad /
+    /// kinetic trackpoint): those are position deltas, not wheel ticks, and
+    /// feeding them in as `WheelDiscrete` stacks one velocity impulse per
+    /// event — the jerky touchpad scrolling Wayland already fixed via
+    /// `axis_source` classification.
+    pub(super) fn handle_scroll_input(
+        &mut self,
+        delta_x: f32,
+        delta_y: f32,
+        position: LogicalPosition,
+        continuous: bool,
     ) -> ProcessEventResult {
         // Save previous state BEFORE making changes
         self.common.previous_window_state = Some(self.common.current_window_state.clone());
@@ -717,17 +848,26 @@ impl X11Window {
 
                 let now = Instant::from(std::time::Instant::now());
 
+                let (source, device) = if continuous {
+                    (
+                        ScrollInputSource::TrackpadContinuous,
+                        azul_layout::managers::scroll_state::ScrollInputDevice::Touchpad,
+                    )
+                } else {
+                    (
+                        ScrollInputSource::WheelDiscrete,
+                        azul_layout::managers::scroll_state::ScrollInputDevice::MouseWheel,
+                    )
+                };
+
                 if let Some((_dom_id, _node_id, start_timer)) =
                     layout_window.scroll_manager.record_scroll_from_hit_test(
                         // Raw delta; direction sign is applied centrally in
                         // ScrollManager::record_scroll_input (natural-scroll flag).
-                        delta_x * X11_SCROLL_TICK_PIXELS,
-                        delta_y * X11_SCROLL_TICK_PIXELS,
-                        ScrollInputSource::WheelDiscrete,
-                        // Core-protocol buttons 4-7 are ratcheting wheel
-                        // clicks (XI2 smooth-scroll touchpads land in the
-                        // valuator path, not here).
-                        azul_layout::managers::scroll_state::ScrollInputDevice::MouseWheel,
+                        delta_x,
+                        delta_y,
+                        source,
+                        device,
                         &layout_window.hover_manager,
                         &InputPointId::Mouse,
                         now,
@@ -865,6 +1005,14 @@ impl X11Window {
         }
         self.common.previous_window_state = Some(prev_snapshot);
 
+        // Resync the modifier bits the SERVER reports for this event. Key
+        // events never did this — only pointer events did — so a modifier
+        // released while another window held focus stayed latched until the
+        // user happened to move the mouse. Runs BEFORE the keysym bookkeeping
+        // below so that a modifier key's OWN press/release still wins: the
+        // `state` field describes the moment BEFORE this event.
+        self.update_modifiers_from_x11_state(event.state);
+
         // Record text input if we have a character and it's a key press.
         // Don't feed CONTROL characters into text input. XLookupString returns a
         // byte for keys like Backspace (0x08), Tab (0x09), Enter (0x0d), Escape
@@ -931,70 +1079,152 @@ impl X11Window {
     /// X11 events (XButtonEvent, XMotionEvent, XCrossingEvent, XKeyEvent) contain a `state`
     /// field that indicates which modifier keys were held when the event occurred.
     /// This function synchronizes the KeyboardState with that information.
-    fn update_modifiers_from_x11_state(&mut self, state: std::ffi::c_uint) {
+    ///
+    /// Alt / Super / AltGr are read from `self.modifier_masks` — queried from
+    /// `XGetModifierMapping` and refreshed on `MappingNotify` — instead of the
+    /// hardcoded Mod1/Mod4 defaults, which are wrong on any remapped keyboard
+    /// and never carried AltGr at all.
+    pub(super) fn update_modifiers_from_x11_state(&mut self, state: std::ffi::c_uint) {
         use azul_core::window::VirtualKeyCode;
 
-        // Check each modifier mask and update the keyboard state accordingly
+        let masks = self.modifier_masks;
         let keyboard_state = &mut self.common.current_window_state.keyboard_state;
 
-        // Shift
-        let shift_down = (state & SHIFT_MASK) != 0;
-        if shift_down {
-            keyboard_state
-                .pressed_virtual_keycodes
-                .insert_hm_item(VirtualKeyCode::LShift);
-        } else {
-            keyboard_state
-                .pressed_virtual_keycodes
-                .remove_hm_item(&VirtualKeyCode::LShift);
-            keyboard_state
-                .pressed_virtual_keycodes
-                .remove_hm_item(&VirtualKeyCode::RShift);
+        // The `state` bits say WHETHER a modifier is held, never WHICH side —
+        // so only synthesize the left key when neither side is already
+        // recorded. Unconditionally inserting the left one left a phantom
+        // LShift/LControl behind whenever the user actually held the right key
+        // and released it (the keysym path removed RShift, this one had just
+        // re-added LShift).
+        let alt_down = masks.alt != 0 && (state & masks.alt) != 0;
+        {
+            let mut sync = |down: bool, left: VirtualKeyCode, right: VirtualKeyCode| {
+                let already =
+                    keyboard_state.is_key_down(left) || keyboard_state.is_key_down(right);
+                if down {
+                    if !already {
+                        keyboard_state.pressed_virtual_keycodes.insert_hm_item(left);
+                    }
+                } else {
+                    keyboard_state.pressed_virtual_keycodes.remove_hm_item(&left);
+                    keyboard_state.pressed_virtual_keycodes.remove_hm_item(&right);
+                }
+            };
+
+            sync(
+                (state & SHIFT_MASK) != 0,
+                VirtualKeyCode::LShift,
+                VirtualKeyCode::RShift,
+            );
+            sync(
+                (state & CONTROL_MASK) != 0,
+                VirtualKeyCode::LControl,
+                VirtualKeyCode::RControl,
+            );
+            sync(alt_down, VirtualKeyCode::LAlt, VirtualKeyCode::RAlt);
+            sync(
+                masks.super_key != 0 && (state & masks.super_key) != 0,
+                VirtualKeyCode::LWin,
+                VirtualKeyCode::RWin,
+            );
         }
 
-        // Control
-        let ctrl_down = (state & CONTROL_MASK) != 0;
-        if ctrl_down {
-            keyboard_state
-                .pressed_virtual_keycodes
-                .insert_hm_item(VirtualKeyCode::LControl);
-        } else {
-            keyboard_state
-                .pressed_virtual_keycodes
-                .remove_hm_item(&VirtualKeyCode::LControl);
-            keyboard_state
-                .pressed_virtual_keycodes
-                .remove_hm_item(&VirtualKeyCode::RControl);
-        }
-
-        // Alt (Mod1)
-        let alt_down = (state & MOD1_MASK) != 0;
-        if alt_down {
-            keyboard_state
-                .pressed_virtual_keycodes
-                .insert_hm_item(VirtualKeyCode::LAlt);
-        } else {
-            keyboard_state
-                .pressed_virtual_keycodes
-                .remove_hm_item(&VirtualKeyCode::LAlt);
+        // AltGr (ISO_Level3_Shift) lives on its own modifier bit (usually
+        // Mod5) and was invisible here, so AltGr-composed accelerators saw no
+        // modifier at all. It shares RAlt with plain right-Alt (as everywhere
+        // else in the engine), so only touch it when Alt itself is not the
+        // source of that key.
+        if masks.altgr != 0 && (state & masks.altgr) != 0 {
+            if !keyboard_state.is_key_down(VirtualKeyCode::RAlt) {
+                keyboard_state
+                    .pressed_virtual_keycodes
+                    .insert_hm_item(VirtualKeyCode::RAlt);
+            }
+        } else if !alt_down {
             keyboard_state
                 .pressed_virtual_keycodes
                 .remove_hm_item(&VirtualKeyCode::RAlt);
         }
+    }
 
-        // Super/Windows (Mod4)
-        let super_down = (state & MOD4_MASK) != 0;
-        if super_down {
-            keyboard_state
-                .pressed_virtual_keycodes
-                .insert_hm_item(VirtualKeyCode::LWin);
-        } else {
-            keyboard_state
-                .pressed_virtual_keycodes
-                .remove_hm_item(&VirtualKeyCode::LWin);
-            keyboard_state
-                .pressed_virtual_keycodes
-                .remove_hm_item(&VirtualKeyCode::RWin);
+    /// Drop every key the window still believes is held.
+    ///
+    /// Keys released while ANOTHER window had focus are never delivered here,
+    /// so their entries survive a focus round-trip — the classic stuck Alt
+    /// after Alt-Tab. Only pointer events incidentally repaired the modifiers
+    /// (`update_modifiers_from_x11_state`); non-modifier keys never recovered
+    /// at all. Called on focus loss; `resync_keyboard_state_from_vector`
+    /// re-establishes the truth on focus gain.
+    pub(super) fn clear_keyboard_state(&mut self) {
+        use azul_core::window::{OptionVirtualKeyCode, ScanCodeVec, VirtualKeyCodeVec};
+
+        let keyboard_state = &mut self.common.current_window_state.keyboard_state;
+        keyboard_state.pressed_virtual_keycodes = VirtualKeyCodeVec::from_vec(Vec::new());
+        keyboard_state.pressed_scancodes = ScanCodeVec::from_vec(Vec::new());
+        keyboard_state.current_virtual_keycode = OptionVirtualKeyCode::None;
+    }
+
+    /// Rebuild `pressed_virtual_keycodes` / `pressed_scancodes` from a 32-byte
+    /// X11 keycode bit vector (`KeymapNotify.key_vector`, or `XQueryKeymap`).
+    ///
+    /// This is the X11-designed remedy for the stuck-key problem: the server
+    /// reports the FULL keyboard state right after every FocusIn, so the client
+    /// can replace its guess with the truth instead of waiting for a release it
+    /// will never receive.
+    pub(super) fn resync_keyboard_state_from_vector(&mut self, key_vector: &[c_char; 32]) {
+        let held = self
+            .common
+            .current_window_state
+            .keyboard_state
+            .current_virtual_keycode
+            .into_option();
+        self.clear_keyboard_state();
+
+        let Some(to_keysym) = self.xlib.XkbKeycodeToKeysym else {
+            // No translation available: leaving the state cleared is still
+            // strictly better than leaving it stale.
+            return;
+        };
+
+        // Keycodes 8..=255 (0..8 are unused by the X protocol).
+        for keycode in 8u32..256 {
+            let byte = key_vector[(keycode >> 3) as usize] as u8;
+            if byte & (1 << (keycode & 7)) == 0 {
+                continue;
+            }
+            self.common
+                .current_window_state
+                .keyboard_state
+                .pressed_scancodes
+                .insert_hm_item(keycode);
+            // Group 0 / level 0: the unshifted keysym, which is what
+            // keysym_to_virtual_keycode folds shifted variants back onto.
+            let keysym = unsafe { (to_keysym)(self.display, keycode as KeyCode, 0, 0) };
+            if let Some(vk) = keysym_to_virtual_keycode(keysym) {
+                self.common
+                    .current_window_state
+                    .keyboard_state
+                    .pressed_virtual_keycodes
+                    .insert_hm_item(vk);
+            }
+        }
+
+        // Keep the key that fired the last KeyDown if it is STILL held. Event
+        // determination derives KeyUp from `current_virtual_keycode` dropping
+        // to None, and KeymapNotify also follows every EnterNotify — clearing
+        // it unconditionally would fake a release of a key the user is holding.
+        if let Some(vk) = held {
+            if self
+                .common
+                .current_window_state
+                .keyboard_state
+                .is_key_down(vk)
+            {
+                self.common
+                    .current_window_state
+                    .keyboard_state
+                    .current_virtual_keycode = Some(vk).into();
+            }
         }
     }
 
@@ -1276,10 +1506,60 @@ pub fn keysym_to_virtual_keycode(keysym: KeySym) -> Option<VirtualKeyCode> {
         XK_Shift_R => Some(VirtualKeyCode::RShift),
         XK_Control_L => Some(VirtualKeyCode::LControl),
         XK_Control_R => Some(VirtualKeyCode::RControl),
-        XK_Alt_L => Some(VirtualKeyCode::LAlt),
-        XK_Alt_R => Some(VirtualKeyCode::RAlt),
-        XK_Super_L => Some(VirtualKeyCode::LWin),
-        XK_Super_R => Some(VirtualKeyCode::RWin),
+        XK_Alt_L | XK_Meta_L => Some(VirtualKeyCode::LAlt),
+        XK_Alt_R | XK_Meta_R => Some(VirtualKeyCode::RAlt),
+        XK_Super_L | XK_Hyper_L => Some(VirtualKeyCode::LWin),
+        XK_Super_R | XK_Hyper_R => Some(VirtualKeyCode::RWin),
+        // AltGr. X11 has no dedicated code for it; RAlt is where every other
+        // backend lands the third-level shift.
+        XK_ISO_Level3_Shift | XK_Mode_switch => Some(VirtualKeyCode::RAlt),
+        XK_Caps_Lock | XK_Shift_Lock => Some(VirtualKeyCode::Capital),
+        XK_Num_Lock => Some(VirtualKeyCode::Numlock),
+        XK_Menu => Some(VirtualKeyCode::Apps),
+        XK_Print => Some(VirtualKeyCode::Snapshot),
+        XK_Sys_Req => Some(VirtualKeyCode::Sysrq),
+
+        // Punctuation / OEM keys. Both the plain AND the shifted keysym of one
+        // physical key must map to the SAME code: the press is recorded with
+        // Shift held and the release usually is not, and a mismatch leaves the
+        // key stuck in `pressed_virtual_keycodes` forever. Without these,
+        // VirtualKeyDown never fired for them at all — Ctrl+`-` / Ctrl+`=`
+        // (zoom) were dead on X11 while passing headlessly.
+        XK_minus | XK_underscore => Some(VirtualKeyCode::Minus),
+        XK_equal | XK_plus => Some(VirtualKeyCode::Equals),
+        XK_comma | XK_less => Some(VirtualKeyCode::Comma),
+        XK_period | XK_greater => Some(VirtualKeyCode::Period),
+        XK_semicolon | XK_colon => Some(VirtualKeyCode::Semicolon),
+        XK_apostrophe | XK_quotedbl => Some(VirtualKeyCode::Apostrophe),
+        XK_grave | XK_asciitilde => Some(VirtualKeyCode::Grave),
+        XK_bracketleft | XK_braceleft => Some(VirtualKeyCode::LBracket),
+        XK_bracketright | XK_braceright => Some(VirtualKeyCode::RBracket),
+        XK_backslash | XK_bar => Some(VirtualKeyCode::Backslash),
+        XK_slash | XK_question => Some(VirtualKeyCode::Slash),
+
+        // Keypad. Each key has two keysyms — the digit with Num Lock on, the
+        // navigation function with it off — and both must fold to one code for
+        // the same press/release symmetry reason.
+        XK_KP_0 | XK_KP_Insert => Some(VirtualKeyCode::Numpad0),
+        XK_KP_1 | XK_KP_End => Some(VirtualKeyCode::Numpad1),
+        XK_KP_2 | XK_KP_Down => Some(VirtualKeyCode::Numpad2),
+        XK_KP_3 | XK_KP_Page_Down => Some(VirtualKeyCode::Numpad3),
+        XK_KP_4 | XK_KP_Left => Some(VirtualKeyCode::Numpad4),
+        XK_KP_5 | XK_KP_Begin => Some(VirtualKeyCode::Numpad5),
+        XK_KP_6 | XK_KP_Right => Some(VirtualKeyCode::Numpad6),
+        XK_KP_7 | XK_KP_Home => Some(VirtualKeyCode::Numpad7),
+        XK_KP_8 | XK_KP_Up => Some(VirtualKeyCode::Numpad8),
+        XK_KP_9 | XK_KP_Page_Up => Some(VirtualKeyCode::Numpad9),
+        XK_KP_Decimal | XK_KP_Delete => Some(VirtualKeyCode::NumpadDecimal),
+        XK_KP_Separator => Some(VirtualKeyCode::NumpadComma),
+        XK_KP_Enter => Some(VirtualKeyCode::NumpadEnter),
+        XK_KP_Add => Some(VirtualKeyCode::NumpadAdd),
+        XK_KP_Subtract => Some(VirtualKeyCode::NumpadSubtract),
+        XK_KP_Multiply => Some(VirtualKeyCode::NumpadMultiply),
+        XK_KP_Divide => Some(VirtualKeyCode::NumpadDivide),
+        XK_KP_Equal => Some(VirtualKeyCode::NumpadEquals),
+        XK_KP_Space => Some(VirtualKeyCode::Space),
+        XK_KP_Tab => Some(VirtualKeyCode::Tab),
         _ => None,
     }
 }

--- a/dll/src/desktop/shell2/linux/x11/mod.rs
+++ b/dll/src/desktop/shell2/linux/x11/mod.rs
@@ -12,6 +12,7 @@
 //! - [`X11Window::render_and_present`] — full render cycle: layout
 //!   regeneration, WebRender update, and buffer swap (GPU) or XPutImage (CPU).
 
+use azul_layout::solver3::LayoutNodeId;
 use crate::impl_platform_window_getters;
 
 pub mod accessibility;
@@ -3905,7 +3906,7 @@ impl X11Window {
             .layout_window
             .as_ref()
             .and_then(|lw| lw.layout_results.get(&azul_core::dom::DomId { inner: 0 }))
-            .map(|lr| lr.layout_tree.get_content_size(0));
+            .map(|lr| lr.layout_tree.get_content_size(LayoutNodeId::new(0)));
 
         // 3. Resize to it (≥1px). DPI handled by WindowSize's logical→physical.
         let mut final_size = orig;

--- a/dll/src/desktop/shell2/linux/x11/mod.rs
+++ b/dll/src/desktop/shell2/linux/x11/mod.rs
@@ -26,7 +26,7 @@ pub mod tooltip;
 use std::{
     cell::RefCell,
     ffi::{c_void, CStr, CString},
-    os::raw::{c_char, c_int, c_long, c_ulong},
+    os::raw::{c_char, c_int, c_long, c_uint, c_ulong},
     rc::Rc,
     sync::{Arc, Condvar, Mutex},
 };
@@ -476,11 +476,104 @@ fn try_create_argb_window(
     Some((window, true, Some(colormap)))
 }
 
-/// Initialise XInput2 for touch + pen/tablet. Best-effort: returns
-/// `(None, 0, empty)` if libXi or the XInputExtension is unavailable (the shell
-/// then falls back to core pointer events). Selects Button/Motion/Touch for all
-/// master devices and maps each device's pressure/tilt valuator numbers via
-/// their label atoms. ABI per scripts/WACOM_TOUCH_API_RESEARCH.md.
+/// The smooth-scroll (XI2.1) axes of ONE physical device.
+///
+/// A scroll valuator carries an ACCUMULATING absolute value; a scroll delta is
+/// `(new - last) / increment`, which is fractional for a touchpad and exactly
+/// ±1 per detent for a wheel.
+#[derive(Debug, Clone, Copy, Default)]
+struct ScrollAxes {
+    /// `(valuator number, increment)` of the vertical axis.
+    vert: Option<(i32, f64)>,
+    horiz: Option<(i32, f64)>,
+    /// Device reports position deltas rather than detents, so its scrolls are
+    /// `TrackpadContinuous`. Seeded from the device name and latched the first
+    /// time the device reports a fraction of a detent.
+    continuous: bool,
+}
+
+/// Which `ModN` bits carry Alt / Super / AltGr on the CURRENT keyboard.
+///
+/// The `state` field of every X event reports modifiers as `ModN` bits, and
+/// WHICH `ModN` holds Alt / Super / AltGr is a per-keyboard mapping — the
+/// Mod1/Mod4 defaults are just the common case, and AltGr (usually Mod5) had no
+/// default at all. Refreshed on `MappingNotify`.
+#[derive(Debug, Clone, Copy)]
+struct ModifierMasks {
+    alt: c_uint,
+    super_key: c_uint,
+    altgr: c_uint,
+}
+
+impl Default for ModifierMasks {
+    fn default() -> Self {
+        Self {
+            alt: MOD1_MASK,
+            super_key: MOD4_MASK,
+            altgr: 0,
+        }
+    }
+}
+
+/// Ask the server which modifier bit each of Alt / Super / AltGr sits on.
+///
+/// Falls back to the Mod1/Mod4 defaults when the (leniently loaded) symbols are
+/// missing or the mapping is empty.
+fn query_modifier_masks(xlib: &Xlib, display: *mut Display) -> ModifierMasks {
+    let mut masks = ModifierMasks::default();
+    let (Some(get_mapping), Some(free_mapping), Some(to_keysym)) = (
+        xlib.XGetModifierMapping,
+        xlib.XFreeModifiermap,
+        xlib.XkbKeycodeToKeysym,
+    ) else {
+        return masks;
+    };
+
+    unsafe {
+        let map = (get_mapping)(display);
+        if map.is_null() {
+            return masks;
+        }
+        let per_mod = (*map).max_keypermod.max(0) as usize;
+        let (mut alt, mut super_key, mut altgr) = (0u32, 0u32, 0u32);
+        if !(*map).modifiermap.is_null() {
+            // Row order is fixed: Shift, Lock, Control, Mod1..Mod5.
+            for row in 0..8usize {
+                let bit = 1u32 << row;
+                for slot in 0..per_mod {
+                    let keycode = *(*map).modifiermap.add(row * per_mod + slot);
+                    if keycode == 0 {
+                        continue;
+                    }
+                    match (to_keysym)(display, keycode, 0, 0) as u32 {
+                        XK_Alt_L | XK_Alt_R | XK_Meta_L | XK_Meta_R => alt |= bit,
+                        XK_Super_L | XK_Super_R | XK_Hyper_L | XK_Hyper_R => super_key |= bit,
+                        XK_ISO_Level3_Shift | XK_Mode_switch => altgr |= bit,
+                        _ => {}
+                    }
+                }
+            }
+        }
+        (free_mapping)(map);
+
+        if alt != 0 {
+            masks.alt = alt;
+        }
+        if super_key != 0 {
+            masks.super_key = super_key;
+        }
+        masks.altgr = altgr;
+    }
+
+    masks
+}
+
+/// Initialise XInput2 for touch + pen/tablet + smooth scroll. Best-effort:
+/// returns `(None, 0, empty, empty)` if libXi or the XInputExtension is
+/// unavailable (the shell then falls back to core pointer events). Selects
+/// Button/Motion/Touch for all master devices, maps each device's pressure/tilt
+/// valuator numbers via their label atoms and records its scroll axes.
+/// ABI per scripts/WACOM_TOUCH_API_RESEARCH.md.
 fn init_xinput2(
     xlib: &Rc<Xlib>,
     display: *mut Display,
@@ -489,6 +582,7 @@ fn init_xinput2(
     Option<Rc<dlopen::Xi>>,
     c_int,
     std::collections::HashMap<c_int, (i32, i32, i32, f64)>,
+    std::collections::HashMap<c_int, ScrollAxes>,
 ) {
     use std::collections::HashMap;
     unsafe {
@@ -502,7 +596,7 @@ fn init_xinput2(
             &mut first_err,
         ) == 0
         {
-            return (None, 0, HashMap::new());
+            return (None, 0, HashMap::new(), HashMap::new());
         }
         let xi = match dlopen::Xi::new() {
             Ok(x) => x,
@@ -514,7 +608,7 @@ fn init_xinput2(
                      touch/pen input will NOT work in this window",
                     e
                 );
-                return (None, 0, HashMap::new());
+                return (None, 0, HashMap::new(), HashMap::new());
             }
         };
         let (mut maj, mut min) = (2i32, 2i32);
@@ -544,15 +638,33 @@ fn init_xinput2(
         let tx_atom = (xlib.XInternAtom)(display, b"Abs Tilt X\0".as_ptr() as *const _, 0);
         let ty_atom = (xlib.XInternAtom)(display, b"Abs Tilt Y\0".as_ptr() as *const _, 0);
         let mut map = HashMap::new();
+        let mut scroll: HashMap<c_int, ScrollAxes> = HashMap::new();
         let mut ndev = 0i32;
         let devs = (xi.XIQueryDevice)(display, defines::XIAllDevices, &mut ndev);
         if !devs.is_null() {
             for i in 0..ndev as isize {
                 let dev = &*devs.offset(i);
                 let (mut p, mut tx, mut ty, mut pmax) = (-1i32, -1i32, -1i32, 1.0f64);
+                let mut axes = ScrollAxes::default();
                 for c in 0..dev.num_classes as isize {
                     let cls = *dev.classes.offset(c);
-                    if cls.is_null() || (*cls).type_ != defines::XIValuatorClass {
+                    if cls.is_null() {
+                        continue;
+                    }
+                    if (*cls).type_ == defines::XIScrollClass {
+                        // XI2.1 smooth scroll. Without decoding these the
+                        // server's legacy button 4-7 emulation is the only
+                        // scroll this client sees, which quantizes every
+                        // touchpad gesture into fixed detents.
+                        let s = &*(cls as *const defines::XIScrollClassInfo);
+                        if s.scroll_type == defines::XIScrollTypeVertical {
+                            axes.vert = Some((s.number, s.increment));
+                        } else if s.scroll_type == defines::XIScrollTypeHorizontal {
+                            axes.horiz = Some((s.number, s.increment));
+                        }
+                        continue;
+                    }
+                    if (*cls).type_ != defines::XIValuatorClass {
                         continue;
                     }
                     let v = &*(cls as *const defines::XIValuatorClassInfo);
@@ -568,11 +680,83 @@ fn init_xinput2(
                 if p >= 0 || tx >= 0 || ty >= 0 {
                     map.insert(dev.deviceid, (p, tx, ty, pmax));
                 }
+                if axes.vert.is_some() || axes.horiz.is_some() {
+                    // XI2 exposes no "is a touchpad" bit. The device NAME is
+                    // the signal every toolkit uses; a device that turns out to
+                    // report fractional detents is latched as continuous at
+                    // runtime regardless (see decode_smooth_scroll).
+                    if !dev.name.is_null() {
+                        let name = CStr::from_ptr(dev.name).to_string_lossy().to_lowercase();
+                        axes.continuous = name.contains("touchpad")
+                            || name.contains("trackpad")
+                            || name.contains("glidepoint");
+                    }
+                    // Events carry the MASTER deviceid but the valuator numbers
+                    // belong to the SLAVE that produced them, so key by the id
+                    // events report as `sourceid` (same rule as pen_valuators).
+                    scroll.insert(dev.deviceid, axes);
+                }
             }
             (xi.XIFreeDeviceInfo)(devs);
         }
-        (Some(xi), opcode, map)
+        (Some(xi), opcode, map, scroll)
     }
+}
+
+/// One scroll axis of an XI2 motion event, in wheel detents.
+///
+/// `None` when the axis is absent from this event or when this is the first
+/// event from the device — the valuator ACCUMULATES, so the first value only
+/// establishes the baseline (otherwise the first scroll jumps by the whole
+/// session's total).
+unsafe fn scroll_axis_delta(
+    win: &mut X11Window,
+    ev: &defines::XIDeviceEvent,
+    axis: Option<(i32, f64)>,
+) -> Option<f64> {
+    let (number, increment) = axis?;
+    if increment == 0.0 {
+        return None;
+    }
+    let value = decode_valuator(ev, number)?;
+    let previous = win.scroll_last_values.insert((ev.sourceid, number), value);
+    Some((value - previous?) / increment)
+}
+
+/// Decode the XI2 smooth-scroll valuators of a motion event.
+///
+/// Returns `(delta_x, delta_y, continuous)` in PIXELS, in the engine's
+/// canonical X11 sign convention (up = +1, left = +1) — `ScrollManager` applies
+/// the natural-scroll flag centrally on top of that.
+unsafe fn decode_smooth_scroll(
+    win: &mut X11Window,
+    ev: &defines::XIDeviceEvent,
+) -> Option<(f32, f32, bool)> {
+    let axes = *win.scroll_valuators.get(&ev.sourceid)?;
+    let vert = scroll_axis_delta(win, ev, axes.vert).unwrap_or(0.0);
+    let horiz = scroll_axis_delta(win, ev, axes.horiz).unwrap_or(0.0);
+    if vert == 0.0 && horiz == 0.0 {
+        return None;
+    }
+
+    // A device that ever reports a fraction of a detent is a continuous
+    // scroller; latch it so the classification does not flip back on the
+    // occasional whole-detent event.
+    let fractional = vert.fract().abs() > 1e-3 || horiz.fract().abs() > 1e-3;
+    if fractional && !axes.continuous {
+        if let Some(a) = win.scroll_valuators.get_mut(&ev.sourceid) {
+            a.continuous = true;
+        }
+    }
+
+    // XI2 scroll valuators INCREASE downward / rightward; the canonical
+    // convention here is button 4 (up) = +1 and button 6 (left) = +1.
+    let px = f64::from(events::X11_SCROLL_TICK_PIXELS);
+    Some((
+        -(horiz * px) as f32,
+        -(vert * px) as f32,
+        axes.continuous || fractional,
+    ))
 }
 
 /// Decode an XI2 valuator value by valuator number. The `values` array is
@@ -612,6 +796,7 @@ fn x11_event_name(t: i32) -> &'static str {
         8 => "LeaveNotify",
         9 => "FocusIn",
         10 => "FocusOut",
+        11 => "KeymapNotify",
         12 => "Expose",
         18 => "UnmapNotify",
         19 => "MapNotify",
@@ -624,6 +809,21 @@ fn x11_event_name(t: i32) -> &'static str {
         35 => "GenericEvent",
         _ => "Other",
     }
+}
+
+/// Is this FocusIn/FocusOut a side effect of a GRAB rather than a real change
+/// of keyboard focus?
+///
+/// X sends a FocusOut/FocusIn pair with mode `NotifyGrab`/`NotifyUngrab`
+/// whenever ANY grab activates — including this application's own menus, which
+/// grab the pointer. Acting on those fired WindowFocusLost on the parent,
+/// dropped its XIC and ran a full pass plus restyle every time a context menu
+/// opened. `detail == NotifyPointer` is likewise not a window focus change (the
+/// focus merely follows the pointer). Same rule winit and GTK apply.
+fn is_grab_focus_change(ev: &defines::XFocusChangeEvent) -> bool {
+    ev.mode == defines::NotifyGrab
+        || ev.mode == defines::NotifyUngrab
+        || ev.detail == defines::NotifyPointer
 }
 
 /// Parse an XDND `text/uri-list` payload into local filesystem paths.
@@ -704,13 +904,45 @@ fn handle_xi_event(win: &mut X11Window, xev: &mut defines::XEvent) -> ProcessEve
             return ProcessEventResult::DoNothing;
         }
         let ev = &*(cookie.data as *const defines::XIDeviceEvent);
+        // XI2 events name their target in `ev.event` (the event window) —
+        // `xev.any.window` overlays the cookie's `extension` field and is NOT
+        // a window, so `dispatch_shared_display_event` cannot route them and
+        // every XI2 pointer event lands on the display owner. Re-route here,
+        // the first point where the cookie data (and thus the real target)
+        // exists. libX11 caches fetched cookie data until XFreeEventData, so
+        // the child's own XGetEventData reuses the same buffer; returning
+        // early skips this frame's free and the child's tail frees exactly
+        // once.
+        let xi_target = ev.event as u64;
+        if xi_target != win.window as u64 {
+            if let Some(wptr) = super::registry::get_window(xi_target) {
+                if let super::LinuxWindow::X11(child) = &mut *wptr {
+                    return handle_xi_event(child, xev);
+                }
+            }
+            // Unknown / just-closed target: fall through, handle on self so
+            // the event isn't lost (matches dispatch_shared_display_event).
+        }
         let evtype = ev.evtype;
         // XI2 event coords are physical; touch/pen state wants logical.
         let pos = win.to_logical_pos(ev.event_x as f32, ev.event_y as f32);
+        // Anything that is not a pointer motion ends the motion-compression
+        // batch: the newest position must be delivered BEFORE this event so the
+        // ordering the app sees is the ordering the server sent.
+        if evtype != defines::XI_Motion {
+            win.flush_pending_motion();
+        }
         if evtype == defines::XI_TouchBegin
             || evtype == defines::XI_TouchUpdate
             || evtype == defines::XI_TouchEnd
         {
+            // CONTRACT: snapshot the event-diff baseline BEFORE mutating, run a
+            // pass after. This branch used to mutate touch_state + the gesture
+            // manager and return DoNothing, so TouchStart/Move/End never fired
+            // and no redraw was requested — AND the un-snapshotted mutation
+            // destroyed the delta of whatever event came next.
+            win.common.previous_window_state = Some(win.common.current_window_state.clone());
+
             // Touch: ev.detail = touch tracking id; merge into touch_state.
             let is_up = evtype == defines::XI_TouchEnd;
             let id = ev.detail as u64;
@@ -745,6 +977,8 @@ fn handle_xi_event(win: &mut X11Window, xev: &mut defines::XEvent) -> ProcessEve
                     }
                 }
             }
+
+            result = win.process_window_events(0);
         } else {
             // Pointer event from a mouse OR a pen/tablet. This window
             // XISelectEvents'd for XI_ButtonPress/Release/Motion at creation, so
@@ -791,48 +1025,91 @@ fn handle_xi_event(win: &mut X11Window, xev: &mut defines::XEvent) -> ProcessEve
             // them) so behaviour is identical to the core path.
             match evtype {
                 defines::XI_ButtonPress | defines::XI_ButtonRelease => {
-                    let btn = defines::XButtonEvent {
-                        type_: if evtype == defines::XI_ButtonPress {
-                            defines::ButtonPress
-                        } else {
-                            defines::ButtonRelease
-                        },
-                        serial: ev.serial,
-                        send_event: ev.send_event,
-                        display: ev.display,
-                        window: ev.event,
-                        root: ev.root,
-                        subwindow: ev.child,
-                        time: ev.time,
-                        x: ev.event_x as c_int,
-                        y: ev.event_y as c_int,
-                        x_root: ev.root_x as c_int,
-                        y_root: ev.root_y as c_int,
-                        state: ev.mods.effective as u32,
-                        button: ev.detail as u32,
-                        same_screen: 1,
-                    };
-                    result = win.handle_mouse_button(&btn);
+                    // The server emits legacy button 4-7 emulation ALONGSIDE
+                    // the smooth-scroll valuators of the same gesture. Now that
+                    // the valuators are decoded below, handling the emulation
+                    // too would apply every touchpad scroll twice.
+                    let emulated_wheel = ev.flags & defines::XIPointerEmulated != 0
+                        && (4..=7).contains(&ev.detail)
+                        && win.scroll_valuators.contains_key(&ev.sourceid);
+                    if !emulated_wheel {
+                        let btn = defines::XButtonEvent {
+                            type_: if evtype == defines::XI_ButtonPress {
+                                defines::ButtonPress
+                            } else {
+                                defines::ButtonRelease
+                            },
+                            serial: ev.serial,
+                            send_event: ev.send_event,
+                            display: ev.display,
+                            window: ev.event,
+                            root: ev.root,
+                            subwindow: ev.child,
+                            time: ev.time,
+                            x: ev.event_x as c_int,
+                            y: ev.event_y as c_int,
+                            x_root: ev.root_x as c_int,
+                            y_root: ev.root_y as c_int,
+                            state: ev.mods.effective as u32,
+                            button: ev.detail as u32,
+                            same_screen: 1,
+                        };
+                        result = win.handle_mouse_button(&btn);
+                    }
                 }
                 defines::XI_Motion => {
-                    let mot = defines::XMotionEvent {
-                        type_: defines::MotionNotify,
-                        serial: ev.serial,
-                        send_event: ev.send_event,
-                        display: ev.display,
-                        window: ev.event,
-                        root: ev.root,
-                        subwindow: ev.child,
-                        time: ev.time,
-                        x: ev.event_x as c_int,
-                        y: ev.event_y as c_int,
-                        x_root: ev.root_x as c_int,
-                        y_root: ev.root_y as c_int,
-                        state: ev.mods.effective as u32,
-                        is_hint: 0,
-                        same_screen: 1,
+                    // Smooth scroll (touchpad / kinetic trackpoint) rides on
+                    // XI_Motion valuators. Decoding them is what makes
+                    // touchpad scrolling continuous instead of a stack of
+                    // fake 20px wheel detents.
+                    let scrolled = match decode_smooth_scroll(win, ev) {
+                        Some((dx, dy, continuous)) => {
+                            result = win.handle_scroll_input(dx, dy, pos, continuous);
+                            true
+                        }
+                        None => false,
                     };
-                    result = win.handle_mouse_move(&mot);
+
+                    // A scroll-only event carries the unchanged pointer
+                    // position; re-running the whole motion pipeline for it
+                    // would double the per-event cost of every scroll.
+                    let pending_xy = win.pending_motion.map(|m| (m.x, m.y));
+                    let last_pos = match pending_xy {
+                        Some((x, y)) => Some(win.to_logical_pos(x as f32, y as f32)),
+                        None => win
+                            .common
+                            .current_window_state
+                            .mouse_state
+                            .cursor_position
+                            .get_position(),
+                    };
+                    let moved = last_pos.map_or(true, |p| {
+                        (p.x - pos.x).abs() > 0.01 || (p.y - pos.y).abs() > 0.01
+                    });
+
+                    if !scrolled || moved {
+                        // COALESCED: a 1000 Hz mouse delivers dozens of these
+                        // per frame and only the newest position can still be
+                        // true. Processed at the batch boundary (or before the
+                        // next non-motion event) by flush_pending_motion.
+                        win.pending_motion = Some(defines::XMotionEvent {
+                            type_: defines::MotionNotify,
+                            serial: ev.serial,
+                            send_event: ev.send_event,
+                            display: ev.display,
+                            window: ev.event,
+                            root: ev.root,
+                            subwindow: ev.child,
+                            time: ev.time,
+                            x: ev.event_x as c_int,
+                            y: ev.event_y as c_int,
+                            x_root: ev.root_x as c_int,
+                            y_root: ev.root_y as c_int,
+                            state: ev.mods.effective as u32,
+                            is_hint: 0,
+                            same_screen: 1,
+                        });
+                    }
                 }
                 _ => {}
             }
@@ -952,6 +1229,20 @@ pub struct X11Window {
     xi_opcode: c_int,
     /// deviceid -> (pressure#, tiltX#, tiltY#, pressure_max); -1 = absent valuator.
     pen_valuators: std::collections::HashMap<c_int, (i32, i32, i32, f64)>,
+    /// deviceid -> smooth-scroll (XI2.1) axes of that device.
+    scroll_valuators: std::collections::HashMap<c_int, ScrollAxes>,
+    /// `(deviceid, valuator number)` -> last absolute value seen. Scroll
+    /// valuators accumulate, so a delta needs the previous reading.
+    scroll_last_values: std::collections::HashMap<(c_int, c_int), f64>,
+    /// Which `ModN` bit is Alt / Super / AltGr on the current keyboard;
+    /// refreshed on `MappingNotify`.
+    modifier_masks: ModifierMasks,
+    /// Newest motion event of the current drain batch, processed once at the
+    /// batch boundary — see `flush_pending_motion`.
+    pending_motion: Option<defines::XMotionEvent>,
+    /// Focus / editing / caret identity the IME state was last synced for.
+    /// Gates the (non-trivial) caret-rect recompute behind an actual change.
+    ime_sync_key: ImeSyncKey,
 
     // Shell2 state (common fields shared with all platforms)
     pub common: event::CommonWindowState,
@@ -1037,6 +1328,16 @@ pub enum X11Event {
     Other,
 }
 
+/// What the IME state depends on: whether the window is focused, WHICH node is
+/// being edited, and where the caret sits inside it.
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+struct ImeSyncKey {
+    window_focused: bool,
+    /// `(dom index, node index)` of the editing session, if any.
+    editing_node: Option<(usize, usize)>,
+    cursor: Option<azul_core::selection::TextCursor>,
+}
+
 // Lifecycle methods (formerly on PlatformWindow V1 trait)
 impl X11Window {
     /// Poll for the next X11 event without blocking.
@@ -1108,6 +1409,8 @@ impl X11Window {
                 unsafe { (self.xlib.XNextEvent)(self.display, &mut event) };
                 self.dispatch_shared_display_event(&mut event);
             }
+            // Batch boundary: deliver the newest motion of this drain.
+            self.flush_pending_motion_all();
         }
 
         None
@@ -1142,30 +1445,10 @@ impl X11Window {
         }
     }
 
-    /// Swap buffers (GPU) or flush (CPU) to present the current frame.
-    pub fn present(&mut self) -> Result<(), WindowError> {
-        match &self.render_mode {
-            RenderMode::Gpu(gl_context, _) => gl_context.swap_buffers(),
-            RenderMode::Cpu(_gc) => {
-                // CPU rendering is handled by render_and_present(); just flush here
-                unsafe { (self.xlib.XFlush)(self.display) };
-                Ok(())
-            }
-            // Only set transiently during Drop; never present in this state.
-            RenderMode::None => Ok(()),
-        }?;
-
-        // CI testing: Exit successfully after first frame render if env var is set
-        if std::env::var("AZ_EXIT_SUCCESS_AFTER_FRAME_RENDER").is_ok() {
-            log_info!(
-                LogCategory::General,
-                "[CI] AZ_EXIT_SUCCESS_AFTER_FRAME_RENDER set - exiting with success"
-            );
-            std::process::exit(0);
-        }
-
-        Ok(())
-    }
+    // NOTE: `X11Window::present` is deliberately GONE (with its sole caller
+    // `LinuxWindow::present`). The real present path is `render_and_present`;
+    // a bare swap-buffers entry bypassed damage bookkeeping and carried its
+    // own duplicate AZ_EXIT_SUCCESS_AFTER_FRAME_RENDER hard-exit.
 
     /// Process pending accessibility actions from assistive technology (e.g. Orca)
     #[cfg(feature = "a11y")]
@@ -1538,7 +1821,11 @@ impl X11Window {
             | StructureNotifyMask
             | EnterWindowMask
             | LeaveWindowMask
-            | FocusChangeMask;
+            | FocusChangeMask
+            // KeymapNotify arrives right after every FocusIn and is the only
+            // way to learn which keys were released while another window had
+            // focus (the stuck-Alt-after-Alt-Tab class of bug).
+            | KeymapStateMask;
 
         // Override-redirect (a borderless, WM-unmanaged popup such as a menu/tooltip)
         // is driven by the explicit window option, NOT by decorations==None: a CSD
@@ -1610,7 +1897,9 @@ impl X11Window {
         unsafe { (xlib.XSelectInput)(display, window_handle, event_mask) };
 
         // XInput2: select touch + pen/tablet events (best-effort; core events otherwise).
-        let (xi, xi_opcode, pen_valuators) = init_xinput2(&xlib, display, window_handle);
+        let (xi, xi_opcode, pen_valuators, scroll_valuators) =
+            init_xinput2(&xlib, display, window_handle);
+        let modifier_masks = query_modifier_masks(&xlib, display);
 
         let wm_delete_window_atom =
             unsafe { (xlib.XInternAtom)(display, b"WM_DELETE_WINDOW\0".as_ptr() as _, 0) };
@@ -1961,6 +2250,11 @@ impl X11Window {
             xi,
             xi_opcode,
             pen_valuators,
+            scroll_valuators,
+            scroll_last_values: std::collections::HashMap::new(),
+            modifier_masks,
+            pending_motion: None,
+            ime_sync_key: ImeSyncKey::default(),
             common: event::CommonWindowState {
                 layout_window: None,
                 current_window_state: FullWindowState {
@@ -1985,6 +2279,7 @@ impl X11Window {
                     active_route: azul_core::resources::OptionRouteMatch::None,
                 },
                 previous_window_state: None,
+                os_synced_state: None,
                 renderer,
                 render_api,
                 hit_tester,
@@ -2502,6 +2797,8 @@ impl X11Window {
                     (self.xlib.XNextEvent)(self.display, &mut event);
                     self.dispatch_shared_display_event(&mut event);
                 }
+                // Batch boundary: deliver the newest motion of this drain.
+                self.flush_pending_motion_all();
                 return Ok(());
             }
 
@@ -2569,6 +2866,8 @@ impl X11Window {
                         (self.xlib.XNextEvent)(self.display, &mut event);
                         self.dispatch_shared_display_event(&mut event);
                     }
+                    // Batch boundary: deliver the newest motion of this drain.
+                    self.flush_pending_motion_all();
                 }
 
                 // Check timerfd's - if any fired, invoke timer callbacks
@@ -2690,6 +2989,17 @@ impl X11Window {
             unsafe { event.type_ }
         );
 
+        // Motion compression boundary: anything that is not itself a motion
+        // must see the newest pointer position FIRST, so the buffered motion is
+        // delivered before it. GenericEvent is excluded here and handled inside
+        // handle_xi_event, which is where the XI2 event type becomes known —
+        // flushing before every cookie would defeat the compression entirely,
+        // since XI2 is the actual delivery path for the mouse.
+        match unsafe { event.type_ } {
+            defines::MotionNotify | defines::GenericEvent => {}
+            _ => self.flush_pending_motion(),
+        }
+
         // Process event with V2 handlers
         let result = match unsafe { event.type_ } {
             defines::Expose => {
@@ -2765,7 +3075,13 @@ impl X11Window {
             defines::ButtonPress | defines::ButtonRelease => {
                 self.handle_mouse_button(unsafe { &event.button })
             }
-            defines::MotionNotify => self.handle_mouse_move(unsafe { &event.motion }),
+            defines::MotionNotify => {
+                // COALESCED — see flush_pending_motion. (Only reachable when
+                // XI2 is unavailable: with XI2 selected the server routes
+                // pointer motion through GenericEvent instead.)
+                self.pending_motion = Some(unsafe { event.motion });
+                ProcessEventResult::DoNothing
+            }
             defines::GenericEvent => handle_xi_event(self, event),
             defines::KeyPress | defines::KeyRelease => {
                 self.handle_keyboard(unsafe { &mut event.key })
@@ -2780,27 +3096,83 @@ impl X11Window {
                 // event's snapshot cloned the already-mutated state), so
                 // WindowFocusReceived callbacks never fired and
                 // focus-conditional styling never repainted on X11.
-                self.common.previous_window_state =
-                    Some(self.common.current_window_state.clone());
-                self.common.current_window_state.window_focused = true;
-                self.dynamic_selector_context.window_focused = true;
-                self.sync_ime_position_to_os();
-                self.sync_ime_focus_state();
-                // MWA-A3b: tell the AT-SPI adapter — accesskit_unix never
-                // learns window focus on its own (Orca got no focus events).
-                #[cfg(feature = "a11y")]
-                self.accessibility_adapter.set_focus(true);
-                self.process_window_events(0)
+                if is_grab_focus_change(unsafe { &event.focus }) {
+                    ProcessEventResult::DoNothing
+                } else {
+                    self.common.previous_window_state =
+                        Some(self.common.current_window_state.clone());
+                    self.common.current_window_state.window_focused = true;
+                    self.dynamic_selector_context.window_focused = true;
+                    // The keyboard state is a guess again: everything released
+                    // while another window had focus was delivered THERE. The
+                    // KeymapNotify that follows this event replaces the guess
+                    // with the server's truth; ask directly when the (lenient)
+                    // symbol is available, so a WM that filters KeymapNotify
+                    // cannot leave a key stuck either.
+                    self.resync_keyboard_state_from_server();
+                    self.sync_ime_position_to_os();
+                    self.sync_ime_focus_state();
+                    // MWA-A3b: tell the AT-SPI adapter — accesskit_unix never
+                    // learns window focus on its own (Orca got no focus events).
+                    #[cfg(feature = "a11y")]
+                    self.accessibility_adapter.set_focus(true);
+                    self.process_window_events(0)
+                }
             }
             defines::FocusOut => {
-                self.common.previous_window_state =
-                    Some(self.common.current_window_state.clone());
-                self.common.current_window_state.window_focused = false;
-                self.dynamic_selector_context.window_focused = false;
-                #[cfg(feature = "a11y")]
-                self.accessibility_adapter.set_focus(false);
-                self.sync_ime_focus_state();
-                self.process_window_events(0)
+                if is_grab_focus_change(unsafe { &event.focus }) {
+                    ProcessEventResult::DoNothing
+                } else {
+                    self.common.previous_window_state =
+                        Some(self.common.current_window_state.clone());
+                    self.common.current_window_state.window_focused = false;
+                    self.dynamic_selector_context.window_focused = false;
+                    // Releases that happen while another window has focus are
+                    // never delivered here, so anything still held would stay
+                    // held forever (the classic stuck Alt after Alt-Tab).
+                    self.clear_keyboard_state();
+                    #[cfg(feature = "a11y")]
+                    self.accessibility_adapter.set_focus(false);
+                    self.sync_ime_focus_state();
+                    self.process_window_events(0)
+                }
+            }
+            defines::KeymapNotify => {
+                // Delivered right after every FocusIn: the server's own report
+                // of which keys are physically down. This is the X11-designed
+                // remedy for stale `pressed_*` entries.
+                //
+                // It also follows every EnterNotify, and the state is identical
+                // almost every time — so the pass only runs when the resync
+                // actually changed something. When it did not, `previous` is
+                // never touched and no delta is introduced.
+                let key_vector = unsafe { event.keymap.key_vector };
+                let baseline = self.common.current_window_state.clone();
+                self.resync_keyboard_state_from_vector(&key_vector);
+                if self.common.current_window_state.keyboard_state == baseline.keyboard_state {
+                    ProcessEventResult::DoNothing
+                } else {
+                    self.common.previous_window_state = Some(baseline);
+                    self.process_window_events(0)
+                }
+            }
+            defines::MappingNotify => {
+                // Keyboard layout switch / xmodmap. Without refreshing the
+                // CLIENT-side table, every keycode → keysym translation stays
+                // on the layout that was active when the connection opened —
+                // for the rest of the session.
+                let mut mapping = unsafe { event.mapping };
+                if let Some(refresh) = self.xlib.XRefreshKeyboardMapping {
+                    unsafe {
+                        (refresh)(&mut mapping);
+                    }
+                }
+                if mapping.request == defines::MappingModifier
+                    || mapping.request == defines::MappingKeyboard
+                {
+                    self.modifier_masks = query_modifier_masks(&self.xlib, self.display);
+                }
+                ProcessEventResult::DoNothing
             }
             defines::MapNotify => {
                 // The window just became visible and owes its FIRST frame.
@@ -2888,6 +3260,19 @@ impl X11Window {
                     _ => true,
                 };
 
+                // CONTRACT: snapshot the event-diff baseline BEFORE the OS
+                // geometry lands. `WindowResize` / `Moved` are derived purely
+                // from previous → current, and this arm used to mutate
+                // `current` with no snapshot and never run a pass at all, so
+                // neither event has ever fired on X11 for a drag-resize or a
+                // window move (and the un-consumed mutation then corrupted the
+                // next handler's delta).
+                let needs_pass = size_changed || position_changed;
+                if needs_pass {
+                    self.common.previous_window_state =
+                        Some(self.common.current_window_state.clone());
+                }
+
                 if size_changed {
                     let old_logical = azul_core::geom::LogicalSize::new(
                         old_context.viewport_width,
@@ -2946,8 +3331,10 @@ impl X11Window {
                 );
 
                 // F4: OS-reported geometry (source = Os) — acknowledge into both
-                // current and the sync baseline so it is not echoed back. See the
-                // main-loop handler + CommonWindowState::update_window_state.
+                // current and the OS-SYNC baseline (`os_synced_state`) so it is
+                // not echoed back. It deliberately does NOT touch
+                // `previous_window_state`: that is the event-diff baseline the
+                // pass at the end of this arm consumes.
                 let new_pos = azul_core::window::WindowPosition::Initialized(
                     azul_core::geom::PhysicalPositionI32::new(abs_x, abs_y),
                 );
@@ -3026,7 +3413,16 @@ impl X11Window {
                     }
                 }
 
-                ProcessEventResult::DoNothing
+                // Run the pass so Resized / Moved (and the DpiChanged above)
+                // actually reach callbacks. The resize DECISION is untouched:
+                // request_regeneration_for_resize already chose full vs
+                // relayout-only above, and render_and_present still coalesces
+                // one relayout per frame.
+                if needs_pass {
+                    self.process_window_events(0)
+                } else {
+                    ProcessEventResult::DoNothing
+                }
             }
             other => {
                 // Check for XRandR screen change event (dynamic event type)
@@ -3047,6 +3443,53 @@ impl X11Window {
             }
         };
 
+        self.apply_event_result(result);
+
+        // Focus, the editing session or the caret may have moved in that pass;
+        // the XIC focus and the over-the-spot candidate position follow from
+        // exactly those. Gated internally on an actual change.
+        self.sync_ime_state();
+    }
+
+    /// Process the newest motion event of the current drain batch, if any.
+    ///
+    /// Every `MotionNotify` used to run the FULL pipeline (state clone,
+    /// modifier sync, hit test, cursor CSS resolution, event pass) — a 1000 Hz
+    /// mouse during a drag-select delivers dozens per frame and only the newest
+    /// position can still be true. Motions are therefore buffered and this
+    /// flushes the survivor: before any non-motion event (so ordering is
+    /// preserved) and at every drain boundary.
+    fn flush_pending_motion(&mut self) {
+        let Some(motion) = self.pending_motion.take() else {
+            return;
+        };
+        let result = self.handle_mouse_move(&motion);
+        self.apply_event_result(result);
+        self.sync_ime_state();
+    }
+
+    /// End-of-batch motion flush for THIS window and every other window on the
+    /// shared display: a child menu's motions are dispatched to ITS window, so
+    /// its buffered motion has no other flush point.
+    fn flush_pending_motion_all(&mut self) {
+        self.flush_pending_motion();
+        for wid in super::registry::get_all_window_ids() {
+            if wid == self.window as u64 {
+                continue;
+            }
+            if let Some(wptr) = unsafe { super::registry::get_window(wid) } {
+                if let super::LinuxWindow::X11(w) = unsafe { &mut *wptr } {
+                    w.flush_pending_motion();
+                }
+            }
+        }
+    }
+
+    /// Everything a completed event pass owes the frame pipeline: regeneration
+    /// marking, the cross-window refresh fan-out, the incremental-relayout fast
+    /// path and the redraw request. Shared by `handle_event` and the deferred
+    /// motion flush, which must not skip any of it.
+    fn apply_event_result(&mut self, result: ProcessEventResult) {
         // Mark SELF for DOM regeneration. process_window_events requests
         // regeneration only for callback returns of
         // Update::RefreshDom* — producers that return the result directly
@@ -3663,9 +4106,7 @@ impl X11Window {
         // already inserted the Pending tiles, so the AfterMount handler sees them.
 
         // Phase 2: Post-Layout callback - sync IME position after layout (MOST IMPORTANT)
-        self.update_ime_position_from_cursor();
-        self.sync_ime_position_to_os();
-        self.sync_ime_focus_state();
+        self.sync_ime_state();
 
         // Export the (possibly changed) application menu bar to GNOME Shell.
         // No-op unless GNOME native menus are active for this window.
@@ -3809,6 +4250,14 @@ impl X11Window {
         } else {
             false
         };
+
+        // The caret may have moved on ANY of those paths — including the
+        // relayout-only fast path, which skips regenerate_layout_inner's tail
+        // entirely. Without this an over-the-spot IME kept drawing its
+        // candidate window wherever the caret was when the last FULL
+        // regeneration happened. Gated internally on the caret/focus identity
+        // actually having changed.
+        self.sync_ime_state();
 
         // Drain accessibility actions queued by the AT-SPI adapter (a screen
         // reader's 'click' on a button, etc.). The accesskit thread only parks
@@ -4458,18 +4907,24 @@ impl X11Window {
             (self.xlib.XFlush)(self.display);
         }
 
-        // CRITICAL: Set previous_window_state so sync_window_state() works for future changes
+        // Seed BOTH baselines: the event-diff one (so the first pass has
+        // something to diff against) and the OS-sync one — everything above is
+        // now applied on the window, so sync_window_state() must not re-push it.
         self.common.previous_window_state = Some(self.common.current_window_state.clone());
+        self.common.mark_os_synced();
     }
 
     /// Synchronize X11 window properties with current_window_state
     fn sync_window_state(&mut self) {
         use std::ffi::CString;
 
-        // Get copies of previous and current state to avoid borrow checker issues
-        let (previous, current) = match &self.common.previous_window_state {
-            Some(prev) => (prev.clone(), self.common.current_window_state.clone()),
-            None => return, // First frame, nothing to sync
+        // Diff against the OS-SYNC baseline, not the event baseline:
+        // `previous_window_state` is advanced by every completed event pass, so
+        // diffing it here would push (and echo) geometry the WM itself just
+        // reported. `take_os_sync_diff` hands over (baseline, current) and
+        // advances the baseline in the same call.
+        let Some((previous, current)) = self.common.take_os_sync_diff() else {
+            return; // First frame, nothing to sync
         };
 
         // MWA-B5: decoration mode changed at runtime → re-apply motif hints
@@ -5124,6 +5579,61 @@ impl X11Window {
             }
             self.ime_ic_focused = want;
         }
+    }
+
+    /// Keep the IME in step with the LIVE focus / editing / caret state.
+    ///
+    /// `sync_ime_focus_state` and the spot update used to run only from
+    /// FocusIn/FocusOut and from the tail of a FULL `regenerate_layout_inner`.
+    /// Clicking into a contenteditable produces a focus restyle, an incremental
+    /// relayout and a re-render — none of which run that tail — so the XIC
+    /// stayed unfocused and a CJK input method never engaged; and while typing,
+    /// the relayout-only frame path never moved the spot, so an over-the-spot
+    /// IME drew its candidate window at a stale position.
+    ///
+    /// Called at the end of every event pass and every frame. The caret-rect
+    /// recompute (a walk of the layout tree) is gated on the focus/editing/caret
+    /// identity actually having changed; the XIC focus call diffs internally.
+    pub(super) fn sync_ime_state(&mut self) {
+        let key = {
+            let lw = self.common.layout_window.as_ref();
+            ImeSyncKey {
+                window_focused: self.common.current_window_state.window_focused,
+                editing_node: lw.and_then(|lw| {
+                    let dom = lw.text_edit_manager.get_editing_dom_id()?;
+                    let node = lw.text_edit_manager.get_editing_node_id()?;
+                    Some((dom.inner, node.index()))
+                }),
+                cursor: lw.and_then(|lw| lw.text_edit_manager.get_primary_cursor()),
+            }
+        };
+
+        // Cheap: diffs against `ime_ic_focused` internally.
+        self.sync_ime_focus_state();
+
+        if key != self.ime_sync_key {
+            self.ime_sync_key = key;
+            self.update_ime_position_from_cursor();
+            self.sync_ime_position_to_os();
+        }
+    }
+
+    /// Replace the guessed keyboard state with the server's, via `XQueryKeymap`.
+    ///
+    /// The KeymapNotify that follows FocusIn does the same job; this covers the
+    /// case where it never arrives (a WM/compositor that does not deliver it,
+    /// or a build whose libX11 lacks the lenient symbol keeps the cleared
+    /// state, which is still better than a stale one).
+    pub(super) fn resync_keyboard_state_from_server(&mut self) {
+        let Some(query) = self.xlib.XQueryKeymap else {
+            self.clear_keyboard_state();
+            return;
+        };
+        let mut key_vector = [0 as c_char; 32];
+        unsafe {
+            (query)(self.display, key_vector.as_mut_ptr());
+        }
+        self.resync_keyboard_state_from_vector(&key_vector);
     }
 
     pub fn sync_ime_position_to_os(&self) {

--- a/dll/src/desktop/shell2/macos/events.rs
+++ b/dll/src/desktop/shell2/macos/events.rs
@@ -6,7 +6,7 @@ use crate::{log_debug, log_error, log_info, log_trace, log_warn};
 use azul_core::{
     callbacks::LayoutCallbackInfo,
     dom::{DomId, NodeId, ScrollbarOrientation},
-    events::{EventFilter, MouseButton, ProcessEventResult, SyntheticEvent},
+    events::{EventFilter, MouseButton, ProcessEventResult},
     geom::{LogicalPosition, PhysicalPositionI32},
     hit_test::{CursorTypeHitTest, FullHitTest},
     window::{
@@ -40,6 +40,37 @@ const MACOS_KEYCODE_LSHIFT: u16 = 0x38;
 const MACOS_KEYCODE_LCONTROL: u16 = 0x3B;
 const MACOS_KEYCODE_LALT: u16 = 0x3A;
 const MACOS_KEYCODE_LWIN: u16 = 0x37;
+const MACOS_KEYCODE_RSHIFT: u16 = 0x3C;
+const MACOS_KEYCODE_RCONTROL: u16 = 0x3E;
+const MACOS_KEYCODE_RALT: u16 = 0x3D;
+const MACOS_KEYCODE_RWIN: u16 = 0x36;
+const MACOS_KEYCODE_CAPSLOCK: u16 = 0x39;
+
+/// Device-DEPENDENT modifier masks (IOKit `IOLLEvent.h`), carried in the low
+/// 16 bits of `modifierFlags` next to the device-independent class flags
+/// (`Shift`, `Control`, …, all `1<<16` and above). They are the only way to
+/// tell a left modifier from its right twin AND the only way to read a
+/// release correctly: letting go of LShift while RShift is held leaves the
+/// `Shift` class flag set, so the class flag alone reports "still down".
+const NX_DEVICE_LCONTROL: usize = 0x0000_0001;
+const NX_DEVICE_LSHIFT: usize = 0x0000_0002;
+const NX_DEVICE_RSHIFT: usize = 0x0000_0004;
+const NX_DEVICE_LWIN: usize = 0x0000_0008;
+const NX_DEVICE_RWIN: usize = 0x0000_0010;
+const NX_DEVICE_LALT: usize = 0x0000_0020;
+const NX_DEVICE_RALT: usize = 0x0000_0040;
+const NX_DEVICE_RCONTROL: usize = 0x0000_2000;
+
+/// Pixels per line for a scroll delta that is NOT precise (a ratcheting mouse
+/// wheel: `hasPreciseScrollingDeltas() == false`, so AppKit reports LINE units,
+/// ~±1 per notch). The engine's raw-delta chokepoint takes pixels — X11 scales
+/// its ±1 button-4/5 ticks by `X11_SCROLL_TICK_PIXELS` and Win32 its
+/// `WHEEL_DELTA` quotient by the same 20 — so passing the line count through
+/// unscaled made a physical wheel crawl ~20x slower on macOS than everywhere
+/// else. Precise (trackpad) deltas are already pixels and pass through raw.
+#[allow(clippy::cast_lossless)]
+const MACOS_SCROLL_LINE_PIXELS: f64 =
+    crate::desktop::shell2::common::event::WHEEL_SCROLL_PIXELS_PER_LINE as f64;
 
 fn button_to_flags(button: MouseButton) -> u8 {
     match button {
@@ -227,15 +258,20 @@ impl MacOSWindow {
         // Feed Wacom/pen state on tablet events (pen tip lifted = not in contact).
         self.feed_tablet_pen(event, position, false);
 
-        // Check for right-click context menu (before event processing)
+        // Resolve a right-click context menu, but do NOT present it here: a
+        // native menu spins a synchronous nested tracking runloop, and we are
+        // holding a `&mut MacOSWindow` reconstructed from the registry's raw
+        // pointer. The tick timers run in `kCFRunLoopCommonModes` (deliberately,
+        // so blink/tweens survive menu tracking) and would take a SECOND `&mut`
+        // to this same window — aliased `&mut` plus logical re-entrancy. The
+        // view handler presents `pending_context_menu` after the borrow ends.
+        //
+        // Returning early here ALSO destroyed the mouse-up delta this handler
+        // had just recorded (`right_down = false`), so MouseUp(Right) callbacks
+        // never fired on a node that carried a context menu.
         if button == MouseButton::Right {
             if let Some(hit_node) = self.get_first_hovered_node() {
-                if self
-                    .try_show_context_menu(hit_node, position, event)
-                    .is_some()
-                {
-                    return EventProcessResult::DoNothing;
-                }
+                self.resolve_context_menu(hit_node, position);
             }
         }
 
@@ -398,7 +434,7 @@ impl MacOSWindow {
             let sel = sel!(scrollingDeltaX);
             objc2::msg_send![event, respondsToSelector: sel]
         };
-        let (delta_x, delta_y, has_precise) = if has_modern_scroll {
+        let (raw_delta_x, raw_delta_y, has_precise) = if has_modern_scroll {
             let dx = unsafe { event.scrollingDeltaX() };
             let dy = unsafe { event.scrollingDeltaY() };
             let precise = unsafe { event.hasPreciseScrollingDeltas() };
@@ -408,6 +444,18 @@ impl MacOSWindow {
             let dx = unsafe { event.deltaX() };
             let dy = unsafe { event.deltaY() };
             (dx, dy, false)
+        };
+
+        // Trackpad/precise deltas are already pixels; a ratcheting wheel (and the
+        // pre-10.7 fallback) reports LINES and must be scaled to match X11/Win32
+        // (see MACOS_SCROLL_LINE_PIXELS).
+        let (delta_x, delta_y) = if has_precise {
+            (raw_delta_x, raw_delta_y)
+        } else {
+            (
+                raw_delta_x * MACOS_SCROLL_LINE_PIXELS,
+                raw_delta_y * MACOS_SCROLL_LINE_PIXELS,
+            )
         };
 
         let location = unsafe { event.locationInWindow() };
@@ -456,9 +504,15 @@ impl MacOSWindow {
             if has_precise {
                 let phase = unsafe { event.phase() };
                 let momentum_phase = unsafe { event.momentumPhase() };
+                // momentumPhase == Cancelled means the momentum scroll was
+                // interrupted (a finger landed on the trackpad). Like Ended it
+                // is the LAST event of the gesture and carries a zero delta, so
+                // omitting it left the physics timer in TrackpadContinuous and
+                // the rubber-band spring-back was never triggered.
                 if phase == objc2_app_kit::NSEventPhase::Ended
                     || phase == objc2_app_kit::NSEventPhase::Cancelled
                     || momentum_phase == objc2_app_kit::NSEventPhase::Ended
+                    || momentum_phase == objc2_app_kit::NSEventPhase::Cancelled
                 {
                     ScrollInputSource::TrackpadEnd
                 } else {
@@ -599,13 +653,26 @@ impl MacOSWindow {
         }
         self.common.previous_window_state = Some(prev_snapshot);
 
-        // Update keyboard state with keycode
-        self.update_keyboard_state(key_code, modifiers, true);
-
-        // Handle text input for printable characters directly.
+        // RECORD (do not apply) the text this key produces, BEFORE the pass —
+        // the same order X11 and Wayland use. `record_text_input` only stages a
+        // pending changeset in the TextInputManager; the pass dispatches
+        // VirtualKeyDown first and the shared post-callback filter then emits
+        // `ApplyPendingTextInput` → `ApplyTextChangeset` →
+        // `ScrollCursorIntoViewAfterTextInput`, but ONLY when no callback called
+        // `prevent_default()`.
+        //
+        // This used to call `handle_text_input()` — which takes its OWN
+        // `previous = current.clone()` snapshot — AFTER the keycode had already
+        // been written into `current`. That left `previous == current`, so the
+        // None→Some(key) diff was gone and NO VirtualKeyDown ever fired for a
+        // printable key (Shift+letter included); only control chars, PUA
+        // function keys and Cmd/Ctrl combos, which skip the branch, kept theirs.
+        // It also inserted the text BEFORE dispatch, so a KeyDown handler could
+        // never suppress the insertion.
+        //
         // Note: interpretKeyEvents → insertText: does NOT work reliably with objc2's
         // protocol conformance. The insertText:replacementRange: method may not be called
-        // by the ObjC runtime. So we insert text directly here for printable characters.
+        // by the ObjC runtime. So we stage text here for printable characters.
         // Control characters and modified keys (Cmd+X, Ctrl+C) are NOT inserted as text.
         if let Some(ch) = character {
             let is_control_char = ch.is_control();
@@ -620,11 +687,16 @@ impl MacOSWindow {
                 let text_input = ch.to_string();
                 crate::log_debug!(
                     crate::desktop::shell2::common::debug_server::LogCategory::Input,
-                    "[handle_key_down] inserting text '{}' directly", text_input
+                    "[handle_key_down] recording text '{}' for this pass", text_input
                 );
-                self.handle_text_input(&text_input);
+                if let Some(layout_window) = self.get_layout_window_mut() {
+                    layout_window.record_text_input(&text_input);
+                }
             }
         }
+
+        // Update keyboard state with keycode
+        self.update_keyboard_state(key_code, modifiers, true);
 
         // V2 system will detect VirtualKeyDown from state diff
         let result = self.process_window_events(0);
@@ -655,8 +727,19 @@ impl MacOSWindow {
     ///
     /// This is the proper way to handle text input on macOS, as it respects
     /// the IME composition system for non-ASCII characters (accents, CJK, etc.)
+    ///
+    /// Routed through the SHARED `CallbackChange::CreateTextInput` arm (the same
+    /// one the headless runner and the debug server use) instead of a bespoke
+    /// re-implementation: the local copy dispatched the synthetic Input events
+    /// and applied the changeset correctly but omitted the arm's closing
+    /// `scroll_selection_into_view(Cursor, Instant)`, so typing ran off the
+    /// bottom of a scrollable text node without ever following the caret.
+    ///
+    /// NOT used by the key-down path any more — `handle_key_down` stages the
+    /// text with `record_text_input` and lets its own pass apply it, which is
+    /// what makes a KeyDown callback able to `prevent_default()` the insertion.
     pub fn handle_text_input(&mut self, text: &str) {
-        use azul_core::events::ProcessEventResult;
+        use azul_layout::callbacks::CallbackChange;
 
         let focused = self.common.layout_window.as_ref()
             .and_then(|lw| lw.focus_manager.get_focused_node().copied());
@@ -668,79 +751,21 @@ impl MacOSWindow {
             "[handle_text_input] text='{}', focused={:?}, has_cursor={}", text, focused, has_cursor
         );
 
-        // Save previous state BEFORE making changes
+        // Save previous state BEFORE making changes: the arm dispatches its own
+        // synthetic Input events and a user callback inside that dispatch may
+        // re-enter `process_window_events`, which needs a baseline.
         self.common.previous_window_state = Some(self.common.current_window_state.clone());
 
-        // Record text input - this returns a map of nodes that need TextInput event dispatched
-        let affected_nodes = if let Some(layout_window) = self.get_layout_window_mut() {
-            layout_window.record_text_input(text)
-        } else {
-            crate::log_debug!(
-                crate::desktop::shell2::common::debug_server::LogCategory::Input,
-                "[handle_text_input] no layout window!"
-            );
-            return;
-        };
-
-        crate::log_debug!(
-            crate::desktop::shell2::common::debug_server::LogCategory::Input,
-            "[handle_text_input] record_text_input returned {} affected nodes", affected_nodes.len()
-        );
-
-        if affected_nodes.is_empty() {
-            return;
-        }
-
-        // Manually process the generated text input event.
-        // We do NOT call process_window_events() here, because that function
-        // is for discovering events from state diffs. Here, we already know the exact event.
-        let mut overall_result = ProcessEventResult::DoNothing;
-
-        // Build synthetic events for each affected node
-        let now = {
-            #[cfg(feature = "std")]
-            { azul_core::task::Instant::from(std::time::Instant::now()) }
-            #[cfg(not(feature = "std"))]
-            { azul_core::task::Instant::Tick(azul_core::task::SystemTick::new(0)) }
-        };
-
-        let text_events: Vec<azul_core::events::SyntheticEvent> = affected_nodes.keys().map(|dom_node_id| {
-                azul_core::events::SyntheticEvent::new(
-                    azul_core::events::EventType::Input,
-                    azul_core::events::EventSource::User,
-                    *dom_node_id,
-                    now.clone(),
-                    azul_core::events::EventData::None,
-                )
-            })
-            .collect();
-
-        if !text_events.is_empty() {
-            let (text_changes_result, text_update, _) = self.dispatch_events_propagated(&text_events);
-            overall_result = overall_result.max(text_changes_result);
-            use azul_core::callbacks::Update;
-            if matches!(text_update, Update::RefreshDom | Update::RefreshDomAllWindows) {
-                overall_result = overall_result.max(ProcessEventResult::ShouldRegenerateDomCurrentWindow);
-            }
-        }
-
-        // Apply text changeset after callbacks
-        if let Some(layout_window) = self.get_layout_window_mut() {
-            let changeset_result = layout_window.apply_text_changeset();
-            if !changeset_result.dirty_nodes.is_empty() {
-                if changeset_result.needs_relayout {
-                    overall_result = overall_result.max(ProcessEventResult::ShouldIncrementalRelayout);
-                } else {
-                    overall_result = overall_result.max(ProcessEventResult::ShouldUpdateDisplayListCurrentWindow);
-                }
-            }
-        }
+        let result = self.apply_user_change(&CallbackChange::CreateTextInput {
+            text: text.into(),
+        });
 
         // Apply the result: text edits go through the incremental path
-        // (display_list_dirty), NOT the full DOM rebuild path (a regeneration request).
-        // The display list was already regenerated inside apply_text_changeset() →
-        // update_text_cache_after_edit() → regenerate_display_list_for_dom().
-        let event_result = self.convert_result_with_fanout(overall_result);
+        // (display_list_dirty / incremental_relayout), NOT the full DOM rebuild
+        // path (a regeneration request). The display list was already regenerated
+        // inside apply_text_changeset() → update_text_cache_after_edit() →
+        // regenerate_display_list_for_dom().
+        let event_result = self.convert_result_with_fanout(result);
         match event_result {
             EventProcessResult::RegenerateDisplayList => {
                 self.common.request_regeneration(azul_core::callbacks::RelayoutReason::RefreshDom);
@@ -750,6 +775,13 @@ impl MacOSWindow {
                 self.common.display_list_dirty = true;
                 self.request_redraw();
             }
+            // A text edit that changed the line count returns
+            // ShouldIncrementalRelayout. This arm was MISSING — it fell into
+            // `_ => {}`, so a reflowing edit ran no relayout and requested no
+            // frame at all and the window kept showing the pre-edit layout.
+            EventProcessResult::RegenerateLayoutIncremental => {
+                self.apply_incremental_relayout_result();
+            }
             EventProcessResult::RequestRedraw => {
                 self.request_redraw();
             }
@@ -758,46 +790,53 @@ impl MacOSWindow {
     }
 
     /// Process a flags changed event (modifier keys).
+    ///
+    /// A `flagsChanged:` event carries the keyCode of the ONE physical key whose
+    /// state flipped, so that is what decides which `VirtualKeyCode` to report —
+    /// the previous version only ever synthesized the `L*` twins from the
+    /// device-independent class flags, so a physical RShift/RAlt/RControl/RCmd
+    /// arrived as its left counterpart and Caps Lock produced nothing at all.
     pub fn handle_flags_changed(&mut self, event: &NSEvent) -> EventProcessResult {
         let modifiers = unsafe { event.modifierFlags() };
+        let key_code = unsafe { event.keyCode() };
+        let raw = modifiers.0 as usize;
 
-        // Determine which modifier keys are currently pressed
-        let shift_pressed = modifiers.contains(NSEventModifierFlags::Shift);
-        let ctrl_pressed = modifiers.contains(NSEventModifierFlags::Control);
-        let alt_pressed = modifiers.contains(NSEventModifierFlags::Option);
-        let cmd_pressed = modifiers.contains(NSEventModifierFlags::Command);
+        // Is the key that changed now DOWN? Read its device-DEPENDENT bit, not
+        // the class flag: releasing one Shift while the other is held leaves the
+        // `Shift` class flag set. Caps Lock is a LOCK — the class flag IS its
+        // state and the keyboard sends a flagsChanged on each toggle.
+        let is_down = match key_code {
+            MACOS_KEYCODE_LSHIFT => raw & NX_DEVICE_LSHIFT != 0,
+            MACOS_KEYCODE_RSHIFT => raw & NX_DEVICE_RSHIFT != 0,
+            MACOS_KEYCODE_LCONTROL => raw & NX_DEVICE_LCONTROL != 0,
+            MACOS_KEYCODE_RCONTROL => raw & NX_DEVICE_RCONTROL != 0,
+            MACOS_KEYCODE_LALT => raw & NX_DEVICE_LALT != 0,
+            MACOS_KEYCODE_RALT => raw & NX_DEVICE_RALT != 0,
+            MACOS_KEYCODE_LWIN => raw & NX_DEVICE_LWIN != 0,
+            MACOS_KEYCODE_RWIN => raw & NX_DEVICE_RWIN != 0,
+            MACOS_KEYCODE_CAPSLOCK => modifiers.contains(NSEventModifierFlags::CapsLock),
+            // Fn and anything else this table doesn't map: no engine key.
+            _ => return EventProcessResult::DoNothing,
+        };
 
-        // Track previous state to detect what changed
-        let keyboard_state = &self.common.current_window_state.keyboard_state;
-        let was_shift_down = keyboard_state.shift_down();
-        let was_ctrl_down = keyboard_state.ctrl_down();
-        let was_alt_down = keyboard_state.alt_down();
-        let was_cmd_down = keyboard_state.super_down();
-
-        // Update keyboard state based on changes
-        if shift_pressed != was_shift_down {
-            self.update_keyboard_state(MACOS_KEYCODE_LSHIFT, modifiers, shift_pressed);
-        }
-        if ctrl_pressed != was_ctrl_down {
-            self.update_keyboard_state(MACOS_KEYCODE_LCONTROL, modifiers, ctrl_pressed);
-        }
-        if alt_pressed != was_alt_down {
-            self.update_keyboard_state(MACOS_KEYCODE_LALT, modifiers, alt_pressed);
-        }
-        if cmd_pressed != was_cmd_down {
-            self.update_keyboard_state(MACOS_KEYCODE_LWIN, modifiers, cmd_pressed);
+        // Nothing to dispatch if the engine already agrees with the OS (a
+        // duplicate flagsChanged, or a modifier we re-synced on focus).
+        let Some(vk) = self.convert_keycode(key_code) else {
+            return EventProcessResult::DoNothing;
+        };
+        if self.common.current_window_state.keyboard_state.is_key_down(vk) == is_down {
+            return EventProcessResult::DoNothing;
         }
 
-        if shift_pressed != was_shift_down
-            || ctrl_pressed != was_ctrl_down
-            || alt_pressed != was_alt_down
-            || cmd_pressed != was_cmd_down
-        {
-            let result = self.process_window_events(0);
-            self.convert_result_with_fanout(result)
-        } else {
-            EventProcessResult::DoNothing
-        }
+        // Save previous state BEFORE making changes: this handler used to mutate
+        // in place and rely on the next handler's snapshot, which destroyed the
+        // very transition it had just produced.
+        self.common.previous_window_state = Some(self.common.current_window_state.clone());
+
+        self.update_keyboard_state(key_code, modifiers, is_down);
+
+        let result = self.process_window_events(0);
+        self.convert_result_with_fanout(result)
     }
 
     /// Process a window resize event.
@@ -812,8 +851,22 @@ impl MacOSWindow {
         // Store old context for comparison
         let old_context = self.dynamic_selector_context.clone();
 
-        // Update window state
-        self.common.current_window_state.size.dimensions = new_size;
+        // Save previous state BEFORE making changes. The size delta is what the
+        // shared pass turns into a `WindowResize` dispatch — this handler used to
+        // mutate in place with no snapshot and no pass, so the delta simply sat
+        // there until the NEXT handler's snapshot overwrote it and the resize
+        // was never dispatched to any callback.
+        self.common.previous_window_state = Some(self.common.current_window_state.clone());
+
+        // Update window state. Size REPORTED by the OS (source = Os): the
+        // OS-sync baseline must advance in lockstep, or the next
+        // `sync_window_state()` diffs a stale baseline against the new size and
+        // echoes a `setContentSize` back at AppKit — mid-live-resize that echo
+        // carries the PREVIOUS frame's size and fights the user's drag.
+        self.common.update_window_state(
+            crate::desktop::shell2::common::event::WindowStateSource::Os,
+            |ws| ws.size.dimensions = new_size,
+        );
 
         // Update dynamic selector context with new viewport dimensions
         self.dynamic_selector_context.viewport_width = new_width as f32;
@@ -835,7 +888,13 @@ impl MacOSWindow {
                 old_hidpi.inner.get(),
                 current_hidpi.inner.get()
             );
-            self.common.current_window_state.size.dpi = (current_hidpi.inner.get() * 96.0) as u32;
+            // Same Os-source routing as the dimension write above (the scale is
+            // an OS fact; keep the OS-sync baseline in lockstep).
+            let new_dpi = (current_hidpi.inner.get() * 96.0) as u32;
+            self.common.update_window_state(
+                crate::desktop::shell2::common::event::WindowStateSource::Os,
+                |ws| ws.size.dpi = new_dpi,
+            );
         }
 
         // Notify compositor of resize (this is private in mod.rs, so we inline it here)
@@ -851,8 +910,13 @@ impl MacOSWindow {
                     > 0.5;
 
         if !viewport_changed {
-            // No significant change, just update compositor
-            return EventProcessResult::RequestRedraw;
+            // No significant change, just update compositor. The pass still runs
+            // so the (sub-pixel) delta is consumed here instead of being left
+            // live for an unrelated later pass to re-detect as a resize.
+            let result = self.process_window_events(0);
+            return self
+                .convert_result_with_fanout(result)
+                .max(EventProcessResult::RequestRedraw);
         }
 
         // RESIZE POLICY (user ruling 2026-08-08, same as Wayland/X11/Win32):
@@ -887,10 +951,16 @@ impl MacOSWindow {
             );
         }
 
+        // Dispatch the size transition (WindowResize + any size-conditional
+        // restyle) and consume the delta.
+        let result = self.process_window_events(0);
+
         // Either way the compositor needs a frame; the caller's RequestRedraw
         // arm sets surface_needs_update + request_redraw, and the fast path's
-        // latch is consumed (once, coalesced) at the top of build_atomic_txn.
-        EventProcessResult::RequestRedraw
+        // latch is consumed (once, coalesced) at the top of build_atomic_txn —
+        // so the pass result is floored at RequestRedraw, never below it.
+        self.convert_result_with_fanout(result)
+            .max(EventProcessResult::RequestRedraw)
     }
 
     /// Process a file drop event (the user released the dragged files over the
@@ -1063,9 +1133,53 @@ fn convert_keycode(keycode: u16) -> Option<VirtualKeyCode> {
         0x39 => Some(VirtualKeyCode::Capital), // Caps Lock
         0x3A => Some(VirtualKeyCode::LAlt),    // Option
         0x3B => Some(VirtualKeyCode::LControl),
+        0x36 => Some(VirtualKeyCode::RWin), // Right Command
         0x3C => Some(VirtualKeyCode::RShift),
         0x3D => Some(VirtualKeyCode::RAlt),
         0x3E => Some(VirtualKeyCode::RControl),
+        // Keypad. Its digits/operators also produce ordinary characters, so the
+        // text-insert path in handle_key_down keeps working; these entries are
+        // what gives them a VirtualKeyDown as well.
+        0x41 => Some(VirtualKeyCode::NumpadDecimal),
+        0x43 => Some(VirtualKeyCode::NumpadMultiply),
+        0x45 => Some(VirtualKeyCode::NumpadAdd),
+        0x47 => Some(VirtualKeyCode::Numlock), // Keypad Clear sits in the NumLock position
+        0x4B => Some(VirtualKeyCode::NumpadDivide),
+        0x4C => Some(VirtualKeyCode::NumpadEnter),
+        0x4E => Some(VirtualKeyCode::NumpadSubtract),
+        0x51 => Some(VirtualKeyCode::NumpadEquals),
+        0x52 => Some(VirtualKeyCode::Numpad0),
+        0x53 => Some(VirtualKeyCode::Numpad1),
+        0x54 => Some(VirtualKeyCode::Numpad2),
+        0x55 => Some(VirtualKeyCode::Numpad3),
+        0x56 => Some(VirtualKeyCode::Numpad4),
+        0x57 => Some(VirtualKeyCode::Numpad5),
+        0x58 => Some(VirtualKeyCode::Numpad6),
+        0x59 => Some(VirtualKeyCode::Numpad7),
+        0x5B => Some(VirtualKeyCode::Numpad8),
+        0x5C => Some(VirtualKeyCode::Numpad9),
+        // Function row. macOS orders these by hardware position, not by number.
+        0x60 => Some(VirtualKeyCode::F5),
+        0x61 => Some(VirtualKeyCode::F6),
+        0x62 => Some(VirtualKeyCode::F7),
+        0x63 => Some(VirtualKeyCode::F3),
+        0x64 => Some(VirtualKeyCode::F8),
+        0x65 => Some(VirtualKeyCode::F9),
+        0x67 => Some(VirtualKeyCode::F11),
+        0x6D => Some(VirtualKeyCode::F10),
+        0x6E => Some(VirtualKeyCode::Apps), // PC "Menu" / contextual-menu key
+        0x6F => Some(VirtualKeyCode::F12),
+        0x76 => Some(VirtualKeyCode::F4),
+        0x78 => Some(VirtualKeyCode::F2),
+        0x7A => Some(VirtualKeyCode::F1),
+        // Navigation cluster. These emit Private-Use-Area characters
+        // (U+F700..U+F7FF), which handle_key_down correctly refuses to insert as
+        // text — so without an entry here they produced no engine event AT ALL.
+        0x73 => Some(VirtualKeyCode::Home),
+        0x74 => Some(VirtualKeyCode::PageUp),
+        0x75 => Some(VirtualKeyCode::Delete), // ForwardDelete (Back = 0x33 is Backspace)
+        0x77 => Some(VirtualKeyCode::End),
+        0x79 => Some(VirtualKeyCode::PageDown),
         0x7B => Some(VirtualKeyCode::Left),
         0x7C => Some(VirtualKeyCode::Right),
         0x7D => Some(VirtualKeyCode::Down),
@@ -1188,13 +1302,15 @@ impl MacOSWindow {
         Ok(())
     }
 
-    /// Try to show context menu for the given node at position.
-    /// Returns Some if a menu was shown, None otherwise.
-    fn try_show_context_menu(
+    /// Resolve a context menu for the given node at position and QUEUE it.
+    /// Returns Some if a menu was queued, None otherwise.
+    ///
+    /// Presentation is deliberately not done here — see `pending_context_menu`
+    /// and `take_pending_context_menu` in `macos/mod.rs`.
+    fn resolve_context_menu(
         &mut self,
         node: HitTestNode,
         position: LogicalPosition,
-        event: &NSEvent,
     ) -> Option<()> {
         use azul_core::dom::DomId;
 
@@ -1217,7 +1333,7 @@ impl MacOSWindow {
 
         log_debug!(
             LogCategory::Input,
-            "[Context Menu] Showing context menu at ({}, {}) for node {:?} with {} items",
+            "[Context Menu] Queuing context menu at ({}, {}) for node {:?} with {} items",
             position.x,
             position.y,
             node,
@@ -1226,7 +1342,7 @@ impl MacOSWindow {
 
         // Check if native context menus are enabled
         if self.common.current_window_state.flags.use_native_context_menus {
-            self.show_native_context_menu_at_position(&context_menu, position, event);
+            self.queue_native_context_menu_at_position(&context_menu, position);
         } else {
             self.show_window_based_context_menu(&context_menu, position);
         }
@@ -1234,15 +1350,15 @@ impl MacOSWindow {
         Some(())
     }
 
-    /// Show an NSMenu as a context menu at the given screen position.
-    fn show_native_context_menu_at_position(
+    /// Build the NSMenu for a context menu and park it in `pending_context_menu`
+    /// together with the view + view-space point it must pop up at.
+    fn queue_native_context_menu_at_position(
         &mut self,
         menu: &azul_core::menu::Menu,
         position: LogicalPosition,
-        event: &NSEvent,
     ) {
-        use objc2_app_kit::{NSMenu, NSMenuItem};
-        use objc2_foundation::{MainThreadMarker, NSPoint, NSString};
+        use objc2_app_kit::NSMenu;
+        use objc2_foundation::{MainThreadMarker, NSPoint};
 
         let mtm = match MainThreadMarker::new() {
             Some(m) => m,
@@ -1272,29 +1388,34 @@ impl MacOSWindow {
             y: (window_height - position.y) as f64,
         };
 
-        let view = if let Some(ref gl_view) = self.gl_view {
-            Some(&**gl_view as &objc2::runtime::AnyObject)
-        } else { self.cpu_view.as_ref().map(|cpu_view| &**cpu_view as &objc2::runtime::AnyObject) };
+        // Retain the view: the pending menu outlives this `&mut self` borrow by
+        // design, so it cannot hold a reference back into `self`.
+        use objc2::Message;
+        let view: Option<objc2::rc::Retained<objc2_app_kit::NSView>> =
+            if let Some(ref gl_view) = self.gl_view {
+                let v: &objc2_app_kit::NSView = &**gl_view;
+                Some(v.retain())
+            } else {
+                self.cpu_view.as_ref().map(|cpu_view| {
+                    let v: &objc2_app_kit::NSView = &**cpu_view;
+                    v.retain()
+                })
+            };
 
         if let Some(view) = view {
             log_debug!(
                 LogCategory::Input,
-                "[Context Menu] Showing native menu at position ({}, {}) with {} items",
+                "[Context Menu] Queued native menu at position ({}, {}) with {} items",
                 position.x,
                 position.y,
                 menu.items.as_slice().len()
             );
 
-            unsafe {
-                use objc2::{msg_send, runtime::AnyObject};
-
-                let _: () = msg_send![
-                    &ns_menu,
-                    popUpMenuPositioningItem: Option::<&AnyObject>::None,
-                    atLocation: view_point,
-                    inView: view
-                ];
-            }
+            self.pending_context_menu = Some(super::PendingContextMenu {
+                menu: ns_menu,
+                view,
+                location: view_point,
+            });
         }
     }
 
@@ -1417,5 +1538,61 @@ mod tests {
         assert_eq!(Some(VirtualKeyCode::LAlt), convert_keycode(0x3A));
         assert_eq!(Some(VirtualKeyCode::LWin), convert_keycode(0x37));
         assert_eq!(None, convert_keycode(0xFF));
+    }
+
+    /// The navigation cluster emits Private-Use-Area characters that the
+    /// text-input filter (correctly) refuses to insert, so a missing entry here
+    /// means the key produces NO engine event whatsoever.
+    #[test]
+    fn test_keycode_conversion_navigation() {
+        assert_eq!(Some(VirtualKeyCode::Home), convert_keycode(0x73));
+        assert_eq!(Some(VirtualKeyCode::End), convert_keycode(0x77));
+        assert_eq!(Some(VirtualKeyCode::PageUp), convert_keycode(0x74));
+        assert_eq!(Some(VirtualKeyCode::PageDown), convert_keycode(0x79));
+        // ForwardDelete, NOT Backspace (0x33 = Back).
+        assert_eq!(Some(VirtualKeyCode::Delete), convert_keycode(0x75));
+        assert_eq!(Some(VirtualKeyCode::Back), convert_keycode(0x33));
+        assert_eq!(Some(VirtualKeyCode::Left), convert_keycode(0x7B));
+        assert_eq!(Some(VirtualKeyCode::Up), convert_keycode(0x7E));
+    }
+
+    /// macOS orders the function row by hardware position, not by number — the
+    /// table is easy to transpose, so pin every entry.
+    #[test]
+    fn test_keycode_conversion_function_row() {
+        assert_eq!(Some(VirtualKeyCode::F1), convert_keycode(0x7A));
+        assert_eq!(Some(VirtualKeyCode::F2), convert_keycode(0x78));
+        assert_eq!(Some(VirtualKeyCode::F3), convert_keycode(0x63));
+        assert_eq!(Some(VirtualKeyCode::F4), convert_keycode(0x76));
+        assert_eq!(Some(VirtualKeyCode::F5), convert_keycode(0x60));
+        assert_eq!(Some(VirtualKeyCode::F6), convert_keycode(0x61));
+        assert_eq!(Some(VirtualKeyCode::F7), convert_keycode(0x62));
+        assert_eq!(Some(VirtualKeyCode::F8), convert_keycode(0x64));
+        assert_eq!(Some(VirtualKeyCode::F9), convert_keycode(0x65));
+        assert_eq!(Some(VirtualKeyCode::F10), convert_keycode(0x6D));
+        assert_eq!(Some(VirtualKeyCode::F11), convert_keycode(0x67));
+        assert_eq!(Some(VirtualKeyCode::F12), convert_keycode(0x6F));
+    }
+
+    #[test]
+    fn test_keycode_conversion_keypad_and_right_modifiers() {
+        assert_eq!(Some(VirtualKeyCode::Numpad0), convert_keycode(0x52));
+        assert_eq!(Some(VirtualKeyCode::Numpad7), convert_keycode(0x59));
+        assert_eq!(Some(VirtualKeyCode::Numpad8), convert_keycode(0x5B));
+        assert_eq!(Some(VirtualKeyCode::Numpad9), convert_keycode(0x5C));
+        assert_eq!(Some(VirtualKeyCode::NumpadEnter), convert_keycode(0x4C));
+        assert_eq!(Some(VirtualKeyCode::NumpadDecimal), convert_keycode(0x41));
+        assert_eq!(Some(VirtualKeyCode::NumpadAdd), convert_keycode(0x45));
+        assert_eq!(Some(VirtualKeyCode::NumpadSubtract), convert_keycode(0x4E));
+        assert_eq!(Some(VirtualKeyCode::NumpadMultiply), convert_keycode(0x43));
+        assert_eq!(Some(VirtualKeyCode::NumpadDivide), convert_keycode(0x4B));
+
+        // Right-hand modifiers must NOT collapse onto their left twins.
+        assert_eq!(Some(VirtualKeyCode::RWin), convert_keycode(0x36));
+        assert_eq!(Some(VirtualKeyCode::RShift), convert_keycode(0x3C));
+        assert_eq!(Some(VirtualKeyCode::RAlt), convert_keycode(0x3D));
+        assert_eq!(Some(VirtualKeyCode::RControl), convert_keycode(0x3E));
+        assert_eq!(Some(VirtualKeyCode::Capital), convert_keycode(0x39));
+        assert_eq!(Some(VirtualKeyCode::Apps), convert_keycode(0x6E));
     }
 }

--- a/dll/src/desktop/shell2/macos/mod.rs
+++ b/dll/src/desktop/shell2/macos/mod.rs
@@ -297,26 +297,71 @@ mod view_handlers {
 
     pub(super) fn right_mouse_up(window_ptr: Option<*mut std::ffi::c_void>, event: &NSEvent) {
         if let Some(window_ptr) = window_ptr {
-            unsafe {
+            // The `&mut MacOSWindow` lives in this block ONLY. A native context
+            // menu resolved by the mouse-up pass is handed out here and popped
+            // up below, after the borrow has ended: popUpMenuPositioningItem:
+            // spins a nested tracking runloop in which the common-mode tick
+            // timers fire and take their own `&mut` to this same window.
+            let pending_menu = unsafe {
                 let macos_window = &mut *(window_ptr as *mut MacOSWindow);
                 let result = macos_window.handle_mouse_up(event, azul_core::events::MouseButton::Right);
-                match result {
-                    EventProcessResult::RegenerateDisplayList => {
-                        macos_window.common.request_regeneration(azul_core::callbacks::RelayoutReason::RefreshDom);
-                        macos_window.request_redraw();
-                    }
-                    EventProcessResult::UpdateDisplayList => {
-                        macos_window.common.display_list_dirty = true;
-                        macos_window.request_redraw();
-                    }
-                    EventProcessResult::RequestRedraw => {
-                        macos_window.request_redraw();
-                    }
-                    EventProcessResult::RegenerateLayoutIncremental => {
-                        macos_window.apply_incremental_relayout_result();
-                    }
-                    _ => {}
-                }
+                route_result(macos_window, result);
+                macos_window.sync_window_state();
+                macos_window.take_pending_context_menu()
+            };
+            if let Some(pending_menu) = pending_menu {
+                present_pending_context_menu(&pending_menu);
+            }
+        }
+    }
+
+    /// `buttonNumber` → azul `MouseButton`. AppKit numbers buttons 0 = left,
+    /// 1 = right, 2 = middle, 3+ = extra (thumb/back/forward); only 2 and up
+    /// ever reach the `otherMouse*` selectors.
+    fn other_mouse_button(event: &NSEvent) -> azul_core::events::MouseButton {
+        use azul_core::events::MouseButton;
+        match unsafe { event.buttonNumber() } {
+            2 => MouseButton::Middle,
+            n => MouseButton::Other(n.clamp(0, u8::MAX as isize) as u8),
+        }
+    }
+
+    pub(super) fn other_mouse_down(window_ptr: Option<*mut std::ffi::c_void>, event: &NSEvent) {
+        if let Some(window_ptr) = window_ptr {
+            unsafe {
+                let macos_window = &mut *(window_ptr as *mut MacOSWindow);
+                let button = other_mouse_button(event);
+                let result = macos_window.handle_mouse_down(event, button);
+                route_result(macos_window, result);
+                macos_window.sync_window_state();
+            }
+        }
+    }
+
+    pub(super) fn other_mouse_up(window_ptr: Option<*mut std::ffi::c_void>, event: &NSEvent) {
+        if let Some(window_ptr) = window_ptr {
+            unsafe {
+                let macos_window = &mut *(window_ptr as *mut MacOSWindow);
+                let button = other_mouse_button(event);
+                let result = macos_window.handle_mouse_up(event, button);
+                route_result(macos_window, result);
+                macos_window.sync_window_state();
+            }
+        }
+    }
+
+    /// A drag with a non-left button held. Same handler as `mouseDragged:` —
+    /// the engine derives the drag from the cursor delta plus the button flags
+    /// already in `mouse_state`, so there is nothing button-specific to do.
+    pub(super) fn non_left_mouse_dragged(
+        window_ptr: Option<*mut std::ffi::c_void>,
+        event: &NSEvent,
+    ) {
+        if let Some(window_ptr) = window_ptr {
+            unsafe {
+                let macos_window = &mut *(window_ptr as *mut MacOSWindow);
+                let result = macos_window.handle_mouse_move(event);
+                route_result(macos_window, result);
                 macos_window.sync_window_state();
             }
         }
@@ -463,6 +508,11 @@ mod view_handlers {
                     }
                     _ => {}
                 }
+                // Same trailing sync every mouse handler performs: a callback
+                // fired from this event can change the title / size / position,
+                // and without this the NSWindow only learned about it whenever
+                // the next MOUSE event happened to arrive.
+                macos_window.sync_window_state();
             }
         }
     }
@@ -490,6 +540,7 @@ mod view_handlers {
                     }
                     _ => {}
                 }
+                macos_window.sync_window_state();
             }
         }
     }
@@ -517,6 +568,7 @@ mod view_handlers {
                     }
                     _ => {}
                 }
+                macos_window.sync_window_state();
             }
         }
     }
@@ -840,6 +892,31 @@ define_class!(
             view_handlers::right_mouse_up(*self.ivars().window_ptr.borrow(), event);
         }
 
+        // Middle / extra buttons and non-left drags. `process_event` routes
+        // OtherMouseDown/Up and RightMouseDragged "to the NSView responder
+        // methods", but neither view declared them — so the whole middle button
+        // and every right/middle drag were silently dropped even though the
+        // engine side (handle_mouse_down/up with MouseButton::Middle) exists.
+        #[unsafe(method(otherMouseDown:))]
+        fn other_mouse_down(&self, event: &NSEvent) {
+            view_handlers::other_mouse_down(*self.ivars().window_ptr.borrow(), event);
+        }
+
+        #[unsafe(method(otherMouseUp:))]
+        fn other_mouse_up(&self, event: &NSEvent) {
+            view_handlers::other_mouse_up(*self.ivars().window_ptr.borrow(), event);
+        }
+
+        #[unsafe(method(otherMouseDragged:))]
+        fn other_mouse_dragged(&self, event: &NSEvent) {
+            view_handlers::non_left_mouse_dragged(*self.ivars().window_ptr.borrow(), event);
+        }
+
+        #[unsafe(method(rightMouseDragged:))]
+        fn right_mouse_dragged(&self, event: &NSEvent) {
+            view_handlers::non_left_mouse_dragged(*self.ivars().window_ptr.borrow(), event);
+        }
+
         #[unsafe(method(scrollWheel:))]
         fn scroll_wheel(&self, event: &NSEvent) {
             view_handlers::scroll_wheel(*self.ivars().window_ptr.borrow(), event);
@@ -972,9 +1049,21 @@ define_class!(
                 if ime_consumed {
                     if let Some(window_ptr) = *self.ivars().window_ptr.borrow() {
                         unsafe {
+                            use crate::desktop::shell2::common::event::PlatformWindow;
                             let macos_window = &mut *(window_ptr as *mut MacOSWindow);
                             macos_window.common.display_list_dirty = true;
                             macos_window.request_redraw();
+                            // Still run the pass. Returning here made every
+                            // keystroke of an active composition invisible to
+                            // the event system: no end-of-pass focus finalize,
+                            // no window-state sync, and any state a text-input
+                            // callback changed sat unprocessed until the next
+                            // unrelated event. insertText:/setMarkedText: have
+                            // already taken their own `previous` snapshot, so
+                            // this dispatches exactly what they produced.
+                            let result = macos_window.process_window_events(0);
+                            macos_window.apply_activation_pass_result(result);
+                            macos_window.sync_window_state();
                         }
                     }
                     return;
@@ -1004,6 +1093,10 @@ define_class!(
                         }
                         _ => {}
                     }
+                    // Same trailing sync the mouse handlers perform: a key
+                    // callback that changes title / size / position otherwise
+                    // reached the NSWindow only on the next mouse event.
+                    macos_window.sync_window_state();
                 }
             }
         }
@@ -1214,8 +1307,9 @@ define_class!(
             &self,
             string: &NSObject,
             selected_range: NSRange,
-            _replacement_range: NSRange,
+            replacement_range: NSRange,
         ) {
+            let _ = ime_replacement_range_is_implicit(replacement_range, "setMarkedText");
             // macOS sends either NSString or NSAttributedString — handle both.
             let preedit = if let Some(ns_string) = string.downcast_ref::<NSString>() {
                 ns_string.to_string()
@@ -1254,11 +1348,18 @@ define_class!(
 
         #[unsafe(method(unmarkText))]
         fn unmark_text(&self) {
+            log_trace!(LogCategory::Input, "[IME unmarkText] composition cancelled");
             if let Some(window_ptr) = *self.ivars().window_ptr.borrow() {
                 unsafe {
                     let macos_window = &mut *(window_ptr as *mut MacOSWindow);
                     if let Some(ref mut lw) = macos_window.common.layout_window {
+                        // Cancelling drops the composition ENTIRELY. Clearing
+                        // the preedit string alone left the composed glyphs
+                        // shaped into the node's inline layout, so a cancelled
+                        // composition stayed on screen until something else
+                        // happened to re-shape that node.
                         lw.text_edit_manager.clear_preedit();
+                        lw.end_preedit_shaping();
                     }
                     macos_window.request_redraw();
                 }
@@ -1281,7 +1382,7 @@ define_class!(
         }
 
         #[unsafe(method(insertText:replacementRange:))]
-        fn insert_text(&self, string: &NSObject, _replacement_range: NSRange) {
+        fn insert_text(&self, string: &NSObject, replacement_range: NSRange) {
             // macOS sends either NSString or NSAttributedString — handle both.
             let committed_text = if let Some(ns_string) = string.downcast_ref::<NSString>() {
                 ns_string.to_string()
@@ -1291,6 +1392,7 @@ define_class!(
                 String::new()
             };
             log_trace!(LogCategory::Input, "[IME insertText] text='{}'", committed_text);
+            let _ = ime_replacement_range_is_implicit(replacement_range, "insertText");
             self.ivars().ime_key_handled.set(true);
             let window_ptr = match self.get_window_ptr() {
                 Some(ptr) => ptr,
@@ -1303,7 +1405,13 @@ define_class!(
             unsafe {
                 let macos_window = &mut *(window_ptr as *mut MacOSWindow);
                 if let Some(ref mut lw) = macos_window.common.layout_window {
+                    // END the composition before inserting: the composed string
+                    // is glyphs in the node's inline layout, never document
+                    // text, so it has to be un-shaped or the commit lands next
+                    // to a composition that is still on screen (typing "か" and
+                    // committing rendered "かか").
                     lw.text_edit_manager.clear_preedit();
+                    lw.end_preedit_shaping();
                 }
                 macos_window.handle_text_input(&committed_text);
             }
@@ -1535,6 +1643,31 @@ define_class!(
             view_handlers::right_mouse_up(*self.ivars().window_ptr.borrow(), event);
         }
 
+        // Middle / extra buttons and non-left drags. `process_event` routes
+        // OtherMouseDown/Up and RightMouseDragged "to the NSView responder
+        // methods", but neither view declared them — so the whole middle button
+        // and every right/middle drag were silently dropped even though the
+        // engine side (handle_mouse_down/up with MouseButton::Middle) exists.
+        #[unsafe(method(otherMouseDown:))]
+        fn other_mouse_down(&self, event: &NSEvent) {
+            view_handlers::other_mouse_down(*self.ivars().window_ptr.borrow(), event);
+        }
+
+        #[unsafe(method(otherMouseUp:))]
+        fn other_mouse_up(&self, event: &NSEvent) {
+            view_handlers::other_mouse_up(*self.ivars().window_ptr.borrow(), event);
+        }
+
+        #[unsafe(method(otherMouseDragged:))]
+        fn other_mouse_dragged(&self, event: &NSEvent) {
+            view_handlers::non_left_mouse_dragged(*self.ivars().window_ptr.borrow(), event);
+        }
+
+        #[unsafe(method(rightMouseDragged:))]
+        fn right_mouse_dragged(&self, event: &NSEvent) {
+            view_handlers::non_left_mouse_dragged(*self.ivars().window_ptr.borrow(), event);
+        }
+
         #[unsafe(method(scrollWheel:))]
         fn scroll_wheel(&self, event: &NSEvent) {
             view_handlers::scroll_wheel(*self.ivars().window_ptr.borrow(), event);
@@ -1667,9 +1800,21 @@ define_class!(
                 if ime_consumed {
                     if let Some(window_ptr) = *self.ivars().window_ptr.borrow() {
                         unsafe {
+                            use crate::desktop::shell2::common::event::PlatformWindow;
                             let macos_window = &mut *(window_ptr as *mut MacOSWindow);
                             macos_window.common.display_list_dirty = true;
                             macos_window.request_redraw();
+                            // Still run the pass. Returning here made every
+                            // keystroke of an active composition invisible to
+                            // the event system: no end-of-pass focus finalize,
+                            // no window-state sync, and any state a text-input
+                            // callback changed sat unprocessed until the next
+                            // unrelated event. insertText:/setMarkedText: have
+                            // already taken their own `previous` snapshot, so
+                            // this dispatches exactly what they produced.
+                            let result = macos_window.process_window_events(0);
+                            macos_window.apply_activation_pass_result(result);
+                            macos_window.sync_window_state();
                         }
                     }
                     return;
@@ -1699,6 +1844,10 @@ define_class!(
                         }
                         _ => {}
                     }
+                    // Same trailing sync the mouse handlers perform: a key
+                    // callback that changes title / size / position otherwise
+                    // reached the NSWindow only on the next mouse event.
+                    macos_window.sync_window_state();
                 }
             }
         }
@@ -1906,8 +2055,9 @@ define_class!(
             &self,
             string: &NSObject,
             selected_range: NSRange,
-            _replacement_range: NSRange,
+            replacement_range: NSRange,
         ) {
+            let _ = ime_replacement_range_is_implicit(replacement_range, "setMarkedText");
             // macOS sends either NSString or NSAttributedString — handle both.
             let preedit = if let Some(ns_string) = string.downcast_ref::<NSString>() {
                 ns_string.to_string()
@@ -1946,11 +2096,18 @@ define_class!(
 
         #[unsafe(method(unmarkText))]
         fn unmark_text(&self) {
+            log_trace!(LogCategory::Input, "[IME unmarkText] composition cancelled");
             if let Some(window_ptr) = *self.ivars().window_ptr.borrow() {
                 unsafe {
                     let macos_window = &mut *(window_ptr as *mut MacOSWindow);
                     if let Some(ref mut lw) = macos_window.common.layout_window {
+                        // Cancelling drops the composition ENTIRELY. Clearing
+                        // the preedit string alone left the composed glyphs
+                        // shaped into the node's inline layout, so a cancelled
+                        // composition stayed on screen until something else
+                        // happened to re-shape that node.
                         lw.text_edit_manager.clear_preedit();
+                        lw.end_preedit_shaping();
                     }
                     macos_window.request_redraw();
                 }
@@ -1973,7 +2130,7 @@ define_class!(
         }
 
         #[unsafe(method(insertText:replacementRange:))]
-        fn insert_text(&self, string: &NSObject, _replacement_range: NSRange) {
+        fn insert_text(&self, string: &NSObject, replacement_range: NSRange) {
             // macOS sends either NSString or NSAttributedString — handle both.
             let committed_text = if let Some(ns_string) = string.downcast_ref::<NSString>() {
                 ns_string.to_string()
@@ -1983,6 +2140,7 @@ define_class!(
                 String::new()
             };
             log_trace!(LogCategory::Input, "[IME insertText] text='{}'", committed_text);
+            let _ = ime_replacement_range_is_implicit(replacement_range, "insertText");
             self.ivars().ime_key_handled.set(true);
             let window_ptr = match self.get_window_ptr() {
                 Some(ptr) => ptr,
@@ -1995,7 +2153,13 @@ define_class!(
             unsafe {
                 let macos_window = &mut *(window_ptr as *mut MacOSWindow);
                 if let Some(ref mut lw) = macos_window.common.layout_window {
+                    // END the composition before inserting: the composed string
+                    // is glyphs in the node's inline layout, never document
+                    // text, so it has to be un-shaped or the commit lands next
+                    // to a composition that is still on screen (typing "か" and
+                    // committing rendered "かか").
                     lw.text_edit_manager.clear_preedit();
+                    lw.end_preedit_shaping();
                 }
                 macos_window.handle_text_input(&committed_text);
             }
@@ -2381,7 +2545,7 @@ define_class!(
             if let Some(window_ptr) = *self.ivars().window_ptr.borrow() {
                 unsafe {
                     let macos_window = &mut *(window_ptr as *mut MacOSWindow);
-                    macos_window.common.current_window_state.flags.frame = WindowFrame::Minimized;
+                    set_window_frame_and_dispatch(macos_window, WindowFrame::Minimized);
                     macos_window.set_display_link_paused(true);
                 }
                 log_debug!(LogCategory::Window, "[WindowDelegate] Window minimized");
@@ -2394,7 +2558,7 @@ define_class!(
             if let Some(window_ptr) = *self.ivars().window_ptr.borrow() {
                 unsafe {
                     let macos_window = &mut *(window_ptr as *mut MacOSWindow);
-                    macos_window.common.current_window_state.flags.frame = WindowFrame::Normal;
+                    set_window_frame_and_dispatch(macos_window, WindowFrame::Normal);
                     macos_window.set_display_link_paused(false);
                 }
                 log_debug!(LogCategory::Window, "[WindowDelegate] Window deminiaturized");
@@ -2430,7 +2594,7 @@ define_class!(
             if let Some(window_ptr) = *self.ivars().window_ptr.borrow() {
                 unsafe {
                     let macos_window = &mut *(window_ptr as *mut MacOSWindow);
-                    macos_window.common.current_window_state.flags.frame = WindowFrame::Fullscreen;
+                    set_window_frame_and_dispatch(macos_window, WindowFrame::Fullscreen);
                 }
                 log_debug!(LogCategory::Window, "[WindowDelegate] Window entered fullscreen");
             }
@@ -2443,7 +2607,7 @@ define_class!(
                 unsafe {
                     let macos_window = &mut *(window_ptr as *mut MacOSWindow);
                     // Return to normal frame, will be updated by resize check if maximized
-                    macos_window.common.current_window_state.flags.frame = WindowFrame::Normal;
+                    set_window_frame_and_dispatch(macos_window, WindowFrame::Normal);
                 }
                 log_debug!(LogCategory::Window, "[WindowDelegate] Window exited fullscreen");
             }
@@ -2582,6 +2746,12 @@ define_class!(
                 unsafe {
                     let macos_window = &mut *(window_ptr as *mut MacOSWindow);
                     let frame = macos_window.window.frame();
+                    // Snapshot the EVENT baseline before mutating. `update_window_state`
+                    // with source = Os no longer advances it (it advances the OS-sync
+                    // baseline instead), so without this the move delta would be left
+                    // live for the next handler's snapshot to erase.
+                    macos_window.common.previous_window_state =
+                        Some(macos_window.common.current_window_state.clone());
                     // MWA-B9: same primary-screen flip as sync_window_state —
                     // the per-screen height read-back produced coordinates in
                     // a DIFFERENT convention on secondary monitors, so the
@@ -2607,6 +2777,9 @@ define_class!(
                     }
                     // GL surface may have moved to a different screen
                     macos_window.surface_needs_update = true;
+                    // Dispatch the move and consume the delta in THIS handler.
+                    let result = macos_window.process_window_events(0);
+                    macos_window.apply_activation_pass_result(result);
                 }
             }
         }
@@ -2715,6 +2888,96 @@ fn create_opengl_pixel_format(
 // MacOSWindow - Main window implementation
 
 /// macOS window implementation with dual rendering backend support
+/// A native context menu that a right-click resolved but that has NOT been
+/// presented yet.
+///
+/// `popUpMenuPositioningItem:atLocation:inView:` runs a SYNCHRONOUS nested
+/// tracking runloop, so it must never be sent while a `&mut MacOSWindow`
+/// reconstructed from the registry pointer is live: the tick timers are
+/// registered in `kCFRunLoopCommonModes` (deliberately — blink and tweens have
+/// to survive menu tracking and live resize) and `tickTimers:` takes a SECOND
+/// `&mut` to the same window, which is aliasing UB on top of plain re-entrancy.
+/// The mouse-up handler parks the built menu here; the view handler drains it
+/// with `take_pending_context_menu()` and presents it AFTER the borrow ends.
+pub(crate) struct PendingContextMenu {
+    menu: Retained<NSMenu>,
+    view: Retained<NSView>,
+    /// Pop-up point in the VIEW's (bottom-left origin) coordinate system.
+    location: NSPoint,
+}
+
+/// Apply an OS-reported window-frame transition (minimize / restore / enter or
+/// exit fullscreen) under the event contract: snapshot `previous`, mutate
+/// `current`, run the pass.
+///
+/// The four delegate methods used to assign `flags.frame` in place with no
+/// snapshot and no pass, so the transition was never dispatched — the delta just
+/// waited for the next handler's snapshot to overwrite it, and the window-frame
+/// callbacks, `:fullscreen` styling and minimize-driven timer policy all
+/// silently never ran.
+fn set_window_frame_and_dispatch(window: &mut MacOSWindow, frame: WindowFrame) {
+    if window.common.current_window_state.flags.frame == frame {
+        return;
+    }
+    window.common.previous_window_state = Some(window.common.current_window_state.clone());
+    // OS-REPORTED transition (the delegate fires AFTER the OS performed it), so
+    // the OS-sync baseline must advance in lockstep (source = Os). A direct
+    // `flags.frame = frame` write left `os_synced_state` stale, and the next
+    // `sync_window_state()` re-issued the frame op from the stale diff — for
+    // Fullscreen that op is `toggleFullScreen`, a TOGGLE, so an OS-initiated
+    // fullscreen enter was immediately toggled back out and the exit toggled
+    // back in: the window flapped indefinitely.
+    window
+        .common
+        .update_window_state(event::WindowStateSource::Os, |ws| ws.flags.frame = frame);
+    let result = window.process_window_events(0);
+    window.apply_activation_pass_result(result);
+}
+
+/// `NSTextInputClient` hands `insertText:` and `setMarkedText:` a
+/// `replacementRange` naming the part of the client's text the operation
+/// replaces. `location == NSNotFound` means "the current selection / marked
+/// range", which is the only form this client can honour: the engine addresses
+/// text through its own cursor model and exposes no UTF-16 offset mapping into
+/// it (which is also why `selectedRange` is a fixed stub). An explicit range is
+/// reported instead of being silently applied at the caret, where it would
+/// insert text in the wrong place.
+fn ime_replacement_range_is_implicit(range: NSRange, method: &str) -> bool {
+    // AppKit passes NSNotFound (== NSIntegerMax) through NSRange's unsigned
+    // location field; accept usize::MAX too, which is what `markedRange`
+    // returns here for "no marked text".
+    if range.location == objc2_foundation::NSNotFound as usize || range.location == usize::MAX {
+        return true;
+    }
+    log_warn!(
+        LogCategory::Input,
+        "[IME {}] replacementRange ({}, {}) not honoured: the engine exposes no UTF-16 offset \
+         mapping into its text model",
+        method,
+        range.location,
+        range.length
+    );
+    false
+}
+
+/// Present a menu parked by [`PendingContextMenu`]. Blocks in a nested tracking
+/// runloop until the user picks an item or dismisses the menu, so it may ONLY be
+/// called once every `&mut MacOSWindow` has been dropped — the retained menu and
+/// view keep themselves alive without borrowing the window.
+pub(crate) fn present_pending_context_menu(pending: &PendingContextMenu) {
+    // Typed binding, not msg_send!: the method returns BOOL (YES if an item was
+    // selected), and the moved-verbatim `let _: () = msg_send![…]` declared a
+    // void return — objc2's debug-assertions signature verification panics on
+    // that mismatch (release builds only got away with it by ignoring the
+    // register). The BOOL itself is deliberately unused: item activation is
+    // delivered through the menu-item target/action, not this return.
+    let _selected: bool = pending.menu.popUpMenuPositioningItem_atLocation_inView(
+        None,
+        pending.location,
+        Some(&*pending.view),
+    );
+}
+
 pub struct MacOSWindow {
     /// The NSWindow instance
     window: Retained<NSWindow>,
@@ -2765,6 +3028,11 @@ pub struct MacOSWindow {
     /// Pending window creation requests (for popup menus, dialogs, etc.)
     /// Processed in Phase 3 of the event loop
     pub pending_window_creates: Vec<WindowCreateOptions>,
+
+    /// Native context menu resolved by the last right-click, awaiting
+    /// presentation outside the `&mut MacOSWindow` borrow (see
+    /// [`PendingContextMenu`]).
+    pending_context_menu: Option<PendingContextMenu>,
 
     // Tooltip
     /// Tooltip panel (for programmatic tooltip display)
@@ -4117,6 +4385,7 @@ impl MacOSWindow {
             menu_state: menu::MenuState::new(), // TODO: build initial menu state from layout_window
             common: event::CommonWindowState {
                 previous_window_state: None,
+                os_synced_state: None,
                 current_window_state,
                 last_hovered_node: None,
                 layout_window: Some(layout_window),
@@ -4149,6 +4418,7 @@ impl MacOSWindow {
             #[cfg(feature = "a11y")]
             accessibility_adapter: None, // Will be initialized after first layout
             pending_window_creates: Vec::new(),
+            pending_context_menu: None,
             tooltip: None,         // Created lazily when first needed
             gpu_damage_rects: Vec::new(),
             pm_assertion_id: None, // No sleep prevention by default
@@ -4329,6 +4599,16 @@ impl MacOSWindow {
                 }
             }
         }
+
+        // Re-seed both baselines AFTER the last creation-time mutation. The
+        // position just read back from the OS has to be in both or the first
+        // sync_window_state() echoes it straight back as a setFrameTopLeftPoint
+        // and the first event pass reports a phantom window move. (No pass has
+        // run yet, so this is the creation-time equivalent of a handler's
+        // pre-mutation snapshot, not a mid-flight baseline rewrite.)
+        window.common.previous_window_state =
+            Some(window.common.current_window_state.clone());
+        window.common.mark_os_synced();
 
         log_info!(
             LogCategory::Window,
@@ -4550,8 +4830,17 @@ impl MacOSWindow {
             new_hidpi.inner.get()
         );
 
-        // Update window state with new DPI
-        self.common.current_window_state.size.dpi = (new_hidpi.inner.get() * BASE_DPI) as u32;
+        // Snapshot the event baseline, write the new DPI, dispatch. Without the
+        // snapshot + pass the scale change was invisible to the event system, so
+        // no DPI-conditional callback ever ran and the delta was left for the
+        // next handler's snapshot to erase.
+        self.common.previous_window_state = Some(self.common.current_window_state.clone());
+        self.common.update_window_state(
+            crate::desktop::shell2::common::event::WindowStateSource::Os,
+            |ws| ws.size.dpi = (new_hidpi.inner.get() * BASE_DPI) as u32,
+        );
+        let result = self.process_window_events(0);
+        self.apply_activation_pass_result(result);
 
         // Regenerate layout with new DPI
         self.regenerate_layout()?;
@@ -4638,14 +4927,23 @@ impl MacOSWindow {
             let _ = self.set_prevent_system_sleep(true);
         }
 
-        // CRITICAL: Set previous_window_state so sync_window_state() works for future changes
+        // CRITICAL: seed BOTH baselines — the event-diff one (previous_window_state,
+        // so the first pass has something to diff against) and the OS-sync one
+        // (os_synced_state, which sync_window_state() diffs against). Until
+        // mark_os_synced() has run, take_os_sync_diff() answers None and nothing
+        // is pushed, which is what keeps the first frame from firing a burst of
+        // redundant setFrame/setContentSize calls.
         self.common.previous_window_state = Some(self.common.current_window_state.clone());
+        self.common.mark_os_synced();
     }
 
     fn sync_window_state(&mut self) {
-        // Get copies of previous and current state to avoid borrow checker issues
-        let (previous, current) = match &self.common.previous_window_state {
-            Some(prev) => (prev.clone(), self.common.current_window_state.clone()),
+        // Diff against the OS-SYNC baseline, never against `previous_window_state`
+        // (which is the event-diff baseline and is free to hold a live delta —
+        // diffing against it here would push half-processed geometry at AppKit).
+        // `take_os_sync_diff` advances the baseline as part of the call.
+        let (previous, current) = match self.common.take_os_sync_diff() {
+            Some(pair) => pair,
             None => return, // First frame, nothing to sync
         };
 
@@ -4932,6 +5230,14 @@ impl MacOSWindow {
         self.common.current_window_state.flags.close_requested
     }
 
+    /// Take the context menu the last right-click resolved, if any.
+    ///
+    /// The caller MUST let its `&mut MacOSWindow` end before calling
+    /// [`present_pending_context_menu`] — see [`PendingContextMenu`].
+    pub(crate) fn take_pending_context_menu(&mut self) -> Option<PendingContextMenu> {
+        self.pending_context_menu.take()
+    }
+
     /// Run an incremental relayout (restyle / runtime edit — hover/focus CSS,
     /// `set_css_property`, `set_node_text`) on the EXISTING StyledDom and arm the
     /// relayout-only fast path. The main-window mouse/key handlers call this from
@@ -4992,39 +5298,27 @@ impl MacOSWindow {
         }
     }
 
-    /// Actually close the window
-    /// Start the thread polling timer (16ms interval for ~60 FPS)
+    /// Start the thread-polling tick timer (delegates to the trait
+    /// `start_thread_poll_timer` so external callers have a stable inherent API,
+    /// same as the Win32 method of this name).
+    ///
+    /// It used to install its OWN NSTimer carrying an EMPTY block into
+    /// `thread_timer_running` — no thread was ever polled by it, and because
+    /// `start_thread_poll_timer` early-returns when that slot is occupied, any
+    /// caller would have permanently disabled the real poll timer, so thread
+    /// writebacks would never have landed.
     pub fn start_thread_tick_timer(&mut self) {
-        use block2::RcBlock;
-        if self.thread_timer_running.is_none() {
-            // Create a timer that fires every 16ms (60 FPS)
-            // Using scheduledTimerWithTimeInterval for simplicity
-            let timer: Retained<NSTimer> = unsafe {
-                let interval: f64 = TIMER_INTERVAL_60FPS;
-                msg_send_id![
-                    NSTimer::class(),
-                    scheduledTimerWithTimeInterval: interval,
-                    repeats: true,
-                    block: &*RcBlock::new(|| {
-                        // Thread tick callback - poll thread messages
-                        // This will be called every 16ms
-                    })
-                ]
-            };
-
-            self.thread_timer_running = Some(timer);
-        }
+        use crate::desktop::shell2::common::event::PlatformWindow;
+        PlatformWindow::start_thread_poll_timer(self);
     }
 
     /// Stop the thread polling timer
     pub fn stop_thread_tick_timer(&mut self) {
-        if let Some(timer) = self.thread_timer_running.take() {
-            unsafe {
-                timer.invalidate();
-            }
-        }
+        use crate::desktop::shell2::common::event::PlatformWindow;
+        PlatformWindow::stop_thread_poll_timer(self);
     }
 
+    /// Actually close the window
     fn close_window(&mut self) {
         // Unregister from the global registry before closing, and park the box
         // for deferred drop — we cannot drop `self` from behind `&mut self`.
@@ -5439,9 +5733,18 @@ impl MacOSWindow {
         if (old_dims.width - new_logical_width).abs() > 0.5
             || (old_dims.height - new_logical_height).abs() > 0.5
         {
-            // F4: size REPORTED by the OS (source = Os) — acknowledge into both
-            // current and the sync baseline so sync_window_state() doesn't echo it
-            // back via setFrame.
+            // Snapshot the event-diff baseline BEFORE mutating: this fallback
+            // (for a windowDidResize the loop never saw) has to dispatch the
+            // resize like the notification path does, and a mutation with no
+            // snapshot leaves a delta for the next handler's snapshot to erase.
+            // Echo suppression is NOT this baseline's job — `update_window_state`
+            // with source = Os advances the OS-sync baseline instead.
+            self.common.previous_window_state =
+                Some(self.common.current_window_state.clone());
+
+            // F4: size REPORTED by the OS (source = Os) — acknowledged into the
+            // sync baseline so sync_window_state() doesn't echo it back via
+            // setFrame.
             let new_dims = azul_core::geom::LogicalSize {
                 width: new_logical_width,
                 height: new_logical_height,
@@ -5458,7 +5761,13 @@ impl MacOSWindow {
                     .map(|screen| screen.backingScaleFactor() as f32)
                     .unwrap_or(1.0)
             };
-            self.common.current_window_state.size.dpi = (scale_factor * BASE_DPI) as u32;
+            // Os-source for the same reason as the dimension write above: the
+            // scale is an OS fact, keep the OS-sync baseline in lockstep.
+            let new_dpi = (scale_factor * BASE_DPI) as u32;
+            self.common.update_window_state(
+                crate::desktop::shell2::common::event::WindowStateSource::Os,
+                |ws| ws.size.dpi = new_dpi,
+            );
 
             // The dimensions AND the backing scale just changed — that is a
             // `Resize` by the enum's own definition, and it is what the X11 and
@@ -5476,6 +5785,11 @@ impl MacOSWindow {
                 new_logical_height,
                 self.common.current_window_state.size.dpi
             );
+
+            // Dispatch the size transition and consume the delta, exactly as
+            // handle_resize does on the notification path.
+            let result = self.process_window_events(0);
+            self.apply_activation_pass_result(result);
         }
     }
 
@@ -5516,12 +5830,15 @@ impl MacOSWindow {
         };
 
         if new_frame != self.common.current_window_state.flags.frame {
-            self.common.current_window_state.flags.frame = new_frame;
             log_debug!(
                 LogCategory::Window,
                 "[MacOSWindow] Window frame changed to: {:?}",
                 new_frame
             );
+            // Same contract as the miniaturize / fullscreen delegates: this used
+            // to assign in place with no snapshot and no pass, so a zoom that the
+            // OS performed never reached a callback.
+            set_window_frame_and_dispatch(self, new_frame);
         }
     }
 
@@ -7547,5 +7864,50 @@ mod objc_class_registration_tests {
         let _ = super::GLView::class();
         let _ = super::CPUView::class();
         let _ = super::WindowDelegate::class();
+    }
+
+    /// The opposite failure of a duplicate registration: a selector AppKit
+    /// dispatches that no view declares. `process_event` routes
+    /// OtherMouseDown/Up and RightMouseDragged "to the NSView responder
+    /// methods", and for a long time neither view had them — so the middle
+    /// mouse button and every right/middle drag were silently dead with nothing
+    /// to see in a log. Assert the responder surface both views must expose.
+    #[test]
+    fn objc_view_classes_declare_every_routed_mouse_selector() {
+        use objc2::{sel, ClassType};
+
+        let selectors = [
+            sel!(mouseDown:),
+            sel!(mouseUp:),
+            sel!(mouseDragged:),
+            sel!(rightMouseDown:),
+            sel!(rightMouseUp:),
+            sel!(rightMouseDragged:),
+            sel!(otherMouseDown:),
+            sel!(otherMouseUp:),
+            sel!(otherMouseDragged:),
+            sel!(scrollWheel:),
+        ];
+
+        for (name, class) in [
+            ("GLView", super::GLView::class()),
+            ("CPUView", super::CPUView::class()),
+        ] {
+            // `class_copyMethodList` (NOT `class_getInstanceMethod`): every one
+            // of these selectors is declared by NSResponder, so an inherited
+            // lookup would pass even when the view overrides nothing — which is
+            // exactly the bug being guarded against.
+            let declared: Vec<_> = class
+                .instance_methods()
+                .iter()
+                .map(|method| method.name())
+                .collect();
+            for selector in selectors {
+                assert!(
+                    declared.contains(&selector),
+                    "{name} does not declare {selector:?}"
+                );
+            }
+        }
     }
 }

--- a/dll/src/desktop/shell2/run.rs
+++ b/dll/src/desktop/shell2/run.rs
@@ -931,7 +931,17 @@ pub fn run(
                             );
                         }
 
-                        // After the run loop wakes, drain any pending NSEvents
+                        // After the run loop wakes, drain any pending NSEvents.
+                        // SAME two steps as the drain at the top of the loop —
+                        // our handlers first, then the system. This one used to
+                        // call sendEvent only, so every event that happened to
+                        // be consumed here (a burst arriving while the run loop
+                        // was blocked) permanently lost `process_event`'s tail:
+                        // the "regeneration pending → request_redraw" hand-off
+                        // documented as load-bearing in macos/mod.rs, and the
+                        // a11y action poll that rides along with it. That is
+                        // the documented "UI runs one interaction behind during
+                        // bursts".
                         loop {
                             let event = unsafe {
                                 app.nextEventMatchingMask_untilDate_inMode_dequeue(
@@ -942,6 +952,15 @@ pub fn run(
                                 )
                             };
                             if let Some(event) = event {
+                                let window_ptrs = super::macos::registry::get_all_window_ptrs();
+                                for wptr in &window_ptrs {
+                                    unsafe {
+                                        let window = &mut **wptr;
+                                        let macos_event =
+                                            super::macos::MacOSEvent::from_nsevent(&event);
+                                        window.process_event(&event, &macos_event);
+                                    }
+                                }
                                 unsafe {
                                     app.sendEvent(&event);
                                 }
@@ -1162,30 +1181,114 @@ pub fn run(
         let mut had_messages = false;
 
         for hwnd in &window_handles {
-            if let Some(wptr) = registry::get_window(*hwnd) {
-                unsafe {
-                    let window = &mut *wptr;
-                    let mut msg: MSG = std::mem::zeroed();
+            unsafe {
+                let mut msg: MSG = std::mem::zeroed();
+                loop {
+                    // Re-fetch the window on EVERY iteration, and copy the three
+                    // entry points out instead of holding a `&mut Win32Window`
+                    // across the dispatch. `DispatchMessageW` below runs the
+                    // window procedure, and WM_CLOSE -> DestroyWindow ->
+                    // WM_DESTROY happens synchronously inside it — which
+                    // unregisters this window and parks its box for a deferred
+                    // free. The old shape hoisted one borrow above the `while`
+                    // and then re-read `window.win32.user32.PeekMessageW`
+                    // through it on the next loop condition: a use-after-free
+                    // the moment anything actually frees the box (Lane 6's F5
+                    // does). An unregistered window is the correct exit.
+                    let Some(wptr) = registry::get_window(*hwnd) else {
+                        break;
+                    };
+                    let (peek_message, translate_message, dispatch_message) = {
+                        let window = &*wptr;
+                        (
+                            window.win32.user32.PeekMessageW,
+                            window.win32.user32.TranslateMessage,
+                            window.win32.user32.DispatchMessageW,
+                        )
+                    };
 
                     // PeekMessage with PM_REMOVE to process all pending messages for this window
-                    while (window.win32.user32.PeekMessageW)(
-                        &mut msg, *hwnd, 0, 0, 1, // PM_REMOVE
-                    ) > 0
-                    {
-                        had_messages = true;
-
-                        // Check for WM_QUIT
-                        if msg.message == 0x0012 {
-                            // WM_QUIT - exit event loop
-                            return Ok(());
-                        }
-
-                        (window.win32.user32.TranslateMessage)(&msg);
-                        (window.win32.user32.DispatchMessageW)(&msg);
+                    if (peek_message)(&mut msg, *hwnd, 0, 0, 1 /* PM_REMOVE */) <= 0 {
+                        break;
                     }
+
+                    had_messages = true;
+
+                    // Check for WM_QUIT
+                    if msg.message == 0x0012 {
+                        // WM_QUIT - exit event loop
+                        return Ok(());
+                    }
+
+                    (translate_message)(&msg);
+                    (dispatch_message)(&msg);
                 }
             }
         }
+
+        // --- Drain the THREAD queue (hwnd filter = NULL) ---
+        // The per-window peeks above cannot see two whole classes of message:
+        //   * WM_QUIT, which `PostQuitMessage` posts to the THREAD and which is
+        //     associated with no window at all — the `msg.message == WM_QUIT`
+        //     test above could therefore never be true, so a PostQuitMessage
+        //     from user or library code never terminated this loop (masked
+        //     only because exit normally happens via registry::is_empty()).
+        //   * genuine thread messages (`PostThreadMessage`, hwnd == NULL),
+        //     which stayed in the queue forever and, being "available", also
+        //     defeat the WaitMessage() below — a spin at the bottom of the
+        //     loop rather than a block.
+        // An hwnd filter of NULL retrieves messages for any window on this
+        // thread PLUS thread messages, which is exactly the remainder.
+        //
+        // The entry points are copied out ONCE (they are process-global symbols
+        // from user32.dll, identical for every window) so that no reference to a
+        // Win32Window is live across a dispatch that may destroy it.
+        let thread_pump = registry::get_all_window_handles()
+            .first()
+            .and_then(|h| registry::get_window(*h))
+            .map(|wptr| unsafe {
+                let window = &*wptr;
+                (
+                    window.win32.user32.PeekMessageW,
+                    window.win32.user32.TranslateMessage,
+                    window.win32.user32.DispatchMessageW,
+                )
+            });
+        if let Some((peek_message, translate_message, dispatch_message)) = thread_pump {
+            unsafe {
+                let mut msg: MSG = std::mem::zeroed();
+                while (peek_message)(
+                    &mut msg,
+                    std::ptr::null_mut(),
+                    0,
+                    0,
+                    1, // PM_REMOVE
+                ) > 0
+                {
+                    had_messages = true;
+
+                    // Check for WM_QUIT
+                    if msg.message == 0x0012 {
+                        // WM_QUIT - exit event loop
+                        return Ok(());
+                    }
+
+                    (translate_message)(&msg);
+                    (dispatch_message)(&msg);
+                }
+            }
+        }
+
+        // --- Free windows destroyed during the dispatch above ---
+        // WM_DESTROY cannot free its own Win32Window: it runs in a nested
+        // window procedure underneath `DispatchMessageW`, with the pump still
+        // walking that window. It unregisters and PARKS the box instead
+        // (registry::queue_window_free); this is the only place the parked
+        // boxes are actually dropped, and it runs with no borrow live. Without
+        // this call the GL context and WebRender renderer are released but the
+        // allocation leaks — one whole Win32Window per closed window. Mirrors
+        // `super::macos::drain_closed_windows()` in the macOS loop.
+        registry::drain_closed_windows();
 
         // --- State diffing and callback dispatch ---
         // This is where callbacks fire (comparing previous_window_state vs current_window_state)
@@ -1200,6 +1303,12 @@ pub fn run(
                     // Save previous state if not already done
                     if window.common.previous_window_state.is_none() {
                         window.common.previous_window_state = Some(window.common.current_window_state.clone());
+                    }
+                    // R5: the OS-sync baseline is a SEPARATE field with its own
+                    // seeding — sharing one baseline with event determination is
+                    // what made OS-reported resizes undetectable.
+                    if window.common.os_synced_state.is_none() {
+                        window.common.mark_os_synced();
                     }
 
                     // Process pending window creates (for popup menus, dialogs, etc.)
@@ -1326,6 +1435,10 @@ pub fn run(
             }
         }
     }
+    // …plus anything WM_DESTROY parked on the FINAL iteration, which never
+    // reached the in-loop drain because the loop exited on registry::is_empty()
+    // in the same breath.
+    registry::drain_closed_windows();
 
     // Handle termination behavior
     match config.termination_behavior {

--- a/dll/src/desktop/shell2/windows/dlopen.rs
+++ b/dll/src/desktop/shell2/windows/dlopen.rs
@@ -69,6 +69,22 @@ pub struct POINT {
     pub y: i32,
 }
 
+/// Win32 MONITORINFOEXW structure — `GetMonitorInfoW` with the device-name
+/// tail. `cbSize` must be set to the size of THIS struct (not MONITORINFO)
+/// or the call fails.
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct MONITORINFOEXW {
+    pub cbSize: u32,
+    pub rcMonitor: RECT,
+    pub rcWork: RECT,
+    pub dwFlags: u32,
+    pub szDevice: [u16; 32],
+}
+
+/// `MonitorFromWindow` flag: return the monitor closest to the window.
+pub const MONITOR_DEFAULTTONEAREST: u32 = 2;
+
 /// Win32 TRACKMOUSEEVENT structure
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
@@ -127,8 +143,39 @@ pub struct COMPOSITIONFORM {
     pub rcArea: RECT,
 }
 
+/// Win32 CANDIDATEFORM structure for IME candidate-list positioning.
+///
+/// The composition (preedit) window and the candidate list are positioned
+/// through two SEPARATE forms — `ImmSetCompositionWindow` moves only the
+/// former, so the candidate list has to be placed with this one.
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct CANDIDATEFORM {
+    pub dwIndex: u32,
+    pub dwStyle: u32,
+    pub ptCurrentPos: POINT,
+    pub rcArea: RECT,
+}
+
+/// Win32 IMECHARPOSITION structure — the reply buffer of a
+/// `WM_IME_REQUEST` / `IMR_QUERYCHARPOSITION`, which is what TSF-based IMEs
+/// query instead of reading the IMM composition form. `dwSize` and
+/// `dwCharPos` are filled in by the IME; the application fills `pt`
+/// (SCREEN coordinates), `cLineHeight` and `rcDocument` (also screen).
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct IMECHARPOSITION {
+    pub dwSize: u32,
+    pub dwCharPos: u32,
+    pub pt: POINT,
+    pub cLineHeight: u32,
+    pub rcDocument: RECT,
+}
+
 // IME Composition Form Styles
 pub const CFS_RECT: u32 = 0x0001;
+// IME Candidate Form Styles
+pub const CFS_CANDIDATEPOS: u32 = 0x0040;
 
 /// Helper to encode ASCII string for GetProcAddress
 pub fn encode_ascii(input: &str) -> Vec<i8> {
@@ -400,6 +447,10 @@ pub struct User32Functions {
     pub GetWindowRect: unsafe extern "system" fn(HWND, *mut RECT) -> BOOL,
     pub InvalidateRect: unsafe extern "system" fn(HWND, *const RECT, BOOL) -> BOOL,
 
+    // Monitors
+    pub MonitorFromWindow: unsafe extern "system" fn(HWND, u32) -> HMONITOR,
+    pub GetMonitorInfoW: unsafe extern "system" fn(HMONITOR, *mut MONITORINFOEXW) -> BOOL,
+
     // Window properties
     pub SetWindowLongPtrW: unsafe extern "system" fn(HWND, i32, isize) -> isize,
     pub GetWindowLongPtrW: unsafe extern "system" fn(HWND, i32) -> isize,
@@ -419,9 +470,20 @@ pub struct User32Functions {
     pub ClientToScreen: unsafe extern "system" fn(HWND, *mut POINT) -> BOOL,
     pub SetCapture: unsafe extern "system" fn(HWND) -> HWND,
     pub ReleaseCapture: unsafe extern "system" fn() -> BOOL,
+    /// The window that currently owns the mouse capture (NULL = none). Used to
+    /// tell a real pointer-leave apart from the `WM_MOUSELEAVE` that fires
+    /// while a captured drag is still running.
+    pub GetCapture: unsafe extern "system" fn() -> HWND,
     pub LoadCursorW: unsafe extern "system" fn(HINSTANCE, *const u16) -> HCURSOR,
     pub SetCursor: unsafe extern "system" fn(HCURSOR) -> HCURSOR,
     pub TrackMouseEvent: unsafe extern "system" fn(*mut TRACKMOUSEEVENT) -> BOOL,
+
+    // Keyboard
+    /// Snapshot of all 256 virtual-key states (high bit = down). The only way
+    /// to learn about key releases that were delivered to ANOTHER window —
+    /// after Alt+Tab the Alt release never reaches us, so the pressed set has
+    /// to be re-read from the OS on focus gain instead of tracked by messages.
+    pub GetKeyboardState: unsafe extern "system" fn(*mut u8) -> BOOL,
 
     // Pointer input (touch + pen, Windows 8+). Optional — None on older Windows.
     pub GetPointerType: Option<unsafe extern "system" fn(u32, *mut u32) -> BOOL>,
@@ -525,6 +587,10 @@ pub struct Imm32Functions {
     pub ImmGetCompositionStringW:
         unsafe extern "system" fn(HIMC, u32, *mut core::ffi::c_void, u32) -> i32,
     pub ImmSetCompositionWindow: unsafe extern "system" fn(HIMC, *const COMPOSITIONFORM) -> BOOL,
+    /// Positions the CANDIDATE list (`ImmSetCompositionWindow` only moves the
+    /// preedit window) — without it the candidate list stays wherever the IME
+    /// first placed it while the caret moves on.
+    pub ImmSetCandidateWindow: unsafe extern "system" fn(HIMC, *const CANDIDATEFORM) -> BOOL,
     /// MWA-C-text_input: associate/dissociate the IME context per editable
     /// focus (NULL HIMC = IME disabled for the window). Returns the
     /// previously associated context.
@@ -696,6 +762,10 @@ impl Win32Libraries {
                 GetWindowRect: user32_dll.get_symbol("GetWindowRect")?,
                 InvalidateRect: user32_dll.get_symbol("InvalidateRect")?,
 
+                // Monitors
+                MonitorFromWindow: user32_dll.get_symbol("MonitorFromWindow")?,
+                GetMonitorInfoW: user32_dll.get_symbol("GetMonitorInfoW")?,
+
                 // Window properties
                 // SetWindowLongPtrW/GetWindowLongPtrW are 64-bit-aware wrappers
                 // that only exist as real exports on 64-bit Windows. On 32-bit
@@ -723,9 +793,15 @@ impl Win32Libraries {
                 ClientToScreen: user32_dll.get_symbol("ClientToScreen")?,
                 SetCapture: user32_dll.get_symbol("SetCapture")?,
                 ReleaseCapture: user32_dll.get_symbol("ReleaseCapture")?,
+                GetCapture: user32_dll.get_symbol("GetCapture")?,
                 LoadCursorW: user32_dll.get_symbol("LoadCursorW")?,
                 SetCursor: user32_dll.get_symbol("SetCursor")?,
                 TrackMouseEvent: user32_dll.get_symbol("TrackMouseEvent")?,
+
+                // Keyboard
+                GetKeyboardState: user32_dll.get_symbol("GetKeyboardState")?,
+
+                // Pointer input (optional)
                 GetPointerType: user32_dll.get_symbol("GetPointerType").ok(),
                 GetPointerPenInfo: user32_dll.get_symbol("GetPointerPenInfo").ok(),
                 GetPointerTouchInfo: user32_dll.get_symbol("GetPointerTouchInfo").ok(),
@@ -780,6 +856,7 @@ impl Win32Libraries {
                 ImmReleaseContext: dll.get_symbol("ImmReleaseContext").ok()?,
                 ImmGetCompositionStringW: dll.get_symbol("ImmGetCompositionStringW").ok()?,
                 ImmSetCompositionWindow: dll.get_symbol("ImmSetCompositionWindow").ok()?,
+                ImmSetCandidateWindow: dll.get_symbol("ImmSetCandidateWindow").ok()?,
                 ImmAssociateContext: dll.get_symbol("ImmAssociateContext").ok()?,
             })
         });

--- a/dll/src/desktop/shell2/windows/mod.rs
+++ b/dll/src/desktop/shell2/windows/mod.rs
@@ -730,7 +730,9 @@ impl Win32Window {
                     {
                         let root_size = dom_result
                             .layout_tree
-                            .get_content_size(dom_result.layout_tree.root);
+                            .get_content_size(azul_layout::solver3::layout_tree::LayoutNodeId::new(
+                                dom_result.layout_tree.root,
+                            ));
                         // root_size is LOGICAL; the OS sizes the OUTER frame
                         // in PHYSICAL px — scale by DPI and fit the CLIENT
                         // area (set_client_size adds the frame delta), or the

--- a/dll/src/desktop/shell2/windows/mod.rs
+++ b/dll/src/desktop/shell2/windows/mod.rs
@@ -641,6 +641,7 @@ impl Win32Window {
                 display_list_dirty: false,
                 a11y_dirty: true,
                 previous_window_state: None,
+                os_synced_state: None,
                 current_window_state,
                 renderer_resources: RendererResources::default(),
                 last_hovered_node: None,
@@ -1979,8 +1980,9 @@ impl Win32Window {
     /// - is_visible (deferred to first_frame_shown logic)
     /// - frame (handled by first_frame_shown show command)
     ///
-    /// This method applies the remaining fields and sets previous_window_state
-    /// so that sync_window_state() works correctly for future changes.
+    /// This method applies the remaining fields and seeds both baselines
+    /// (event-diff and OS-sync) so that sync_window_state() works correctly for
+    /// future changes.
     fn apply_initial_window_state(&mut self) {
         // is_always_on_top
         if self.common.current_window_state.flags.is_always_on_top {
@@ -2017,8 +2019,13 @@ impl Win32Window {
             let _ = self.set_prevent_system_sleep(true);
         }
 
-        // CRITICAL: Set previous_window_state so sync_window_state() works for future changes
+        // Seed BOTH baselines: the event-diff one (so the first pass has
+        // something to diff against) and the OS-sync one — everything above is
+        // now applied on the HWND, so the first sync_window_state() must not
+        // re-push the whole initial state (title, size, position, visibility,
+        // frame) at the OS.
         self.common.previous_window_state = Some(self.common.current_window_state.clone());
+        self.common.mark_os_synced();
     }
 
     /// Synchronize window state with Windows OS
@@ -2028,9 +2035,14 @@ impl Win32Window {
     fn sync_window_state(&mut self) {
         use std::{ffi::OsStr, os::windows::ffi::OsStrExt};
 
-        // Get copies of previous and current state to avoid borrow checker issues
-        let (previous, current) = match &self.common.previous_window_state {
-            Some(prev) => (prev.clone(), self.common.current_window_state.clone()),
+        // Diff against the OS-SYNC baseline, never `previous_window_state` (the
+        // event-diff baseline, which is free to hold a live delta): diffing that
+        // here echoed WM_SIZE back as a SetWindowPos and re-issued
+        // SetFocus/SetForegroundWindow after WM_SETFOCUS, stealing focus back
+        // from whatever the user Alt+Tabbed to. `take_os_sync_diff` advances the
+        // baseline as part of the call.
+        let (previous, current) = match self.common.take_os_sync_diff() {
+            Some(pair) => pair,
             None => return, // First frame, nothing to sync
         };
 
@@ -2524,10 +2536,47 @@ impl Win32Window {
                 (self.win32.user32.TranslateMessage)(&msg);
                 (self.win32.user32.DispatchMessageW)(&msg);
             }
-            true
-        } else {
-            false
+            return true;
         }
+
+        // --- Drain the THREAD queue (hwnd filter = NULL) ---
+        // The hwnd-filtered peek above cannot see two whole classes of
+        // message (same hole run.rs's Win32 loop had, fixed the same way):
+        //   * WM_QUIT, which `PostQuitMessage` posts to the THREAD and which
+        //     is associated with no window at all — an hwnd-filtered
+        //     PeekMessage/GetMessage can NEVER retrieve it, so a
+        //     PostQuitMessage from user or library code was invisible to
+        //     this pump;
+        //   * genuine thread messages (`PostThreadMessage`, hwnd == NULL),
+        //     which stayed in the queue forever and, being "available",
+        //     defeat any WaitMessage a caller blocks on between polls — an
+        //     idle block turns into a spin.
+        // An hwnd filter of NULL retrieves messages for any window of this
+        // thread PLUS thread messages, which is exactly the remainder;
+        // DispatchMessageW routes window messages by msg.hwnd, so nothing is
+        // misdelivered.
+        let has_thread_message = unsafe {
+            (self.win32.user32.PeekMessageW)(&mut msg, std::ptr::null_mut(), 0, 0, PM_REMOVE)
+        };
+        if has_thread_message != 0 {
+            // WM_QUIT = "terminate the message loop". The bool contract here
+            // cannot say "quit", so surface it the way poll-driven callers
+            // observe shutdown: mark the window closed and report the event
+            // as handled. (Deliberately NOT close_requested — that flag is
+            // the WM_CLOSE veto-protocol's, and WM_QUIT is not veto-able.)
+            const WM_QUIT: u32 = 0x0012;
+            if msg.message == WM_QUIT {
+                self.is_open = false;
+                return true;
+            }
+            unsafe {
+                (self.win32.user32.TranslateMessage)(&msg);
+                (self.win32.user32.DispatchMessageW)(&msg);
+            }
+            return true;
+        }
+
+        false
     }
 
     /// Try to show context menu at the given screen position
@@ -2764,18 +2813,22 @@ impl Win32Window {
     /// pressure/tilt/eraser -> the gesture manager's pen state, and per-finger
     /// touch points -> the window's `touch_state`. `is_up` = WM_POINTERUP.
     /// Mirrors the iOS/Android pen+touch feed; no-op on pre-Win8 (fns absent).
-    unsafe fn feed_pointer(&mut self, hwnd: HWND, pointer_id: u32, is_up: bool) {
+    ///
+    /// Returns `true` when it actually changed input state, i.e. when the
+    /// caller owes the state-diff pipeline a pass (touch/gesture transitions
+    /// are derived from the previous→current delta like everything else).
+    unsafe fn feed_pointer(&mut self, hwnd: HWND, pointer_id: u32, is_up: bool) -> bool {
         use winapi::um::winuser::{
             PEN_FLAG_BARREL, PEN_FLAG_ERASER, POINTER_FLAG_INCONTACT, POINTER_PEN_INFO,
             POINTER_TOUCH_INFO, PT_PEN, PT_TOUCH,
         };
         let get_type = match self.win32.user32.GetPointerType {
             Some(f) => f,
-            None => return,
+            None => return false,
         };
         let mut ptype: u32 = 0;
         if get_type(pointer_id, &mut ptype) == 0 {
-            return;
+            return false;
         }
         let hf = self
             .common
@@ -2788,11 +2841,11 @@ impl Win32Window {
         if ptype == PT_PEN {
             let get_pen = match self.win32.user32.GetPointerPenInfo {
                 Some(f) => f,
-                None => return,
+                None => return false,
             };
             let mut pi: POINTER_PEN_INFO = core::mem::zeroed();
             if get_pen(pointer_id, &mut pi) == 0 {
-                return;
+                return false;
             }
             let mut pt = dlopen::POINT {
                 x: pi.pointerInfo.ptPixelLocation.x,
@@ -2820,11 +2873,11 @@ impl Win32Window {
         } else if ptype == PT_TOUCH {
             let get_touch = match self.win32.user32.GetPointerTouchInfo {
                 Some(f) => f,
-                None => return,
+                None => return false,
             };
             let mut ti: POINTER_TOUCH_INFO = core::mem::zeroed();
             if get_touch(pointer_id, &mut ti) == 0 {
-                return;
+                return false;
             }
             let mut pt = dlopen::POINT {
                 x: ti.pointerInfo.ptPixelLocation.x,
@@ -2872,7 +2925,95 @@ impl Win32Window {
                     }
                 }
             }
+        } else {
+            return false;
         }
+
+        true
+    }
+
+    /// [`Self::feed_pointer`] plus the state-diff pass it owes.
+    ///
+    /// Touch points live in `current_window_state.touch_state` and the gesture
+    /// sessions in the layout window — both are diff-derived like every other
+    /// input. A SECOND finger going down is not promoted to a WM_MOUSE
+    /// message, so without a pass here that transition reached nobody: the
+    /// gesture recogniser saw pinch/rotate start one event late, or not at
+    /// all. The pass runs BEFORE `DefWindowProc` promotes the pointer to
+    /// WM_MOUSE messages, because those arms snapshot `previous` themselves
+    /// and would otherwise consume the touch delta first.
+    unsafe fn feed_pointer_and_dispatch(&mut self, hwnd: HWND, pointer_id: u32, is_up: bool) {
+        let prev_snapshot = self.common.current_window_state.clone();
+        if !self.feed_pointer(hwnd, pointer_id, is_up) {
+            return;
+        }
+        self.common.previous_window_state = Some(prev_snapshot);
+        let r = self.process_window_events(0);
+        self.route_main_window_result(hwnd, r);
+    }
+
+    /// (Re-)arm the `WM_MOUSELEAVE` notification.
+    ///
+    /// `TrackMouseEvent(TME_LEAVE)` is a ONE-SHOT: it has to be re-armed after
+    /// every pointer move, and again after a captured drag ends — the leave
+    /// that fired mid-capture was suppressed, and Win32 posts a fresh one
+    /// immediately if the pointer is already outside the client area.
+    unsafe fn arm_mouse_leave(&self) {
+        use self::dlopen::{TME_LEAVE, TRACKMOUSEEVENT};
+        let mut tme = TRACKMOUSEEVENT {
+            cbSize: std::mem::size_of::<TRACKMOUSEEVENT>() as u32,
+            dwFlags: TME_LEAVE,
+            hwndTrack: self.hwnd,
+            dwHoverTime: 0,
+        };
+        (self.win32.user32.TrackMouseEvent)(&mut tme);
+    }
+
+    /// Re-read the pressed-key set from the OS.
+    ///
+    /// Key RELEASES go to whichever window has the focus: after Alt+Tab this
+    /// window saw LAlt's `WM_KEYDOWN` but never its `WM_KEYUP`, so Alt stayed
+    /// latched in `pressed_virtual_keycodes` and every later click behaved as
+    /// Alt+click. `GetKeyboardState` is the only way to learn about those
+    /// releases — on focus GAIN it also preserves a modifier that is genuinely
+    /// still held (clicking into a window with Shift down).
+    ///
+    /// Mutates `current_window_state` only; the caller owns the diff snapshot
+    /// and the event pass.
+    unsafe fn resync_keyboard_state_from_os(&mut self) {
+        use azul_core::window::{
+            OptionVirtualKeyCode, ScanCodeVec, VirtualKeyCode, VirtualKeyCodeVec,
+        };
+
+        let mut keys = [0u8; 256];
+        let ok = (self.win32.user32.GetKeyboardState)(keys.as_mut_ptr()) != 0;
+
+        let mut pressed: Vec<VirtualKeyCode> = Vec::new();
+        if ok {
+            // High bit set = key is down. Mouse buttons (VK_LBUTTON …
+            // VK_XBUTTON2) have no VirtualKeyCode and drop out in the
+            // translation; the generic and side-specific modifier codes both
+            // map onto the left variant, hence the dedup.
+            for (vk, state) in keys.iter().enumerate() {
+                if *state & 0x80 == 0 {
+                    continue;
+                }
+                if let Some(k) = win_event::vkey_to_winit_vkey(vk as i32) {
+                    if !pressed.contains(&k) {
+                        pressed.push(k);
+                    }
+                }
+            }
+        }
+
+        let ks = &mut self.common.current_window_state.keyboard_state;
+        ks.current_virtual_keycode = OptionVirtualKeyCode::None;
+        ks.pressed_virtual_keycodes = VirtualKeyCodeVec::from_vec(pressed);
+        // Scancodes are physical-key ids and cannot be recovered from a
+        // virtual-key snapshot; dropping the set is the honest reading (the
+        // next WM_KEYDOWN refills it) — keeping it would keep exactly the
+        // stale entries this resync exists to remove.
+        ks.pressed_scancodes = ScanCodeVec::from_vec(Vec::new());
     }
 }
 
@@ -2884,6 +3025,7 @@ unsafe extern "system" fn window_proc(
 ) -> dlopen::LRESULT {
     // Message constants
     const WM_NCCREATE: u32 = 0x0081;
+    const WM_NCDESTROY: u32 = 0x0082;
     const WM_CREATE: u32 = 0x0001;
     const WM_DESTROY: u32 = 0x0002;
     const WM_PAINT: u32 = 0x000F;
@@ -3028,11 +3170,44 @@ unsafe extern "system" fn window_proc(
             // COM ref held by RegisterDragDrop). Must happen here, not in the
             // registry cleanup, because RevokeDragDrop needs a live HWND.
             dnd::revoke_drag_drop(hwnd);
+            // Fallback teardown for destroy paths that never went through
+            // WM_CLOSE (a destroyed parent, an external DestroyWindow): the
+            // HWND and the GL context are still alive here, and
+            // deinit_renderer() takes the renderer, so the WM_CLOSE path
+            // having run first makes this a no-op.
+            window.release_gpu_resources();
             // Window destroyed - unregister from global registry
             window.is_open = false;
-            registry::unregister_window(hwnd);
+            // The registry holds the only owning pointer (run.rs boxed the
+            // window and handed it over). Dropping it HERE is a
+            // use-after-free — WM_DESTROY is dispatched from inside
+            // DestroyWindow, i.e. inside this very window procedure, and the
+            // event loop holds a `&mut Win32Window` across the dispatch. Park
+            // it instead; the loop reclaims it via
+            // registry::drain_closed_windows() at a safe point. Discarding the
+            // pointer (what this used to do) leaked the whole window — GL
+            // context, WebRender renderer and layout window — per closed
+            // window.
+            if let Some(freed) = registry::unregister_window(hwnd) {
+                registry::queue_window_free(freed);
+            }
             log_debug!(LogCategory::Window, "[Win32] Window unregistered, remaining windows: {}", registry::window_count());
             0
+        }
+
+        WM_NCDESTROY => {
+            // Belt-and-braces half of the deferred-free fix: WM_NCDESTROY is
+            // the LAST message a window receives (after WM_DESTROY parked the
+            // box for registry::drain_closed_windows). Null GWLP_USERDATA here
+            // so any straggler SendMessage that still reaches this HWND takes
+            // window_proc's null early-out instead of dereferencing a pointer
+            // whose box the event loop may since have reclaimed. The parked
+            // box itself is still alive at THIS point (the drain only runs
+            // from the loop, never from inside a dispatch), so touching
+            // `window` above this line was sound — but nothing after this arm
+            // may use it again.
+            (window.win32.user32.SetWindowLongPtrW)(hwnd, GWLP_USERDATA, 0);
+            def_window_proc_w(hwnd, msg, wparam, lparam)
         }
 
         WM_CLOSE => {
@@ -3053,6 +3228,13 @@ unsafe extern "system" fn window_proc(
             if window.common.current_window_state.flags.close_requested {
                 // Not cancelled - proceed with close
                 window.is_open = false;
+                // Release the GPU side while the HWND and the GL context are
+                // still alive — WebRender's Renderer must be deinit()'d, not
+                // dropped (texture deletion has to happen inside a frame).
+                // Only Win32Window::close() used to do this, and nothing calls
+                // it on the user-clicked-X path, so closing a window through
+                // its title-bar button leaked the renderer.
+                window.release_gpu_resources();
                 (window.win32.user32.DestroyWindow)(hwnd);
             } else {
                 // Callback cancelled close - clear flag and keep window open
@@ -3171,9 +3353,12 @@ unsafe extern "system" fn window_proc(
             const SIZE_MINIMIZED: usize = 1;
             if (wparam as usize) == SIZE_MINIMIZED {
                 use azul_core::window::WindowFrame;
-                window.common.previous_window_state =
-                    Some(window.common.current_window_state.clone());
-                window.common.current_window_state.flags.frame = WindowFrame::Minimized;
+                let prev_snapshot = window.common.current_window_state.clone();
+                window.common.update_window_state(
+                    crate::desktop::shell2::common::event::WindowStateSource::Os,
+                    |ws| ws.flags.frame = WindowFrame::Minimized,
+                );
+                window.common.previous_window_state = Some(prev_snapshot);
                 let r = window.process_window_events(0);
                 window.route_main_window_result(hwnd, r);
                 return 0;
@@ -3229,9 +3414,9 @@ unsafe extern "system" fn window_proc(
                     );
                 }
 
-                // Update window state
-                let mut new_window_state = window.common.current_window_state.clone();
-                new_window_state.size.dimensions = logical_size;
+                // The EVENT-DIFF baseline for the pass at the end of this arm:
+                // the state as it was BEFORE the resize was applied.
+                let prev_snapshot = window.common.current_window_state.clone();
 
                 // Determine window frame state
                 use azul_core::window::WindowFrame;
@@ -3240,7 +3425,19 @@ unsafe extern "system" fn window_proc(
                     0x0001 => WindowFrame::Minimized, // SIZE_MINIMIZED
                     _ => WindowFrame::Normal,         // SIZE_RESTORED
                 };
-                new_window_state.flags.frame = frame;
+
+                // WM_SIZE is an OS-reported geometry/frame change (already
+                // applied by the OS), so it is acknowledged into the OS-sync
+                // baseline — otherwise sync_window_state() pushes it straight
+                // back out via SetWindowPos/ShowWindow, the OS→app→OS loop.
+                // (Source = Os, not App.)
+                window.common.update_window_state(
+                    crate::desktop::shell2::common::event::WindowStateSource::Os,
+                    |ws| {
+                        ws.size.dimensions = logical_size;
+                        ws.flags.frame = frame;
+                    },
+                );
 
                 // Update WebRender document view
                 use webrender::{
@@ -3266,14 +3463,6 @@ unsafe extern "system" fn window_proc(
                     render_api.send_transaction(wr_translate_document_id(document_id), txn);
                 }
 
-                // F4: WM_SIZE is an OS-reported geometry/frame change (already
-                // applied by the OS), so set BOTH current AND the sync baseline
-                // (previous) to the new state. Setting previous to the OLD state
-                // would leave a non-zero diff that sync_window_state() echoes back
-                // via SetWindowPos — the OS→app→OS loop. (Source = Os, not App.)
-                window.common.current_window_state = new_window_state.clone();
-                window.common.previous_window_state = Some(new_window_state);
-
                 // RESIZE POLICY (user ruling 2026-08-08, same as Wayland/X11):
                 // a drag delivers one WM_SIZE per frame; the app's layout() is
                 // only re-invoked when a recorded window-size query answer flips
@@ -3295,6 +3484,17 @@ unsafe extern "system" fn window_proc(
                         logical_size.height
                     );
                 }
+
+                // The relayout is already scheduled above; this pass exists so
+                // the app's WindowResize / Maximize / Restore callbacks
+                // actually run. All three are DERIVED from the previous→current
+                // delta, so an arm that applies the new geometry to both sides
+                // and never runs a pass (what this used to do) cannot fire
+                // them at all — no resize event has ever reached a Windows app.
+                // Mirrors the Wayland xdg_toplevel.configure handler.
+                window.common.previous_window_state = Some(prev_snapshot);
+                let r = window.process_window_events(0);
+                window.route_main_window_result(hwnd, r);
 
                 // Request redraw (WM_PAINT consumes whichever path was chosen)
                 (window.win32.user32.InvalidateRect)(hwnd, ptr::null(), 0);
@@ -3329,6 +3529,9 @@ unsafe extern "system" fn window_proc(
             let pos = azul_core::window::WindowPosition::Initialized(
                 azul_core::geom::PhysicalPositionI32::new(x, y),
             );
+            // The EVENT-DIFF baseline for the pass at the end of this arm: the
+            // state as it was BEFORE the move was applied.
+            let prev_snapshot = window.common.current_window_state.clone();
             // F4: position REPORTED by the OS (source = Os) — acknowledge into both
             // current and the sync baseline so sync_window_state() doesn't echo it
             // back via SetWindowPos (the OS→app→OS geometry loop).
@@ -3340,46 +3543,43 @@ unsafe extern "system" fn window_proc(
             // Detect which monitor the window is on via MonitorFromWindow
             // This updates monitor_id so that DPI/MonitorChanged events can fire
             {
-                const MONITOR_DEFAULTTONEAREST: u32 = 2;
-                extern "system" {
-                    fn MonitorFromWindow(hwnd: *mut core::ffi::c_void, flags: u32) -> *mut core::ffi::c_void;
-                    fn GetMonitorInfoW(hmonitor: *mut core::ffi::c_void, lpmi: *mut MonitorInfoExW) -> i32;
-                }
-                #[repr(C)]
-                #[allow(non_snake_case)]
-                struct Rect { left: i32, top: i32, right: i32, bottom: i32 }
-                #[repr(C)]
-                #[allow(non_snake_case)]
-                struct MonitorInfoExW {
-                    cbSize: u32,
-                    rcMonitor: Rect,
-                    rcWork: Rect,
-                    dwFlags: u32,
-                    szDevice: [u16; 32],
-                }
-                let hmonitor = unsafe { MonitorFromWindow(hwnd as _, MONITOR_DEFAULTTONEAREST as u32) };
+                use dlopen::{MONITORINFOEXW, MONITOR_DEFAULTTONEAREST};
+                let hmonitor = unsafe {
+                    (window.win32.user32.MonitorFromWindow)(hwnd, MONITOR_DEFAULTTONEAREST)
+                };
                 if !hmonitor.is_null() {
-                    let mut mi = MonitorInfoExW {
-                        cbSize: core::mem::size_of::<MonitorInfoExW>() as u32,
-                        rcMonitor: Rect { left: 0, top: 0, right: 0, bottom: 0 },
-                        rcWork: Rect { left: 0, top: 0, right: 0, bottom: 0 },
+                    let mut mi = MONITORINFOEXW {
+                        cbSize: core::mem::size_of::<MONITORINFOEXW>() as u32,
+                        rcMonitor: dlopen::RECT::default(),
+                        rcWork: dlopen::RECT::default(),
                         dwFlags: 0,
                         szDevice: [0u16; 32],
                     };
-                    if unsafe { GetMonitorInfoW(hmonitor, &mut mi) } != 0 {
+                    if unsafe { (window.win32.user32.GetMonitorInfoW)(hmonitor, &mut mi) } != 0 {
                         // Find matching monitor in cache by position
-                        if let Some(ref lw) = window.common.layout_window {
-                            if let Ok(guard) = lw.monitors.lock() {
-                                for m in guard.as_ref().iter() {
-                                    if m.position.x == mi.rcMonitor.left as isize
+                        let found = window.common.layout_window.as_ref().and_then(|lw| {
+                            let guard = lw.monitors.lock().ok()?;
+                            guard
+                                .as_ref()
+                                .iter()
+                                .find(|m| {
+                                    m.position.x == mi.rcMonitor.left as isize
                                         && m.position.y == mi.rcMonitor.top as isize
-                                    {
-                                        window.common.current_window_state.monitor_id =
-                                            azul_css::corety::OptionU32::Some(m.monitor_id.index as u32);
-                                        break;
-                                    }
-                                }
-                            }
+                                })
+                                .map(|m| m.monitor_id.index as u32)
+                        });
+                        if let Some(index) = found {
+                            // Also OS-reported, and it goes through the same
+                            // helper as the position above — writing
+                            // current_window_state directly left the two
+                            // halves of one OS geometry report on different
+                            // state authorities.
+                            window.common.update_window_state(
+                                crate::desktop::shell2::common::event::WindowStateSource::Os,
+                                |ws| {
+                                    ws.monitor_id = azul_css::corety::OptionU32::Some(index);
+                                },
+                            );
                         }
                     }
                 }
@@ -3389,6 +3589,20 @@ unsafe extern "system" fn window_proc(
                 lw.current_window_state.position = pos;
                 lw.current_window_state.monitor_id = window.common.current_window_state.monitor_id;
             }
+
+            // Dispatch WindowMove / WindowMonitorChanged NOW rather than
+            // leaving a live delta for whatever pass happens to run next
+            // (which, before this, was also what tripped
+            // check_input_delta_consumed's "position" arm at the next
+            // WM_TIMER under AZ_VALIDATE / debug). The old feedback-loop
+            // worry — a move callback writing `position` back — died with
+            // the baseline split: an OS-equal write leaves a zero
+            // current-vs-os_synced diff, so sync_window_state() has nothing
+            // to echo. Same snapshot/ack/restore/pass shape as WM_SIZE.
+            window.common.previous_window_state = Some(prev_snapshot);
+            let r = window.process_window_events(0);
+            window.route_main_window_result(hwnd, r);
+
             0
         }
 
@@ -3488,16 +3702,7 @@ unsafe extern "system" fn window_proc(
             let result = window.process_window_events(0);
 
             // Request WM_MOUSELEAVE notification
-            use self::dlopen::{TME_LEAVE, TRACKMOUSEEVENT};
-            unsafe {
-                let mut tme = TRACKMOUSEEVENT {
-                    cbSize: std::mem::size_of::<TRACKMOUSEEVENT>() as u32,
-                    dwFlags: TME_LEAVE,
-                    hwndTrack: hwnd,
-                    dwHoverTime: 0,
-                };
-                (window.win32.user32.TrackMouseEvent)(&mut tme);
-            }
+            window.arm_mouse_leave();
 
             // Request redraw if needed
             window.route_main_window_result(hwnd, result);
@@ -3506,7 +3711,22 @@ unsafe extern "system" fn window_proc(
         }
 
         WM_MOUSELEAVE => {
-            // Mouse left the window area
+            // Mouse left the window area.
+            //
+            // NOT while a capture is held: TME_LEAVE is re-armed on every
+            // WM_MOUSEMOVE and fires as soon as the pointer crosses the client
+            // edge, but a captured drag (text selection, scrollbar thumb) is
+            // still receiving those moves and is still logically inside the
+            // window. Handling the leave there pushed an empty hit test and
+            // OutOfWindow, zeroing the hover chain mid-drag. WM_LBUTTONUP
+            // re-arms TME_LEAVE right after ReleaseCapture, and Win32 then
+            // posts WM_MOUSELEAVE immediately if the pointer really is
+            // outside — so the leave is deferred to the end of the drag, not
+            // lost.
+            if (window.win32.user32.GetCapture)() == hwnd {
+                return 0;
+            }
+
             // Save previous state
             window.common.previous_window_state = Some(window.common.current_window_state.clone());
 
@@ -3547,12 +3767,12 @@ unsafe extern "system" fn window_proc(
             // Touch + pen (Win8+). Promoted WM_MOUSE messages still drive
             // cursor/click; this adds pressure/tilt + multi-touch state.
             let pointer_id = (wparam & 0xFFFF) as u32;
-            window.feed_pointer(hwnd, pointer_id, false);
+            window.feed_pointer_and_dispatch(hwnd, pointer_id, false);
             def_window_proc_w(hwnd, msg, wparam, lparam)
         }
         WM_POINTERUP => {
             let pointer_id = (wparam & 0xFFFF) as u32;
-            window.feed_pointer(hwnd, pointer_id, true);
+            window.feed_pointer_and_dispatch(hwnd, pointer_id, true);
             def_window_proc_w(hwnd, msg, wparam, lparam)
         }
 
@@ -3708,6 +3928,10 @@ unsafe extern "system" fn window_proc(
                 unsafe {
                     (window.win32.user32.ReleaseCapture)();
                 }
+                // Re-arm the leave notification the capture suppressed: if the
+                // thumb drag ended outside the client area, Win32 posts
+                // WM_MOUSELEAVE right away and the hover state is cleaned up.
+                window.arm_mouse_leave();
                 return 0;
             }
 
@@ -3764,6 +3988,10 @@ unsafe extern "system" fn window_proc(
 
             // Release mouse capture
             (window.win32.user32.ReleaseCapture)();
+            // Re-arm the leave notification the capture suppressed: a
+            // selection drag that ended outside the client area gets its
+            // WM_MOUSELEAVE now instead of never.
+            window.arm_mouse_leave();
 
             // V2 system will detect MouseUp event
             let result = window.process_window_events(0);
@@ -3974,6 +4202,32 @@ unsafe extern "system" fn window_proc(
             let scroll_amount = delta as f32 / WHEEL_DELTA as f32;
             let horizontal = msg == WM_MOUSEHWHEEL;
 
+            // Pixels per wheel notch, from the USER's setting.
+            // SystemParametersInfo(SPI_GETWHEELSCROLLLINES) was already being
+            // captured into SystemStyle.input.wheel_scroll_lines and then read
+            // by nobody — the notch was hardcoded at WHEEL_TICK_PIXELS, so the
+            // Control Panel / mouse-driver scroll speed did nothing on
+            // Windows.
+            //
+            // WHEEL_TICK_PIXELS is calibrated for the Windows DEFAULT of 3
+            // lines (and matches X11_SCROLL_TICK_PIXELS), so the setting is
+            // applied as a ratio against that default rather than as an
+            // absolute line height, which keeps the default behaviour
+            // bit-identical.
+            const WHEEL_TICK_PIXELS: f32 =
+                crate::desktop::shell2::common::event::WHEEL_SCROLL_PIXELS_PER_LINE;
+            const DEFAULT_WHEEL_SCROLL_LINES: f32 = 3.0;
+            // WHEEL_PAGESCROLL: "scroll one screen at a time".
+            const WHEEL_PAGESCROLL: u32 = u32::MAX;
+            let wheel_lines = window.common.system_style.input.wheel_scroll_lines;
+            let px_per_notch = if wheel_lines == WHEEL_PAGESCROLL {
+                let dims = window.common.current_window_state.size.dimensions;
+                if horizontal { dims.width } else { dims.height }
+            } else {
+                // 0 lines is a legal setting and means "wheel scrolling off".
+                WHEEL_TICK_PIXELS * (wheel_lines as f32 / DEFAULT_WHEEL_SCROLL_LINES)
+            };
+
             // MWA-C-scroll: WM_MOUSEWHEEL/WM_MOUSEHWHEEL carry SCREEN
             // coordinates in lparam (unlike the client-relative WM_MOUSE*
             // messages) — convert first, or on any window not at the
@@ -4034,7 +4288,7 @@ unsafe extern "system" fn window_proc(
 
             // Queue scroll input for the physics timer instead of directly setting offsets.
             // The timer will consume these via ScrollInputQueue and push CallbackChange::ScrollTo.
-            if delta.abs() > 0 {
+            if delta.abs() > 0 && px_per_notch > 0.0 {
                 let mut should_start_timer = false;
                 let mut input_queue_clone = None;
 
@@ -4055,8 +4309,8 @@ unsafe extern "system" fn window_proc(
                             // (positive = rotated away = up = +1); horizontal
                             // must be NEGATED or tilt-wheel / trackpad
                             // horizontal scrolling runs backwards.
-                            if horizontal { -scroll_amount * 20.0 } else { 0.0 },
-                            if horizontal { 0.0 } else { scroll_amount * 20.0 },
+                            if horizontal { -scroll_amount * px_per_notch } else { 0.0 },
+                            if horizontal { 0.0 } else { scroll_amount * px_per_notch },
                             ScrollInputSource::WheelDiscrete,
                             // WM_MOUSEWHEEL is also what precision touchpads
                             // fall back to; without DirectManipulation there
@@ -4158,7 +4412,18 @@ unsafe extern "system" fn window_proc(
                 window.route_main_window_result(hwnd, result);
             }
 
-            0
+            // The SYS variants MUST reach DefWindowProc: that is what turns
+            // Alt+F4's WM_SYSKEYDOWN into WM_SYSCOMMAND/SC_CLOSE and what puts
+            // F10 / Alt into menu mode. Neither produces a WM_SYSCHAR (the arm
+            // below that already forwards), so swallowing WM_SYSKEYDOWN killed
+            // Alt+F4, F10 and every Alt mnemonic outright. The plain
+            // WM_KEYDOWN stays swallowed — DefWindowProc has nothing to add
+            // there, and the WM_CHAR text path comes from TranslateMessage.
+            if msg == WM_SYSKEYDOWN {
+                def_window_proc_w(hwnd, msg, wparam, lparam)
+            } else {
+                0
+            }
         }
 
         WM_KEYUP | WM_SYSKEYUP => {
@@ -4196,7 +4461,14 @@ unsafe extern "system" fn window_proc(
                 window.route_main_window_result(hwnd, result);
             }
 
-            0
+            // Same as WM_SYSKEYDOWN: DefWindowProc completes the menu-mode
+            // entry a bare Alt press starts (Alt down + up activates the menu
+            // bar), so the SYS variant falls through.
+            if msg == WM_SYSKEYUP {
+                def_window_proc_w(hwnd, msg, wparam, lparam)
+            } else {
+                0
+            }
         }
 
         WM_SYSCHAR => {
@@ -4363,6 +4635,30 @@ unsafe extern "system" fn window_proc(
                     }
                 }
 
+                // Re-run layout on the existing StyledDom so the caret rect
+                // accounts for the preedit that was just spliced into the text
+                // cache, then push the new rect to the IME. Only
+                // WM_IME_STARTCOMPOSITION, WM_SETFOCUS and the
+                // regenerate_layout tail used to sync it, so the composition
+                // and candidate windows stayed pinned to the
+                // composition-START rect while the preedit grew and wrapped —
+                // a long Japanese phrase ended up with its candidate list
+                // lines away from the text it belonged to.
+                if let Some(layout_window) = window.common.layout_window.as_mut() {
+                    let mut debug_messages = None;
+                    if let Err(e) = crate::desktop::shell2::common::layout::incremental_relayout(
+                        layout_window,
+                        &window.common.current_window_state,
+                        &mut window.common.renderer_resources,
+                        &mut debug_messages,
+                    ) {
+                        log_warn!(LogCategory::Layout, "IME preedit relayout failed: {}", e);
+                    }
+                }
+                window.common.request_relayout_only();
+                window.update_ime_position_from_cursor();
+                window.sync_ime_position_to_os();
+
                 // Trigger redraw so preedit indicator is rendered
                 (window.win32.user32.InvalidateRect)(hwnd, ptr::null(), 0);
                 // Let Windows show composition window by default
@@ -4398,24 +4694,118 @@ unsafe extern "system" fn window_proc(
             // This character will be processed by the event system automatically
             let char_code = wparam as u32;
 
-            if let Some(chr) = char::from_u32(char_code) {
-                if !chr.is_control() {
-                    window.common.previous_window_state = Some(window.common.current_window_state.clone());
+            // WM_IME_CHAR carries UTF-16 exactly like WM_CHAR, so a
+            // supplementary-plane commit (rare CJK ideographs, emoji from an
+            // IME) arrives as two surrogate halves. Feeding a half straight to
+            // char::from_u32 returns None, which silently DROPPED both halves
+            // — pair them with the same `high_surrogate` slot WM_CHAR uses
+            // (the two messages never interleave: an IME commit produces one
+            // or the other, not both).
+            let is_high_surrogate = (0xD800..=0xDBFF).contains(&char_code);
+            let is_low_surrogate = (0xDC00..=0xDFFF).contains(&char_code);
 
-                    // Record text input in the TextInputManager
-                    if let Some(ref mut layout_window) = window.common.layout_window {
-                        let text_str = chr.to_string();
-                        let _ = layout_window.record_text_input(&text_str);
+            let mut char_opt = None;
+            if is_high_surrogate {
+                window.high_surrogate = Some(char_code as u16);
+            } else if is_low_surrogate {
+                if let Some(high) = window.high_surrogate {
+                    let pair = [high, char_code as u16];
+                    if let Some(Ok(chr)) = char::decode_utf16(pair.iter().copied()).next() {
+                        char_opt = Some(chr);
                     }
-
-                    // V2 system will detect TextInput event
-                    let result = window.process_window_events(0);
-
-                    window.route_main_window_result(hwnd, result);
+                }
+                window.high_surrogate = None;
+            } else {
+                window.high_surrogate = None;
+                if let Some(chr) = char::from_u32(char_code) {
+                    if !chr.is_control() {
+                        char_opt = Some(chr);
+                    }
                 }
             }
 
+            if let Some(chr) = char_opt {
+                window.common.previous_window_state = Some(window.common.current_window_state.clone());
+
+                // Record text input in the TextInputManager
+                if let Some(ref mut layout_window) = window.common.layout_window {
+                    let text_str = chr.to_string();
+                    let _ = layout_window.record_text_input(&text_str);
+                }
+
+                // V2 system will detect TextInput event
+                let result = window.process_window_events(0);
+
+                window.route_main_window_result(hwnd, result);
+            }
+
             0
+        }
+
+        WM_IME_REQUEST => {
+            // IMR_QUERYCHARPOSITION is how a TSF-based IME (i.e. every modern
+            // one) asks where the caret is; it does NOT read the IMM
+            // composition form. The message was declared but never matched, so
+            // it fell through to DefWindowProc, which answers FALSE — and the
+            // IME then guessed, parking the candidate list at the window
+            // origin. Answer it with the live caret rect in SCREEN coords.
+            const IMR_QUERYCHARPOSITION: usize = 0x0006;
+
+            if (wparam as usize) == IMR_QUERYCHARPOSITION && lparam != 0 {
+                use azul_core::window::ImePosition;
+
+                let cp = &mut *(lparam as *mut dlopen::IMECHARPOSITION);
+                // The IME declares how much of the struct it allocated; a
+                // smaller one is a different (older) layout and must not be
+                // written through.
+                let caret = match window.common.current_window_state.ime_position {
+                    ImePosition::Initialized(r)
+                        if cp.dwSize as usize
+                            >= core::mem::size_of::<dlopen::IMECHARPOSITION>() =>
+                    {
+                        Some(r)
+                    }
+                    _ => None,
+                };
+
+                if let Some(rect) = caret {
+                    let hf = window
+                        .common
+                        .current_window_state
+                        .size
+                        .get_hidpi_factor()
+                        .inner
+                        .get();
+
+                    // Caret origin: client (logical) -> client (physical) -> screen.
+                    let mut pt = dlopen::POINT {
+                        x: libm::roundf(rect.origin.x * hf) as i32,
+                        y: libm::roundf(rect.origin.y * hf) as i32,
+                    };
+                    (window.win32.user32.ClientToScreen)(hwnd, &mut pt);
+
+                    // Document area: the whole client rect, also in screen coords.
+                    let mut client = dlopen::RECT::default();
+                    (window.win32.user32.GetClientRect)(hwnd, &mut client);
+                    let mut tl = dlopen::POINT { x: client.left, y: client.top };
+                    let mut br = dlopen::POINT { x: client.right, y: client.bottom };
+                    (window.win32.user32.ClientToScreen)(hwnd, &mut tl);
+                    (window.win32.user32.ClientToScreen)(hwnd, &mut br);
+
+                    cp.pt = pt;
+                    cp.cLineHeight =
+                        (libm::roundf(rect.size.height * hf) as i32).max(1) as u32;
+                    cp.rcDocument = dlopen::RECT {
+                        left: tl.x,
+                        top: tl.y,
+                        right: br.x,
+                        bottom: br.y,
+                    };
+                    return 1;
+                }
+            }
+
+            (window.win32.user32.DefWindowProcW)(hwnd, msg, wparam, lparam)
         }
 
         WM_IME_NOTIFY | WM_IME_SETCONTEXT => {
@@ -4425,10 +4815,26 @@ unsafe extern "system" fn window_proc(
 
         WM_SETFOCUS => {
             // Window gained focus
-            window.common.previous_window_state = Some(window.common.current_window_state.clone());
-            window.common.current_window_state.flags.has_focus = true;
-            window.common.current_window_state.window_focused = true;
+            let prev_snapshot = window.common.current_window_state.clone();
+            // Focus is OS-reported (source = Os): acknowledging it into the
+            // sync baseline is what stops sync_window_state() from answering
+            // with a SetFocus/SetForegroundWindow of its own.
+            window.common.update_window_state(
+                crate::desktop::shell2::common::event::WindowStateSource::Os,
+                |ws| {
+                    ws.flags.has_focus = true;
+                    ws.window_focused = true;
+                },
+            );
             window.dynamic_selector_context.window_focused = true;
+
+            // Re-read the pressed-key set: the releases that happened while
+            // another window had the focus never reached us (Alt+Tab's LAlt
+            // release is the classic one), so without this Alt stays latched
+            // and every later click is treated as an Alt+click.
+            window.resync_keyboard_state_from_os();
+
+            window.common.previous_window_state = Some(prev_snapshot);
 
             // Phase 2: OnFocus callback - sync IME position after focus
             window.sync_ime_position_to_os();
@@ -4446,10 +4852,32 @@ unsafe extern "system" fn window_proc(
 
         WM_KILLFOCUS => {
             // Window lost focus
-            window.common.previous_window_state = Some(window.common.current_window_state.clone());
-            window.common.current_window_state.flags.has_focus = false;
-            window.common.current_window_state.window_focused = false;
+            let prev_snapshot = window.common.current_window_state.clone();
+            window.common.update_window_state(
+                crate::desktop::shell2::common::event::WindowStateSource::Os,
+                |ws| {
+                    ws.flags.has_focus = false;
+                    ws.window_focused = false;
+                },
+            );
             window.dynamic_selector_context.window_focused = false;
+
+            // Drop every held key. Nothing that happens while we are unfocused
+            // reaches us — least of all the KEY-UP of the modifier that caused
+            // the focus change (Alt of Alt+Tab), which is exactly the key that
+            // would stay latched. `current_virtual_keycode = None` also makes
+            // the diff fire the matching KeyUp.
+            {
+                use azul_core::window::{
+                    OptionVirtualKeyCode, ScanCodeVec, VirtualKeyCodeVec,
+                };
+                let ks = &mut window.common.current_window_state.keyboard_state;
+                ks.current_virtual_keycode = OptionVirtualKeyCode::None;
+                ks.pressed_virtual_keycodes = VirtualKeyCodeVec::from_vec(Vec::new());
+                ks.pressed_scancodes = ScanCodeVec::from_vec(Vec::new());
+            }
+
+            window.common.previous_window_state = Some(prev_snapshot);
 
             // Same as WM_SETFOCUS: process + route so blur callbacks fire and
             // unfocused styling repaints.
@@ -4611,12 +5039,21 @@ unsafe extern "system" fn window_proc(
         WM_DPICHANGED => {
             // DPI changed
             let new_dpi = ((wparam >> 16) & 0xFFFF) as u32;
+            let old_dpi = window.common.current_window_state.size.dpi;
 
-            // Save previous state
-            window.common.previous_window_state = Some(window.common.current_window_state.clone());
-
-            // Update DPI in window state
-            window.common.current_window_state.size.dpi = new_dpi;
+            // Update DPI in window state. The SetWindowPos below dispatches
+            // WM_SIZE SYNCHRONOUSLY and that handler reads size.dpi to convert
+            // the physical client rect, so the new DPI has to be in place
+            // first — which is also why the diff baseline cannot simply be
+            // snapshotted here: the nested WM_SIZE runs its own pass, and a
+            // pass ends by consuming the delta (previous = current), so a
+            // baseline taken now would be gone before this arm could dispatch
+            // WindowDpiChanged. It is rebuilt AFTER the nested resize settles,
+            // at the bottom of this arm.
+            window.common.update_window_state(
+                crate::desktop::shell2::common::event::WindowStateSource::Os,
+                |ws| ws.size.dpi = new_dpi,
+            );
 
             // Get suggested size from lParam (RECT*). Per MSDN this is "a
             // suggested size and position of the current window scaled for
@@ -4655,8 +5092,11 @@ unsafe extern "system" fn window_proc(
             // (same physical client / new scale = different logical size).
             if let Ok((w, h)) = wcreate::get_client_rect(hwnd, &window.win32) {
                 let physical_size = azul_core::geom::PhysicalSizeU32::new(w, h);
-                window.common.current_window_state.size.dimensions =
-                    physical_size.to_logical(new_dpi as f32 / 96.0);
+                let logical = physical_size.to_logical(new_dpi as f32 / 96.0);
+                window.common.update_window_state(
+                    crate::desktop::shell2::common::event::WindowStateSource::Os,
+                    |ws| ws.size.dimensions = logical,
+                );
             }
 
             // DPI change requires a full relayout, tagged `Resize` — the enum's
@@ -4665,6 +5105,21 @@ unsafe extern "system" fn window_proc(
             // untouched, so the same physical event reported a different reason
             // to the user's `layout()` depending on which OS delivered it.
             window.common.request_regeneration(azul_core::callbacks::RelayoutReason::Resize);
+
+            // Dispatch the DPI transition. `WindowDpiChanged` is derived from
+            // the size.dpi delta, so the baseline is the state as it stands
+            // NOW with the dpi rolled back — that is the one and only
+            // difference left, so the nested WM_SIZE's WindowResize is not
+            // dispatched a second time here. Building the baseline this way
+            // (rather than snapshotting at the top of the arm) is what makes
+            // the transition survive that nested pass.
+            {
+                let mut baseline = window.common.current_window_state.clone();
+                baseline.size.dpi = old_dpi;
+                window.common.previous_window_state = Some(baseline);
+                let r = window.process_window_events(0);
+                window.route_main_window_result(hwnd, r);
+            }
 
             // Request redraw
             unsafe {
@@ -4780,10 +5235,17 @@ unsafe extern "system" fn window_proc(
                 Some(window.common.current_window_state.clone());
             let new_style =
                 std::sync::Arc::new(crate::desktop::app::discover_system_style());
-            window.common.current_window_state.theme = match new_style.theme {
+            let new_theme = match new_style.theme {
                 azul_css::system::Theme::Dark => azul_core::window::WindowTheme::DarkMode,
                 azul_css::system::Theme::Light => azul_core::window::WindowTheme::LightMode,
             };
+            // OS-reported (source = Os): the theme is already the system's, so
+            // the OS-sync baseline advances with `current` and only the event
+            // diff carries the transition.
+            window.common.update_window_state(
+                crate::desktop::shell2::common::event::WindowStateSource::Os,
+                |ws| ws.theme = new_theme,
+            );
             window.common.system_style = new_style;
             let r = window.process_window_events(0);
             window.route_main_window_result(hwnd, r);
@@ -4960,20 +5422,34 @@ impl Win32Window {
         self.is_open
     }
 
-    pub fn close(&mut self) {
-        // WebRender's Renderer must be deinit()'d, not dropped — texture
-        // deletion has to happen inside a frame. Never doing so crashed debug
-        // builds on close and leaked GPU resources in release.
+    /// Release the GPU-side resources of this window.
+    ///
+    /// WebRender's `Renderer` must be `deinit()`'d, not dropped — texture
+    /// deletion has to happen inside a frame. Never doing so crashed debug
+    /// builds on close and leaked GPU resources in release.
+    ///
+    /// Must run while the HWND and the GL context are still alive, i.e. before
+    /// `DestroyWindow`. `deinit_renderer()` takes the renderer out of the
+    /// common state, so calling this twice is a no-op.
+    fn release_gpu_resources(&mut self) {
         self.common.deinit_renderer();
-        // Close the window by posting WM_CLOSE
+        if let Some(doc_id) = self.common.document_id {
+            crate::desktop::gl_texture_integration::remove_document_textures(&doc_id);
+        }
+    }
+
+    pub fn close(&mut self) {
+        // Request the close through WM_CLOSE, which is VETO-ABLE: the close
+        // callback can cancel it. Tearing the renderer down here (what this
+        // used to do, before the message was even posted) left a cancelled
+        // close with a live, visible window and no renderer — every later
+        // frame had nothing to render with. The WM_CLOSE handler releases the
+        // GPU resources on the path where the close actually proceeds, and
+        // WM_DESTROY clears `is_open`.
         unsafe {
             const WM_CLOSE: u32 = 0x0010;
             (self.win32.user32.PostMessageW)(self.hwnd, WM_CLOSE, 0, 0);
         }
-        if let Some(doc_id) = self.common.document_id {
-            crate::desktop::gl_texture_integration::remove_document_textures(&doc_id);
-        }
-        self.is_open = false;
     }
 
     pub fn request_redraw(&mut self) {
@@ -5527,7 +6003,9 @@ impl Win32Window {
                 let himc = (imm32.ImmGetContext)(hwnd);
 
                 if !himc.is_null() {
-                    use dlopen::{CFS_RECT, COMPOSITIONFORM, POINT, RECT};
+                    use dlopen::{
+                        CANDIDATEFORM, CFS_CANDIDATEPOS, CFS_RECT, COMPOSITIONFORM, POINT, RECT,
+                    };
 
                     // rect is LOGICAL (cursor rect from layout);
                     // COMPOSITIONFORM takes CLIENT-AREA coordinates in
@@ -5541,21 +6019,30 @@ impl Win32Window {
                         .get_hidpi_factor()
                         .inner
                         .get();
-                    let mut comp_form = COMPOSITIONFORM {
+                    let left = libm::roundf(rect.origin.x * hf) as i32;
+                    let top = libm::roundf(rect.origin.y * hf) as i32;
+                    let right = libm::roundf((rect.origin.x + rect.size.width) * hf) as i32;
+                    let bottom = libm::roundf((rect.origin.y + rect.size.height) * hf) as i32;
+                    let comp_form = COMPOSITIONFORM {
                         dwStyle: CFS_RECT,
-                        ptCurrentPos: POINT {
-                            x: libm::roundf(rect.origin.x * hf) as i32,
-                            y: libm::roundf(rect.origin.y * hf) as i32,
-                        },
-                        rcArea: RECT {
-                            left: libm::roundf(rect.origin.x * hf) as i32,
-                            top: libm::roundf(rect.origin.y * hf) as i32,
-                            right: libm::roundf((rect.origin.x + rect.size.width) * hf) as i32,
-                            bottom: libm::roundf((rect.origin.y + rect.size.height) * hf) as i32,
-                        },
+                        ptCurrentPos: POINT { x: left, y: top },
+                        rcArea: RECT { left, top, right, bottom },
                     };
 
                     (imm32.ImmSetCompositionWindow)(himc, &comp_form);
+
+                    // The CANDIDATE list is a separate form: without this it
+                    // stays wherever the IME first opened it while the caret
+                    // moves on. CFS_CANDIDATEPOS places its top-left corner,
+                    // so anchor it under the caret's BOTTOM-left.
+                    let cand_form = CANDIDATEFORM {
+                        dwIndex: 0,
+                        dwStyle: CFS_CANDIDATEPOS,
+                        ptCurrentPos: POINT { x: left, y: bottom },
+                        rcArea: RECT::default(),
+                    };
+                    (imm32.ImmSetCandidateWindow)(himc, &cand_form);
+
                     (imm32.ImmReleaseContext)(hwnd, himc);
                 }
             }

--- a/dll/src/desktop/shell2/windows/registry.rs
+++ b/dll/src/desktop/shell2/windows/registry.rs
@@ -4,7 +4,8 @@
 //! Uses thread-local storage for simplicity and to avoid complex `Rc<RefCell>` patterns.
 //!
 //! Public API: `register_window`, `unregister_window`, `get_window`,
-//! `get_all_window_handles`, `is_empty`, `window_count`.
+//! `get_all_window_handles`, `is_empty`, `window_count`,
+//! `queue_window_free`, `drain_closed_windows`.
 //! Primary consumers are `run.rs` (event loop) and `mod.rs` (window lifecycle).
 
 use std::{cell::RefCell, collections::BTreeMap};
@@ -19,6 +20,19 @@ thread_local! {
     /// SAFETY: Pointers are valid for the lifetime of the window.
     /// Windows are created and destroyed on the same thread.
     static WINDOW_REGISTRY: RefCell<WindowRegistry> = RefCell::new(WindowRegistry::new());
+
+    /// Windows whose `WM_DESTROY` has run and which have been removed from the
+    /// registry, parked for deferred drop.
+    ///
+    /// They cannot be freed at their unregister site: `WM_DESTROY` is dispatched
+    /// *inside* `DestroyWindow`, which itself runs inside the window procedure —
+    /// and the event loop holds a `&mut Win32Window` across that dispatch, so
+    /// dropping the box there frees the window out from under both frames. The
+    /// raw `Box` pointers are parked here and reclaimed by
+    /// [`drain_closed_windows`] once the event loop is back at a safe point —
+    /// the same deferred-drop strategy the macOS backend uses.
+    static PENDING_WINDOW_FREES: RefCell<Vec<*mut super::Win32Window>> =
+        RefCell::new(Vec::new());
 }
 
 /// Registry of active windows for the current thread
@@ -86,6 +100,34 @@ pub fn unregister_window(hwnd: HWND) -> Option<*mut super::Win32Window> {
         window_count()
     );
     result
+}
+
+/// Park a window pointer (already removed from the registry) for deferred drop.
+pub fn queue_window_free(window_ptr: *mut super::Win32Window) {
+    PENDING_WINDOW_FREES.with(|q| q.borrow_mut().push(window_ptr));
+    log_debug!(
+        LogCategory::Window,
+        "[Windows Registry] Parked window {:p} for deferred drop",
+        window_ptr
+    );
+}
+
+/// Reclaim every window parked by [`queue_window_free`], running
+/// `Win32Window`'s destructor (GL context, WebRender renderer, layout window).
+///
+/// Must only be called from the event loop, i.e. outside the window procedure
+/// and outside any live `&mut Win32Window` borrow.
+pub fn drain_closed_windows() {
+    let pending: Vec<*mut super::Win32Window> =
+        PENDING_WINDOW_FREES.with(|q| std::mem::take(&mut *q.borrow_mut()));
+    for window_ptr in pending {
+        // SAFETY: each pointer came from `Box::into_raw(Box::new(Win32Window))`
+        // (run.rs) and was removed from the registry exactly once before being
+        // queued, so this is its sole owner and the box is freed exactly once.
+        unsafe {
+            drop(Box::from_raw(window_ptr));
+        }
+    }
 }
 
 /// Get a window pointer from the registry

--- a/dll/src/desktop/wr_translate2.rs
+++ b/dll/src/desktop/wr_translate2.rs
@@ -793,13 +793,13 @@ pub fn fullhittest_new_webrender(
                     };
                     let node_pos = layout_result
                         .calculated_positions
-                        .get(layout_idx)
+                        .get(layout_idx.index())
                         .copied()
                         .unwrap_or_default();
                     let node_size = layout_node.used_size.unwrap_or_default();
                     let parent_rect = LogicalRect::new(node_pos, node_size);
                     let child_rect =
-                        compute_scroll_child_rect(layout_result, layout_idx, parent_rect);
+                        compute_scroll_child_rect(layout_result, layout_idx.index(), parent_rect);
 
                     let scroll_node = OverflowingScrollNode {
                         parent_rect,
@@ -883,13 +883,13 @@ pub fn fullhittest_new_webrender(
                 };
                 let node_pos = layout_result
                     .calculated_positions
-                    .get(layout_idx)
+                    .get(layout_idx.index())
                     .copied()
                     .unwrap_or_default();
                 let node_size = layout_node.used_size.unwrap_or_default();
                 let parent_rect = LogicalRect::new(node_pos, node_size);
                 let child_rect =
-                    compute_scroll_child_rect(layout_result, layout_idx, parent_rect);
+                    compute_scroll_child_rect(layout_result, layout_idx.index(), parent_rect);
 
                 use azul_core::hit_test::{OverflowingScrollNode, ScrollHitTestItem};
                 let scroll_node = OverflowingScrollNode {
@@ -1067,14 +1067,14 @@ pub fn fullhittest_new_webrender(
 
                 let node_pos = layout_result
                     .calculated_positions
-                    .get(layout_idx)
+                    .get(layout_idx.index())
                     .copied()
                     .unwrap_or_default();
 
                 let node_size = layout_node.used_size.unwrap_or_default();
                 let parent_rect = LogicalRect::new(node_pos, node_size);
                 let child_rect =
-                    compute_scroll_child_rect(layout_result, layout_idx, parent_rect);
+                    compute_scroll_child_rect(layout_result, layout_idx.index(), parent_rect);
 
                 let scroll_id = layout_result
                     .scroll_ids

--- a/dll/tests/headless_lifecycle.rs
+++ b/dll/tests/headless_lifecycle.rs
@@ -101,13 +101,13 @@ extern "C" fn layout_cb(mut data: RefAny, _info: LayoutCallbackInfo) -> Dom {
     match frame {
         0 => Dom::create_body(),
         1 => {
-            let mut a = NodeData::create_text("A");
+            let mut a = NodeData::create_text_do_not_use_without_block_level_wrapper("A");
             a.add_callback(
                 EventFilter::Component(ComponentEventFilter::AfterMount),
                 RefAny::new(counters.clone()),
                 mount_cb,
             );
-            let mut b = NodeData::create_text("B");
+            let mut b = NodeData::create_text_do_not_use_without_block_level_wrapper("B");
             b.add_callback(
                 EventFilter::Component(ComponentEventFilter::BeforeUnmount),
                 RefAny::new(counters.clone()),
@@ -121,7 +121,7 @@ extern "C" fn layout_cb(mut data: RefAny, _info: LayoutCallbackInfo) -> Dom {
             // Keep B (so it'll see BeforeUnmount) — no, we *remove* both A and B
             // to force two unmounts; then add C with AfterMount + Updated so the
             // next frame can fire Updated on the same keyed node.
-            let mut c = NodeData::create_text("v1").with_key(0xC0FFEEu64);
+            let mut c = NodeData::create_text_do_not_use_without_block_level_wrapper("v1").with_key(0xC0FFEEu64);
             c.add_callback(
                 EventFilter::Component(ComponentEventFilter::AfterMount),
                 RefAny::new(counters.clone()),
@@ -136,7 +136,7 @@ extern "C" fn layout_cb(mut data: RefAny, _info: LayoutCallbackInfo) -> Dom {
         }
         _ => {
             // Same keyed C, but with new content — this is the Updated path.
-            let mut c = NodeData::create_text("v2").with_key(0xC0FFEEu64);
+            let mut c = NodeData::create_text_do_not_use_without_block_level_wrapper("v2").with_key(0xC0FFEEu64);
             c.add_callback(
                 EventFilter::Component(ComponentEventFilter::AfterMount),
                 RefAny::new(counters.clone()),
@@ -204,7 +204,7 @@ extern "C" fn layout_cb_widgets_on_first_frame(
     for i in 0..widget_count {
         // Distinct keys so the nodes are stable across relayout (Tier-1 match →
         // no spurious unmount/remount on a second regenerate).
-        let mut w = NodeData::create_text("widget").with_key(0xA000u64 + i as u64);
+        let mut w = NodeData::create_text_do_not_use_without_block_level_wrapper("widget").with_key(0xA000u64 + i as u64);
         w.add_callback(
             EventFilter::Component(ComponentEventFilter::AfterMount),
             RefAny::new(counters.clone()),
@@ -379,7 +379,7 @@ extern "C" fn layout_cb_counting(mut data: RefAny, _info: LayoutCallbackInfo) ->
 
     let cb = Callback { cb: on_mount_asking_for_refresh, ctx: azul_core::refany::OptionRefAny::None }
         .to_core();
-    let mut w = NodeData::create_text("widget").with_key(0xBEEF_0001u64);
+    let mut w = NodeData::create_text_do_not_use_without_block_level_wrapper("widget").with_key(0xBEEF_0001u64);
     w.add_callback(
         EventFilter::Component(ComponentEventFilter::AfterMount),
         RefAny::new(counters.clone()),

--- a/dll/tests/headless_patch_blit.rs
+++ b/dll/tests/headless_patch_blit.rs
@@ -23,8 +23,8 @@ fn page_dom() -> StyledDom {
         .with_child(
             Dom::create_node(NodeType::Div)
                 .with_ids_and_classes(vec![IdOrClass::Class("page".into())].into())
-                .with_child(Dom::create_text("blit golden paragraph one"))
-                .with_child(Dom::create_text("second line of golden text")),
+                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("blit golden paragraph one"))
+                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("second line of golden text")),
         );
     let css = r#"
         * { margin: 0px; padding: 0px; }

--- a/dll/tests/headless_user_property_override.rs
+++ b/dll/tests/headless_user_property_override.rs
@@ -97,7 +97,7 @@ extern "C" fn layout_cb(mut data: RefAny, _info: LayoutCallbackInfo) -> Dom {
     }
     .to_core();
 
-    let mut child = NodeData::create_text("target");
+    let mut child = NodeData::create_text_do_not_use_without_block_level_wrapper("target");
     child.add_callback(
         EventFilter::Component(ComponentEventFilter::AfterMount),
         RefAny::new(state),

--- a/dll/tests/xml_to_rust_compilation.rs
+++ b/dll/tests/xml_to_rust_compilation.rs
@@ -349,7 +349,7 @@ mod xml_compilation_tests {
         assert!(cpp.contains("Dom::create_p_with_text(String(\"hi\"))"), "{}", cpp);
         assert!(py.contains("azul.Dom.create_p_with_text(\"hi\")"), "{}", py);
         // text folded into the ctor — never also emitted as a child text node
-        assert!(!c.contains("AzDom_createText(AZ_STR(\"hi\"))"), "text not consumed: {}", c);
+        assert!(!c.contains("AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AZ_STR(\"hi\"))"), "text not consumed: {}", c);
         assert!(!rust.contains("Dom::create_text_do_not_use_without_block_level_wrapper(\"hi\")"), "text not consumed: {}", rust);
     }
 
@@ -361,7 +361,7 @@ mod xml_compilation_tests {
         assert!(c.contains("AzDom_createButton(AZ_STR(\"Go\"), AzSmallAriaInfo_label(AZ_STR(\"Go\")))"), "{}", c);
         assert!(cpp.contains("Dom::create_button(String(\"Go\"), SmallAriaInfo::label(String(\"Go\")))"), "{}", cpp);
         assert!(py.contains("azul.Dom.create_button(\"Go\", azul.SmallAriaInfo.label(\"Go\"))"), "{}", py);
-        assert!(!c.contains("AzDom_createText(AZ_STR(\"Go\"))"), "button text must be consumed: {}", c);
+        assert!(!c.contains("AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AZ_STR(\"Go\"))"), "button text must be consumed: {}", c);
     }
 
     // Tier C — `<a href="x">link</a>` (no aria) → create_a_no_a11y(href, Some(label)).

--- a/dll/tests/xml_to_rust_compilation.rs
+++ b/dll/tests/xml_to_rust_compilation.rs
@@ -124,7 +124,7 @@ mod xml_compilation_tests {
         // import path that holds for both forms.
         assert!(rust_code.contains("use azul::"));
         assert!(rust_code.contains("dom::Dom"));
-        // Text content will be in Dom::create_text() calls
+        // Text content will be in Dom::create_text_do_not_use_without_block_level_wrapper() calls
         assert!(rust_code.contains("Dom::text") || rust_code.contains("Hello World"));
     }
 
@@ -350,7 +350,7 @@ mod xml_compilation_tests {
         assert!(py.contains("azul.Dom.create_p_with_text(\"hi\")"), "{}", py);
         // text folded into the ctor — never also emitted as a child text node
         assert!(!c.contains("AzDom_createText(AZ_STR(\"hi\"))"), "text not consumed: {}", c);
-        assert!(!rust.contains("Dom::create_text(\"hi\")"), "text not consumed: {}", rust);
+        assert!(!rust.contains("Dom::create_text_do_not_use_without_block_level_wrapper(\"hi\")"), "text not consumed: {}", rust);
     }
 
     // Tier C — `<button aria-label="Go">Go</button>` → create_button(text, aria).

--- a/doc/guide/en/dom.md
+++ b/doc/guide/en/dom.md
@@ -257,8 +257,21 @@ let _ = Dom::create_p_with_text("A paragraph.");
 let _ = Dom::create_span_with_text("inline");
 let _ = Dom::create_strong_with_text("important");
 let _ = Dom::create_code_with_text("println!()");
-let _ = Dom::create_text("standalone text node");
+let _ = Dom::create_text_do_not_use_without_block_level_wrapper("standalone text node");
 ```
+
+> **Why the scary name?** Browsers silently wrap a raw text run in an
+> *anonymous block box* whenever one is needed; azul does not. A bare text
+> node therefore has **no box of its own** — no rect, no clip, no layout
+> constraints — and any box-model CSS property, callback, `tab_index` or
+> `dataset` you attach to it is silently inert. This has shipped real bugs
+> (text escaping its widget, click targets that never fire). Put the text
+> inside a block-level wrapper that carries the styling instead: use the
+> `create_*_with_text` family (`create_p_with_text`, `create_div_with_text`,
+> `create_span_with_text`, `create_h1_with_text`, ...) and style the wrapper.
+> The engine also warns on stderr after layout when it finds a text node
+> used without a containing block; once you have read and accepted the
+> warnings, silence them with `AZ_SUPPRESS=bare_text`.
 
 `NodeType` (in `core/src/dom.rs`) lists every variant. The set covers
 all HTML elements plus the SVG subset plus four leaf types: `Text`,

--- a/doc/guide/en/dom/datasets.md
+++ b/doc/guide/en/dom/datasets.md
@@ -182,7 +182,7 @@ enum ColumnKind { Name, Email, Avatar, DeleteButton }
 
 fn row(row_id: u64, kind: ColumnKind, label: &str) -> Dom {
     Dom::create_td()
-        .with_child(Dom::create_text(label))
+        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper(label))
         .with_dataset(OptionRefAny::Some(RefAny::new(RowMarker { row_id, column: kind })))
         .with_callback(EventFilter::Hover(HoverEventFilter::MouseUp),
                        RefAny::new(()), on_cell_click)

--- a/doc/guide/en/dom/virtual-views.md
+++ b/doc/guide/en/dom/virtual-views.md
@@ -208,7 +208,7 @@ extern "C" fn table_render(
 
     let dom: Dom = tdata.visible_rows.iter().map(|r| {
         Dom::create_div()
-            .with_child(Dom::create_text(r.text.clone()))
+            .with_child(Dom::create_text_do_not_use_without_block_level_wrapper(r.text.clone()))
             .with_css(format!("height: {}px;", tdata.row_height))
     }).collect();
 

--- a/doc/guide/en/hello-world/cpp.md
+++ b/doc/guide/en/hello-world/cpp.md
@@ -224,7 +224,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     return Dom::create_body()
         .with_child(Dom::create_div()
             .with_css("font-size: 32px;"sv)
-            .with_child(Dom::create_text(String(std::to_string(d->counter).c_str()))))
+            .with_child(Dom::create_text_do_not_use_without_block_level_wrapper(String(std::to_string(d->counter).c_str()))))
         .with_child(Button::create("Increase counter"sv)
             .with_button_type(ButtonType::Primary)   // scoped enum constants
             .with_on_click(data_wrapper.clone(), on_click)

--- a/doc/guide/en/hello-world/crystal.md
+++ b/doc/guide/en/hello-world/crystal.md
@@ -158,7 +158,7 @@ LAYOUT = ->(data : LibAzul::AzRefAny, _info : LibAzul::AzLayoutCallbackInfo) : L
 
   text = m.value.counter.to_s
   counter_str = LibAzul.azString_fromUtf8(text.to_unsafe, LibC::SizeT.new(text.bytesize))
-  label = LibAzul.azDom_createText(counter_str)
+  label = LibAzul.azDom_createTextDoNotUseWithoutBlockLevelWrapper(counter_str)
 
   label_wrapper = LibAzul.azDom_createDiv
   font_size = LibAzul.azStyleFontSize_px(32.0_f32)

--- a/doc/guide/en/hello-world/csharp.md
+++ b/doc/guide/en/hello-world/csharp.md
@@ -115,7 +115,7 @@ namespace HelloWorld
 
             var label = Dom.CreateDiv()
                 .WithCss("font-size: 32px;")
-                .WithChild(Dom.CreateText(m.Counter.ToString()));
+                .WithChild(Dom.CreateTextDoNotUseWithoutBlockLevelWrapper(m.Counter.ToString()));
 
             var buttonDom = Button.Create("Increase counter")
                 .WithButtonType(ButtonType.Primary)

--- a/doc/guide/en/hello-world/d.md
+++ b/doc/guide/en/hello-world/d.md
@@ -154,7 +154,7 @@ extern(C) AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     ubyte[16] buf;
     size_t n = u32_write(m.counter, buf[]);
     AzString counter_str = AzString_fromUtf8(buf.ptr, n);
-    AzDom label = AzDom_createText(counter_str);
+    AzDom label = AzDom_createTextDoNotUseWithoutBlockLevelWrapper(counter_str);
 
     AzDom label_wrapper = AzDom_createDiv();
     AzStyleFontSize font_size = AzStyleFontSize_px(32.0);

--- a/doc/guide/en/hello-world/fortran.md
+++ b/doc/guide/en/hello-world/fortran.md
@@ -182,7 +182,7 @@ contains
       label_wrap = az_dom_create_div()
       label_wrap = az_dom_with_css(label_wrap, mk_str('font-size: 32px;'))
       label_wrap = az_dom_with_child(label_wrap, &
-                                     az_dom_create_text(mk_str(trim(num))))
+                                     az_dom_create_text_do_not_use_without_block_level_wrapper(mk_str(trim(num))))
 
       click_cb = azul_register_buttononclickcallback(my_on_click)
       click_data = azul_refany_create(c_loc(model))

--- a/doc/guide/en/hello-world/go.md
+++ b/doc/guide/en/hello-world/go.md
@@ -210,7 +210,7 @@ func goLayout(data C.AzRefAny, _ C.AzLayoutCallbackInfo) C.AzDom {
 	// Counter label (wrapped in a div so the font-size sticks).
 	counterStr := []byte(fmt.Sprintf("%d", m.counter))
 	counterAz := C.AzString_fromUtf8((*C.uint8_t)(unsafe.Pointer(&counterStr[0])), C.size_t(len(counterStr)))
-	label := C.AzDom_createText(counterAz)
+	label := C.AzDom_createTextDoNotUseWithoutBlockLevelWrapper(counterAz)
 
 	labelWrapper := C.AzDom_createDiv()
 	fontSize := C.AzStyleFontSize_px(C.float(32.0))

--- a/doc/guide/en/hello-world/java.md
+++ b/doc/guide/en/hello-world/java.md
@@ -114,7 +114,7 @@ public final class HelloWorld {
             MyDataModel m = (MyDataModel) recovered;
             Dom label = Dom.createDiv()
                 .withCss("font-size: 32px;")
-                .withChild(Dom.createText(String.valueOf(m.counter)));
+                .withChild(Dom.createTextDoNotUseWithoutBlockLevelWrapper(String.valueOf(m.counter)));
             Dom buttonDom = Button.create("Increase counter")
                 .withButtonType(ButtonType.Primary.value)
                 .onClick(m, ON_CLICK)

--- a/doc/guide/en/hello-world/julia.md
+++ b/doc/guide/en/hello-world/julia.md
@@ -149,7 +149,7 @@ function layout(data::Azul.AzRefAny, info::Azul.AzLayoutCallbackInfo)::Azul.AzDo
     end
     counter === nothing && return Azul.AzDom_createBody()
 
-    label = Azul.AzDom_createText(Azul.az_string(string(counter)))
+    label = Azul.AzDom_createTextDoNotUseWithoutBlockLevelWrapper(Azul.az_string(string(counter)))
     label_wrapper = Ref(Azul.AzDom_createDiv())
     css_prop = Azul.AzCssProperty_fontSize(Azul.AzStyleFontSize_px(32.0f0))
     cond = Azul.AzCssPropertyWithConditions_simple(css_prop)

--- a/doc/guide/en/hello-world/kotlin.md
+++ b/doc/guide/en/hello-world/kotlin.md
@@ -98,7 +98,7 @@ private val layout = AzulHostInvoker.LayoutCallback { _, dataPtr, _ ->
     } else {
         val label = Dom.createDiv()
             .withCss("font-size: 32px;")
-            .withChild(Dom.createText(m.counter.toString()))
+            .withChild(Dom.createTextDoNotUseWithoutBlockLevelWrapper(m.counter.toString()))
         val buttonDom = Button.create("Increase counter")
             .withButtonType(ButtonType.Primary.value)
             .onClick(m, onClick)

--- a/doc/guide/en/hello-world/lua.md
+++ b/doc/guide/en/hello-world/lua.md
@@ -78,7 +78,7 @@ local function layout(data, _info)
     local label = azul.Dom.create_div()
         :add_css_property(azul.CssPropertyWithConditions.simple(
             azul.CssProperty.font_size(azul.StyleFontSize.px(32.0))))
-        :add_child(azul.Dom.create_text(tostring(m.counter)))
+        :add_child(azul.Dom.create_text_do_not_use_without_block_level_wrapper(tostring(m.counter)))
 
     local button_dom = azul.Button.create('Increase counter')
         :set_button_type(azul.ButtonType.Primary)

--- a/doc/guide/en/hello-world/nim.md
+++ b/doc/guide/en/hello-world/nim.md
@@ -146,7 +146,7 @@ proc layout(data: AzRefAny, info: AzLayoutCallbackInfo): AzDom {.cdecl.} =
   let m = myDataDowncast(addr d)
   if m == nil: return AzDom_createBody()
 
-  let label = AzDom_createText(azStr($m.counter))
+  let label = AzDom_createTextDoNotUseWithoutBlockLevelWrapper(azStr($m.counter))
   var labelWrapper = AzDom_createDiv()
   let cond = AzCssPropertyWithConditions_simple(
     AzCssProperty_fontSize(AzStyleFontSize_px(32.0'f32)))

--- a/doc/guide/en/hello-world/node.md
+++ b/doc/guide/en/hello-world/node.md
@@ -94,7 +94,7 @@ function layout(dataPtr, _info) {
         .with_css_property(
             CssPropertyWithConditions.simple(
                 CssProperty.font_size(StyleFontSize.px(32.0))))
-        .with_child(Dom.create_text(String(m.counter)));
+        .with_child(Dom.create_text_do_not_use_without_block_level_wrapper(String(m.counter)));
 
     const button = Button.create('Increase counter')
         .with_button_type(ButtonType.Primary)

--- a/doc/guide/en/hello-world/ocaml.md
+++ b/doc/guide/en/hello-world/ocaml.md
@@ -106,7 +106,7 @@ let layout (data_ptr : unit Ctypes.ptr) (_info : unit Ctypes.ptr)
       let label_div =
         Azul.Dom.create_div ()
         |> with_css "font-size: 32px;"
-        |> with_child (Azul.raw_dom (Azul.Dom.create_text (string_of_int m.counter)))
+        |> with_child (Azul.raw_dom (Azul.Dom.create_text_do_not_use_without_block_level_wrapper (string_of_int m.counter)))
       in
       let button_dom =
         Azul.Button.create "Increase counter"

--- a/doc/guide/en/hello-world/odin.md
+++ b/doc/guide/en/hello-world/odin.md
@@ -147,7 +147,7 @@ layout :: proc "c" (data: azul.AzRefAny, info: azul.AzLayoutCallbackInfo) -> azu
 	buf: [16]u8
 	n := u32_write(m.counter, buf[:])
 	counter_str := azul.AzString_fromUtf8(raw_data(buf[:]), uint(n))
-	label := azul.AzDom_createText(counter_str)
+	label := azul.AzDom_createTextDoNotUseWithoutBlockLevelWrapper(counter_str)
 
 	label_wrapper := azul.AzDom_createDiv()
 	font_size := azul.AzStyleFontSize_px(32.0)

--- a/doc/guide/en/hello-world/pascal.md
+++ b/doc/guide/en/hello-world/pascal.md
@@ -162,11 +162,11 @@ begin
     Exit;
   end;
 
-  { Idiomatic wrapper classes: TDom.CreateText / CreateDiv / CreateBody are
+  { Idiomatic wrapper classes: TDom.CreateTextDoNotUseWithoutBlockLevelWrapper / CreateDiv / CreateBody are
     named constructors; builder methods return fresh TDom wrappers and
     consume their by-value inputs, so .Free on a consumed wrapper only
     releases the object shell, never the DOM it was moved into. }
-  counter_text := TDom.CreateText(MakeAzString(IntToStr(TMyModel(m).Counter)));
+  counter_text := TDom.CreateTextDoNotUseWithoutBlockLevelWrapper(MakeAzString(IntToStr(TMyModel(m).Counter)));
   label_wrap := TDom.CreateDiv.WithCss(MakeAzString('font-size: 32px;'))
                               .WithChild(counter_text);
 

--- a/doc/guide/en/hello-world/php.md
+++ b/doc/guide/en/hello-world/php.md
@@ -97,10 +97,10 @@ function on_click(int $data): int {
 function layout(int $data): \Azul\Dom {
     $m   = json_decode(azul_refany_get($data), true);
     $div = \Azul\Dom::createDiv();
-    $div->addChild(\Azul\Dom::createText((string) ($m['counter'] ?? 0)));
+    $div->addChild(\Azul\Dom::createTextDoNotUseWithoutBlockLevelWrapper((string) ($m['counter'] ?? 0)));
 
     $btn = \Azul\Dom::createDiv();
-    $btn->addChild(\Azul\Dom::createText('Increase counter'));
+    $btn->addChild(\Azul\Dom::createTextDoNotUseWithoutBlockLevelWrapper('Increase counter'));
     $btn->onClick($data, $GLOBALS['azul_onclick_id']);
 
     $body = \Azul\Dom::createBody();

--- a/doc/guide/en/hello-world/python.md
+++ b/doc/guide/en/hello-world/python.md
@@ -96,7 +96,7 @@ def layout(data, info):
     # .with_css(...) consumes self and returns a new Dom, so builder
     # calls chain inline.
     label = (Dom.create_div()
-             .with_child(Dom.create_text(str(data.counter)))
+             .with_child(Dom.create_text_do_not_use_without_block_level_wrapper(str(data.counter)))
              .with_css("font-size: 32px;"))
 
     # Button widget with a click handler. Everything lives in the flat

--- a/doc/guide/en/hello-world/ruby.md
+++ b/doc/guide/en/hello-world/ruby.md
@@ -95,7 +95,7 @@ layout = lambda do |data_ptr, _info|
   # Style a node with a plain CSS string via .with_css.
   label = Azul::Dom.create_div
     .with_css('font-size: 32px;')
-    .with_child(Azul::Dom.create_text(m.counter.to_s))
+    .with_child(Azul::Dom.create_text_do_not_use_without_block_level_wrapper(m.counter.to_s))
 
   # Smart .on_click(data, &block) wraps refany + registers internally.
   button = Azul::Button.create('Increase counter')

--- a/doc/guide/en/hello-world/rust.md
+++ b/doc/guide/en/hello-world/rust.md
@@ -221,7 +221,7 @@ fn my_layout_func(mut data: RefAny, _: LayoutCallbackInfo) -> Dom {
     // Canonical shape: body > div{font-size:32px} > text(counter).
     let label_dom = Dom::create_div()
         .with_css("font-size: 32px")
-        .with_child(Dom::create_text(counter.as_str()));
+        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper(counter.as_str()));
 
     // We use the "button" widget with its own API
     let mut button = Button::create("Update counter");

--- a/doc/guide/en/hello-world/scala.md
+++ b/doc/guide/en/hello-world/scala.md
@@ -123,7 +123,7 @@ object HelloWorld {
           case m: MyDataModel =>
             val label = Dom.createDiv()
               .withCss("font-size: 32px;")
-              .withChild(Dom.createText(String.valueOf(m.counter)))
+              .withChild(Dom.createTextDoNotUseWithoutBlockLevelWrapper(String.valueOf(m.counter)))
             val buttonDom = new Dom(
               Button.create("Increase counter")
                 .withButtonType(ButtonType.Primary.value)

--- a/doc/guide/en/hello-world/swift.md
+++ b/doc/guide/en/hello-world/swift.md
@@ -160,7 +160,7 @@ func layout(_ data: AzRefAny, _ info: AzLayoutCallbackInfo) -> AzDom {
     guard let m = myDataDowncast(&d) else { return AzDom_createBody() }
 
     let counterStr = azString(String(m.pointee.counter))
-    let label = AzDom_createText(counterStr)
+    let label = AzDom_createTextDoNotUseWithoutBlockLevelWrapper(counterStr)
 
     var labelWrapper = AzDom_createDiv()
     let fontSize = AzStyleFontSize_px(32.0)

--- a/doc/guide/en/hello-world/v.md
+++ b/doc/guide/en/hello-world/v.md
@@ -148,7 +148,7 @@ fn layout(data azul.AzRefAny, info azul.AzLayoutCallbackInfo) azul.AzDom {
 	}
 
 	counter_val := unsafe { m.counter }
-	label := C.AzDom_createText(az_str(counter_val.str()))
+	label := C.AzDom_createTextDoNotUseWithoutBlockLevelWrapper(az_str(counter_val.str()))
 
 	mut label_wrapper := C.AzDom_createDiv()
 	css_prop := C.AzCssProperty_fontSize(C.AzStyleFontSize_px(32.0))

--- a/doc/guide/en/hello-world/zig.md
+++ b/doc/guide/en/hello-world/zig.md
@@ -166,7 +166,7 @@ fn layout(data: C.AzRefAny, _: C.AzLayoutCallbackInfo) callconv(.c) C.AzDom {
     var buf: [16]u8 = undefined;
     const slice = std.fmt.bufPrint(&buf, "{d}", .{m.counter}) catch return C.AzDom_createBody();
     const counter_str = C.AzString_fromUtf8(slice.ptr, slice.len);
-    const label = C.AzDom_createText(counter_str);
+    const label = C.AzDom_createTextDoNotUseWithoutBlockLevelWrapper(counter_str);
 
     var label_wrapper = C.AzDom_createDiv();
     const font_size = C.AzStyleFontSize_px(32.0);

--- a/doc/guide/en/internals/dom.md
+++ b/doc/guide/en/internals/dom.md
@@ -74,7 +74,7 @@ Anonymous boxes are inserted by the table-layout fixup pass when a `<table>` anc
 
 ## Building a Dom
 
-The builder API is method-chained. `Dom::create_div()`, `Dom::create_p()`, `Dom::create_text(s)` are `const fn` constructors; `with_child`, `with_id`, `with_class`, `with_callback` consume `self` and return it:
+The builder API is method-chained. `Dom::create_div()`, `Dom::create_p()`, `Dom::create_text_do_not_use_without_block_level_wrapper(s)` are `const fn` constructors; `with_child`, `with_id`, `with_class`, `with_callback` consume `self` and return it:
 
 ```rust,ignore
 use azul::dom::{Dom, On};
@@ -85,7 +85,7 @@ let dom = Dom::create_div()
     .with_class("container".into())
     .with_child(
         Dom::create_p()
-            .with_child(Dom::create_text("Hello"))
+            .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Hello"))
     )
     .with_child(
         Dom::create_button()

--- a/doc/guide/en/pdf.md
+++ b/doc/guide/en/pdf.md
@@ -65,7 +65,7 @@ layout splits the document across as many pages as it needs, each
 ```rust
 fn doc_page() -> Dom {
     Dom::create_body()
-        .with_child(Dom::create_text("Invoice #42").with_css("font-size: 32px;"))
+        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Invoice #42").with_css("font-size: 32px;"))
         .with_child(/* ... tables, paragraphs, images ... */)
 }
 

--- a/doc/guide/en/widgets/structural.md
+++ b/doc/guide/en/widgets/structural.md
@@ -65,7 +65,7 @@ let dom = Dom::create_div()
             .with_on_click(RefAny::new(()), on_tab)
             .dom()
     )
-    .with_child(Dom::create_text("Settings go here."));
+    .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Settings go here."));
 ```
 
 `TabHeader` keeps `active_tab: usize` and emits `TabHeaderState { active_tab }`

--- a/doc/src/codegen/v2/lang_lua/mod.rs
+++ b/doc/src/codegen/v2/lang_lua/mod.rs
@@ -284,7 +284,7 @@ pub fn generate(ir: &CodegenIR, _config: &CodegenConfig) -> Result<String> {
     //    - `azul.String.from_lua(s)` — explicit Lua-string → AzString.
     //    - `azul._az_string(v)` — auto-conversion helper used by the
     //      wrapper codegen for every Owned `String` arg, so plain Lua
-    //      strings flow through `Dom.create_text("hi")` directly.
+    //      strings flow through `Dom.create_text_do_not_use_without_block_level_wrapper("hi")` directly.
     builder.line("");
     builder.line("-- Postlude: convenience helpers that hang off generated wrappers.");
     builder.line("azul.String.from_lua = function(s)");

--- a/doc/src/codegen/v2/lang_node/wrappers.rs
+++ b/doc/src/codegen/v2/lang_node/wrappers.rs
@@ -89,7 +89,7 @@ pub fn generate_wrappers(b: &mut CodeBuilder, ir: &CodegenIR) {
 
     // Auto-AzString-conversion helper. Wrapper methods route Owned
     // `String` args through this so user code can pass plain JS
-    // strings directly (`Dom.create_text(\"hi\")`). Pass-through for
+    // strings directly (`Dom.create_text_do_not_use_without_block_level_wrapper(\"hi\")`). Pass-through for
     // already-AzString values (existing koffi objects or wrapper
     // instances with `_ptr`). Pure type-driven; no method-name allow-
     // list (the codegen detects `type_name == \"String\"` + Owned in

--- a/doc/src/codegen/v2/lang_ruby/managed.rs
+++ b/doc/src/codegen/v2/lang_ruby/managed.rs
@@ -115,7 +115,7 @@ pub fn emit_managed_module(builder: &mut super::super::generator::CodeBuilder, i
     // idempotent across the wrapper layer's call paths.
     builder.line("# Auto-AzString-conversion helper.");
     builder.line("# Wrapper methods route every Owned `String` arg through this so");
-    builder.line("# user code can pass plain Ruby strings directly (Dom.create_text(\"hi\")).");
+    builder.line("# user code can pass plain Ruby strings directly (Dom.create_text_do_not_use_without_block_level_wrapper(\"hi\")).");
     builder.line("def self._az_string(val)");
     builder.indent();
     builder.line("return val if val.is_a?(FFI::Struct) || val.is_a?(FFI::Pointer)");

--- a/doc/src/codegen/v2/lang_rust.rs
+++ b/doc/src/codegen/v2/lang_rust.rs
@@ -2098,7 +2098,7 @@ impl RustGenerator {
                 //   fn append_children(children: impl Into<DomVec>) allows vec![...] directly
                 //
                 // This allows ergonomic API like:
-                //   Dom::create_text("hello")  where &str: Into<AzString>
+                //   Dom::create_text_do_not_use_without_block_level_wrapper("hello")  where &str: Into<AzString>
                 //   Dom::append(button)  where button: Button (if Button: Into<Dom>)
                 //   Dom::append_children(vec![child1, child2])  where Vec<Dom>: Into<DomVec>
                 let is_callback_type = callback_typedefs.contains(arg.type_name.as_str())

--- a/examples/azul-camera/src/main.rs
+++ b/examples/azul-camera/src/main.rs
@@ -52,8 +52,8 @@ extern "C" fn layout(mut data: RefAny, _info: LayoutCallbackInfo) -> Dom {
     Dom::create_body().with_child(
         Dom::create_div()
             .with_css(ROOT)
-            .with_child(Dom::create_text("📷 AzCamera").with_css(TITLE))
-            .with_child(Dom::create_text("live preview · CameraWidget").with_css(SUBTITLE))
+            .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("📷 AzCamera").with_css(TITLE))
+            .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("live preview · CameraWidget").with_css(SUBTITLE))
             .with_child(CameraWidget::create(config).dom().with_css(PREVIEW)),
     )
 }

--- a/examples/azul-gamepad/src/main.rs
+++ b/examples/azul-gamepad/src/main.rs
@@ -83,7 +83,7 @@ const TRIG_TRACK: &str = "width: 124px; height: 16px; border-radius: 8px; \
 fn chip(label: &str, pressed: bool) -> Dom {
     Dom::create_div()
         .with_css(if pressed { CHIP_ON } else { CHIP_OFF })
-        .with_child(Dom::create_text(label))
+        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper(label))
 }
 
 fn button_row(pad: &GamepadState, group: &[(&str, GamepadButton)]) -> Dom {
@@ -124,11 +124,11 @@ extern "C" fn layout(mut data: RefAny, _info: LayoutCallbackInfo) -> Dom {
     let body = match pad {
         None => Dom::create_div()
             .with_css(WAITING)
-            .with_child(Dom::create_text("No controller connected — plug one in.")),
+            .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("No controller connected — plug one in.")),
         Some(p) => Dom::create_div()
             .with_css(PANEL)
             .with_child(
-                Dom::create_text(format!("Controller #{}", p.id.id).as_str()).with_css(SUBTITLE),
+                Dom::create_text_do_not_use_without_block_level_wrapper(format!("Controller #{}", p.id.id).as_str()).with_css(SUBTITLE),
             )
             .with_child(button_row(&p, &FACE))
             .with_child(button_row(&p, &SHOULDER))
@@ -151,7 +151,7 @@ extern "C" fn layout(mut data: RefAny, _info: LayoutCallbackInfo) -> Dom {
     Dom::create_body().with_child(
         Dom::create_div()
             .with_css(ROOT)
-            .with_child(Dom::create_text("🎮 Gamepad").with_css(TITLE))
+            .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("🎮 Gamepad").with_css(TITLE))
             .with_child(body),
     )
 }

--- a/examples/azul-maps/src/lib.rs
+++ b/examples/azul-maps/src/lib.rs
@@ -237,14 +237,14 @@ extern "C" fn layout(mut data: RefAny, _info: LayoutCallbackInfo) -> Dom {
 
     let header = Dom::create_div()
         .with_css(HEADER)
-        .with_child(Dom::create_text(header_text.as_str()))
+        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper(header_text.as_str()))
         .with_child(
             Dom::create_div()
                 .with_css("display: flex; flex-direction: row;")
                 .with_child(
                     Dom::create_div()
                         .with_css(BTN)
-                        .with_child(Dom::create_text("←"))
+                        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("←"))
                         .with_callback(
                             EventFilter::Hover(HoverEventFilter::MouseUp),
                             data.clone(),
@@ -254,7 +254,7 @@ extern "C" fn layout(mut data: RefAny, _info: LayoutCallbackInfo) -> Dom {
                 .with_child(
                     Dom::create_div()
                         .with_css(BTN)
-                        .with_child(Dom::create_text("→"))
+                        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("→"))
                         .with_callback(
                             EventFilter::Hover(HoverEventFilter::MouseUp),
                             data.clone(),
@@ -264,7 +264,7 @@ extern "C" fn layout(mut data: RefAny, _info: LayoutCallbackInfo) -> Dom {
                 .with_child(
                     Dom::create_div()
                         .with_css(BTN)
-                        .with_child(Dom::create_text("↑"))
+                        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("↑"))
                         .with_callback(
                             EventFilter::Hover(HoverEventFilter::MouseUp),
                             data.clone(),
@@ -274,7 +274,7 @@ extern "C" fn layout(mut data: RefAny, _info: LayoutCallbackInfo) -> Dom {
                 .with_child(
                     Dom::create_div()
                         .with_css(BTN)
-                        .with_child(Dom::create_text("↓"))
+                        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("↓"))
                         .with_callback(
                             EventFilter::Hover(HoverEventFilter::MouseUp),
                             data.clone(),
@@ -284,7 +284,7 @@ extern "C" fn layout(mut data: RefAny, _info: LayoutCallbackInfo) -> Dom {
                 .with_child(
                     Dom::create_div()
                         .with_css(BTN)
-                        .with_child(Dom::create_text("+"))
+                        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("+"))
                         .with_callback(
                             EventFilter::Hover(HoverEventFilter::MouseUp),
                             data.clone(),
@@ -294,7 +294,7 @@ extern "C" fn layout(mut data: RefAny, _info: LayoutCallbackInfo) -> Dom {
                 .with_child(
                     Dom::create_div()
                         .with_css(BTN)
-                        .with_child(Dom::create_text("−"))
+                        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("−"))
                         .with_callback(
                             EventFilter::Hover(HoverEventFilter::MouseUp),
                             data.clone(),
@@ -304,7 +304,7 @@ extern "C" fn layout(mut data: RefAny, _info: LayoutCallbackInfo) -> Dom {
                 .with_child(
                     Dom::create_div()
                         .with_css(BTN)
-                        .with_child(Dom::create_text("Recentre"))
+                        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Recentre"))
                         .with_callback(
                             EventFilter::Hover(HoverEventFilter::MouseUp),
                             data.clone(),
@@ -314,7 +314,7 @@ extern "C" fn layout(mut data: RefAny, _info: LayoutCallbackInfo) -> Dom {
                 .with_child(
                     Dom::create_div()
                         .with_css(if locating { BTN_ON } else { BTN })
-                        .with_child(Dom::create_text(if locating {
+                        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper(if locating {
                             "Locating…"
                         } else if locate_failed {
                             "Location N/A"
@@ -330,7 +330,7 @@ extern "C" fn layout(mut data: RefAny, _info: LayoutCallbackInfo) -> Dom {
                 .with_child(
                     Dom::create_div()
                         .with_css(BTN)
-                        .with_child(Dom::create_text("Clear pins"))
+                        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Clear pins"))
                         .with_callback(
                             EventFilter::Hover(HoverEventFilter::MouseUp),
                             data.clone(),
@@ -392,7 +392,7 @@ extern "C" fn layout(mut data: RefAny, _info: LayoutCallbackInfo) -> Dom {
             .with_child(
                 Dom::create_div()
                     .with_css(LOCATION_READOUT)
-                    .with_child(Dom::create_text(readout.as_str())),
+                    .with_child(Dom::create_text_do_not_use_without_block_level_wrapper(readout.as_str())),
             );
     }
 
@@ -432,7 +432,7 @@ extern "C" fn layout(mut data: RefAny, _info: LayoutCallbackInfo) -> Dom {
             map_container = map_container.with_child(
                 Dom::create_div()
                     .with_css(callout_style.as_str())
-                    .with_child(Dom::create_text(
+                    .with_child(Dom::create_text_do_not_use_without_block_level_wrapper(
                         format!("{:.4}, {:.4}", lat, lon).as_str(),
                     )),
             );
@@ -464,7 +464,7 @@ extern "C" fn layout(mut data: RefAny, _info: LayoutCallbackInfo) -> Dom {
     map_container = map_container.with_child(
         Dom::create_div()
             .with_css(ATTRIB)
-            .with_child(Dom::create_text(attribution_text.as_str())),
+            .with_child(Dom::create_text_do_not_use_without_block_level_wrapper(attribution_text.as_str())),
     );
 
     Dom::create_body()

--- a/examples/azul-meet/src/main.rs
+++ b/examples/azul-meet/src/main.rs
@@ -42,23 +42,23 @@ const BTN_ON: &str = "padding: 10px 18px; margin: 0 6px; border-radius: 8px; \
     background: #2f6db0; color: #ffffff; font-size: 14px;";
 
 fn participant(name: &str) -> Dom {
-    Dom::create_div().with_css(TILE).with_child(Dom::create_text(name))
+    Dom::create_div().with_css(TILE).with_child(Dom::create_text_do_not_use_without_block_level_wrapper(name))
 }
 
 /// One column of the settings strip: a device-kind heading + the device names.
 fn device_col(title: &str, devices: &[String]) -> Dom {
     let mut col = Dom::create_div().with_css("display: flex; flex-direction: column; margin: 0 28px;");
     col = col.with_child(
-        Dom::create_text(title).with_css("font-size: 13px; color: #8890a8; margin-bottom: 4px;"),
+        Dom::create_text_do_not_use_without_block_level_wrapper(title).with_css("font-size: 13px; color: #8890a8; margin-bottom: 4px;"),
     );
     if devices.is_empty() {
         col = col.with_child(
-            Dom::create_text("(none detected)").with_css("font-size: 13px; color: #667;"),
+            Dom::create_text_do_not_use_without_block_level_wrapper("(none detected)").with_css("font-size: 13px; color: #667;"),
         );
     } else {
         for d in devices {
             col = col.with_child(
-                Dom::create_text(d.as_str()).with_css("font-size: 13px; color: #ccd; padding: 2px 0;"),
+                Dom::create_text_do_not_use_without_block_level_wrapper(d.as_str()).with_css("font-size: 13px; color: #ccd; padding: 2px 0;"),
             );
         }
     }
@@ -88,7 +88,7 @@ extern "C" fn layout(mut data: RefAny, _info: LayoutCallbackInfo) -> Dom {
     } else {
         Dom::create_div()
             .with_css(TILE)
-            .with_child(Dom::create_text("You · camera off"))
+            .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("You · camera off"))
     };
 
     // --- video grid: self + (optional) screen-share + remote placeholders ---
@@ -115,7 +115,7 @@ extern "C" fn layout(mut data: RefAny, _info: LayoutCallbackInfo) -> Dom {
         .with_child(
             Dom::create_div()
                 .with_css(if mic { BTN_ON } else { BTN })
-                .with_child(Dom::create_text(if mic { "Mute" } else { "Unmute mic" }))
+                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper(if mic { "Mute" } else { "Unmute mic" }))
                 .with_callback(
                     EventFilter::Hover(HoverEventFilter::MouseUp),
                     data.clone(),
@@ -125,7 +125,7 @@ extern "C" fn layout(mut data: RefAny, _info: LayoutCallbackInfo) -> Dom {
         .with_child(
             Dom::create_div()
                 .with_css(if cam { BTN_ON } else { BTN })
-                .with_child(Dom::create_text(if cam { "Stop video" } else { "Start video" }))
+                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper(if cam { "Stop video" } else { "Start video" }))
                 .with_callback(
                     EventFilter::Hover(HoverEventFilter::MouseUp),
                     data.clone(),
@@ -135,7 +135,7 @@ extern "C" fn layout(mut data: RefAny, _info: LayoutCallbackInfo) -> Dom {
         .with_child(
             Dom::create_div()
                 .with_css(if screen { BTN_ON } else { BTN })
-                .with_child(Dom::create_text(if screen { "Stop share" } else { "Share screen" }))
+                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper(if screen { "Stop share" } else { "Share screen" }))
                 .with_callback(
                     EventFilter::Hover(HoverEventFilter::MouseUp),
                     data.clone(),
@@ -157,7 +157,7 @@ extern "C" fn layout(mut data: RefAny, _info: LayoutCallbackInfo) -> Dom {
          background: #0e0e14; font-family: sans-serif; color: #e6e6f0;",
     );
     body = body.with_child(
-        Dom::create_text(format!("AzMeet · meeting {}", link).as_str())
+        Dom::create_text_do_not_use_without_block_level_wrapper(format!("AzMeet · meeting {}", link).as_str())
             .with_css("padding: 12px; font-size: 18px; background: #15151c;"),
     );
     // While unmuted, a (visually tiny) MicrophoneWidget captures audio — its

--- a/examples/azul-paint/src/lib.rs
+++ b/examples/azul-paint/src/lib.rs
@@ -787,7 +787,7 @@ extern "C" fn layout(mut data: RefAny, _info: LayoutCallbackInfo) -> Dom {
     let mode_label = if metaballs { "Metaballs" } else { "Brush" };
     let header = Dom::create_div()
         .with_css(HEADER)
-        .with_child(Dom::create_text(
+        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper(
             format!("AzulPaint  ·  {} strokes  ·  Effect: {}", n_strokes, mode_label).as_str(),
         ));
 

--- a/examples/azul-screenshare/src/main.rs
+++ b/examples/azul-screenshare/src/main.rs
@@ -50,8 +50,8 @@ extern "C" fn layout(mut data: RefAny, _info: LayoutCallbackInfo) -> Dom {
     Dom::create_body().with_child(
         Dom::create_div()
             .with_css(ROOT)
-            .with_child(Dom::create_text("🖥 AzScreenShare").with_css(TITLE))
-            .with_child(Dom::create_text("live screen capture · ScreenCaptureWidget").with_css(SUBTITLE))
+            .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("🖥 AzScreenShare").with_css(TITLE))
+            .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("live screen capture · ScreenCaptureWidget").with_css(SUBTITLE))
             .with_child(ScreenCaptureWidget::create(config).dom().with_css(PREVIEW)),
     )
 }

--- a/examples/azul-self-test/src/lib.rs
+++ b/examples/azul-self-test/src/lib.rs
@@ -337,8 +337,8 @@ extern "C" fn layout(mut data: RefAny, _info: LayoutCallbackInfo) -> Dom {
     let camera = CameraWidget::create(CameraConfig::default()).dom();
 
     Dom::create_body()
-        .with_child(Dom::create_text("azul-self-test"))
-        .with_child(Dom::create_text(status.as_str()))
+        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("azul-self-test"))
+        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper(status.as_str()))
         .with_child(mic)
         .with_child(camera)
 }

--- a/examples/azul-spirit-level/src/main.rs
+++ b/examples/azul-spirit-level/src/main.rs
@@ -122,8 +122,8 @@ extern "C" fn layout(mut data: RefAny, _info: LayoutCallbackInfo) -> Dom {
     Dom::create_body().with_child(
         Dom::create_div()
             .with_css(ROOT)
-            .with_child(Dom::create_text("Spirit Level").with_css(TITLE))
-            .with_child(Dom::create_text("Wasserwaage · accelerometer").with_css(SUBTITLE))
+            .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Spirit Level").with_css(TITLE))
+            .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Wasserwaage · accelerometer").with_css(SUBTITLE))
             .with_child(
                 Dom::create_div().with_css(LEVEL_AREA).with_child(
                     Dom::create_div()
@@ -131,8 +131,8 @@ extern "C" fn layout(mut data: RefAny, _info: LayoutCallbackInfo) -> Dom {
                         .with_child(Dom::create_div().with_css(bubble_css.as_str())),
                 ),
             )
-            .with_child(Dom::create_text(readout.as_str()).with_css(READOUT))
-            .with_child(Dom::create_text(status).with_css(status_css)),
+            .with_child(Dom::create_text_do_not_use_without_block_level_wrapper(readout.as_str()).with_css(READOUT))
+            .with_child(Dom::create_text_do_not_use_without_block_level_wrapper(status).with_css(status_css)),
     )
 }
 

--- a/examples/azul-vault/src/main.rs
+++ b/examples/azul-vault/src/main.rs
@@ -103,12 +103,12 @@ extern "C" fn layout(mut data: RefAny, _info: LayoutCallbackInfo) -> Dom {
         return Dom::create_body().with_child(
             Dom::create_div()
                 .with_css(LOCKED)
-                .with_child(Dom::create_text("🔒 AzulVault").with_css(TITLE))
-                .with_child(Dom::create_text(status.as_str()).with_css(STATUS))
+                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("🔒 AzulVault").with_css(TITLE))
+                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper(status.as_str()).with_css(STATUS))
                 .with_child(
                     Dom::create_div()
                         .with_css(BTN)
-                        .with_child(Dom::create_text("Unlock with biometrics"))
+                        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Unlock with biometrics"))
                         .with_callback(
                             EventFilter::Hover(HoverEventFilter::MouseUp),
                             data.clone(),
@@ -125,23 +125,23 @@ extern "C" fn layout(mut data: RefAny, _info: LayoutCallbackInfo) -> Dom {
     );
     let mut body = Dom::create_div()
         .with_css(BODY)
-        .with_child(Dom::create_text(summary.as_str()));
+        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper(summary.as_str()));
     if entries.is_empty() {
-        body = body.with_child(Dom::create_text("No entries yet — add one.").with_css(EMPTY));
+        body = body.with_child(Dom::create_text_do_not_use_without_block_level_wrapper("No entries yet — add one.").with_css(EMPTY));
     } else {
         for (k, v) in &entries {
             body = body.with_child(
                 Dom::create_div()
                     .with_css(ENTRY_ROW)
-                    .with_child(Dom::create_text(k.as_str()).with_css(ENTRY_K))
-                    .with_child(Dom::create_text(v.as_str()).with_css(ENTRY_V)),
+                    .with_child(Dom::create_text_do_not_use_without_block_level_wrapper(k.as_str()).with_css(ENTRY_K))
+                    .with_child(Dom::create_text_do_not_use_without_block_level_wrapper(v.as_str()).with_css(ENTRY_V)),
             );
         }
     }
     body = body.with_child(
         Dom::create_div()
             .with_css(BTN)
-            .with_child(Dom::create_text("Add sample entry"))
+            .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Add sample entry"))
             .with_callback(
                 EventFilter::Hover(HoverEventFilter::MouseUp),
                 data.clone(),
@@ -151,7 +151,7 @@ extern "C" fn layout(mut data: RefAny, _info: LayoutCallbackInfo) -> Dom {
     Dom::create_body().with_child(
         Dom::create_div()
             .with_css(ROOT)
-            .with_child(Dom::create_text("🔓 AzulVault — unlocked").with_css(HEADER))
+            .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("🔓 AzulVault — unlocked").with_css(HEADER))
             .with_child(body),
     )
 }

--- a/examples/azul-widgets/src/lib.rs
+++ b/examples/azul-widgets/src/lib.rs
@@ -60,7 +60,7 @@ fn labelled(label: &str, widget: Dom) -> Dom {
     Dom::create_div()
         .with_css("display: flex; flex-direction: column; margin-bottom: 16px;")
         .with_child(
-            Dom::create_text(label)
+            Dom::create_text_do_not_use_without_block_level_wrapper(label)
                 .with_css("font-size: 12px; font-weight: bold; color: #667085; margin-bottom: 6px;"),
         )
         .with_child(widget)
@@ -74,7 +74,7 @@ fn section(title: &str, items: Vec<Dom>) -> Dom {
              border-radius: 10px; padding: 18px; margin-bottom: 20px;",
         )
         .with_child(
-            Dom::create_text(title).with_css(
+            Dom::create_text_do_not_use_without_block_level_wrapper(title).with_css(
                 "font-size: 18px; font-weight: bold; color: #1d2939; margin-bottom: 14px;",
             ),
         );
@@ -237,7 +237,7 @@ extern "C" fn layout(mut data: RefAny, _: LayoutCallbackInfo) -> Dom {
             labelled("Avatar", Avatar::create("FS").with_size(AvatarSize::Large).dom()),
             labelled(
                 "Card",
-                Card::create(Dom::create_text("Card body content"))
+                Card::create(Dom::create_text_do_not_use_without_block_level_wrapper("Card body content"))
                     .with_flex_grow(0.0)
                     .dom(),
             ),
@@ -287,7 +287,7 @@ extern "C" fn layout(mut data: RefAny, _: LayoutCallbackInfo) -> Dom {
             ),
             labelled(
                 "Modal (starts closed)",
-                Modal::create(Dom::create_text("Modal body goes here."))
+                Modal::create(Dom::create_text_do_not_use_without_block_level_wrapper("Modal body goes here."))
                     .with_title("Example dialog")
                     .with_open(false)
                     .with_close_button(true)
@@ -337,12 +337,12 @@ extern "C" fn layout(mut data: RefAny, _: LayoutCallbackInfo) -> Dom {
                 Accordion::new(vec![
                     AccordionSection {
                         title: "What is Azul?".into(),
-                        content: Dom::create_text("A cross-platform Rust GUI framework."),
+                        content: Dom::create_text_do_not_use_without_block_level_wrapper("A cross-platform Rust GUI framework."),
                         is_open: true,
                     },
                     AccordionSection {
                         title: "How do widgets work?".into(),
-                        content: Dom::create_text("Each widget builds a styled Dom."),
+                        content: Dom::create_text_do_not_use_without_block_level_wrapper("Each widget builds a styled Dom."),
                         is_open: false,
                     },
                 ])
@@ -364,7 +364,7 @@ extern "C" fn layout(mut data: RefAny, _: LayoutCallbackInfo) -> Dom {
                 "Popover (starts closed)",
                 Popover::new(
                     Button::create("Open popover").dom(),
-                    Dom::create_text("Popover content"),
+                    Dom::create_text_do_not_use_without_block_level_wrapper("Popover content"),
                 )
                 .with_open(false)
                 .with_on_toggle(
@@ -377,8 +377,8 @@ extern "C" fn layout(mut data: RefAny, _: LayoutCallbackInfo) -> Dom {
                 "SplitPane",
                 SplitPane::create(
                     SplitDirection::Horizontal,
-                    Dom::create_text("Left pane"),
-                    Dom::create_text("Right pane"),
+                    Dom::create_text_do_not_use_without_block_level_wrapper("Left pane"),
+                    Dom::create_text_do_not_use_without_block_level_wrapper("Right pane"),
                 )
                 .with_ratio(0.5)
                 .with_on_resize(
@@ -418,9 +418,9 @@ extern "C" fn layout(mut data: RefAny, _: LayoutCallbackInfo) -> Dom {
     );
 
     // ── Header ──────────────────────────────────────────────────────────
-    let heading = Dom::create_text("Azul Widget Showcase")
+    let heading = Dom::create_text_do_not_use_without_block_level_wrapper("Azul Widget Showcase")
         .with_css("font-size: 26px; font-weight: bold; color: #101828; margin-bottom: 4px;");
-    let subtitle = Dom::create_text(
+    let subtitle = Dom::create_text_do_not_use_without_block_level_wrapper(
         format!("Every built-in widget (callbacks fired so far: {})", s.interactions).as_str(),
     )
     .with_css("font-size: 13px; color: #667085; margin-bottom: 20px;");

--- a/examples/azul-writer/src/document.rs
+++ b/examples/azul-writer/src/document.rs
@@ -303,7 +303,7 @@ pub fn markdown_to_content_dom(markdown: &str) -> Dom {
         }
         Err(e) => Dom::create_div()
             .with_css(DOC_CSS)
-            .with_child(Dom::create_text(format!("markdown parse error: {e}"))),
+            .with_child(Dom::create_text_do_not_use_without_block_level_wrapper(format!("markdown parse error: {e}"))),
     }
 }
 

--- a/examples/azul-writer/src/editor_ui.rs
+++ b/examples/azul-writer/src/editor_ui.rs
@@ -131,17 +131,13 @@ fn canvas(
             crate::on_pages_unmounted as azul_layout::callbacks::CallbackType as usize,
         )
         // The VirtualView node IS the scroll container (same as
-        // examples/rust/src/infinity.rs): it needs its own scroll id to become
-        // a wheel target, or its ScrollManager offset never moves and
-        // `check_reinvoke` never sees an edge scroll — no paging, no scrollbar.
-        // `scroll` rather than `auto` because a VirtualView is a replaced
-        // element with no flow content, so the layout-side `auto` test
-        // (content > container) can never fire; `scroll` also reserves the
-        // bar's width during layout so it doesn't overlay the sheets.
-        .with_css(
-            "flex-grow: 1; min-height: 0px; width: 100%; \
-             overflow-x: hidden; overflow-y: scroll;",
-        ),
+        // examples/rust/src/infinity.rs). No overflow CSS needed: the UA
+        // stylesheet defaults a VirtualView to `overflow: auto`, and the
+        // virtual-size-aware necessity rule paints/updates the bar exactly
+        // when the published `virtual_scroll_size` overflows the viewport.
+        // (A VV that must not wheel-scroll opts out with `overflow: hidden`,
+        // as the map and video widgets do.)
+        .with_css("flex-grow: 1; min-height: 0px; width: 100%;"),
     );
     area
 }

--- a/examples/azul-writer/src/editor_ui.rs
+++ b/examples/azul-writer/src/editor_ui.rs
@@ -81,16 +81,17 @@ fn canvas(
 ) -> Dom {
     let _ = state;
     let mut area = Dom::create_div().with_css(
-        // overflow-y:auto (was hidden): the classic office-suite canvas SCROLLS — hidden
-        // cropped the sheet stack AND killed wheel + scrollbar entirely
-        // (live-run 2026-08-11 finding; the status bar was misread as the
-        // only chrome). With the #28 VirtualView the page window scrolls in
-        // ITS OWN frame (the engine synthesizes it from
-        // `virtual_scroll_size`); this stays `auto` as an inert fallback and
-        // must not regress.
+        // `overflow: hidden`, NOT `auto`: the scroll container is the
+        // VirtualView below, not this box. `compute_scroll_ids` hands a scroll
+        // id — and with it the wheel target — to every node whose overflow is
+        // hidden/scroll/auto, so an `auto` canvas swallowed the wheel that the
+        // VirtualView needs to page, and (with padding-top: 18px inflating the
+        // Taffy content size) grew a phantom scrollbar with a full-track thumb.
+        // `hidden` still crops the sheet stack the way classic office suites do
+        // and stays out of the wheel-target list.
         "flex-grow: 1; min-height: 0px; background: #e3e3e3; display: flex; \
          flex-direction: column; align-items: center; padding-top: 18px; \
-         overflow-x: hidden; overflow-y: auto;",
+         overflow: hidden;",
     );
     // #28: pages materialize lazily — the callback renders a ~3-page window
     // around the scroll position; everything else exists only as scrollbar
@@ -129,7 +130,18 @@ fn canvas(
             mount_ctx,
             crate::on_pages_unmounted as azul_layout::callbacks::CallbackType as usize,
         )
-        .with_css("flex-grow: 1; min-height: 0px; width: 100%;"),
+        // The VirtualView node IS the scroll container (same as
+        // examples/rust/src/infinity.rs): it needs its own scroll id to become
+        // a wheel target, or its ScrollManager offset never moves and
+        // `check_reinvoke` never sees an edge scroll — no paging, no scrollbar.
+        // `scroll` rather than `auto` because a VirtualView is a replaced
+        // element with no flow content, so the layout-side `auto` test
+        // (content > container) can never fire; `scroll` also reserves the
+        // bar's width during layout so it doesn't overlay the sheets.
+        .with_css(
+            "flex-grow: 1; min-height: 0px; width: 100%; \
+             overflow-x: hidden; overflow-y: scroll;",
+        ),
     );
     area
 }

--- a/examples/azul-writer/src/fonts.rs
+++ b/examples/azul-writer/src/fonts.rs
@@ -63,7 +63,7 @@ pub const WHITE: ColorU = ColorU { r: 255, g: 255, b: 255, a: 255 };
 /// same path the widgets use — is reliable, so every app-side label goes
 /// through this helper; wrapping DIVs own margins and layout.
 pub fn text(contents: &str, size_px: isize, color: ColorU) -> Dom {
-    Dom::create_text(contents).with_css_props(CssPropertyWithConditionsVec::from_vec(vec![
+    Dom::create_text_do_not_use_without_block_level_wrapper(contents).with_css_props(CssPropertyWithConditionsVec::from_vec(vec![
         CssPropertyWithConditions::simple(CssProperty::const_font_size(StyleFontSize::const_px(
             size_px,
         ))),

--- a/examples/azul-writer/src/ribbon_ui.rs
+++ b/examples/azul-writer/src/ribbon_ui.rs
@@ -117,7 +117,7 @@ fn column(items: Vec<RibbonItem>) -> RibbonItem {
 }
 
 fn cell(preview_css: &str, sample: &str, name: &str) -> RibbonGalleryCell {
-    RibbonGalleryCell::new(Dom::create_text(sample).with_css(preview_css), s(name))
+    RibbonGalleryCell::new(Dom::create_text_do_not_use_without_block_level_wrapper(sample).with_css(preview_css), s(name))
 }
 
 // ---------------------------------------------------------------------------

--- a/examples/c/a11y-test.c
+++ b/examples/c/a11y-test.c
@@ -36,7 +36,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
 
     // === Heading ===
     AzDom h1 = AzDom_createNode(AzNodeType_h1());
-    AzDom_addChild(&h1, AzDom_createText(AZ_STR("Accessibility Test Page")));
+    AzDom_addChild(&h1, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AZ_STR("Accessibility Test Page")));
     AzDom_addChild(&body, h1);
 
     // === Section 1: Text content ===
@@ -45,15 +45,15 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
         AzDom_addClass(&section, AZ_STR("section"));
 
         AzDom h2 = AzDom_createNode(AzNodeType_h2());
-        AzDom_addChild(&h2, AzDom_createText(AZ_STR("1. Text Content")));
+        AzDom_addChild(&h2, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AZ_STR("1. Text Content")));
         AzDom_addChild(&section, h2);
 
         AzDom p1 = AzDom_createP();
-        AzDom_addChild(&p1, AzDom_createText(AZ_STR("This is a paragraph of text. VoiceOver should read this content.")));
+        AzDom_addChild(&p1, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AZ_STR("This is a paragraph of text. VoiceOver should read this content.")));
         AzDom_addChild(&section, p1);
 
         AzDom p2 = AzDom_createP();
-        AzDom_addChild(&p2, AzDom_createText(AZ_STR("This is a second paragraph with different content.")));
+        AzDom_addChild(&p2, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AZ_STR("This is a second paragraph with different content.")));
         AzDom_addChild(&section, p2);
 
         AzDom_addChild(&body, section);
@@ -65,7 +65,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
         AzDom_addClass(&section, AZ_STR("section"));
 
         AzDom h2 = AzDom_createNode(AzNodeType_h2());
-        AzDom_addChild(&h2, AzDom_createText(AZ_STR("2. Buttons")));
+        AzDom_addChild(&h2, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AZ_STR("2. Buttons")));
         AzDom_addChild(&section, h2);
 
         AzDom btn1 = AzDom_createButton(AZ_STR("Click Me"), AzSmallAriaInfo_label(AZ_STR("Click Me")));
@@ -86,13 +86,13 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
         AzDom_addClass(&section, AZ_STR("section"));
 
         AzDom h2 = AzDom_createNode(AzNodeType_h2());
-        AzDom_addChild(&h2, AzDom_createText(AZ_STR("3. Links")));
+        AzDom_addChild(&h2, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AZ_STR("3. Links")));
         AzDom_addChild(&section, h2);
 
         AzDom link1 = AzDom_createA(AZ_STR("https://example.com"), AZ_STR("Example Website"), AzSmallAriaInfo_label(AZ_STR("Example Website")));
         AzDom_addChild(&section, link1);
 
-        AzDom_addChild(&section, AzDom_createText(AZ_STR(" | ")));
+        AzDom_addChild(&section, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AZ_STR(" | ")));
 
         AzDom link2 = AzDom_createA(AZ_STR("https://azul.rs"), AZ_STR("Azul Homepage"), AzSmallAriaInfo_label(AZ_STR("Azul Homepage")));
         AzDom_addChild(&section, link2);
@@ -106,7 +106,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
         AzDom_addClass(&section, AZ_STR("section"));
 
         AzDom h2 = AzDom_createNode(AzNodeType_h2());
-        AzDom_addChild(&h2, AzDom_createText(AZ_STR("4. Form Inputs")));
+        AzDom_addChild(&h2, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AZ_STR("4. Form Inputs")));
         AzDom_addChild(&section, h2);
 
         AzDom input1 = AzDom_createInput(AZ_STR("text"), AZ_STR("username"), AZ_STR("Username:"), AzSmallAriaInfo_label(AZ_STR("Username")));
@@ -127,18 +127,18 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
         AzDom_addClass(&section, AZ_STR("section"));
 
         AzDom h2 = AzDom_createNode(AzNodeType_h2());
-        AzDom_addChild(&h2, AzDom_createText(AZ_STR("5. Lists")));
+        AzDom_addChild(&h2, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AZ_STR("5. Lists")));
         AzDom_addChild(&section, h2);
 
         AzDom ul = AzDom_createUl();
         AzDom li1 = AzDom_createLi();
-        AzDom_addChild(&li1, AzDom_createText(AZ_STR("First item")));
+        AzDom_addChild(&li1, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AZ_STR("First item")));
         AzDom_addChild(&ul, li1);
         AzDom li2 = AzDom_createLi();
-        AzDom_addChild(&li2, AzDom_createText(AZ_STR("Second item")));
+        AzDom_addChild(&li2, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AZ_STR("Second item")));
         AzDom_addChild(&ul, li2);
         AzDom li3 = AzDom_createLi();
-        AzDom_addChild(&li3, AzDom_createText(AZ_STR("Third item")));
+        AzDom_addChild(&li3, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AZ_STR("Third item")));
         AzDom_addChild(&ul, li3);
         AzDom_addChild(&section, ul);
 
@@ -151,7 +151,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
         AzDom_addClass(&section, AZ_STR("section"));
 
         AzDom h2 = AzDom_createNode(AzNodeType_h2());
-        AzDom_addChild(&h2, AzDom_createText(AZ_STR("6. Table")));
+        AzDom_addChild(&h2, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AZ_STR("6. Table")));
         AzDom_addChild(&section, h2);
 
         AzDom table = AzDom_createTable(AZ_STR("Employee Directory"), AzSmallAriaInfo_label(AZ_STR("Employee directory table")));
@@ -159,29 +159,29 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
         // Header row
         AzDom tr_head = AzDom_createTr();
         AzDom th1 = AzDom_createTh();
-        AzDom_addChild(&th1, AzDom_createText(AZ_STR("Name")));
+        AzDom_addChild(&th1, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AZ_STR("Name")));
         AzDom_addChild(&tr_head, th1);
         AzDom th2 = AzDom_createTh();
-        AzDom_addChild(&th2, AzDom_createText(AZ_STR("Role")));
+        AzDom_addChild(&th2, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AZ_STR("Role")));
         AzDom_addChild(&tr_head, th2);
         AzDom_addChild(&table, tr_head);
 
         // Data rows
         AzDom tr1 = AzDom_createTr();
         AzDom td1a = AzDom_createTd();
-        AzDom_addChild(&td1a, AzDom_createText(AZ_STR("Alice")));
+        AzDom_addChild(&td1a, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AZ_STR("Alice")));
         AzDom_addChild(&tr1, td1a);
         AzDom td1b = AzDom_createTd();
-        AzDom_addChild(&td1b, AzDom_createText(AZ_STR("Developer")));
+        AzDom_addChild(&td1b, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AZ_STR("Developer")));
         AzDom_addChild(&tr1, td1b);
         AzDom_addChild(&table, tr1);
 
         AzDom tr2 = AzDom_createTr();
         AzDom td2a = AzDom_createTd();
-        AzDom_addChild(&td2a, AzDom_createText(AZ_STR("Bob")));
+        AzDom_addChild(&td2a, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AZ_STR("Bob")));
         AzDom_addChild(&tr2, td2a);
         AzDom td2b = AzDom_createTd();
-        AzDom_addChild(&td2b, AzDom_createText(AZ_STR("Designer")));
+        AzDom_addChild(&td2b, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AZ_STR("Designer")));
         AzDom_addChild(&tr2, td2b);
         AzDom_addChild(&table, tr2);
 
@@ -195,13 +195,13 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
         AzDom_addClass(&section, AZ_STR("section"));
 
         AzDom h2 = AzDom_createNode(AzNodeType_h2());
-        AzDom_addChild(&h2, AzDom_createText(AZ_STR("7. Contenteditable")));
+        AzDom_addChild(&h2, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AZ_STR("7. Contenteditable")));
         AzDom_addChild(&section, h2);
 
         AzDom editable = AzDom_createDiv();
         AzDom_addClass(&editable, AZ_STR("editable"));
         AzDom_setContenteditable(&editable, true);
-        AzDom_addChild(&editable, AzDom_createText(AZ_STR("Click here and type to edit this text.")));
+        AzDom_addChild(&editable, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AZ_STR("Click here and type to edit this text.")));
         AzDom_addChild(&section, editable);
 
         AzDom_addChild(&body, section);

--- a/examples/c/async.c
+++ b/examples/c/async.c
@@ -54,7 +54,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     
     // Title
     AzString title_text = str("Background Thread Progress Demo");
-    AzDom title = AzDom_createText(title_text);
+    AzDom title = AzDom_createTextDoNotUseWithoutBlockLevelWrapper(title_text);
     AzString title_style = str("font-size: 24px; margin-bottom: 30px;");
     AzDom_setCss(&title, title_style);
     AzDom_addChild(&body, title);
@@ -69,7 +69,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     char progress_buf[32];
     snprintf(progress_buf, sizeof(progress_buf), "Progress: %.0f%%", state.ptr->progress);
     AzString progress_label_text = str(progress_buf);
-    AzDom progress_label = AzDom_createText(progress_label_text);
+    AzDom progress_label = AzDom_createTextDoNotUseWithoutBlockLevelWrapper(progress_label_text);
     AzString progress_label_style = str("margin-bottom: 20px;");
     AzDom_setCss(&progress_label, progress_label_style);
     AzDom_addChild(&body, progress_label);
@@ -85,7 +85,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
         AzDom_addChild(&body, button);
     } else {
         AzString running_text = str("Processing...");
-        AzDom running = AzDom_createText(running_text);
+        AzDom running = AzDom_createTextDoNotUseWithoutBlockLevelWrapper(running_text);
         AzString running_style = str("color: #666;");
         AzDom_setCss(&running, running_style);
         AzDom_addChild(&body, running);

--- a/examples/c/azul-bench-flat.c
+++ b/examples/c/azul-bench-flat.c
@@ -112,7 +112,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
         int len = snprintf(buf, sizeof(buf), "row #%u (id=%u)", i, base_id + i);
         AzString label = AzString_copyFromBytes((const uint8_t*)buf, 0, len);
         AzDom row = AzDom_createDiv();
-        AzDom_addChild(&row, AzDom_createText(label));
+        AzDom_addChild(&row, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(label));
         AzDom_addChild(&body, row);
     }
 

--- a/examples/c/baseline.c
+++ b/examples/c/baseline.c
@@ -25,23 +25,23 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     AzDom_setCss(&para, az_str("background-color: #f0f0f0; padding: 20px;"));
     
     // Multiple text nodes with different font sizes
-    AzDom t1 = AzDom_createText(az_str("Small "));
+    AzDom t1 = AzDom_createTextDoNotUseWithoutBlockLevelWrapper(az_str("Small "));
     AzDom_setCss(&t1, az_str("font-size: 12px; background-color: #fdd;"));
     AzDom_addChild(&para, t1);
     
-    AzDom t2 = AzDom_createText(az_str("LARGE "));
+    AzDom t2 = AzDom_createTextDoNotUseWithoutBlockLevelWrapper(az_str("LARGE "));
     AzDom_setCss(&t2, az_str("font-size: 32px; background-color: #dfd;"));
     AzDom_addChild(&para, t2);
     
-    AzDom t3 = AzDom_createText(az_str("Medium "));
+    AzDom t3 = AzDom_createTextDoNotUseWithoutBlockLevelWrapper(az_str("Medium "));
     AzDom_setCss(&t3, az_str("font-size: 18px; background-color: #ddf;"));
     AzDom_addChild(&para, t3);
     
-    AzDom t4 = AzDom_createText(az_str("tiny "));
+    AzDom t4 = AzDom_createTextDoNotUseWithoutBlockLevelWrapper(az_str("tiny "));
     AzDom_setCss(&t4, az_str("font-size: 10px; background-color: #ffd;"));
     AzDom_addChild(&para, t4);
     
-    AzDom t5 = AzDom_createText(az_str("HUGE"));
+    AzDom t5 = AzDom_createTextDoNotUseWithoutBlockLevelWrapper(az_str("HUGE"));
     AzDom_setCss(&t5, az_str("font-size: 48px; background-color: #fdf;"));
     AzDom_addChild(&para, t5);
     

--- a/examples/c/bench-full-startup.c
+++ b/examples/c/bench-full-startup.c
@@ -37,7 +37,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     }
 
     AzDom body = AzDom_createBody();
-    AzDom label = AzDom_createText(AZ_STR("Hello World - Timing Benchmark"));
+    AzDom label = AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AZ_STR("Hello World - Timing Benchmark"));
     AzDom_addChild(&body, label);
     return body;
 }

--- a/examples/c/browser.c
+++ b/examples/c/browser.c
@@ -563,13 +563,13 @@ AzDom layout(AzRefAny data_ref, AzLayoutCallbackInfo info) {
     // If still loading or error, show status
     if (data->error_message != NULL) {
         AzDom body = AzDom_createBody();
-        AzDom_addChild(&body, AzDom_createText(az_str(data->error_message)));
+        AzDom_addChild(&body, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(az_str(data->error_message)));
         return body;
     }
 
     if (!data->has_xml) {
         AzDom body = AzDom_createBody();
-        AzDom_addChild(&body, AzDom_createText(az_str(data->status_message ? data->status_message : "Loading...")));
+        AzDom_addChild(&body, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(az_str(data->status_message ? data->status_message : "Loading...")));
         return body;
     }
     

--- a/examples/c/calc.c
+++ b/examples/c/calc.c
@@ -98,7 +98,7 @@ AzDom create_button(AzRefAny* calc, const char* label, EventType evt, char digit
     AzString style_str = AzString_copyFromBytes((const uint8_t*)style, 0, strlen(style));
     AzDom_setCss(&button, style_str);
     AzString label_str = AzString_copyFromBytes((const uint8_t*)label, 0, strlen(label));
-    AzDom_addChild(&button, AzDom_createText(label_str));
+    AzDom_addChild(&button, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(label_str));
     AzEventFilter event = AzEventFilter_hover(AzHoverEventFilter_mouseUp());
     AzDom_addCallback(&button, event, ButtonData_upcast(bd), on_button_click);
     
@@ -222,7 +222,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     AzDom display = AzDom_createDiv();
     AzString display_style = AzString_copyFromBytes((const uint8_t*)DISPLAY_STYLE, 0, strlen(DISPLAY_STYLE));
     AzDom_setCss(&display, display_style);
-    AzDom_addChild(&display, AzDom_createText(AzString_copyFromBytes((uint8_t*)display_text, 0, strlen(display_text))));
+    AzDom_addChild(&display, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AzString_copyFromBytes((uint8_t*)display_text, 0, strlen(display_text))));
 
     // Buttons grid
     AzDom buttons = AzDom_createDiv();

--- a/examples/c/chart.c
+++ b/examples/c/chart.c
@@ -157,7 +157,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     ));
 
     // === Title ===
-    AzDom title = AzDom_createText(az_str("Chart Demo - SVG Clip Masks"));
+    AzDom title = AzDom_createTextDoNotUseWithoutBlockLevelWrapper(az_str("Chart Demo - SVG Clip Masks"));
     AzDom_setCss(&title, az_str(
         "font-size: 24px;"
         "color: white;"
@@ -175,7 +175,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
         "border-radius: 12px;"
     ));
 
-    AzDom bar_title = AzDom_createText(az_str("Monthly Revenue (Bar Chart with Clip Masks)"));
+    AzDom bar_title = AzDom_createTextDoNotUseWithoutBlockLevelWrapper(az_str("Monthly Revenue (Bar Chart with Clip Masks)"));
     AzDom_setCss(&bar_title, az_str(
         "font-size: 16px;"
         "color: #eee;"
@@ -235,7 +235,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
         AzDom_addChild(&bar_col, bar);
 
         // Label below bar
-        AzDom label = AzDom_createText(az_str(bar_labels[i]));
+        AzDom label = AzDom_createTextDoNotUseWithoutBlockLevelWrapper(az_str(bar_labels[i]));
         AzDom_setCss(&label, az_str(
             "color: #aaa;"
             "font-size: 12px;"
@@ -246,7 +246,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
         // Value label
         char val_buf[32];
         snprintf(val_buf, sizeof(val_buf), "%d%%", (int)(bar_values[i] * 100));
-        AzDom val_label = AzDom_createText(az_str(val_buf));
+        AzDom val_label = AzDom_createTextDoNotUseWithoutBlockLevelWrapper(az_str(val_buf));
         AzDom_setCss(&val_label, az_str(
             "color: white;"
             "font-size: 11px;"
@@ -270,7 +270,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
         "border-radius: 12px;"
     ));
 
-    AzDom pie_title = AzDom_createText(az_str("Distribution (Pie Chart with Clip Masks)"));
+    AzDom pie_title = AzDom_createTextDoNotUseWithoutBlockLevelWrapper(az_str("Distribution (Pie Chart with Clip Masks)"));
     AzDom_setCss(&pie_title, az_str(
         "font-size: 16px;"
         "color: #eee;"

--- a/examples/c/drag-drop-test.c
+++ b/examples/c/drag-drop-test.c
@@ -394,7 +394,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     );
     drag_box = AzDom_withClass(drag_box, AZ_STR("drag-box"));
     drag_box = AzDom_withAttribute(drag_box, AzAttributeType_draggable(true));
-    drag_box = AzDom_withChild(drag_box, AzDom_createText(AZ_STR("Drag Me")));
+    drag_box = AzDom_withChild(drag_box, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AZ_STR("Drag Me")));
     drag_box = AzDom_withCallback(drag_box,
         AzEventFilter_hover(AzHoverEventFilter_dragStart()),
         data1, on_drag_start);
@@ -424,11 +424,11 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     );
     zone_a = AzDom_withClass(zone_a, AZ_STR("drop-zone"));
     zone_a = AzDom_withChild(zone_a, AzDom_withCss(
-        AzDom_createText(AZ_STR("Drop Zone A")),
+        AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AZ_STR("Drop Zone A")),
         AZ_STR("font-size: 16px; font-weight: bold;")
     ));
     zone_a = AzDom_withChild(zone_a, AzDom_withCss(
-        AzDom_createText(AZ_STR("(text/plain)")),
+        AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AZ_STR("(text/plain)")),
         AZ_STR("font-size: 12px; margin-top: 5px; color: #60a5fa;")
     ));
     zone_a = AzDom_withCallback(zone_a,
@@ -451,11 +451,11 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     );
     zone_b = AzDom_withClass(zone_b, AZ_STR("drop-zone"));
     zone_b = AzDom_withChild(zone_b, AzDom_withCss(
-        AzDom_createText(AZ_STR("Drop Zone B")),
+        AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AZ_STR("Drop Zone B")),
         AZ_STR("font-size: 16px; font-weight: bold;")
     ));
     zone_b = AzDom_withChild(zone_b, AzDom_withCss(
-        AzDom_createText(AZ_STR("(text/html)")),
+        AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AZ_STR("(text/html)")),
         AZ_STR("font-size: 12px; margin-top: 5px; color: #fb923c;")
     ));
     zone_b = AzDom_withCallback(zone_b,
@@ -470,14 +470,14 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
 
     // ── Status display ──
     AzDom status_text = AzDom_withCss(
-        AzDom_createText(AzString_copyFromBytes(
+        AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AzString_copyFromBytes(
             (const uint8_t*)status_buf, 0, strlen(status_buf))),
         AZ_STR("font-size: 14px; color: #e2e8f0; background: #1e293b; "
                "padding: 10px; border-radius: 4px; font-family: monospace;")
     );
 
     AzDom stats_text = AzDom_withCss(
-        AzDom_createText(AzString_copyFromBytes(
+        AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AzString_copyFromBytes(
             (const uint8_t*)stats_buf, 0, strlen(stats_buf))),
         AZ_STR("font-size: 12px; color: #94a3b8; background: #1e293b; "
                "padding: 8px; border-radius: 4px; margin-top: 5px; "

--- a/examples/c/dropdown.c
+++ b/examples/c/dropdown.c
@@ -58,12 +58,12 @@ AzDom layout(AzRefAny data_ref, AzLayoutCallbackInfo info) {
     AzDom title = AzDom_createP();
     AzDom_addCssProperty(&title, AzCssPropertyWithConditions_simple(
         AzCssProperty_fontSize(AzStyleFontSize_px(20.0))));
-    AzDom_addChild(&title, AzDom_createText(az("Dropdown Widget Demo")));
+    AzDom_addChild(&title, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(az("Dropdown Widget Demo")));
     AzDom_addChild(&body, title);
 
     // Fruit label — wrapped in <p>
     AzDom fruit_label = AzDom_createP();
-    AzDom_addChild(&fruit_label, AzDom_createText(az("Fruit:")));
+    AzDom_addChild(&fruit_label, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(az("Fruit:")));
     AzDom_addChild(&body, fruit_label);
 
     AzDropDown fruit_dd = AzDropDown_create(make_choices(FRUITS, NUM_FRUITS));
@@ -73,7 +73,7 @@ AzDom layout(AzRefAny data_ref, AzLayoutCallbackInfo info) {
 
     // Color label — wrapped in <p>
     AzDom color_label = AzDom_createP();
-    AzDom_addChild(&color_label, AzDom_createText(az("Color:")));
+    AzDom_addChild(&color_label, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(az("Color:")));
     AzDom_addChild(&body, color_label);
 
     AzDropDown color_dd = AzDropDown_create(make_choices(COLORS, NUM_COLORS));
@@ -86,7 +86,7 @@ AzDom layout(AzRefAny data_ref, AzLayoutCallbackInfo info) {
     int len = snprintf(status, sizeof(status), "Selected: %s, %s",
         FRUITS[sel_fruit], COLORS[sel_color]);
     AzDom status_p = AzDom_createP();
-    AzDom_addChild(&status_p, AzDom_createText(
+    AzDom_addChild(&status_p, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(
         AzString_copyFromBytes((const uint8_t*)status, 0, len)));
     AzDom_addChild(&body, status_p);
 

--- a/examples/c/effects-showcase.c
+++ b/examples/c/effects-showcase.c
@@ -16,7 +16,7 @@ static AzDom make_styled_div(const char* css, const char* text) {
     AzDom div = AzDom_createDiv();
     AzDom_setCss(&div, AZ_STR(css));
     if (text && text[0]) {
-        AzDom_addChild(&div, AzDom_createText(AZ_STR(text)));
+        AzDom_addChild(&div, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AZ_STR(text)));
     }
     return div;
 }
@@ -26,7 +26,7 @@ static AzDom make_label(const char* text) {
     AzDom_setCss(&label, AZ_STR(
         "font-size: 10px; color: #888; text-align: center; margin-top: 4px;"
     ));
-    AzDom_addChild(&label, AzDom_createText(AZ_STR(text)));
+    AzDom_addChild(&label, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AZ_STR(text)));
     return label;
 }
 
@@ -57,7 +57,7 @@ static AzDom make_section_header(const char* title) {
         "grid-column-start: 1; grid-column-end: 5;"
         "border-bottom: 1px solid #ddd; padding-bottom: 4px;"
     ));
-    AzDom_addChild(&h, AzDom_createText(AZ_STR(title)));
+    AzDom_addChild(&h, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AZ_STR(title)));
     return h;
 }
 
@@ -83,7 +83,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     AzDom_setCss(&title, AZ_STR(
         "font-size: 28px; font-weight: bold; margin-bottom: 16px; color: #111;"
     ));
-    AzDom_addChild(&title, AzDom_createText(AZ_STR("Effects Showcase")));
+    AzDom_addChild(&title, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AZ_STR("Effects Showcase")));
     add_child(&body, title);
 
     // Main grid: 4 columns

--- a/examples/c/finder.c
+++ b/examples/c/finder.c
@@ -150,7 +150,7 @@ AzDom layout(AzRefAny data_ref, AzLayoutCallbackInfo info) {
     set_flex_grow(&sidebar, 0.0);
 
     AzDom stitle = AzDom_createP();
-    AzDom_addChild(&stitle, AzDom_createText(az("Favorites")));
+    AzDom_addChild(&stitle, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(az("Favorites")));
     set_font_size(&stitle, 11.0);
     set_text_color(&stitle, 140, 140, 140);
     AzDom_addChild(&sidebar, stitle);
@@ -161,7 +161,7 @@ AzDom layout(AzRefAny data_ref, AzLayoutCallbackInfo info) {
     };
     for (int i = 0; i < 8; i++) {
         AzDom item = AzDom_createP();
-        AzDom_addChild(&item, AzDom_createText(az(sidebar_items[i])));
+        AzDom_addChild(&item, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(az(sidebar_items[i])));
         set_font_size(&item, 13.0);
         AzDom_addChild(&sidebar, item);
     }
@@ -181,7 +181,7 @@ AzDom layout(AzRefAny data_ref, AzLayoutCallbackInfo info) {
     const char* cols[] = { "Name", "Date Modified", "Size", "Kind" };
     for (int i = 0; i < 4; i++) {
         AzDom c = AzDom_createP();
-        AzDom_addChild(&c, AzDom_createText(az(cols[i])));
+        AzDom_addChild(&c, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(az(cols[i])));
         set_flex_grow(&c, 1.0);
         AzDom_addChild(&hdr, c);
     }
@@ -196,7 +196,7 @@ AzDom layout(AzRefAny data_ref, AzLayoutCallbackInfo info) {
         const char* cells[] = { FILES[i].name, FILES[i].date, FILES[i].size, FILES[i].kind };
         for (int j = 0; j < 4; j++) {
             AzDom cell = AzDom_createP();
-            AzDom_addChild(&cell, AzDom_createText(az(cells[j])));
+            AzDom_addChild(&cell, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(az(cells[j])));
             set_flex_grow(&cell, 1.0);
             AzDom_addChild(&row, cell);
         }
@@ -209,7 +209,7 @@ AzDom layout(AzRefAny data_ref, AzLayoutCallbackInfo info) {
     char status[64];
     int slen = snprintf(status, sizeof(status), "%d items", NUM_FILES);
     AzDom sbar = AzDom_createP();
-    AzDom_addChild(&sbar, AzDom_createText(AzString_copyFromBytes((const uint8_t*)status, 0, slen)));
+    AzDom_addChild(&sbar, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AzString_copyFromBytes((const uint8_t*)status, 0, slen)));
     set_font_size(&sbar, 11.0);
     set_text_color(&sbar, 140, 140, 140);
     AzDom_addChild(&body, sbar);

--- a/examples/c/hello-world-medium.c
+++ b/examples/c/hello-world-medium.c
@@ -43,7 +43,7 @@ AzUpdate on_click(AzRefAny data, AzCallbackInfo info) {
 AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     // Static label (no snprintf)
     AzString label_text = AZ_STR("Counter");
-    AzDom label = AzDom_createText(label_text);
+    AzDom label = AzDom_createTextDoNotUseWithoutBlockLevelWrapper(label_text);
 
     // Button
     AzButton button = AzButton_create(AZ_STR("Increase"));

--- a/examples/c/hello-world-v4.c
+++ b/examples/c/hello-world-v4.c
@@ -13,7 +13,7 @@ AzResultRefAnyString MyDataModel_fromJson(AzJson json) {
 }
 AzUpdate on_click(AzRefAny data, AzCallbackInfo info) { return AzUpdate_DoNothing; }
 AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
-    AzDom unused_text = AzDom_createText(AZ_STR("X"));
+    AzDom unused_text = AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AZ_STR("X"));
     AzDom_delete(&unused_text);
     AzDom body = AzDom_createBody();
     return body;

--- a/examples/c/hello-world.c
+++ b/examples/c/hello-world.c
@@ -60,7 +60,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     MyDataModelRef_delete(&d);
 
     AzString label_text = AzString_copyFromBytes((const uint8_t*)buffer, 0, written);
-    AzDom label = AzDom_createText(label_text);
+    AzDom label = AzDom_createTextDoNotUseWithoutBlockLevelWrapper(label_text);
     AzDom label_wrapper = AzDom_createDiv();
     AzDom_addCssProperty(&label_wrapper, AzCssPropertyWithConditions_simple(
         AzCssProperty_fontSize(AzStyleFontSize_px(32.0))

--- a/examples/c/icons.c
+++ b/examples/c/icons.c
@@ -26,7 +26,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     
     // Title
     AzDom title = AzDom_createDiv();
-    AzDom title_text = AzDom_createText(az_str("Icon System Demo"));
+    AzDom title_text = AzDom_createTextDoNotUseWithoutBlockLevelWrapper(az_str("Icon System Demo"));
     AzDom_setCss(&title_text, az_str("font-size: 24px; font-weight: bold;"));
     AzDom_addChild(&title, title_text);
     AzDom_addChild(&root, title);
@@ -34,7 +34,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     // Description  
     AzDom desc = AzDom_createDiv();
     AzDom_setCss(&desc, az_str("margin-top: 16px;"));
-    AzDom desc_text = AzDom_createText(az_str("The favicon icon below is loaded from favicon.ico."));
+    AzDom desc_text = AzDom_createTextDoNotUseWithoutBlockLevelWrapper(az_str("The favicon icon below is loaded from favicon.ico."));
     AzDom_setCss(&desc_text, az_str("font-size: 14px; color: #666;"));
     AzDom_addChild(&desc, desc_text);
     AzDom_addChild(&root, desc);
@@ -52,7 +52,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     // Material icons row
     AzDom icons_label = AzDom_createDiv();
     AzDom_setCss(&icons_label, az_str("margin-top: 20px;"));
-    AzDom icons_label_text = AzDom_createText(az_str("Material Icons:"));
+    AzDom icons_label_text = AzDom_createTextDoNotUseWithoutBlockLevelWrapper(az_str("Material Icons:"));
     AzDom_setCss(&icons_label_text, az_str("font-size: 14px;"));
     AzDom_addChild(&icons_label, icons_label_text);
     AzDom_addChild(&root, icons_label);

--- a/examples/c/infinity.c
+++ b/examples/c/infinity.c
@@ -54,7 +54,7 @@ AzVirtualViewReturn render_rows(AzRefAny data, AzVirtualViewCallbackInfo info) {
         char buf[64];
         int len = snprintf(buf, sizeof(buf), "Row %d", row_idx);
         AzString label = AzString_copyFromBytes((const uint8_t*)buf, 0, (size_t)len);
-        AzDom text_node = AzDom_createText(label);
+        AzDom text_node = AzDom_createTextDoNotUseWithoutBlockLevelWrapper(label);
 
         // Row div
         AzDom row = AzDom_createDiv();
@@ -105,7 +105,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     int tlen = snprintf(title_buf, sizeof(title_buf), "VirtualView Test - %d virtual rows", TOTAL_ROWS);
     AzString title_text = AzString_copyFromBytes((const uint8_t*)title_buf, 0, (size_t)tlen);
     AzDom title = AzDom_createDiv();
-    AzDom_addChild(&title, AzDom_createText(title_text));
+    AzDom_addChild(&title, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(title_text));
     AzString title_style = AzString_copyFromBytes(
         (const uint8_t*)"padding: 12px; background: #4a90d9; color: white; font-size: 18px; font-weight: bold;",
         0, 85);
@@ -123,7 +123,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
         (const uint8_t*)"Scroll inside the yellow box. Only ~100 rows are rendered at a time via VirtualViewCallback.",
         0, 87);
     AzDom footer = AzDom_createDiv();
-    AzDom_addChild(&footer, AzDom_createText(footer_text));
+    AzDom_addChild(&footer, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(footer_text));
     AzString footer_style = AzString_copyFromBytes(
         (const uint8_t*)"padding: 8px; background: #f0f0f0; color: #666; font-size: 12px; text-align: center;",
         0, 85);

--- a/examples/c/opengl_simple.c
+++ b/examples/c/opengl_simple.c
@@ -92,7 +92,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     ));
     
     // Add a button on top of the OpenGL content
-    AzDom button = AzDom_createText(az_str("Button drawn on top of OpenGL!"));
+    AzDom button = AzDom_createTextDoNotUseWithoutBlockLevelWrapper(az_str("Button drawn on top of OpenGL!"));
     AzDom_setCss(&button, az_str(
         "margin-top: 50px;"
         "margin-left: 50px;"

--- a/examples/c/scrolling.c
+++ b/examples/c/scrolling.c
@@ -34,7 +34,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     AzString title_text = AzString_copyFromBytes(
         (const uint8_t*)"Regular Scroll Test (no VirtualView)", 0, 36);
     AzDom title = AzDom_createDiv();
-    AzDom_addChild(&title, AzDom_createText(title_text));
+    AzDom_addChild(&title, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(title_text));
     AzString title_style = AzString_copyFromBytes(
         (const uint8_t*)"padding: 12px; background: #4a90d9; color: white; font-size: 18px; font-weight: bold;",
         0, 85);
@@ -46,7 +46,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
         char buf[64];
         int len = snprintf(buf, sizeof(buf), "Row %d", i);
         AzString label = AzString_copyFromBytes((const uint8_t*)buf, 0, (size_t)len);
-        AzDom text_node = AzDom_createText(label);
+        AzDom text_node = AzDom_createTextDoNotUseWithoutBlockLevelWrapper(label);
 
         AzDom row = AzDom_createDiv();
         AzDom_addChild(&row, text_node);
@@ -73,7 +73,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
         "Regular scroll container with %d real DOM rows (no VirtualView).", total);
     AzString footer_text = AzString_copyFromBytes((const uint8_t*)footer_buf, 0, (size_t)flen);
     AzDom footer = AzDom_createDiv();
-    AzDom_addChild(&footer, AzDom_createText(footer_text));
+    AzDom_addChild(&footer, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(footer_text));
     AzString footer_style = AzString_copyFromBytes(
         (const uint8_t*)"padding: 8px; background: #f0f0f0; color: #666; font-size: 12px; text-align: center;",
         0, 85);

--- a/examples/c/text-selection-test.c
+++ b/examples/c/text-selection-test.c
@@ -30,25 +30,25 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     // Label
     AzDom label1 = AzDom_createDiv();
     AzDom_addClass(&label1, AZ_STR("label"));
-    AzDom_addChild(&label1, AzDom_createText(AZ_STR("Selectable text (click and drag):")));
+    AzDom_addChild(&label1, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AZ_STR("Selectable text (click and drag):")));
     AzDom_addChild(&body, label1);
 
     // Selectable text paragraph
     AzDom p1 = AzDom_createDiv();
-    AzDom_addChild(&p1, AzDom_createText(AZ_STR("The quick brown fox jumps over the lazy dog. This text should be selectable by clicking and dragging.")));
+    AzDom_addChild(&p1, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AZ_STR("The quick brown fox jumps over the lazy dog. This text should be selectable by clicking and dragging.")));
     AzDom_addChild(&body, p1);
 
     // Label
     AzDom label2 = AzDom_createDiv();
     AzDom_addClass(&label2, AZ_STR("label"));
-    AzDom_addChild(&label2, AzDom_createText(AZ_STR("Contenteditable div (click and type):")));
+    AzDom_addChild(&label2, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AZ_STR("Contenteditable div (click and type):")));
     AzDom_addChild(&body, label2);
 
     // Contenteditable div
     AzDom editable = AzDom_createDiv();
     AzDom_addClass(&editable, AZ_STR("editable"));
     AzDom_setContenteditable(&editable, true);
-    AzDom_addChild(&editable, AzDom_createText(AZ_STR("Click here and type to edit this text.")));
+    AzDom_addChild(&editable, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AZ_STR("Click here and type to edit this text.")));
     AzDom_addChild(&body, editable);
 
     return AzDom_withCss(body, css_str);

--- a/examples/c/video.c
+++ b/examples/c/video.c
@@ -292,12 +292,12 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
         "display: flex; flex-direction: column; padding: 16px; background: #0e0e14; "
         "font-family: sans-serif; color: #e6e6f0;"));
 
-    AzDom title = AzDom_createText(AZ_STR("AzVideo (C) - H.264 hardware decode (Big Buck Bunny)"));
+    AzDom title = AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AZ_STR("AzVideo (C) - H.264 hardware decode (Big Buck Bunny)"));
     AzDom_setCss(&title, AZ_STR("font-size: 22px; margin-bottom: 10px;"));
     AzDom_addChild(&body, title);
 
     for (int i = 0; i < d.ptr->n_status; i++) {
-        AzDom line = AzDom_createText(AZ_STR(d.ptr->status[i]));
+        AzDom line = AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AZ_STR(d.ptr->status[i]));
         AzDom_setCss(&line, AZ_STR("font-size: 13px; color: #b8c0d0; margin-bottom: 5px;"));
         AzDom_addChild(&body, line);
     }
@@ -317,7 +317,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
         size_t idx = d.ptr->idx;
         char pbuf[64];
         snprintf(pbuf, sizeof(pbuf), "playing - frame %zu/%zu", idx + 1, d.ptr->n_frames);
-        AzDom playing = AzDom_createText(AZ_STR(pbuf));
+        AzDom playing = AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AZ_STR(pbuf));
         AzDom_setCss(&playing, AZ_STR("font-size: 12px; color: #7ad17a; margin: 10px 0 5px 0;"));
         AzDom_addChild(&body, playing);
 
@@ -335,7 +335,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
         AzDom_setCss(&img_dom, AZ_STR(css));
         AzDom_addChild(&body, img_dom);
     } else {
-        AzDom note = AzDom_createText(AZ_STR(
+        AzDom note = AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AZ_STR(
             "no decoded frames - no Vulkan Video decode here (see probe summary above)"));
         AzDom_setCss(&note, AZ_STR("font-size: 12px; color: #6a7080; margin: 10px 0 5px 0;"));
         AzDom_addChild(&body, note);

--- a/examples/c/web-events-min.c
+++ b/examples/c/web-events-min.c
@@ -54,7 +54,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     // broadcast (fire regardless of pointer position). 3 divs + 1 text ≈ 5
     // nodes — under the class-B trap threshold that bites the 19-node app.
     AzDom click_div = AzDom_createDiv();
-    AzDom_addChild(&click_div, AzDom_createText(AZ_STR("click me")));
+    AzDom_addChild(&click_div, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AZ_STR("click me")));
     AzRefAny c1 = AzRefAny_clone(&data);
     AzDom_addCallback(&click_div, hover(AzHoverEventFilter_MouseUp), c1, on_click);
     AzDom_addChild(&body, click_div);

--- a/examples/c/web-events.c
+++ b/examples/c/web-events.c
@@ -63,7 +63,7 @@ AzUpdate on_contextmenu(AzRefAny data, AzCallbackInfo info) { return bump(&data,
 
 static AzDom event_div(const char* label, AzRefAny* data,
                        AzEventFilter filter, AzCallbackType cb) {
-    AzDom text = AzDom_createText(AZ_STR(label));
+    AzDom text = AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AZ_STR(label));
     AzDom div = AzDom_createDiv();
     AzDom_addChild(&div, text);
     AzRefAny clone = AzRefAny_clone(data);

--- a/examples/c/web-fontinherit.c
+++ b/examples/c/web-fontinherit.c
@@ -35,7 +35,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     AzStyleFontFamilyVec ffv = AzStyleFontFamilyVec_fromItem(ff);
     add_prop(&body, AzCssProperty_fontFamily(ffv));
 
-    AzDom text = AzDom_createText(s("hello"));
+    AzDom text = AzDom_createTextDoNotUseWithoutBlockLevelWrapper(s("hello"));
     AzDom_addChild(&body, text);
     return body;
 }

--- a/examples/c/web-hovercond.c
+++ b/examples/c/web-hovercond.c
@@ -38,7 +38,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     AzDom_addCssProperty(&div, AzCssPropertyWithConditions_onHover(
         AzCssProperty_width(AzLayoutWidth_px(AzPixelValue_px(500.0f)))
     ));
-    AzDom text = AzDom_createText(s("x"));
+    AzDom text = AzDom_createTextDoNotUseWithoutBlockLevelWrapper(s("x"));
     AzDom_addChild(&div, text);   // div is a PARENT → restyle iterates its props
     AzDom_addChild(&body, div);
     return body;

--- a/examples/c/web-manyprops.c
+++ b/examples/c/web-manyprops.c
@@ -37,7 +37,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     for (int i = 0; i < 160; i++) {
         add_prop(&div, AzCssProperty_width(AzLayoutWidth_px(AzPixelValue_px((float)(100 + i)))));
     }
-    AzDom text = AzDom_createText(s("x"));   // child → div is a PARENT (restyle iterates its props)
+    AzDom text = AzDom_createTextDoNotUseWithoutBlockLevelWrapper(s("x"));   // child → div is a PARENT (restyle iterates its props)
     AzDom_addChild(&div, text);
     AzDom_addChild(&body, div);
     return body;

--- a/examples/c/web-nested-text.c
+++ b/examples/c/web-nested-text.c
@@ -32,7 +32,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     add_prop(&body, AzCssProperty_fontSize(AzStyleFontSize_px(16.0f)));
 
     AzString s = AzString_copyFromBytes((const uint8_t*)"Hello", 0, 5);
-    AzDom text = AzDom_createText(s);
+    AzDom text = AzDom_createTextDoNotUseWithoutBlockLevelWrapper(s);
 
     // The ONLY difference vs web-text-min: wrap the text in a DIV (forces the nested
     // body(BFC) > div(IFC) > text path that hello-world's label_wrapper takes).

--- a/examples/c/web-setcss-min.c
+++ b/examples/c/web-setcss-min.c
@@ -38,7 +38,7 @@ static AzEventFilter hover(AzHoverEventFilter h) {
 AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     AzDom body = AzDom_createBody();
     AzDom div = AzDom_createDiv();
-    AzDom_addChild(&div, AzDom_createText(AZ_STR("click to widen")));
+    AzDom_addChild(&div, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AZ_STR("click to widen")));
     AzRefAny clone = AzRefAny_clone(&data);
     AzDom_addCallback(&div, hover(AzHoverEventFilter_MouseUp), clone, on_click);
     AzDom_addChild(&body, div);

--- a/examples/c/web-text-min.c
+++ b/examples/c/web-text-min.c
@@ -44,7 +44,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
         *(volatile unsigned int*)0x40764 = sp[0];       /* AzString.ptr_lo (expect heap ~0x6xxxxxx) */
         *(volatile unsigned int*)0x40768 = sp[2];       /* AzString.len_lo (expect 5) */
     }
-    AzDom text = AzDom_createText(s);
+    AzDom text = AzDom_createTextDoNotUseWithoutBlockLevelWrapper(s);
     AzDom_addChild(&body, text);
 
     return body;

--- a/examples/c/web-text-min.c
+++ b/examples/c/web-text-min.c
@@ -31,7 +31,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     add_prop(&body, AzCssProperty_fontSize(AzStyleFontSize_px(16.0f)));
 
     /* [az-diag REVERT] capture the AzString that AzString_copyFromBytes returns, BEFORE
-       createText, to split copy_from_bytes-bug from createText-bug. Gated native-safe: in
+       createTextDoNotUseWithoutBlockLevelWrapper, to split copy_from_bytes-bug from createTextDoNotUseWithoutBlockLevelWrapper-bug. Gated native-safe: in
        wasm the "Hello" literal is the LOW mirrored addr (<16MB); natively it's a HIGH real
        addr so the marker writes are SKIPPED (no wild native write / crash). */
     const char* az_hp = "Hello";

--- a/examples/c/web-text.c
+++ b/examples/c/web-text.c
@@ -30,7 +30,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     add_prop(&body, AzCssProperty_width(AzLayoutWidth_px(AzPixelValue_px(800.0f))));
     add_prop(&body, AzCssProperty_height(AzLayoutHeight_px(AzPixelValue_px(600.0f))));
 
-    AzDom text = AzDom_createText(s("Hello"));
+    AzDom text = AzDom_createTextDoNotUseWithoutBlockLevelWrapper(s("Hello"));
     AzDom_addChild(&body, text);
 
     return body;

--- a/examples/c/web-text.c
+++ b/examples/c/web-text.c
@@ -1,6 +1,6 @@
-// Bisection toward hello-world.c: body + ONE createText child. web-2node.c
-// (body + div, no text) WORKS. If THIS cb OOBs → createText/AzString is the
-// hello-world.c trigger (m12_7 flagged the "createText/AzString chain X8 stomp").
+// Bisection toward hello-world.c: body + ONE createTextDoNotUseWithoutBlockLevelWrapper child. web-2node.c
+// (body + div, no text) WORKS. If THIS cb OOBs → createTextDoNotUseWithoutBlockLevelWrapper/AzString is the
+// hello-world.c trigger (m12_7 flagged the "createTextDoNotUseWithoutBlockLevelWrapper/AzString chain X8 stomp").
 // If it RUNS → text is fine, the trigger is the AzButton widget.
 #include "azul.h"
 #include <string.h>

--- a/examples/c/widgets.c
+++ b/examples/c/widgets.c
@@ -35,7 +35,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     AzString btn_style = AzString_copyFromBytes((const uint8_t*)"margin-bottom: 10px;", 0, 20);
     AzDom_setCss(&button, btn_style);
     AzString btn_text = AzString_copyFromBytes((const uint8_t*)"Click me!", 0, 9);
-    AzDom_addChild(&button, AzDom_createText(btn_text));
+    AzDom_addChild(&button, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(btn_text));
     AzEventFilter event = AzEventFilter_hover(AzHoverEventFilter_mouseUp());
     AzDom_addCallback(&button, event, AzRefAny_clone(&data), on_button_click);
 
@@ -80,7 +80,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     for (size_t r = 0; r < 3; r++) {
         AzDom cells[3];
         for (size_t c = 0; c < 3; c++) {
-            cells[c] = AzDom_createText(str(row_data[r][c]));
+            cells[c] = AzDom_createTextDoNotUseWithoutBlockLevelWrapper(str(row_data[r][c]));
         }
         rows[r].cells = AzDomVec_copyFromPtr(cells, 3);
         rows[r].height.None.tag = AzOptionPixelValueNoPercent_Tag_None;
@@ -96,7 +96,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     AzDom_setCss(&body, body_style);
     AzString showcase_title = AzString_copyFromBytes((const uint8_t*)"Widget Showcase", 0, 15);
 
-    AzDom_addChild(&body, AzDom_createText(showcase_title));
+    AzDom_addChild(&body, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(showcase_title));
     AzDom_addChild(&body, button);
     AzDom_addChild(&body, checkbox);
     AzDom_addChild(&body, progress);
@@ -132,7 +132,7 @@ AzUpdate on_list_row_click(AzRefAny data, AzCallbackInfo info, AzListViewState s
 
     // Headless measure: lay out a DOM off-screen to get its natural size
     // (the building block for virtual-list item sizing)
-    AzDom probe = AzDom_createText(str("How tall is this text at 200px width?"));
+    AzDom probe = AzDom_createTextDoNotUseWithoutBlockLevelWrapper(str("How tall is this text at 200px width?"));
     AzLogicalSize avail = { .width = 200.0f, .height = 1000000.0f };
     AzLogicalSize measured = AzCallbackInfo_measureDom(&info, probe, avail);
     printf("probe DOM measures %.1f x %.1f px\n", measured.width, measured.height);

--- a/examples/cpp/cpp03/async.cpp
+++ b/examples/cpp/cpp03/async.cpp
@@ -23,7 +23,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
         status_text = "Connected!";
     }
     
-    Dom label = Dom::create_text(String(status_text));
+    Dom label = Dom::create_text_do_not_use_without_block_level_wrapper(String(status_text));
     label.set_css(String("font-size: 32px;"));
     
     Dom body = Dom::create_body();

--- a/examples/cpp/cpp03/calc.cpp
+++ b/examples/cpp/cpp03/calc.cpp
@@ -33,7 +33,7 @@ Dom make_button(RefAny& calc, const char* label, int evt, char digit, int op, co
     bd.digit = digit;
     bd.op = op;
     
-    Dom text = Dom::create_text(String(label));
+    Dom text = Dom::create_text_do_not_use_without_block_level_wrapper(String(label));
     Dom btn = Dom::create_div();
     btn.set_css(String(style));
     btn.add_child(text);
@@ -46,7 +46,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     const Calculator* c = Calculator_downcast_ref(data_wrapper);
     if (!c) return AzDom_createBody();
     
-    Dom display_text = Dom::create_text(String(c->display));
+    Dom display_text = Dom::create_text_do_not_use_without_block_level_wrapper(String(c->display));
     Dom display = Dom::create_div();
     display.set_css(String("background:#2d2d2d;color:white;font-size:48px;text-align:right;padding:20px;min-height:80px;"));
     display.add_child(display_text);

--- a/examples/cpp/cpp03/hello-world.cpp
+++ b/examples/cpp/cpp03/hello-world.cpp
@@ -25,7 +25,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
 
     Dom label = Dom::create_div()
         .with_css(String("font-size: 32px;"))
-        .with_child(Dom::create_text(String(buffer)));
+        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper(String(buffer)));
 
     Button button = Button::create(String("Increase counter"))
         .with_button_type(ButtonType::Primary)

--- a/examples/cpp/cpp03/infinity.cpp
+++ b/examples/cpp/cpp03/infinity.cpp
@@ -20,7 +20,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     char title_buf[64];
     std::snprintf(title_buf, 64, "Infinite Gallery - %d images", d->file_count);
     
-    Dom title = Dom::create_text(String(title_buf));
+    Dom title = Dom::create_text_do_not_use_without_block_level_wrapper(String(title_buf));
     title.set_css(String("font-size: 20px; margin-bottom: 10px;"));
     
     Dom container = Dom::create_div();
@@ -35,7 +35,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
         
         Dom item = Dom::create_div();
         item.set_css(String("width: 150px; height: 150px; background: white; display: flex; align-items: center; justify-content: center;"));
-        item.add_child(Dom::create_text(String(item_buf)));
+        item.add_child(Dom::create_text_do_not_use_without_block_level_wrapper(String(item_buf)));
         container.add_child(item);
     }
     

--- a/examples/cpp/cpp03/opengl.cpp
+++ b/examples/cpp/cpp03/opengl.cpp
@@ -14,10 +14,10 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     const OpenGlState* d = OpenGlState_downcast_ref(data_wrapper);
     if (!d) return AzDom_createBody();
     
-    Dom title = Dom::create_text(String("OpenGL Integration Demo"));
+    Dom title = Dom::create_text_do_not_use_without_block_level_wrapper(String("OpenGL Integration Demo"));
     title.set_css(String("color: white; font-size: 24px; margin-bottom: 20px;"));
     
-    Dom placeholder = Dom::create_text(String("OpenGL texture would render here"));
+    Dom placeholder = Dom::create_text_do_not_use_without_block_level_wrapper(String("OpenGL texture would render here"));
     placeholder.set_css(String("flex-grow: 1; min-height: 300px; border-radius: 10px; background: #333; color: white; display: flex; align-items: center; justify-content: center;"));
     
     Dom body = Dom::create_body();

--- a/examples/cpp/cpp03/widgets.cpp
+++ b/examples/cpp/cpp03/widgets.cpp
@@ -16,13 +16,13 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     const WidgetShowcase* d = WidgetShowcase_downcast_ref(data_wrapper);
     if (!d) return AzDom_createBody();
     
-    Dom button_text = Dom::create_text(String("Click me!"));
+    Dom button_text = Dom::create_text_do_not_use_without_block_level_wrapper(String("Click me!"));
     Dom button = Dom::create_div();
     button.set_css(String("margin-bottom: 10px; padding: 10px; background: #4CAF50; color: white;"));
     button.add_child(button_text);
     button.add_callback(AzEventFilter_hover(AzHoverEventFilter_MouseUp), data_wrapper.clone(), on_button_click);
 
-    Dom title = Dom::create_text(String("Widget Showcase"));
+    Dom title = Dom::create_text_do_not_use_without_block_level_wrapper(String("Widget Showcase"));
     title.set_css(String("font-size: 24px; margin-bottom: 20px;"));
 
     Dom body = Dom::create_body();

--- a/examples/cpp/cpp03/xhtml.cpp
+++ b/examples/cpp/cpp03/xhtml.cpp
@@ -15,13 +15,13 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     const XhtmlState* d = XhtmlState_downcast_ref(data_wrapper);
     if (!d) return AzDom_createBody();
     
-    Dom title = Dom::create_text(String("XHTML Spreadsheet Demo"));
+    Dom title = Dom::create_text_do_not_use_without_block_level_wrapper(String("XHTML Spreadsheet Demo"));
     title.set_css(String("font-size: 24px; font-weight: bold; margin-bottom: 20px;"));
     
-    Dom cell1 = Dom::create_text(String("Cell A1"));
+    Dom cell1 = Dom::create_text_do_not_use_without_block_level_wrapper(String("Cell A1"));
     cell1.set_css(String("padding: 8px; border: 1px solid #ccc; background: #f9f9f9;"));
     
-    Dom cell2 = Dom::create_text(String("Cell B1"));
+    Dom cell2 = Dom::create_text_do_not_use_without_block_level_wrapper(String("Cell B1"));
     cell2.set_css(String("padding: 8px; border: 1px solid #ccc; background: #f9f9f9;"));
     
     Dom row = Dom::create_div();

--- a/examples/cpp/cpp11/async.cpp
+++ b/examples/cpp/cpp11/async.cpp
@@ -30,7 +30,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     const AsyncState* d = data_wrapper.downcast_ref<AsyncState>();
     if (!d) return AzDom_createBody();
 
-    Dom title = Dom::create_text(String("Async Database Connection"))
+    Dom title = Dom::create_text_do_not_use_without_block_level_wrapper(String("Async Database Connection"))
         .with_css(String("font-size: 24px; margin-bottom: 20px;"));
 
     Dom content = Dom::create_div();
@@ -40,7 +40,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
         case Stage_NotConnected: {
             content = Dom::create_div()
                 .with_css(String("padding: 10px 20px; background: #4CAF50; color: white; cursor: pointer;"))
-                .with_child(Dom::create_text(String("Connect")))
+                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper(String("Connect")))
                 .with_callback(event, data_wrapper.clone(), start_connection);
             break;
         }
@@ -49,22 +49,22 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
             std::ostringstream ss;
             ss << "Progress: " << static_cast<int>(d->progress) << "%";
             content = Dom::create_div()
-                .with_child(Dom::create_text(String(ss.str().c_str())));
+                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper(String(ss.str().c_str())));
             break;
         }
         case Stage_DataLoaded: {
             std::ostringstream ss;
             ss << "Loaded " << d->loaded_data.size() << " records";
             content = Dom::create_div()
-                .with_child(Dom::create_text(String(ss.str().c_str())))
+                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper(String(ss.str().c_str())))
                 .with_child(Dom::create_div()
                     .with_css(String("padding: 10px; background: #2196F3; color: white; cursor: pointer;"))
-                    .with_child(Dom::create_text(String("Reset")))
+                    .with_child(Dom::create_text_do_not_use_without_block_level_wrapper(String("Reset")))
                     .with_callback(event, data_wrapper.clone(), reset_connection));
             break;
         }
         case Stage_Error:
-            content = Dom::create_text(String("Error occurred"));
+            content = Dom::create_text_do_not_use_without_block_level_wrapper(String("Error occurred"));
             break;
     }
 

--- a/examples/cpp/cpp11/calc.cpp
+++ b/examples/cpp/cpp11/calc.cpp
@@ -67,7 +67,7 @@ Dom make_button(RefAny& calc, const char* label, EventType evt, char digit, Oper
 
     Dom btn = Dom::create_div();
     btn.set_css(String(style));
-    btn.add_child(Dom::create_text(String(label)));
+    btn.add_child(Dom::create_text_do_not_use_without_block_level_wrapper(String(label)));
     btn.add_callback(AzEventFilter_hover(AzHoverEventFilter_MouseUp), RefAny::create(std::move(bd)), on_click);
     return btn;
 }
@@ -79,7 +79,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
 
     Dom display = Dom::create_div();
     display.set_css(String(DISPLAY_STYLE));
-    display.add_child(Dom::create_text(String(c->display.c_str())));
+    display.add_child(Dom::create_text_do_not_use_without_block_level_wrapper(String(c->display.c_str())));
 
     Dom buttons = Dom::create_div();
     buttons.set_css(String(BUTTONS_STYLE));

--- a/examples/cpp/cpp11/hello-world.cpp
+++ b/examples/cpp/cpp11/hello-world.cpp
@@ -18,7 +18,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
 
     Dom label = Dom::create_div()
         .with_css(String("font-size: 32px;"))
-        .with_child(Dom::create_text(String(std::to_string(d->counter).c_str())));
+        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper(String(std::to_string(d->counter).c_str())));
 
     Button button = Button::create("Increase counter")
         .with_button_type(ButtonType::Primary)

--- a/examples/cpp/cpp11/infinity.cpp
+++ b/examples/cpp/cpp11/infinity.cpp
@@ -24,7 +24,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     std::ostringstream title_text;
     title_text << "Infinite Gallery - " << d->file_paths.size() << " images";
 
-    Dom title = Dom::create_text(String(title_text.str().c_str()));
+    Dom title = Dom::create_text_do_not_use_without_block_level_wrapper(String(title_text.str().c_str()));
     title.set_css(String("font-size: 20px; margin-bottom: 10px;"));
 
     Dom container = Dom::create_div();
@@ -34,7 +34,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     for (size_t i = d->visible_start; i < end; ++i) {
         Dom item = Dom::create_div();
         item.set_css(String("width: 150px; height: 150px; background: white; display: flex; align-items: center; justify-content: center;"));
-        item.add_child(Dom::create_text(String(d->file_paths[i].c_str())));
+        item.add_child(Dom::create_text_do_not_use_without_block_level_wrapper(String(d->file_paths[i].c_str())));
         container.add_child(std::move(item));
     }
 

--- a/examples/cpp/cpp11/opengl.cpp
+++ b/examples/cpp/cpp11/opengl.cpp
@@ -17,10 +17,10 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     const OpenGlState* d = data_wrapper.downcast_ref<OpenGlState>();
     if (!d) return AzDom_createBody();
 
-    Dom title = Dom::create_text(String("OpenGL Integration Demo"));
+    Dom title = Dom::create_text_do_not_use_without_block_level_wrapper(String("OpenGL Integration Demo"));
     title.set_css(String("color: white; font-size: 24px; margin-bottom: 20px;"));
 
-    Dom placeholder = Dom::create_text(String("OpenGL texture would render here"));
+    Dom placeholder = Dom::create_text_do_not_use_without_block_level_wrapper(String("OpenGL texture would render here"));
     placeholder.set_css(String("flex-grow: 1; min-height: 300px; border-radius: 10px; background: #333; color: white; display: flex; align-items: center; justify-content: center;"));
 
     Dom body = Dom::create_body();

--- a/examples/cpp/cpp11/widgets.cpp
+++ b/examples/cpp/cpp11/widgets.cpp
@@ -26,11 +26,11 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     // Create button
     Dom button = Dom::create_div();
     button.set_css(String("margin-bottom: 10px; padding: 10px; background: #4CAF50; color: white;"));
-    button.add_child(Dom::create_text(String("Click me!")));
+    button.add_child(Dom::create_text_do_not_use_without_block_level_wrapper(String("Click me!")));
     button.add_callback(AzEventFilter_hover(AzHoverEventFilter_MouseUp), data_wrapper.clone(), on_button_click);
 
     // Create title
-    Dom title = Dom::create_text(String("Widget Showcase"));
+    Dom title = Dom::create_text_do_not_use_without_block_level_wrapper(String("Widget Showcase"));
     title.set_css(String("font-size: 24px; margin-bottom: 20px;"));
 
     // Compose body

--- a/examples/cpp/cpp14/async.cpp
+++ b/examples/cpp/cpp14/async.cpp
@@ -30,7 +30,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     const AsyncState* d = data_wrapper.downcast_ref<AsyncState>();
     if (!d) return AzDom_createBody();
 
-    Dom title = Dom::create_text(String("Async Database Connection"))
+    Dom title = Dom::create_text_do_not_use_without_block_level_wrapper(String("Async Database Connection"))
         .with_css(String("font-size: 24px; margin-bottom: 20px;"));
 
     Dom content = Dom::create_div();
@@ -40,7 +40,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
         case Stage_NotConnected: {
             content = Dom::create_div()
                 .with_css(String("padding: 10px 20px; background: #4CAF50; color: white; cursor: pointer;"))
-                .with_child(Dom::create_text(String("Connect")))
+                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper(String("Connect")))
                 .with_callback(event, data_wrapper.clone(), start_connection);
             break;
         }
@@ -49,22 +49,22 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
             std::ostringstream ss;
             ss << "Progress: " << static_cast<int>(d->progress) << "%";
             content = Dom::create_div()
-                .with_child(Dom::create_text(String(ss.str().c_str())));
+                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper(String(ss.str().c_str())));
             break;
         }
         case Stage_DataLoaded: {
             std::ostringstream ss;
             ss << "Loaded " << d->loaded_data.size() << " records";
             content = Dom::create_div()
-                .with_child(Dom::create_text(String(ss.str().c_str())))
+                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper(String(ss.str().c_str())))
                 .with_child(Dom::create_div()
                     .with_css(String("padding: 10px; background: #2196F3; color: white; cursor: pointer;"))
-                    .with_child(Dom::create_text(String("Reset")))
+                    .with_child(Dom::create_text_do_not_use_without_block_level_wrapper(String("Reset")))
                     .with_callback(event, data_wrapper.clone(), reset_connection));
             break;
         }
         case Stage_Error:
-            content = Dom::create_text(String("Error occurred"));
+            content = Dom::create_text_do_not_use_without_block_level_wrapper(String("Error occurred"));
             break;
     }
 

--- a/examples/cpp/cpp14/calc.cpp
+++ b/examples/cpp/cpp14/calc.cpp
@@ -67,7 +67,7 @@ Dom make_button(RefAny& calc, const char* label, EventType evt, char digit, Oper
 
     Dom btn = Dom::create_div();
     btn.set_css(String(style));
-    btn.add_child(Dom::create_text(String(label)));
+    btn.add_child(Dom::create_text_do_not_use_without_block_level_wrapper(String(label)));
     btn.add_callback(AzEventFilter_hover(AzHoverEventFilter_MouseUp), RefAny::create(std::move(bd)), on_click);
     return btn;
 }
@@ -79,7 +79,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
 
     Dom display = Dom::create_div();
     display.set_css(String(DISPLAY_STYLE));
-    display.add_child(Dom::create_text(String(c->display.c_str())));
+    display.add_child(Dom::create_text_do_not_use_without_block_level_wrapper(String(c->display.c_str())));
 
     Dom buttons = Dom::create_div();
     buttons.set_css(String(BUTTONS_STYLE));

--- a/examples/cpp/cpp14/hello-world.cpp
+++ b/examples/cpp/cpp14/hello-world.cpp
@@ -19,7 +19,7 @@ auto layout(AzRefAny data, AzLayoutCallbackInfo info) -> AzDom {
     return Dom::create_body()
         .with_child(Dom::create_div()
             .with_css(String("font-size: 32px;"))
-            .with_child(Dom::create_text(String(std::to_string(d->counter).c_str()))))
+            .with_child(Dom::create_text_do_not_use_without_block_level_wrapper(String(std::to_string(d->counter).c_str()))))
         .with_child(Button::create("Increase counter")
             .with_button_type(ButtonType::Primary)
             .with_on_click(data_wrapper.clone(), on_click)

--- a/examples/cpp/cpp14/infinity.cpp
+++ b/examples/cpp/cpp14/infinity.cpp
@@ -24,7 +24,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     std::ostringstream title_text;
     title_text << "Infinite Gallery - " << d->file_paths.size() << " images";
 
-    Dom title = Dom::create_text(String(title_text.str().c_str()));
+    Dom title = Dom::create_text_do_not_use_without_block_level_wrapper(String(title_text.str().c_str()));
     title.set_css(String("font-size: 20px; margin-bottom: 10px;"));
 
     Dom container = Dom::create_div();
@@ -34,7 +34,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     for (size_t i = d->visible_start; i < end; ++i) {
         Dom item = Dom::create_div();
         item.set_css(String("width: 150px; height: 150px; background: white; display: flex; align-items: center; justify-content: center;"));
-        item.add_child(Dom::create_text(String(d->file_paths[i].c_str())));
+        item.add_child(Dom::create_text_do_not_use_without_block_level_wrapper(String(d->file_paths[i].c_str())));
         container.add_child(std::move(item));
     }
 

--- a/examples/cpp/cpp14/opengl.cpp
+++ b/examples/cpp/cpp14/opengl.cpp
@@ -17,10 +17,10 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     const OpenGlState* d = data_wrapper.downcast_ref<OpenGlState>();
     if (!d) return AzDom_createBody();
 
-    Dom title = Dom::create_text(String("OpenGL Integration Demo"));
+    Dom title = Dom::create_text_do_not_use_without_block_level_wrapper(String("OpenGL Integration Demo"));
     title.set_css(String("color: white; font-size: 24px; margin-bottom: 20px;"));
 
-    Dom placeholder = Dom::create_text(String("OpenGL texture would render here"));
+    Dom placeholder = Dom::create_text_do_not_use_without_block_level_wrapper(String("OpenGL texture would render here"));
     placeholder.set_css(String("flex-grow: 1; min-height: 300px; border-radius: 10px; background: #333; color: white; display: flex; align-items: center; justify-content: center;"));
 
     Dom body = Dom::create_body();

--- a/examples/cpp/cpp14/widgets.cpp
+++ b/examples/cpp/cpp14/widgets.cpp
@@ -26,11 +26,11 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     // Create button
     Dom button = Dom::create_div();
     button.set_css(String("margin-bottom: 10px; padding: 10px; background: #4CAF50; color: white;"));
-    button.add_child(Dom::create_text(String("Click me!")));
+    button.add_child(Dom::create_text_do_not_use_without_block_level_wrapper(String("Click me!")));
     button.add_callback(AzEventFilter_hover(AzHoverEventFilter_MouseUp), data_wrapper.clone(), on_button_click);
 
     // Create title
-    Dom title = Dom::create_text(String("Widget Showcase"));
+    Dom title = Dom::create_text_do_not_use_without_block_level_wrapper(String("Widget Showcase"));
     title.set_css(String("font-size: 24px; margin-bottom: 20px;"));
 
     // Compose body

--- a/examples/cpp/cpp17/async.cpp
+++ b/examples/cpp/cpp17/async.cpp
@@ -30,7 +30,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     const AsyncState* d = data_wrapper.downcast_ref<AsyncState>();
     if (!d) return AzDom_createBody();
 
-    Dom title = Dom::create_text(String("Async Database Connection"))
+    Dom title = Dom::create_text_do_not_use_without_block_level_wrapper(String("Async Database Connection"))
         .with_css(String("font-size: 24px; margin-bottom: 20px;"));
 
     Dom content = Dom::create_div();
@@ -40,7 +40,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
         case Stage_NotConnected: {
             content = Dom::create_div()
                 .with_css(String("padding: 10px 20px; background: #4CAF50; color: white; cursor: pointer;"))
-                .with_child(Dom::create_text(String("Connect")))
+                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper(String("Connect")))
                 .with_callback(event, data_wrapper.clone(), start_connection);
             break;
         }
@@ -49,22 +49,22 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
             std::ostringstream ss;
             ss << "Progress: " << static_cast<int>(d->progress) << "%";
             content = Dom::create_div()
-                .with_child(Dom::create_text(String(ss.str().c_str())));
+                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper(String(ss.str().c_str())));
             break;
         }
         case Stage_DataLoaded: {
             std::ostringstream ss;
             ss << "Loaded " << d->loaded_data.size() << " records";
             content = Dom::create_div()
-                .with_child(Dom::create_text(String(ss.str().c_str())))
+                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper(String(ss.str().c_str())))
                 .with_child(Dom::create_div()
                     .with_css(String("padding: 10px; background: #2196F3; color: white; cursor: pointer;"))
-                    .with_child(Dom::create_text(String("Reset")))
+                    .with_child(Dom::create_text_do_not_use_without_block_level_wrapper(String("Reset")))
                     .with_callback(event, data_wrapper.clone(), reset_connection));
             break;
         }
         case Stage_Error:
-            content = Dom::create_text(String("Error occurred"));
+            content = Dom::create_text_do_not_use_without_block_level_wrapper(String("Error occurred"));
             break;
     }
 

--- a/examples/cpp/cpp17/calc.cpp
+++ b/examples/cpp/cpp17/calc.cpp
@@ -67,7 +67,7 @@ Dom make_button(RefAny& calc, const char* label, EventType evt, char digit, Oper
 
     Dom btn = Dom::create_div();
     btn.set_css(String(style));
-    btn.add_child(Dom::create_text(String(label)));
+    btn.add_child(Dom::create_text_do_not_use_without_block_level_wrapper(String(label)));
     btn.add_callback(AzEventFilter_hover(AzHoverEventFilter_MouseUp), RefAny::create(std::move(bd)), on_click);
     return btn;
 }
@@ -79,7 +79,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
 
     Dom display = Dom::create_div();
     display.set_css(String(DISPLAY_STYLE));
-    display.add_child(Dom::create_text(String(c->display.c_str())));
+    display.add_child(Dom::create_text_do_not_use_without_block_level_wrapper(String(c->display.c_str())));
 
     Dom buttons = Dom::create_div();
     buttons.set_css(String(BUTTONS_STYLE));

--- a/examples/cpp/cpp17/hello-world.cpp
+++ b/examples/cpp/cpp17/hello-world.cpp
@@ -23,7 +23,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     return Dom::create_body()
         .with_child(Dom::create_div()
             .with_css("font-size: 32px;"sv)
-            .with_child(Dom::create_text(String(std::to_string(d->counter).c_str()))))
+            .with_child(Dom::create_text_do_not_use_without_block_level_wrapper(String(std::to_string(d->counter).c_str()))))
         .with_child(Button::create("Increase counter"sv)
             .with_button_type(ButtonType::Primary)
             .with_on_click(data_wrapper.clone(), on_click)

--- a/examples/cpp/cpp17/infinity.cpp
+++ b/examples/cpp/cpp17/infinity.cpp
@@ -24,7 +24,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     std::ostringstream title_text;
     title_text << "Infinite Gallery - " << d->file_paths.size() << " images";
 
-    Dom title = Dom::create_text(String(title_text.str().c_str()));
+    Dom title = Dom::create_text_do_not_use_without_block_level_wrapper(String(title_text.str().c_str()));
     title.set_css(String("font-size: 20px; margin-bottom: 10px;"));
 
     Dom container = Dom::create_div();
@@ -34,7 +34,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     for (size_t i = d->visible_start; i < end; ++i) {
         Dom item = Dom::create_div();
         item.set_css(String("width: 150px; height: 150px; background: white; display: flex; align-items: center; justify-content: center;"));
-        item.add_child(Dom::create_text(String(d->file_paths[i].c_str())));
+        item.add_child(Dom::create_text_do_not_use_without_block_level_wrapper(String(d->file_paths[i].c_str())));
         container.add_child(std::move(item));
     }
 

--- a/examples/cpp/cpp17/opengl.cpp
+++ b/examples/cpp/cpp17/opengl.cpp
@@ -17,10 +17,10 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     const OpenGlState* d = data_wrapper.downcast_ref<OpenGlState>();
     if (!d) return AzDom_createBody();
 
-    Dom title = Dom::create_text(String("OpenGL Integration Demo"));
+    Dom title = Dom::create_text_do_not_use_without_block_level_wrapper(String("OpenGL Integration Demo"));
     title.set_css(String("color: white; font-size: 24px; margin-bottom: 20px;"));
 
-    Dom placeholder = Dom::create_text(String("OpenGL texture would render here"));
+    Dom placeholder = Dom::create_text_do_not_use_without_block_level_wrapper(String("OpenGL texture would render here"));
     placeholder.set_css(String("flex-grow: 1; min-height: 300px; border-radius: 10px; background: #333; color: white; display: flex; align-items: center; justify-content: center;"));
 
     Dom body = Dom::create_body();

--- a/examples/cpp/cpp17/widgets.cpp
+++ b/examples/cpp/cpp17/widgets.cpp
@@ -26,11 +26,11 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     // Create button
     Dom button = Dom::create_div();
     button.set_css(String("margin-bottom: 10px; padding: 10px; background: #4CAF50; color: white;"));
-    button.add_child(Dom::create_text(String("Click me!")));
+    button.add_child(Dom::create_text_do_not_use_without_block_level_wrapper(String("Click me!")));
     button.add_callback(AzEventFilter_hover(AzHoverEventFilter_MouseUp), data_wrapper.clone(), on_button_click);
 
     // Create title
-    Dom title = Dom::create_text(String("Widget Showcase"));
+    Dom title = Dom::create_text_do_not_use_without_block_level_wrapper(String("Widget Showcase"));
     title.set_css(String("font-size: 24px; margin-bottom: 20px;"));
 
     // Compose body

--- a/examples/cpp/cpp20/async.cpp
+++ b/examples/cpp/cpp20/async.cpp
@@ -30,7 +30,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     const AsyncState* d = data_wrapper.downcast_ref<AsyncState>();
     if (!d) return AzDom_createBody();
 
-    Dom title = Dom::create_text(String("Async Database Connection"))
+    Dom title = Dom::create_text_do_not_use_without_block_level_wrapper(String("Async Database Connection"))
         .with_css(String("font-size: 24px; margin-bottom: 20px;"));
 
     Dom content = Dom::create_div();
@@ -40,7 +40,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
         case Stage_NotConnected: {
             content = Dom::create_div()
                 .with_css(String("padding: 10px 20px; background: #4CAF50; color: white; cursor: pointer;"))
-                .with_child(Dom::create_text(String("Connect")))
+                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper(String("Connect")))
                 .with_callback(event, data_wrapper.clone(), start_connection);
             break;
         }
@@ -49,22 +49,22 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
             std::ostringstream ss;
             ss << "Progress: " << static_cast<int>(d->progress) << "%";
             content = Dom::create_div()
-                .with_child(Dom::create_text(String(ss.str().c_str())));
+                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper(String(ss.str().c_str())));
             break;
         }
         case Stage_DataLoaded: {
             std::ostringstream ss;
             ss << "Loaded " << d->loaded_data.size() << " records";
             content = Dom::create_div()
-                .with_child(Dom::create_text(String(ss.str().c_str())))
+                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper(String(ss.str().c_str())))
                 .with_child(Dom::create_div()
                     .with_css(String("padding: 10px; background: #2196F3; color: white; cursor: pointer;"))
-                    .with_child(Dom::create_text(String("Reset")))
+                    .with_child(Dom::create_text_do_not_use_without_block_level_wrapper(String("Reset")))
                     .with_callback(event, data_wrapper.clone(), reset_connection));
             break;
         }
         case Stage_Error:
-            content = Dom::create_text(String("Error occurred"));
+            content = Dom::create_text_do_not_use_without_block_level_wrapper(String("Error occurred"));
             break;
     }
 

--- a/examples/cpp/cpp20/calc.cpp
+++ b/examples/cpp/cpp20/calc.cpp
@@ -67,7 +67,7 @@ Dom make_button(RefAny& calc, const char* label, EventType evt, char digit, Oper
 
     Dom btn = Dom::create_div();
     btn.set_css(String(style));
-    btn.add_child(Dom::create_text(String(label)));
+    btn.add_child(Dom::create_text_do_not_use_without_block_level_wrapper(String(label)));
     btn.add_callback(AzEventFilter_hover(AzHoverEventFilter_MouseUp), RefAny::create(std::move(bd)), on_click);
     return btn;
 }
@@ -79,7 +79,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
 
     Dom display = Dom::create_div();
     display.set_css(String(DISPLAY_STYLE));
-    display.add_child(Dom::create_text(String(c->display.c_str())));
+    display.add_child(Dom::create_text_do_not_use_without_block_level_wrapper(String(c->display.c_str())));
 
     Dom buttons = Dom::create_div();
     buttons.set_css(String(BUTTONS_STYLE));

--- a/examples/cpp/cpp20/hello-world.cpp
+++ b/examples/cpp/cpp20/hello-world.cpp
@@ -23,7 +23,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     return Dom::create_body()
         .with_child(Dom::create_div()
             .with_css("font-size: 32px;"sv)
-            .with_child(Dom::create_text(String(std::to_string(d->counter).c_str()))))
+            .with_child(Dom::create_text_do_not_use_without_block_level_wrapper(String(std::to_string(d->counter).c_str()))))
         .with_child(Button::create("Increase counter"sv)
             .with_button_type(ButtonType::Primary)
             .with_on_click(data_wrapper.clone(), on_click)

--- a/examples/cpp/cpp20/infinity.cpp
+++ b/examples/cpp/cpp20/infinity.cpp
@@ -24,7 +24,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     std::ostringstream title_text;
     title_text << "Infinite Gallery - " << d->file_paths.size() << " images";
 
-    Dom title = Dom::create_text(String(title_text.str().c_str()));
+    Dom title = Dom::create_text_do_not_use_without_block_level_wrapper(String(title_text.str().c_str()));
     title.set_css(String("font-size: 20px; margin-bottom: 10px;"));
 
     Dom container = Dom::create_div();
@@ -34,7 +34,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     for (size_t i = d->visible_start; i < end; ++i) {
         Dom item = Dom::create_div();
         item.set_css(String("width: 150px; height: 150px; background: white; display: flex; align-items: center; justify-content: center;"));
-        item.add_child(Dom::create_text(String(d->file_paths[i].c_str())));
+        item.add_child(Dom::create_text_do_not_use_without_block_level_wrapper(String(d->file_paths[i].c_str())));
         container.add_child(std::move(item));
     }
 

--- a/examples/cpp/cpp20/opengl.cpp
+++ b/examples/cpp/cpp20/opengl.cpp
@@ -17,10 +17,10 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     const OpenGlState* d = data_wrapper.downcast_ref<OpenGlState>();
     if (!d) return AzDom_createBody();
 
-    Dom title = Dom::create_text(String("OpenGL Integration Demo"));
+    Dom title = Dom::create_text_do_not_use_without_block_level_wrapper(String("OpenGL Integration Demo"));
     title.set_css(String("color: white; font-size: 24px; margin-bottom: 20px;"));
 
-    Dom placeholder = Dom::create_text(String("OpenGL texture would render here"));
+    Dom placeholder = Dom::create_text_do_not_use_without_block_level_wrapper(String("OpenGL texture would render here"));
     placeholder.set_css(String("flex-grow: 1; min-height: 300px; border-radius: 10px; background: #333; color: white; display: flex; align-items: center; justify-content: center;"));
 
     Dom body = Dom::create_body();

--- a/examples/cpp/cpp20/widgets.cpp
+++ b/examples/cpp/cpp20/widgets.cpp
@@ -26,11 +26,11 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     // Create button
     Dom button = Dom::create_div();
     button.set_css(String("margin-bottom: 10px; padding: 10px; background: #4CAF50; color: white;"));
-    button.add_child(Dom::create_text(String("Click me!")));
+    button.add_child(Dom::create_text_do_not_use_without_block_level_wrapper(String("Click me!")));
     button.add_callback(AzEventFilter_hover(AzHoverEventFilter_MouseUp), data_wrapper.clone(), on_button_click);
 
     // Create title
-    Dom title = Dom::create_text(String("Widget Showcase"));
+    Dom title = Dom::create_text_do_not_use_without_block_level_wrapper(String("Widget Showcase"));
     title.set_css(String("font-size: 24px; margin-bottom: 20px;"));
 
     // Compose body

--- a/examples/cpp/cpp23/async.cpp
+++ b/examples/cpp/cpp23/async.cpp
@@ -30,7 +30,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     const AsyncState* d = data_wrapper.downcast_ref<AsyncState>();
     if (!d) return AzDom_createBody();
 
-    Dom title = Dom::create_text(String("Async Database Connection"))
+    Dom title = Dom::create_text_do_not_use_without_block_level_wrapper(String("Async Database Connection"))
         .with_css(String("font-size: 24px; margin-bottom: 20px;"));
 
     Dom content = Dom::create_div();
@@ -40,7 +40,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
         case Stage_NotConnected: {
             content = Dom::create_div()
                 .with_css(String("padding: 10px 20px; background: #4CAF50; color: white; cursor: pointer;"))
-                .with_child(Dom::create_text(String("Connect")))
+                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper(String("Connect")))
                 .with_callback(event, data_wrapper.clone(), start_connection);
             break;
         }
@@ -49,22 +49,22 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
             std::ostringstream ss;
             ss << "Progress: " << static_cast<int>(d->progress) << "%";
             content = Dom::create_div()
-                .with_child(Dom::create_text(String(ss.str().c_str())));
+                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper(String(ss.str().c_str())));
             break;
         }
         case Stage_DataLoaded: {
             std::ostringstream ss;
             ss << "Loaded " << d->loaded_data.size() << " records";
             content = Dom::create_div()
-                .with_child(Dom::create_text(String(ss.str().c_str())))
+                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper(String(ss.str().c_str())))
                 .with_child(Dom::create_div()
                     .with_css(String("padding: 10px; background: #2196F3; color: white; cursor: pointer;"))
-                    .with_child(Dom::create_text(String("Reset")))
+                    .with_child(Dom::create_text_do_not_use_without_block_level_wrapper(String("Reset")))
                     .with_callback(event, data_wrapper.clone(), reset_connection));
             break;
         }
         case Stage_Error:
-            content = Dom::create_text(String("Error occurred"));
+            content = Dom::create_text_do_not_use_without_block_level_wrapper(String("Error occurred"));
             break;
     }
 

--- a/examples/cpp/cpp23/calc.cpp
+++ b/examples/cpp/cpp23/calc.cpp
@@ -67,7 +67,7 @@ Dom make_button(RefAny& calc, const char* label, EventType evt, char digit, Oper
 
     Dom btn = Dom::create_div();
     btn.set_css(String(style));
-    btn.add_child(Dom::create_text(String(label)));
+    btn.add_child(Dom::create_text_do_not_use_without_block_level_wrapper(String(label)));
     btn.add_callback(AzEventFilter_hover(AzHoverEventFilter_MouseUp), RefAny::create(std::move(bd)), on_click);
     return btn;
 }
@@ -79,7 +79,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
 
     Dom display = Dom::create_div();
     display.set_css(String(DISPLAY_STYLE));
-    display.add_child(Dom::create_text(String(c->display.c_str())));
+    display.add_child(Dom::create_text_do_not_use_without_block_level_wrapper(String(c->display.c_str())));
 
     Dom buttons = Dom::create_div();
     buttons.set_css(String(BUTTONS_STYLE));

--- a/examples/cpp/cpp23/hello-world.cpp
+++ b/examples/cpp/cpp23/hello-world.cpp
@@ -33,7 +33,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     Dom body = Dom::create_body();
     body = body.with_child(Dom::create_div()
         .with_css("font-size: 32px;"sv)
-        .with_child(Dom::create_text(String(std::to_string(d->counter).c_str()))));
+        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper(String(std::to_string(d->counter).c_str()))));
     body = body.with_child(Button::create("Increase counter"sv)
         .with_button_type(ButtonType::Primary)
         .with_on_click(data_wrapper.clone(), on_click)

--- a/examples/cpp/cpp23/infinity.cpp
+++ b/examples/cpp/cpp23/infinity.cpp
@@ -24,7 +24,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     std::ostringstream title_text;
     title_text << "Infinite Gallery - " << d->file_paths.size() << " images";
 
-    Dom title = Dom::create_text(String(title_text.str().c_str()));
+    Dom title = Dom::create_text_do_not_use_without_block_level_wrapper(String(title_text.str().c_str()));
     title.set_css(String("font-size: 20px; margin-bottom: 10px;"));
 
     Dom container = Dom::create_div();
@@ -34,7 +34,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     for (size_t i = d->visible_start; i < end; ++i) {
         Dom item = Dom::create_div();
         item.set_css(String("width: 150px; height: 150px; background: white; display: flex; align-items: center; justify-content: center;"));
-        item.add_child(Dom::create_text(String(d->file_paths[i].c_str())));
+        item.add_child(Dom::create_text_do_not_use_without_block_level_wrapper(String(d->file_paths[i].c_str())));
         container.add_child(std::move(item));
     }
 

--- a/examples/cpp/cpp23/opengl.cpp
+++ b/examples/cpp/cpp23/opengl.cpp
@@ -17,10 +17,10 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     const OpenGlState* d = data_wrapper.downcast_ref<OpenGlState>();
     if (!d) return AzDom_createBody();
 
-    Dom title = Dom::create_text(String("OpenGL Integration Demo"));
+    Dom title = Dom::create_text_do_not_use_without_block_level_wrapper(String("OpenGL Integration Demo"));
     title.set_css(String("color: white; font-size: 24px; margin-bottom: 20px;"));
 
-    Dom placeholder = Dom::create_text(String("OpenGL texture would render here"));
+    Dom placeholder = Dom::create_text_do_not_use_without_block_level_wrapper(String("OpenGL texture would render here"));
     placeholder.set_css(String("flex-grow: 1; min-height: 300px; border-radius: 10px; background: #333; color: white; display: flex; align-items: center; justify-content: center;"));
 
     Dom body = Dom::create_body();

--- a/examples/cpp/cpp23/widgets.cpp
+++ b/examples/cpp/cpp23/widgets.cpp
@@ -26,11 +26,11 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     // Create button
     Dom button = Dom::create_div();
     button.set_css(String("margin-bottom: 10px; padding: 10px; background: #4CAF50; color: white;"));
-    button.add_child(Dom::create_text(String("Click me!")));
+    button.add_child(Dom::create_text_do_not_use_without_block_level_wrapper(String("Click me!")));
     button.add_callback(AzEventFilter_hover(AzHoverEventFilter_MouseUp), data_wrapper.clone(), on_button_click);
 
     // Create title
-    Dom title = Dom::create_text(String("Widget Showcase"));
+    Dom title = Dom::create_text_do_not_use_without_block_level_wrapper(String("Widget Showcase"));
     title.set_css(String("font-size: 24px; margin-bottom: 20px;"));
 
     // Compose body

--- a/examples/crystal/hello-world.cr
+++ b/examples/crystal/hello-world.cr
@@ -78,7 +78,7 @@ LAYOUT = ->(data : LibAzul::AzRefAny, _info : LibAzul::AzLayoutCallbackInfo) : L
   # Counter label (wrapped in a div so the font-size sticks).
   text = m.value.counter.to_s
   counter_str = LibAzul.azString_fromUtf8(text.to_unsafe, LibC::SizeT.new(text.bytesize))
-  label = LibAzul.azDom_createText(counter_str)
+  label = LibAzul.azDom_createTextDoNotUseWithoutBlockLevelWrapper(counter_str)
 
   label_wrapper = LibAzul.azDom_createDiv
   font_size = LibAzul.azStyleFontSize_px(32.0_f32)

--- a/examples/csharp/hello-world.cs
+++ b/examples/csharp/hello-world.cs
@@ -29,7 +29,7 @@ namespace HelloWorld
             if (m == null) return Dom.CreateBody();
             var label = Dom.CreateDiv()
                 .WithCss("font-size: 32px;")
-                .WithChild(Dom.CreateText(m.Counter.ToString()));
+                .WithChild(Dom.CreateTextDoNotUseWithoutBlockLevelWrapper(m.Counter.ToString()));
             var buttonDom = Button.Create("Increase counter")
                 .WithButtonType(ButtonType.Primary)
                 .OnClick(m, new Func<IntPtr, IntPtr, int>(OnClick))

--- a/examples/d/hello-world.d
+++ b/examples/d/hello-world.d
@@ -102,7 +102,7 @@ extern(C) AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     ubyte[16] buf;
     size_t n = u32_write(m.counter, buf[]);
     AzString counter_str = AzString_fromUtf8(buf.ptr, n);
-    AzDom label = AzDom_createText(counter_str);
+    AzDom label = AzDom_createTextDoNotUseWithoutBlockLevelWrapper(counter_str);
 
     AzDom label_wrapper = AzDom_createDiv();
     AzStyleFontSize font_size = AzStyleFontSize_px(32.0);

--- a/examples/fortran/hello_world.f90
+++ b/examples/fortran/hello_world.f90
@@ -72,7 +72,7 @@ contains
       label_wrap = az_dom_create_div()
       label_wrap = az_dom_with_css(label_wrap, mk_str('font-size: 32px;'))
       label_wrap = az_dom_with_child(label_wrap, &
-                                     az_dom_create_text(mk_str(trim(num))))
+                                     az_dom_create_text_do_not_use_without_block_level_wrapper(mk_str(trim(num))))
 
       click_cb = azul_register_buttononclickcallback(my_on_click)
       click_data = azul_refany_create(c_loc(model))

--- a/examples/freebasic/hello-world.bas
+++ b/examples/freebasic/hello-world.bas
@@ -67,7 +67,7 @@ Function layout Cdecl (ByVal data As AzRefAny, ByVal info As AzLayoutCallbackInf
     ' Counter label, wrapped in a div so the font-size CSS sticks.
     buf = Str(modelPtr->counter)
     labelText  = AzStr(buf)
-    labelDom   = AzDom_createText(labelText)
+    labelDom   = AzDom_createTextDoNotUseWithoutBlockLevelWrapper(labelText)
     labelWrapper = AzDom_createDiv()
 
     fontSize = AzCssProperty_fontSize(AzStyleFontSize_px(32.0))

--- a/examples/go/hello-world-idiomatic/main.go
+++ b/examples/go/hello-world-idiomatic/main.go
@@ -88,7 +88,7 @@ func layout(data *azul.RefAny, _ *azul.LayoutCallbackInfo) *azul.Dom {
 
 	// Counter label: body > div{font-size:32px} > text("5").
 	label := azul.NewDomCreateDiv()
-	label.AddChild(azul.NewDomCreateText(azul.Str(fmt.Sprintf("%d", model.Counter))).Raw())
+	label.AddChild(azul.NewDomCreateTextDoNotUseWithoutBlockLevelWrapper(azul.Str(fmt.Sprintf("%d", model.Counter))).Raw())
 
 	// Increment button: plain Go function as the click handler.
 	button := azul.NewButtonCreate(azul.Str("Increase counter"))

--- a/examples/go/main.go
+++ b/examples/go/main.go
@@ -124,7 +124,7 @@ func goLayout(data C.AzRefAny, _ C.AzLayoutCallbackInfo) C.AzDom {
 	// Counter label (wrapped in a div so the font-size sticks).
 	counterStr := []byte(fmt.Sprintf("%d", m.counter))
 	counterAz := C.AzString_fromUtf8((*C.uint8_t)(unsafe.Pointer(&counterStr[0])), C.size_t(len(counterStr)))
-	label := C.AzDom_createText(counterAz)
+	label := C.AzDom_createTextDoNotUseWithoutBlockLevelWrapper(counterAz)
 
 	labelWrapper := C.AzDom_createDiv()
 	fontSize := C.AzStyleFontSize_px(C.float(32.0))

--- a/examples/java/HelloWorld.java
+++ b/examples/java/HelloWorld.java
@@ -33,7 +33,7 @@ public final class HelloWorld {
             MyDataModel m = (MyDataModel) recovered;
             Dom label = Dom.createDiv()
                 .withCss("font-size: 32px;")
-                .withChild(Dom.createText(String.valueOf(m.counter)));
+                .withChild(Dom.createTextDoNotUseWithoutBlockLevelWrapper(String.valueOf(m.counter)));
             Dom buttonDom = Button.create("Increase counter")
                 .withButtonType(ButtonType.Primary.value)
                 .onClick(m, ON_CLICK)

--- a/examples/julia/hello-world.jl
+++ b/examples/julia/hello-world.jl
@@ -84,7 +84,7 @@ function layout(data::Azul.AzRefAny, info::Azul.AzLayoutCallbackInfo)::Azul.AzDo
     counter === nothing && return Azul.AzDom_createBody()
 
     # Counter label (wrapped in a div so the font-size sticks).
-    label = Azul.AzDom_createText(Azul.az_string(string(counter)))
+    label = Azul.AzDom_createTextDoNotUseWithoutBlockLevelWrapper(Azul.az_string(string(counter)))
 
     label_wrapper = Ref(Azul.AzDom_createDiv())
     font_size = Azul.AzStyleFontSize_px(32.0f0)

--- a/examples/kotlin/HelloWorld.kt
+++ b/examples/kotlin/HelloWorld.kt
@@ -21,7 +21,7 @@ private val layout = AzulHostInvoker.LayoutCallback { _, dataPtr, _ ->
     } else {
         val label = Dom.createDiv()
             .withCss("font-size: 32px;")
-            .withChild(Dom.createText(m.counter.toString()))
+            .withChild(Dom.createTextDoNotUseWithoutBlockLevelWrapper(m.counter.toString()))
         val buttonDom = Button.create("Increase counter")
             .withButtonType(ButtonType.Primary.value)
             .onClick(m, onClick)

--- a/examples/lua/hello-world.lua
+++ b/examples/lua/hello-world.lua
@@ -19,7 +19,7 @@ local function layout(data, _info)
     local label_wrapper = azul.Dom.create_div()
         :add_css_property(azul.CssPropertyWithConditions.simple(
             azul.CssProperty.font_size(azul.StyleFontSize.px(32.0))))
-        :add_child(azul.Dom.create_text(tostring(m.counter)))
+        :add_child(azul.Dom.create_text_do_not_use_without_block_level_wrapper(tostring(m.counter)))
 
     local button_dom = azul.Button.create('Increase counter')
         :set_button_type(azul.ButtonType.Primary)

--- a/examples/nim/hello-world.nim
+++ b/examples/nim/hello-world.nim
@@ -69,7 +69,7 @@ proc layout(data: AzRefAny, info: AzLayoutCallbackInfo): AzDom {.cdecl.} =
     return AzDom_createBody()
 
   # Counter label, wrapped in a div so the font-size sticks.
-  let label = AzDom_createText(azStr($m.counter))
+  let label = AzDom_createTextDoNotUseWithoutBlockLevelWrapper(azStr($m.counter))
   var labelWrapper = AzDom_createDiv()
   let cond = AzCssPropertyWithConditions_simple(
     AzCssProperty_fontSize(AzStyleFontSize_px(32.0'f32)))

--- a/examples/node/hello-world.js
+++ b/examples/node/hello-world.js
@@ -29,7 +29,7 @@ function layout(dataPtr, _info) {
         .with_css_property(
             CssPropertyWithConditions.simple(
                 CssProperty.font_size(StyleFontSize.px(32.0))))
-        .with_child(Dom.create_text(String(m.counter)));
+        .with_child(Dom.create_text_do_not_use_without_block_level_wrapper(String(m.counter)));
 
     const button = Button.create('Increase counter')
         .with_button_type(ButtonType.Primary)

--- a/examples/ocaml/hello_world.ml
+++ b/examples/ocaml/hello_world.ml
@@ -30,7 +30,7 @@ let layout (data_ptr : unit Ctypes.ptr) (_info : unit Ctypes.ptr)
       let label_div =
         Azul.Dom.create_div ()
         |> with_css "font-size: 32px;"
-        |> with_child (Azul.raw_dom (Azul.Dom.create_text (string_of_int m.counter)))
+        |> with_child (Azul.raw_dom (Azul.Dom.create_text_do_not_use_without_block_level_wrapper (string_of_int m.counter)))
       in
       let button_dom =
         Azul.Button.create "Increase counter"

--- a/examples/odin/hello-world.odin
+++ b/examples/odin/hello-world.odin
@@ -99,7 +99,7 @@ layout :: proc "c" (data: azul.AzRefAny, info: azul.AzLayoutCallbackInfo) -> azu
 	buf: [16]u8
 	n := u32_write(m.counter, buf[:])
 	counter_str := azul.AzString_fromUtf8(raw_data(buf[:]), uint(n))
-	label := azul.AzDom_createText(counter_str)
+	label := azul.AzDom_createTextDoNotUseWithoutBlockLevelWrapper(counter_str)
 
 	label_wrapper := azul.AzDom_createDiv()
 	font_size := azul.AzStyleFontSize_px(32.0)

--- a/examples/pascal/hello-world.pas
+++ b/examples/pascal/hello-world.pas
@@ -73,11 +73,11 @@ begin
     Exit;
   end;
 
-  { Idiomatic wrapper classes: TDom.CreateText / CreateDiv / CreateBody are
+  { Idiomatic wrapper classes: TDom.CreateTextDoNotUseWithoutBlockLevelWrapper / CreateDiv / CreateBody are
     named constructors; builder methods return fresh TDom wrappers and
     consume their by-value inputs (ownership flips off, so .Free on a
     consumed wrapper only releases the object shell, never the DOM). }
-  counter_text := TDom.CreateText(MakeAzString(IntToStr(TMyModel(m).Counter)));
+  counter_text := TDom.CreateTextDoNotUseWithoutBlockLevelWrapper(MakeAzString(IntToStr(TMyModel(m).Counter)));
   label_wrap := TDom.CreateDiv.WithCss(MakeAzString('font-size: 32px;'))
                               .WithChild(counter_text);
 

--- a/examples/perl/hello-world.pl
+++ b/examples/perl/hello-world.pl
@@ -42,7 +42,7 @@ my $layout = sub {
     my $label = Azul::FFI::AzDom_createDiv();
     $label = Azul::FFI::AzDom_withCss($label, mk_str('font-size: 32px;'));
     $label = Azul::FFI::AzDom_withChild(
-        $label, Azul::FFI::AzDom_createText(mk_str($m->{counter})));
+        $label, Azul::FFI::AzDom_createTextDoNotUseWithoutBlockLevelWrapper(mk_str($m->{counter})));
 
     my $click_cb   = Azul::register_callback('ButtonOnClickCallback', $on_click);
     my $click_data = Azul::refany_create($model);

--- a/examples/php/hello-world.php
+++ b/examples/php/hello-world.php
@@ -39,10 +39,10 @@ function layout(int $data): \Azul\Dom
     $counter = $m['counter'] ?? 0;
 
     $div = \Azul\Dom::createDiv();
-    $div->addChild(\Azul\Dom::createText((string) $counter));
+    $div->addChild(\Azul\Dom::createTextDoNotUseWithoutBlockLevelWrapper((string) $counter));
 
     $btn = \Azul\Dom::createDiv();
-    $btn->addChild(\Azul\Dom::createText('Increase counter'));
+    $btn->addChild(\Azul\Dom::createTextDoNotUseWithoutBlockLevelWrapper('Increase counter'));
     $btn->onClick($data, $GLOBALS['azul_onclick_id']);
 
     $body = \Azul\Dom::createBody();

--- a/examples/powershell/README.md
+++ b/examples/powershell/README.md
@@ -62,7 +62,7 @@ $app.Run($wco)
 ```
 
 Phase I / J auto-conversion lights up identically through the C#
-bindings (strings flow through `Dom.CreateText("hi")`, `Equals` /
+bindings (strings flow through `Dom.CreateTextDoNotUseWithoutBlockLevelWrapper("hi")`, `Equals` /
 `GetHashCode` / `ToString` route through the C-ABI helpers, etc.).
 
 ## Files

--- a/examples/powershell/hello-world.ps1
+++ b/examples/powershell/hello-world.ps1
@@ -54,7 +54,7 @@ $layout = {
     }
 
     # Counter label, wrapped in a font-size-32 div.
-    $counterDom = [Azul.Dom]::CreateText((Convert-AzulString -Value ([string]$m.Counter)))
+    $counterDom = [Azul.Dom]::CreateTextDoNotUseWithoutBlockLevelWrapper((Convert-AzulString -Value ([string]$m.Counter)))
     $labelDiv   = [Azul.Dom]::CreateDiv().WithCss((Convert-AzulString -Value 'font-size: 32px;'))
     $labelDiv   = $labelDiv.WithChild($counterDom.Raw)
 

--- a/examples/python/async.py
+++ b/examples/python/async.py
@@ -19,31 +19,31 @@ CLICK = EventFilter.Hover(HoverEventFilter.MouseUp)
 def connect_button(data):
     return (Dom.create_div()
             .with_css("padding:10px 20px;background:#4CAF50;color:white;cursor:pointer;")
-            .with_child(Dom.create_text("Connect"))
+            .with_child(Dom.create_text_do_not_use_without_block_level_wrapper("Connect"))
             .with_callback(CLICK, data, start_connection))
 
 
 def reset_button(data):
     return (Dom.create_div()
             .with_css("padding:10px;background:#2196F3;color:white;cursor:pointer;")
-            .with_child(Dom.create_text("Reset"))
+            .with_child(Dom.create_text_do_not_use_without_block_level_wrapper("Reset"))
             .with_callback(CLICK, data, reset_connection))
 
 
 def progress_view(data):
     return (Dom.create_div()
-            .with_child(Dom.create_text(f"Progress: {int(data.progress)}%"))
+            .with_child(Dom.create_text_do_not_use_without_block_level_wrapper(f"Progress: {int(data.progress)}%"))
             .with_child(ProgressBar.create(data.progress).dom()))
 
 
 def loaded_view(data):
     return (Dom.create_div()
-            .with_child(Dom.create_text(f"Loaded {len(data.loaded_data)} records"))
+            .with_child(Dom.create_text_do_not_use_without_block_level_wrapper(f"Loaded {len(data.loaded_data)} records"))
             .with_child(reset_button(data)))
 
 
 def layout(data, info):
-    title = (Dom.create_text("Async Database Connection")
+    title = (Dom.create_text_do_not_use_without_block_level_wrapper("Async Database Connection")
              .with_css("font-size:24px;margin-bottom:20px;"))
 
     if data.stage == "not_connected":
@@ -53,7 +53,7 @@ def layout(data, info):
     elif data.stage == "loaded":
         content = loaded_view(data)
     else:
-        content = Dom.create_text(data.error_message)
+        content = Dom.create_text_do_not_use_without_block_level_wrapper(data.error_message)
 
     body = (Dom.create_body()
             .with_css("padding:30px;font-family:sans-serif;")

--- a/examples/python/calc.py
+++ b/examples/python/calc.py
@@ -114,7 +114,7 @@ def make_callback(calc, event_type, event_data):
 def button(calc, label, event_type, event_data, style):
     return (Dom.create_div()
             .with_css(style)
-            .with_child(Dom.create_text(label))
+            .with_child(Dom.create_text_do_not_use_without_block_level_wrapper(label))
             .with_callback(
                 EventFilter.Hover(HoverEventFilter.MouseUp),
                 calc,
@@ -124,7 +124,7 @@ def button(calc, label, event_type, event_data, style):
 def layout(data, info):
     display = (Dom.create_div()
                .with_css(DISPLAY_STYLE)
-               .with_child(Dom.create_text(data.display)))
+               .with_child(Dom.create_text_do_not_use_without_block_level_wrapper(data.display)))
 
     rows = [
         ("C", "clear", None, BTN_STYLE),

--- a/examples/python/hello-world.py
+++ b/examples/python/hello-world.py
@@ -16,7 +16,7 @@ def layout(data, info):
     # .with_css(...) consumes self and returns a new Dom, so builder
     # calls chain inline.
     label = (Dom.create_div()
-             .with_child(Dom.create_text(str(data.counter)))
+             .with_child(Dom.create_text_do_not_use_without_block_level_wrapper(str(data.counter)))
              .with_css("font-size: 32px;"))
 
     # Button widget with a click handler. with_on_click(data, callback)

--- a/examples/python/hello_world_window.py
+++ b/examples/python/hello_world_window.py
@@ -32,7 +32,7 @@ def layout(data, info):
         Dom: The styled DOM tree to render
     """
     # Create a simple label
-    label = azul.Dom.create_text(f"Hello from Python! Counter: {data.counter}")
+    label = azul.Dom.create_text_do_not_use_without_block_level_wrapper(f"Hello from Python! Counter: {data.counter}")
 
     # Create a button that increments the counter
     button_dom = azul.Button.create("Click me!").dom()

--- a/examples/python/infinity.py
+++ b/examples/python/infinity.py
@@ -11,7 +11,7 @@ class InfinityState:
 
 
 def layout(data, info):
-    title = (Dom.create_text(
+    title = (Dom.create_text_do_not_use_without_block_level_wrapper(
         f"Infinite Gallery - {len(data.file_paths)} images")
         .with_css("font-size:20px;margin-bottom:10px;"))
 
@@ -25,7 +25,7 @@ def layout(data, info):
                 .with_css("width:150px;height:150px;background:white;"
                           "border:1px solid #ddd;display:flex;"
                           "align-items:center;justify-content:center;")
-                .with_child(Dom.create_text(data.file_paths[i])))
+                .with_child(Dom.create_text_do_not_use_without_block_level_wrapper(data.file_paths[i])))
         container = container.with_child(item)
 
     body = (Dom.create_body()

--- a/examples/python/opengl.py
+++ b/examples/python/opengl.py
@@ -10,10 +10,10 @@ class OpenGlState:
 
 
 def layout(data, info):
-    title = (Dom.create_text("OpenGL Integration Demo")
+    title = (Dom.create_text_do_not_use_without_block_level_wrapper("OpenGL Integration Demo")
              .with_css("color:white;font-size:24px;margin-bottom:20px;"))
 
-    placeholder = (Dom.create_text(
+    placeholder = (Dom.create_text_do_not_use_without_block_level_wrapper(
         "OpenGL texture would render here (timer-driven animation pending)")
         .with_css("flex-grow:1;min-height:300px;border-radius:10px;"
                   "background:#222;color:white;display:flex;"

--- a/examples/python/widgets.py
+++ b/examples/python/widgets.py
@@ -16,13 +16,13 @@ CLICK = EventFilter.Hover(HoverEventFilter.MouseUp)
 
 
 def layout(data, info):
-    title = (Dom.create_text("Widget Showcase")
+    title = (Dom.create_text_do_not_use_without_block_level_wrapper("Widget Showcase")
              .with_css("font-size:24px;margin-bottom:20px;"))
 
     button = (Dom.create_div()
               .with_css("margin-bottom:10px;padding:10px;background:#4CAF50;"
                         "color:white;cursor:pointer;")
-              .with_child(Dom.create_text("Click me!"))
+              .with_child(Dom.create_text_do_not_use_without_block_level_wrapper("Click me!"))
               .with_callback(CLICK, data, on_button_click))
 
     checkbox = (CheckBox.create(data.checkbox_checked)

--- a/examples/red/hello-world.red
+++ b/examples/red/hello-world.red
@@ -61,7 +61,7 @@ on-layout: func [[cdecl] arg0 [byte-ptr!] arg1 [byte-ptr!] out [byte-ptr!]
 
         label: AzDom_createDiv
         label: AzDom_withCss label mk-str "font-size: 32px;"
-        label: AzDom_withChild label (AzDom_createText mk-str num)
+        label: AzDom_withChild label (AzDom_createTextDoNotUseWithoutBlockLevelWrapper mk-str num)
 
         click-cb:   azul-register-button-on-click-callback :on-click
         click-data: azul-refany-create as byte-ptr! the-model

--- a/examples/ruby/README.md
+++ b/examples/ruby/README.md
@@ -53,7 +53,7 @@ points the loader at `libazul.dylib`/`libazul.so` in the working directory.)
 
 ## Notes
 
-- Style nodes with plain CSS strings: `Azul::Dom.create_text('5').with_css('font-size: 32px;')`.
+- Style nodes with plain CSS strings: `Azul::Dom.create_text_do_not_use_without_block_level_wrapper('5').with_css('font-size: 32px;')`.
   (No need to build `CssProperty` unions via `Azul::Native.az_css_property_*` —
   `Dom#with_css` parses the string for you.)
 - The codegen's `_register_callback` helper auto-fires inside the

--- a/examples/ruby/hello-world.rb
+++ b/examples/ruby/hello-world.rb
@@ -23,7 +23,7 @@ layout = lambda do |data_ptr, _info|
 
   label = Azul::Dom.create_div
     .with_css('font-size: 32px;')
-    .with_child(Azul::Dom.create_text(m.counter.to_s))
+    .with_child(Azul::Dom.create_text_do_not_use_without_block_level_wrapper(m.counter.to_s))
 
   button = Azul::Button.create('Increase counter')
     .with_button_type(Azul::ButtonType::Primary)

--- a/examples/rust/src/anim.rs
+++ b/examples/rust/src/anim.rs
@@ -50,9 +50,9 @@ extern "C" fn layout(mut data: RefAny, _info: LayoutCallbackInfo) -> Dom {
     Dom::create_body().with_child(
         Dom::create_div()
             .with_css(ROOT)
-            .with_child(Dom::create_text("Timer Animation").with_css(TITLE))
+            .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Timer Animation").with_css(TITLE))
             .with_child(
-                Dom::create_text("box slides via add_timer → RefreshDom").with_css(SUBTITLE),
+                Dom::create_text_do_not_use_without_block_level_wrapper("box slides via add_timer → RefreshDom").with_css(SUBTITLE),
             )
             .with_child(
                 Dom::create_div()
@@ -60,7 +60,7 @@ extern "C" fn layout(mut data: RefAny, _info: LayoutCallbackInfo) -> Dom {
                     .with_child(Dom::create_div().with_css(bubble_css.as_str())),
             )
             .with_child(
-                Dom::create_text(format!("frame {}", frame).as_str()).with_css(COUNTER),
+                Dom::create_text_do_not_use_without_block_level_wrapper(format!("frame {}", frame).as_str()).with_css(COUNTER),
             ),
     )
 }

--- a/examples/rust/src/async.rs
+++ b/examples/rust/src/async.rs
@@ -91,7 +91,7 @@ impl ConnectionStatus {
     pub fn dom(&self, data_clone: RefAny) -> Dom {
         match self {
             NotConnected { database } => Dom::create_div()
-                .with_child(Dom::create_text("Enter database to connect to:"))
+                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Enter database to connect to:"))
                 .with_child(
                     TextInput::create()
                         .with_text(database.clone())
@@ -112,19 +112,19 @@ impl ConnectionStatus {
                 use self::ConnectionStage::*;
 
                 let progress_div = match stage {
-                    EstablishingConnection => Dom::create_text("Establishing connection..."),
+                    EstablishingConnection => Dom::create_text_do_not_use_without_block_level_wrapper("Establishing connection..."),
                     ConnectionEstablished => {
-                        Dom::create_text("Connection established! Waiting for data...")
+                        Dom::create_text_do_not_use_without_block_level_wrapper("Connection established! Waiting for data...")
                     }
                     LoadingData { percent_done } => Dom::create_div()
-                        .with_child(Dom::create_text("Loading data..."))
+                        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Loading data..."))
                         .with_child(ProgressBar::create(*percent_done).dom()),
-                    LoadingFinished => Dom::create_text("Loading finished!"),
+                    LoadingFinished => Dom::create_text_do_not_use_without_block_level_wrapper("Loading finished!"),
                 };
 
                 let mut data_rendered_div = Dom::create_div();
                 for chunk in data_in_progress.chunks(10) {
-                    data_rendered_div.add_child(Dom::create_text(format!("{:?}", chunk).as_str()));
+                    data_rendered_div.add_child(Dom::create_text_do_not_use_without_block_level_wrapper(format!("{:?}", chunk).as_str()));
                 }
 
                 let stop_btn = Button::create("Stop thread")
@@ -139,7 +139,7 @@ impl ConnectionStatus {
             DataLoaded { data: data_loaded } => {
                 let mut data_rendered_div = Dom::create_div();
                 for chunk in data_loaded.chunks(10) {
-                    data_rendered_div.add_child(Dom::create_text(format!("{:?}", chunk).as_str()));
+                    data_rendered_div.add_child(Dom::create_text_do_not_use_without_block_level_wrapper(format!("{:?}", chunk).as_str()));
                 }
 
                 let reset_btn = Button::create("Reset")
@@ -151,7 +151,7 @@ impl ConnectionStatus {
                     .with_child(reset_btn)
             }
             Error { error } => {
-                let error_div = Dom::create_text(format!("{}", error).as_str());
+                let error_div = Dom::create_text_do_not_use_without_block_level_wrapper(format!("{}", error).as_str());
 
                 let reset_btn = Button::create("Reset")
                     .with_on_click(data_clone.clone(), reset)

--- a/examples/rust/src/calc.rs
+++ b/examples/rust/src/calc.rs
@@ -20,7 +20,7 @@ extern "C" fn layout(mut data: RefAny, _info: LayoutCallbackInfo) -> Dom {
     // Build the calculator DOM using CSS Grid
     let display = Dom::create_div()
         .with_css(DISPLAY_STYLE)
-        .with_child(Dom::create_text(display_text));
+        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper(display_text));
 
     let buttons = Dom::create_div()
         .with_css(BUTTONS_STYLE)
@@ -272,7 +272,7 @@ fn calc_button(calc: &RefAny, label: &str, event: CalcEvent, style: &str) -> Dom
 
     Dom::create_div()
         .with_css(style)
-        .with_child(Dom::create_text(label))
+        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper(label))
         .with_callback(
             EventFilter::Hover(HoverEventFilter::MouseUp),
             button_data,

--- a/examples/rust/src/hello-world.rs
+++ b/examples/rust/src/hello-world.rs
@@ -17,7 +17,7 @@ extern "C" fn my_layout_func(mut data: RefAny, _: LayoutCallbackInfo) -> Dom {
     // body > div{font-size:32px} > text(counter), then the button.
     let label = Dom::create_div()
         .with_css("font-size: 32px")
-        .with_child(Dom::create_text(counter.as_str()));
+        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper(counter.as_str()));
 
     let mut button = Button::create("Increase counter");
     button.set_on_click(data.clone(), my_on_click);

--- a/examples/rust/src/icons.rs
+++ b/examples/rust/src/icons.rs
@@ -105,7 +105,7 @@ extern "C" fn icon_demo_layout(_data: RefAny, _info: LayoutCallbackInfo) -> Dom 
         .with_child(edit_icon)
         .with_child(delete_icon);
     
-    let mut note = Dom::create_text("Note: Icons show '?' when no icon provider is registered.");
+    let mut note = Dom::create_text_do_not_use_without_block_level_wrapper("Note: Icons show '?' when no icon provider is registered.");
     note.set_ids_and_classes(IdOrClassVec::from_vec(vec![
         IdOrClass::Class(AzString::from("note"))
     ]));
@@ -115,9 +115,9 @@ extern "C" fn icon_demo_layout(_data: RefAny, _info: LayoutCallbackInfo) -> Dom 
         IdOrClass::Class(AzString::from("container"))
     ]));
     container = container
-        .with_child(Dom::create_text("Navigation Icons"))
+        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Navigation Icons"))
         .with_child(nav_row)
-        .with_child(Dom::create_text("Action Icons"))
+        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Action Icons"))
         .with_child(action_row)
         .with_child(note);
     

--- a/examples/rust/src/infinity.rs
+++ b/examples/rust/src/infinity.rs
@@ -20,7 +20,7 @@ extern "C" fn layout(mut data: RefAny, _: LayoutCallbackInfo) -> Dom {
         d.file_paths.len()
     };
 
-    let title = Dom::create_text(format!("Pictures - {} images", file_count))
+    let title = Dom::create_text_do_not_use_without_block_level_wrapper(format!("Pictures - {} images", file_count))
         .with_css("font-size: 20px; margin-bottom: 10px;");
 
     // Now we can pass the function pointer directly - the API builds the wrapper internally
@@ -62,7 +62,7 @@ extern "C" fn render_virtual_view(mut data: RefAny, info: VirtualViewCallbackInf
             ",
             )
             .with_child(
-                Dom::create_text(d.file_paths[i].clone())
+                Dom::create_text_do_not_use_without_block_level_wrapper(d.file_paths[i].clone())
                     .with_css("font-size: 10px; text-align: center;"),
             );
 

--- a/examples/rust/src/ribbon.rs
+++ b/examples/rust/src/ribbon.rs
@@ -210,7 +210,7 @@ fn column(items: Vec<RibbonItem>) -> RibbonItem {
 }
 
 fn cell(preview_css: &str, sample: &str, name: &str) -> RibbonGalleryCell {
-    RibbonGalleryCell::new(Dom::create_text(sample).with_css(preview_css), name)
+    RibbonGalleryCell::new(Dom::create_text_do_not_use_without_block_level_wrapper(sample).with_css(preview_css), name)
 }
 
 // ---------------------------------------------------------------------------
@@ -391,7 +391,7 @@ fn title_bar() -> Dom {
             "display: flex; align-items: center; justify-content: center; width: 22px; \
              height: 22px; background: #2b579a; margin-right: 10px;",
         )
-        .with_child(Dom::create_text("W").with_css("font-size: 13px; color: white;"));
+        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("W").with_css("font-size: 13px; color: white;"));
 
     let left = Dom::create_div()
         .with_css("display: flex; flex-direction: row; align-items: center;")
@@ -403,7 +403,7 @@ fn title_bar() -> Dom {
             Dom::create_icon("arrow_drop_down").with_css("font-size: 14px; color: #6a6a6a;"),
         );
 
-    let title = Dom::create_text("Document1 - AzWriter")
+    let title = Dom::create_text_do_not_use_without_block_level_wrapper("Document1 - AzWriter")
         .with_css("flex-grow: 1; text-align: center; font-size: 12px; color: #444444;");
 
     let right = Dom::create_div()

--- a/examples/rust/src/scrolling.rs
+++ b/examples/rust/src/scrolling.rs
@@ -32,7 +32,7 @@ fn row(i: usize) -> Dom {
         )
         .as_str(),
     );
-    item.add_child(Dom::create_text(format!("row {i}").as_str()));
+    item.add_child(Dom::create_text_do_not_use_without_block_level_wrapper(format!("row {i}").as_str()));
     item
 }
 

--- a/examples/rust/src/transitions.rs
+++ b/examples/rust/src/transitions.rs
@@ -196,8 +196,8 @@ fn div_with_id(id: &str, css: &str) -> Dom {
 /// would be nothing to animate BETWEEN.
 fn shared_card(title: &str) -> Dom {
     let mut card = div_with_id("shared-card", CARD);
-    card.add_child(Dom::create_text(title));
-    card.add_child(Dom::create_text("same node, different screen").with_css(HINT));
+    card.add_child(Dom::create_text_do_not_use_without_block_level_wrapper(title));
+    card.add_child(Dom::create_text_do_not_use_without_block_level_wrapper("same node, different screen").with_css(HINT));
     card
 }
 
@@ -206,7 +206,7 @@ fn overview(state: &AppState) -> Dom {
     content.add_child(shared_card("Overview"));
     for label in &state.rows {
         let mut row = div_with_id(label, ROW);
-        row.add_child(Dom::create_text(*label));
+        row.add_child(Dom::create_text_do_not_use_without_block_level_wrapper(*label));
         content.add_child(row);
     }
     content
@@ -218,13 +218,13 @@ fn detail(state: &AppState) -> Dom {
         "height: 90px; background: #191926; border-radius: 10px; \
          margin-bottom: 16px; padding: 14px; color: #6a7080; font-size: 13px;",
     );
-    spacer.add_child(Dom::create_text("Detail header"));
+    spacer.add_child(Dom::create_text_do_not_use_without_block_level_wrapper("Detail header"));
     content.add_child(spacer);
     // The shared card is BELOW a header here and at the very top on Overview,
     // so swapping screens moves it — that displacement is the animation.
     content.add_child(shared_card("Detail"));
     let mut note = Dom::create_div().with_css(CARD);
-    note.add_child(Dom::create_text(format!("Shuffles so far: {}", state.shuffles).as_str()));
+    note.add_child(Dom::create_text_do_not_use_without_block_level_wrapper(format!("Shuffles so far: {}", state.shuffles).as_str()));
     content.add_child(note);
     content
 }
@@ -259,7 +259,7 @@ extern "C" fn layout(data: RefAny, _: LayoutCallbackInfo) -> Dom {
                 RefAny::new(()),
             );
         for item in ["Inbox", "Drafts", "Archive", "Trash"] {
-            sidebar.add_child(Dom::create_text(item).with_css(SIDE_ITEM));
+            sidebar.add_child(Dom::create_text_do_not_use_without_block_level_wrapper(item).with_css(SIDE_ITEM));
         }
         body.add_child(sidebar);
     }

--- a/examples/rust/src/widgets.rs
+++ b/examples/rust/src/widgets.rs
@@ -71,14 +71,14 @@ extern "C" fn layout(mut data: RefAny, _: LayoutCallbackInfo) -> Dom {
         .with_on_choice_change(data.clone(), on_dropdown_change)
         .dom()
         .with_css(margin);
-    let selected_label = Dom::create_text(
+    let selected_label = Dom::create_text_do_not_use_without_block_level_wrapper(
         format!("Selected: {}", CHOICES[showcase.selected_choice.min(CHOICES.len() - 1)]).as_str(),
     )
     .with_css("margin-bottom: 10px; color: #2a6;");
 
     // Heading
     let heading = Dom::create_p()
-        .with_child(Dom::create_text("Widget Showcase"))
+        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Widget Showcase"))
         .with_css("font-size: 24px; font-weight: bold; margin-bottom: 20px;");
 
     // Final DOM composition

--- a/examples/scala/HelloWorld.scala
+++ b/examples/scala/HelloWorld.scala
@@ -44,7 +44,7 @@ object HelloWorld {
           case m: MyDataModel =>
             val label = Dom.createDiv()
               .withCss("font-size: 32px;")
-              .withChild(Dom.createText(String.valueOf(m.counter)))
+              .withChild(Dom.createTextDoNotUseWithoutBlockLevelWrapper(String.valueOf(m.counter)))
             val buttonDom = Button.create("Increase counter")
               .withButtonType(ButtonType.Primary.value)
               .onClick(m, ON_CLICK)

--- a/examples/swift/hello-world.swift
+++ b/examples/swift/hello-world.swift
@@ -74,7 +74,7 @@ func layout(_ data: AzRefAny, _ info: AzLayoutCallbackInfo) -> AzDom {
 
     // Counter label (wrapped in a div so the font-size sticks).
     let counterStr = azString(String(m.pointee.counter))
-    let label = AzDom_createText(counterStr)
+    let label = AzDom_createTextDoNotUseWithoutBlockLevelWrapper(counterStr)
 
     var labelWrapper = AzDom_createDiv()
     let fontSize = AzStyleFontSize_px(32.0)

--- a/examples/v/hello-world.v
+++ b/examples/v/hello-world.v
@@ -81,7 +81,7 @@ fn layout(data azul.AzRefAny, info azul.AzLayoutCallbackInfo) azul.AzDom {
 	// Counter label (wrapped in a div so the font-size sticks).
 	counter_val := unsafe { m.counter }
 	counter_str := az_str(counter_val.str())
-	label := C.AzDom_createText(counter_str)
+	label := C.AzDom_createTextDoNotUseWithoutBlockLevelWrapper(counter_str)
 
 	mut label_wrapper := C.AzDom_createDiv()
 	font_size := C.AzStyleFontSize_px(32.0)

--- a/examples/vb6/HelloWorld.bas
+++ b/examples/vb6/HelloWorld.bas
@@ -39,7 +39,7 @@ Public Declare Function AzDom_createBody Lib "azul" Alias "AzDom_createBody" _
     () As Long
 Public Declare Function AzDom_createDiv Lib "azul" Alias "AzDom_createDiv" _
     () As Long
-Public Declare Function AzDom_createText Lib "azul" Alias "AzDom_createText" _
+Public Declare Function AzDom_createTextDoNotUseWithoutBlockLevelWrapper Lib "azul" Alias "AzDom_createTextDoNotUseWithoutBlockLevelWrapper" _
     (ByVal s As Long) As Long
 Public Declare Sub AzDom_addChild Lib "azul" Alias "AzDom_addChild" _
     (ByVal parent As Long, ByVal child As Long)
@@ -141,7 +141,7 @@ Public Function layout(ByVal data As Long, ByVal info As Long) As Long
     ' Counter label, wrapped in a div so the font-size CSS sticks.
     buf = CStr(m.counter)
     labelText = AzStr(buf)
-    labelDom = AzDom_createText(labelText)
+    labelDom = AzDom_createTextDoNotUseWithoutBlockLevelWrapper(labelText)
     labelWrapper = AzDom_createDiv()
 
     fontSize = AzCssProperty_fontSize(AzStyleFontSize_px(32!))

--- a/examples/zig/hello-world.zig
+++ b/examples/zig/hello-world.zig
@@ -61,7 +61,7 @@ fn layout(data: C.AzRefAny, _: C.AzLayoutCallbackInfo) callconv(.c) C.AzDom {
     var buf: [16]u8 = undefined;
     const slice = std.fmt.bufPrint(&buf, "{d}", .{m.counter}) catch return C.AzDom_createBody();
     const counter_str = C.AzString_fromUtf8(slice.ptr, slice.len);
-    const label = C.AzDom_createText(counter_str);
+    const label = C.AzDom_createTextDoNotUseWithoutBlockLevelWrapper(counter_str);
 
     var label_wrapper = C.AzDom_createDiv();
     const font_size = C.AzStyleFontSize_px(32.0);

--- a/layout/src/callbacks.rs
+++ b/layout/src/callbacks.rs
@@ -3685,7 +3685,7 @@ impl CallbackInfo {
 
         // Build scroll offset map from the current ScrollManager state
         let scroll_offsets = layout_window.scroll_manager
-            .build_scroll_offset_map(dom_id, &layout_result.scroll_ids);
+            .build_scroll_offset_map(dom_id, &layout_result.scroll_id_to_node_id);
 
         // Build CPU render state from GpuValueCache - provides current
         // transform values (scrollbar thumb positions) and opacity values

--- a/layout/src/default_actions.rs
+++ b/layout/src/default_actions.rs
@@ -55,6 +55,11 @@ pub struct EditingQueryState {
     pub cursor_at_block_start: bool,
     /// The caret sits at the very end of the block's text.
     pub cursor_at_block_end: bool,
+    /// The editing HOST's computed `white-space` preserves newlines
+    /// (pre / pre-wrap / break-spaces / pre-line). In such a host a literal
+    /// `"\n"` is the native line separator, so Enter inserts one instead of
+    /// recording a structural block split.
+    pub host_preserves_newlines: bool,
 }
 
 #[must_use] pub fn determine_keyboard_default_action(
@@ -118,11 +123,16 @@ pub struct EditingQueryState {
         // Activation (Enter key)
         VirtualKeyCode::Return | VirtualKeyCode::NumpadEnter => {
             focused_node.as_ref().map_or(DefaultAction::None, |focus| {
-                // Enter in a contenteditable host records a structural block
-                // SPLIT for the app to apply — the browser default. Shift+Enter
-                // deliberately falls through (a soft `InlineContent::LineBreak`
-                // via the existing per-IFC text path).
-                if !shift_down && editing.is_some_and(|e| e.is_contenteditable) {
+                // Enter in a contenteditable host: a STRUCTURAL block split
+                // for the app to apply (the browser default) — unless the
+                // host is a plain-text context (`white-space` preserves
+                // newlines), where `"\n"` is the native separator and the
+                // split has no app model to land in. Shift+Enter is the soft
+                // break in either kind of host.
+                if let Some(e) = editing.filter(|e| e.is_contenteditable) {
+                    if shift_down || e.host_preserves_newlines {
+                        return DefaultAction::InsertLineBreakAtCursor { target: *focus };
+                    }
                     return DefaultAction::SplitBlockAtCursor { target: *focus };
                 }
                 if is_element_activatable(focus, layout_results) {
@@ -411,6 +421,7 @@ mod autotest_generated {
             is_contenteditable: true,
             cursor_at_block_start: false,
             cursor_at_block_end: false,
+            host_preserves_newlines: false,
         };
 
         let with = determine_keyboard_default_action_with_editing(
@@ -425,7 +436,9 @@ mod autotest_generated {
             DefaultAction::SplitBlockAtCursor { .. }
         ));
 
-        // Shift+Enter: soft break — NOT structural.
+        // Shift+Enter: the soft break — a literal "\n" through the text
+        // pipeline, never structural. (This used to fall through to nothing;
+        // the documented intent is now implemented.)
         let shift = determine_keyboard_default_action_with_editing(
             &kbd(VirtualKeyCode::Return, &[VirtualKeyCode::LShift]),
             focus,
@@ -433,9 +446,28 @@ mod autotest_generated {
             false,
             Some(&editing),
         );
-        assert!(!matches!(
+        assert!(matches!(
             shift.action,
-            DefaultAction::SplitBlockAtCursor { .. }
+            DefaultAction::InsertLineBreakAtCursor { .. }
+        ));
+
+        // A PLAIN-TEXT host (white-space preserves newlines, e.g. the
+        // text_area widget): plain Enter inserts the newline instead of
+        // splitting blocks — there is no app model for a split to land in.
+        let plaintext = EditingQueryState {
+            host_preserves_newlines: true,
+            ..editing
+        };
+        let plain_enter = determine_keyboard_default_action_with_editing(
+            &kbd(VirtualKeyCode::Return, &[]),
+            focus,
+            &layouts,
+            false,
+            Some(&plaintext),
+        );
+        assert!(matches!(
+            plain_enter.action,
+            DefaultAction::InsertLineBreakAtCursor { .. }
         ));
 
         // Editing-blind: the old behavior, byte for byte.
@@ -460,16 +492,19 @@ mod autotest_generated {
             is_contenteditable: true,
             cursor_at_block_start: true,
             cursor_at_block_end: false,
+            host_preserves_newlines: false,
         };
         let mid = EditingQueryState {
             is_contenteditable: true,
             cursor_at_block_start: false,
             cursor_at_block_end: false,
+            host_preserves_newlines: false,
         };
         let at_end = EditingQueryState {
             is_contenteditable: true,
             cursor_at_block_start: false,
             cursor_at_block_end: true,
+            host_preserves_newlines: false,
         };
 
         let r = |key, e: &EditingQueryState| {

--- a/layout/src/default_actions.rs
+++ b/layout/src/default_actions.rs
@@ -48,6 +48,9 @@ use std::collections::BTreeMap;
 /// caller (`LayoutWindow::build_editing_query_state`) because the decision
 /// function itself deliberately cannot see cursors.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+// Four independent facts about one caret position, not a state enum: any
+// combination of them can hold at once.
+#[allow(clippy::struct_excessive_bools)]
 pub struct EditingQueryState {
     /// The focused node is inside a `contenteditable` host.
     pub is_contenteditable: bool,

--- a/layout/src/document_edit.rs
+++ b/layout/src/document_edit.rs
@@ -182,10 +182,10 @@ fn split_text_dom(node: &mut Dom, byte: usize) -> Dom {
                 .unwrap_or(0);
             (s[..cut].to_string(), s[cut..].to_string())
         }
-        _ => return Dom::create_text(""),
+        _ => return Dom::create_text_do_not_use_without_block_level_wrapper(""),
     };
-    *node = Dom::create_text(head);
-    Dom::create_text(tail)
+    *node = Dom::create_text_do_not_use_without_block_level_wrapper(head);
+    Dom::create_text_do_not_use_without_block_level_wrapper(tail)
 }
 
 /// Split `host.children[node_index]` at the structural position: children
@@ -287,7 +287,7 @@ fn apply_merge(
             };
             match coalesced {
                 Some(joined) => {
-                    *first_children.last_mut().unwrap() = Dom::create_text(joined);
+                    *first_children.last_mut().unwrap() = Dom::create_text_do_not_use_without_block_level_wrapper(joined);
                 }
                 None => first_children.push(second_first),
             }
@@ -492,7 +492,7 @@ fn apply_unwrap(
                 ),
                 _ => unreachable!("checked above"),
             };
-            children[index - 1] = Dom::create_text(joined);
+            children[index - 1] = Dom::create_text_do_not_use_without_block_level_wrapper(joined);
             start = NodePosition::in_text_child(
                 u32::try_from(index - 1).unwrap_or(u32::MAX),
                 prev_len,
@@ -557,7 +557,7 @@ fn apply_unwrap(
                     ),
                     _ => unreachable!("checked above"),
                 };
-                children[holder] = Dom::create_text(joined);
+                children[holder] = Dom::create_text_do_not_use_without_block_level_wrapper(joined);
                 end = NodePosition::in_text_child(
                     u32::try_from(holder).unwrap_or(u32::MAX),
                     seam_byte,
@@ -662,7 +662,7 @@ mod tests {
 
     fn p(text: &str) -> Dom {
         let mut p = Dom::create_p();
-        p.add_child(Dom::create_text(text));
+        p.add_child(Dom::create_text_do_not_use_without_block_level_wrapper(text));
         p
     }
 
@@ -672,7 +672,7 @@ mod tests {
 
     fn li(text: &str) -> Dom {
         let mut li = el("li");
-        li.add_child(Dom::create_text(text));
+        li.add_child(Dom::create_text_do_not_use_without_block_level_wrapper(text));
         li
     }
 
@@ -732,11 +732,11 @@ mod tests {
         // flattened, re-parsed, or byte-walked.
         let mut host = Dom::create_div();
         let mut para = Dom::create_p();
-        para.add_child(Dom::create_text("ab"));
+        para.add_child(Dom::create_text_do_not_use_without_block_level_wrapper("ab"));
         let mut b = el("b");
-        b.add_child(Dom::create_text("bold"));
+        b.add_child(Dom::create_text_do_not_use_without_block_level_wrapper("bold"));
         para.add_child(b);
-        para.add_child(Dom::create_text("cd"));
+        para.add_child(Dom::create_text_do_not_use_without_block_level_wrapper("cd"));
         host.add_child(para);
 
         let cs = changeset(

--- a/layout/src/dom_lint.rs
+++ b/layout/src/dom_lint.rs
@@ -128,7 +128,7 @@ pub fn collect_text_placement_warnings(styled_dom: &StyledDom) -> Vec<String> {
             let mut c = hierarchy.get(parent_id).and_then(|p| p.first_child_id(parent_id));
             while let Some(cc) = c {
                 child_count += 1;
-                c = hierarchy.get(cc).and_then(|s| s.next_sibling_id());
+                c = hierarchy.get(cc).and_then(azul_core::styled_dom::NodeHierarchyItem::next_sibling_id);
             }
             if child_count > 1 {
                 out.push(format!(
@@ -167,7 +167,8 @@ pub fn collect_text_placement_warnings(styled_dom: &StyledDom) -> Vec<String> {
                     break;
                 }
             }
-            sibling = hierarchy.get(sib).and_then(|s| s.next_sibling_id());
+            sibling = hierarchy.get(sib)
+            .and_then(azul_core::styled_dom::NodeHierarchyItem::next_sibling_id);
         }
         if has_block_sibling {
             out.push(format!(

--- a/layout/src/dom_lint.rs
+++ b/layout/src/dom_lint.rs
@@ -1,0 +1,320 @@
+//! Post-layout developer warnings for misused raw text nodes.
+//!
+//! Browsers wrap a raw text run in an ANONYMOUS BLOCK whenever it needs one;
+//! azul does not. A bare `NodeType::Text` therefore has no box of its own —
+//! no rect, no clip, no layout constraints — and every box-model CSS
+//! property, callback, `tab_index` or `dataset` attached to one is silently
+//! inert. That silence has shipped real bugs (text escaping its widget,
+//! click targets that never fire), which is why the raw constructor is named
+//! `create_text_do_not_use_without_block_level_wrapper` and why this pass
+//! exists: after layout, every text node in a shape azul cannot honor is
+//! reported to the developer, once per unique finding.
+//!
+//! The checks are structural (DOM + computed display), deliberately not
+//! geometric: they fire deterministically on the first layout of a DOM,
+//! before any symptom is visible on screen.
+
+use std::collections::BTreeSet;
+use std::sync::Mutex;
+
+use azul_core::{dom::NodeType, id::NodeId, styled_dom::StyledDom};
+use azul_css::props::layout::LayoutDisplay;
+
+use crate::solver3::getters::{get_display_property, MultiValue};
+
+/// One warning per unique message, process-wide. Layouts re-run constantly
+/// (every DOM refresh); a warning that repeats 60 times a second is a warning
+/// nobody reads.
+static EMITTED: Mutex<BTreeSet<u64>> = Mutex::new(BTreeSet::new());
+
+/// The suppression tag for this lint, honored from the `AZ_SUPPRESS`
+/// environment variable (comma-separated list; the common misspelling
+/// `AZ_SUPRESS` is accepted too). Every emitted warning names it.
+pub const SUPPRESS_TAG: &str = "bare_text";
+
+/// `AZ_SUPPRESS=bare_text` (checked once): the developer has read the
+/// warnings and wants them off — e.g. a codebase that deliberately renders
+/// raw text and accepts the differences from browser behavior.
+fn is_suppressed() -> bool {
+    static SUPPRESSED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *SUPPRESSED.get_or_init(|| {
+        let v = std::env::var("AZ_SUPPRESS")
+            .or_else(|_| std::env::var("AZ_SUPRESS"))
+            .unwrap_or_default();
+        v.split(',').any(|t| t.trim().eq_ignore_ascii_case(SUPPRESS_TAG))
+    })
+}
+
+/// Walk `styled_dom` and return one message per text node that is used in a
+/// shape azul cannot honor. Pure — the caller decides how to report.
+#[must_use]
+pub fn collect_text_placement_warnings(styled_dom: &StyledDom) -> Vec<String> {
+    let node_data = styled_dom.node_data.as_container();
+    let hierarchy = styled_dom.node_hierarchy.as_container();
+    let mut out = Vec::new();
+
+    for idx in 0..node_data.len() {
+        let node_id = NodeId::new(idx);
+        let data = &node_data[node_id];
+        let NodeType::Text(text) = data.get_node_type() else {
+            continue;
+        };
+        let snippet = snippet_of(text.as_str());
+
+        // W1 — state on a box-less node: every one of these is inert on a
+        // text node, because only the wrapping block box carries a rect.
+        let mut inert = Vec::new();
+        if !data.get_style().rules.as_ref().is_empty() {
+            inert.push("css properties");
+        }
+        if !data.get_callbacks().as_ref().is_empty() {
+            inert.push("callbacks");
+        }
+        if data.get_tab_index().is_some() {
+            inert.push("a tab_index");
+        }
+        if data.get_dataset().is_some() {
+            inert.push("a dataset");
+        }
+        let Some(h) = hierarchy.get(node_id) else {
+            continue;
+        };
+        if h.first_child_id(node_id).is_some() {
+            inert.push("element children");
+        }
+        if !inert.is_empty() {
+            out.push(format!(
+                "text node {idx} ({snippet}) carries {} — INERT: a text node has no box. \
+                 Move them onto a block wrapper (create_p_with_text / create_div_with_text) \
+                 instead of the raw text node.",
+                inert.join(" + "),
+            ));
+        }
+
+        // W2 — no containing block the text can live in. Browsers would
+        // generate an anonymous block here; azul does not.
+        let Some(parent_id) = h.parent_id() else {
+            out.push(format!(
+                "text node {idx} ({snippet}) has no parent — a raw text run needs a \
+                 block-level container (p / div / ...) to own its box.",
+            ));
+            continue;
+        };
+        let parent_type = node_data[parent_id].get_node_type();
+        if matches!(parent_type, NodeType::Text(_)) {
+            out.push(format!(
+                "text node {idx} ({snippet}) is the child of another text node — \
+                 wrap both in a block-level container (p / div / ...).",
+            ));
+            continue;
+        }
+        let parent_display = match get_display_property(styled_dom, Some(parent_id)) {
+            MultiValue::Exact(d) => d,
+            _ => LayoutDisplay::Block,
+        };
+        if matches!(
+            parent_display,
+            LayoutDisplay::Flex
+                | LayoutDisplay::InlineFlex
+                | LayoutDisplay::Grid
+                | LayoutDisplay::InlineGrid
+        ) {
+            // A text leaf as the SOLE child of a flex/grid box is the
+            // sanctioned wrapper pattern (the parent is the box that carries
+            // the styling — badge, the converted labels). The hazard is text
+            // as ONE OF SEVERAL items: it competes in item layout with no
+            // box of its own.
+            let mut child_count = 0usize;
+            let mut c = hierarchy.get(parent_id).and_then(|p| p.first_child_id(parent_id));
+            while let Some(cc) = c {
+                child_count += 1;
+                c = hierarchy.get(cc).and_then(|s| s.next_sibling_id());
+            }
+            if child_count > 1 {
+                out.push(format!(
+                    "text node {idx} ({snippet}) is one of {child_count} items in a \
+                     {parent_display:?} container — a raw text run competes in flex/grid \
+                     layout with no box of its own (browsers auto-wrap it in an anonymous \
+                     block; azul does not). Wrap it: create_p_with_text / \
+                     create_div_with_text.",
+                ));
+            }
+            continue;
+        }
+
+        // Mixed inline + block content under one parent: the text has no
+        // dedicated line box of its own next to block siblings.
+        let mut sibling = hierarchy
+            .get(parent_id)
+            .and_then(|p| p.first_child_id(parent_id));
+        let mut has_block_sibling = false;
+        while let Some(sib) = sibling {
+            if sib != node_id && !matches!(node_data[sib].get_node_type(), NodeType::Text(_)) {
+                let d = match get_display_property(styled_dom, Some(sib)) {
+                    MultiValue::Exact(d) => d,
+                    _ => LayoutDisplay::Block,
+                };
+                if !matches!(
+                    d,
+                    LayoutDisplay::Inline
+                        | LayoutDisplay::InlineBlock
+                        | LayoutDisplay::InlineFlex
+                        | LayoutDisplay::InlineGrid
+                        | LayoutDisplay::InlineTable
+                        | LayoutDisplay::None
+                ) {
+                    has_block_sibling = true;
+                    break;
+                }
+            }
+            sibling = hierarchy.get(sib).and_then(|s| s.next_sibling_id());
+        }
+        if has_block_sibling {
+            out.push(format!(
+                "text node {idx} ({snippet}) sits NEXT TO block-level siblings — browsers \
+                 would wrap it in an anonymous block, azul does not, so it has no line box \
+                 of its own. Wrap it: create_p_with_text / create_div_with_text.",
+            ));
+        }
+    }
+
+    out
+}
+
+/// Report every finding from [`collect_text_placement_warnings`] to stderr,
+/// once per unique message per process. Call after layout.
+pub fn warn_text_without_block_container(styled_dom: &StyledDom) {
+    if is_suppressed() {
+        return;
+    }
+    let warnings = collect_text_placement_warnings(styled_dom);
+    if warnings.is_empty() {
+        return;
+    }
+    let Ok(mut emitted) = EMITTED.lock() else {
+        return;
+    };
+    for w in warnings {
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        std::hash::Hash::hash(&w, &mut hasher);
+        if emitted.insert(std::hash::Hasher::finish(&hasher)) {
+            eprintln!(
+                "[azul][text-without-block] WARNING: {w} \
+                 (suppress with AZ_SUPPRESS={SUPPRESS_TAG})"
+            );
+        }
+    }
+}
+
+fn snippet_of(text: &str) -> String {
+    let mut s: String = text.chars().take(24).collect();
+    if text.chars().count() > 24 {
+        s.push_str("...");
+    }
+    format!("{s:?}")
+}
+
+#[cfg(test)]
+mod autotest_generated {
+    use azul_core::dom::{Dom, TabIndex};
+    use azul_core::styled_dom::StyledDom;
+    use azul_css::css::Css;
+
+    use super::collect_text_placement_warnings;
+
+    fn styled(mut dom: Dom, css: &str) -> StyledDom {
+        let css = if css.is_empty() {
+            Css::empty()
+        } else {
+            Css::from_string(css.into())
+        };
+        StyledDom::create(&mut dom, css)
+    }
+
+    fn raw_text(s: &str) -> Dom {
+        Dom::create_text_do_not_use_without_block_level_wrapper(s)
+    }
+
+    #[test]
+    fn a_correctly_wrapped_text_produces_no_warning() {
+        let sd = styled(
+            Dom::create_body().with_child(Dom::create_p_with_text("hello")),
+            "",
+        );
+        assert_eq!(collect_text_placement_warnings(&sd), Vec::<String>::new());
+    }
+
+    #[test]
+    fn text_inside_an_inline_span_inside_a_block_is_fine() {
+        let sd = styled(
+            Dom::create_body()
+                .with_child(Dom::create_p().with_child(Dom::create_span_with_text("hi"))),
+            "",
+        );
+        assert_eq!(collect_text_placement_warnings(&sd), Vec::<String>::new());
+    }
+
+    #[test]
+    fn state_on_a_text_node_is_reported_as_inert() {
+        let text = raw_text("styled").with_tab_index(TabIndex::Auto);
+        let sd = styled(Dom::create_body().with_child(Dom::create_p().with_child(text)), "");
+        let w = collect_text_placement_warnings(&sd);
+        assert_eq!(w.len(), 1, "{w:?}");
+        assert!(w[0].contains("INERT"), "{w:?}");
+        assert!(w[0].contains("tab_index"), "{w:?}");
+    }
+
+    #[test]
+    fn a_sole_text_leaf_in_a_flex_wrapper_is_the_sanctioned_pattern() {
+        // badge / the converted labels: the flex box IS the wrapper.
+        let sd = styled(
+            Dom::create_body().with_child(Dom::create_div().with_child(raw_text("flexed"))),
+            "div { display: flex; }",
+        );
+        assert_eq!(collect_text_placement_warnings(&sd), Vec::<String>::new());
+    }
+
+    #[test]
+    fn text_competing_with_other_flex_items_is_reported() {
+        // The tree_view/radio_group shape: a raw label beside element items.
+        let sd = styled(
+            Dom::create_body().with_child(
+                Dom::create_div()
+                    .with_child(Dom::create_div())
+                    .with_child(raw_text("flexed")),
+            ),
+            "body > div { display: flex; }",
+        );
+        let w = collect_text_placement_warnings(&sd);
+        assert_eq!(w.len(), 1, "{w:?}");
+        assert!(w[0].contains("competes in flex/grid"), "{w:?}");
+    }
+
+    #[test]
+    fn text_next_to_a_block_sibling_is_reported() {
+        // The audited frame.rs shape: a title wedged between two divs.
+        let sd = styled(
+            Dom::create_body().with_child(
+                Dom::create_div()
+                    .with_child(Dom::create_div())
+                    .with_child(raw_text("title"))
+                    .with_child(Dom::create_div()),
+            ),
+            "",
+        );
+        let w = collect_text_placement_warnings(&sd);
+        assert_eq!(w.len(), 1, "{w:?}");
+        assert!(w[0].contains("block-level siblings"), "{w:?}");
+    }
+
+    #[test]
+    fn every_widget_dom_is_warning_free() {
+        // The runtime twin of the widgets' label-convention test: none of the
+        // shipped widgets may trip the developer warning.
+        for (name, dom) in crate::widgets::all_widget_doms_for_lint() {
+            let sd = styled(Dom::create_body().with_child(dom), "");
+            let w = collect_text_placement_warnings(&sd);
+            assert_eq!(w, Vec::<String>::new(), "widget {name} trips the text lint: {w:?}");
+        }
+    }
+}

--- a/layout/src/e2e/cpu_backend.rs
+++ b/layout/src/e2e/cpu_backend.rs
@@ -176,7 +176,7 @@ impl CpuBackend {
         // scroll-shift machinery further down.
         let scroll_offsets = layout_window
             .scroll_manager
-            .build_scroll_offset_map(dom_id, &result.scroll_ids);
+            .build_scroll_offset_map(dom_id, &result.scroll_id_to_node_id);
 
         // GPU-value diff: thumb position / fade opacity / transforms change
         // WITHOUT any display-list item changing (items only carry the keys).

--- a/layout/src/e2e/full.rs
+++ b/layout/src/e2e/full.rs
@@ -19,6 +19,7 @@
 //! curl -X POST http://localhost:8765/ -d '{"type":"get_state"}'
 //! ```
 
+use crate::solver3::layout_tree::LayoutNodeId;
 use alloc::collections::BTreeMap;
 use alloc::collections::VecDeque;
 use alloc::string::String;
@@ -12330,7 +12331,7 @@ pub fn process_debug_event(
                             if let Some(layout_node) = layout_result.layout_tree.get(layout_idx) {
                                 let node_pos = layout_result
                                     .calculated_positions
-                    .get(layout_idx)
+                    .get(layout_idx.index())
                                     .copied()
                                     .unwrap_or_default();
                                 let node_size = layout_node.used_size.unwrap_or_default();
@@ -13429,7 +13430,7 @@ pub fn process_debug_event(
                         ("Anonymous", -1i64)
                     };
 
-                    let cold = layout_tree.cold(idx);
+                    let cold = layout_tree.cold(LayoutNodeId::new(idx));
                     nodes.push(LayoutNodeInfo {
                         layout_idx: idx,
                         dom_idx,
@@ -13946,7 +13947,7 @@ pub fn process_debug_event(
             if let Some(layout_result) = layout_window.layout_results.get(&dom_id) {
                 // Check each node in the layout tree to see if it has scrollbar_info (warm tier)
                 for (node_idx, node) in layout_result.layout_tree.nodes.iter().enumerate() {
-                    let scrollbar_info = layout_result.layout_tree.warm(node_idx)
+                    let scrollbar_info = layout_result.layout_tree.warm(LayoutNodeId::new(node_idx))
                         .and_then(|w| w.scrollbar_info.as_ref());
                     if let Some(scrollbar_info) = scrollbar_info {
                         if scrollbar_info.needs_vertical || scrollbar_info.needs_horizontal {

--- a/layout/src/e2e/full.rs
+++ b/layout/src/e2e/full.rs
@@ -11114,7 +11114,7 @@ fn generate_c_scaffold(components: &[ScaffoldComponentInfo]) -> Vec<(String, Str
     let mut layout_body = String::new();
     layout_body.push_str("    AzDom body = AzDom_createBody();\n");
     if components.is_empty() {
-        layout_body.push_str("    AzDom_addChild(&body, AzDom_createText(AZ_STR(\"Hello from Azul!\")));\n");
+        layout_body.push_str("    AzDom_addChild(&body, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AZ_STR(\"Hello from Azul!\")));\n");
     } else {
         for comp in components {
             let struct_name = to_pascal_case(&comp.name);

--- a/layout/src/e2e/full.rs
+++ b/layout/src/e2e/full.rs
@@ -6574,14 +6574,14 @@ fn eval_assert_manager_invariants(
     /// invariant somebody sketches must land here, not in silence.
     const UNIMPLEMENTED_CROSS: &[(&str, &str)] = &[];
 
-    /// Managers this assertion does NOT check, each with the reason. Recorded
-    /// rather than omitted: gpu_state was simply absent from KNOWN_MANAGERS, and
-    /// that silence is exactly how the scrollbar-fade latch stayed invisible to
-    /// every invariant in this file. A reader comparing this list against
-    /// layout/src/managers/ must be able to account for all 22.
-    ///
-    /// Naming one of these in a scenario is a hard failure with its reason
-    /// attached, so nobody can go green believing they asserted something here.
+    // Managers this assertion does NOT check, each with the reason. Recorded
+    // rather than omitted: gpu_state was simply absent from KNOWN_MANAGERS, and
+    // that silence is exactly how the scrollbar-fade latch stayed invisible to
+    // every invariant in this file. A reader comparing this list against
+    // layout/src/managers/ must be able to account for all 22.
+    //
+    // Naming one of these in a scenario is a hard failure with its reason
+    // attached, so nobody can go green believing they asserted something here.
 
     let list = |key: &str, default: &[&str]| -> Result<Vec<String>, String> {
         match params.get(key) {
@@ -11010,7 +11010,7 @@ extern "C" fn {slot_name}(data: &mut RefAny, info: &mut CallbackInfo) -> Update 
     let mut layout_body = String::new();
     if components.is_empty() {
         layout_body.push_str("    Dom::create_body()\n");
-        layout_body.push_str("        .with_child(Dom::create_text(\"Hello from Azul!\"))\n");
+        layout_body.push_str("        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper(\"Hello from Azul!\"))\n");
         layout_body.push_str("        .with_css(\"\")\n");
     } else {
         layout_body.push_str("    Dom::create_body()\n");
@@ -11197,7 +11197,7 @@ fn generate_cpp_scaffold(components: &[ScaffoldComponentInfo]) -> Vec<(String, S
     let mut layout_body = String::new();
     layout_body.push_str("    auto body = Dom::create_body();\n");
     if components.is_empty() {
-        layout_body.push_str("    body.add_child(Dom::create_text(String(\"Hello from Azul!\")));\n");
+        layout_body.push_str("    body.add_child(Dom::create_text_do_not_use_without_block_level_wrapper(String(\"Hello from Azul!\")));\n");
     } else {
         for comp in components {
             let struct_name = to_pascal_case(&comp.name);
@@ -11293,7 +11293,7 @@ fn generate_python_scaffold(components: &[ScaffoldComponentInfo]) -> Vec<(String
     let mut layout_body = String::new();
     layout_body.push_str("    body = Dom.create_body()\n");
     if components.is_empty() {
-        layout_body.push_str("    body = body.with_child(Dom.create_text(\"Hello from Azul!\"))\n");
+        layout_body.push_str("    body = body.with_child(Dom.create_text_do_not_use_without_block_level_wrapper(\"Hello from Azul!\"))\n");
     } else {
         for comp in components {
             let class_name = format!("{}Data", to_pascal_case(&comp.name));

--- a/layout/src/e2e/full.rs
+++ b/layout/src/e2e/full.rs
@@ -6360,9 +6360,24 @@ fn collect_state_machine_leaks(
         );
     }
     if lw.focus_manager.pending_contenteditable_focus.is_some() {
-        leaks.push(
+        // The retry count is in the MESSAGE, not in the condition.
+        // `finalize_pending_focus_changes` may put the request back up to
+        // `MAX_PENDING_FOCUS_RETRIES` times when the node has no entry in
+        // `dom_to_layout` yet (`FocusManager::rearm_pending_contenteditable_focus`),
+        // but a re-arm that is still in flight at scenario end is a caret that
+        // was never seeded — which is precisely what this law is for. Naming the
+        // count only keeps a bounded re-arm from being misread as "finalize
+        // never ran".
+        leaks.push(format!(
             "focus_manager.pending_contenteditable_focus is still Some — contenteditable focus was \
-             queued and never finalized"
+             queued and never finalized (re-armed {} time(s) for want of a text layout)",
+            lw.focus_manager.pending_focus_retries
+        ));
+    }
+    if lw.focus_manager.deferred_focus_target.is_some() {
+        leaks.push(
+            "focus_manager.deferred_focus_target is still Some — a focus request waited for a \
+             layout that never came"
                 .to_string(),
         );
     }
@@ -7720,11 +7735,14 @@ fn fp_focus(m: &azul_layout::managers::focus_cursor::FocusManager) -> ManagerFin
             )
         }
     };
+    if m.deferred_focus_target.is_some() {
+        population += 1;
+    }
     ManagerFingerprint::new(
         population,
         format!(
-            "focused={focused} pending={:?} cursor_init={} pending_ce={pending_ce}",
-            m.pending_focus_request, m.cursor_needs_initialization
+            "focused={focused} pending={:?} cursor_init={} pending_ce={pending_ce} deferred={:?}",
+            m.pending_focus_request, m.cursor_needs_initialization, m.deferred_focus_target
         ),
     )
 }

--- a/layout/src/e2e/runner.rs
+++ b/layout/src/e2e/runner.rs
@@ -28,6 +28,7 @@
 //! `tests/contenteditable_e2e.rs` (LayoutWindow + `RendererResources::default()`
 //! + `ExternalSystemCallbacks::rust_internal()` + `FullWindowState`).
 
+use crate::solver3::layout_tree::LayoutNodeId;
 use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
@@ -2931,7 +2932,7 @@ impl Runner {
                 };
                 let Some(mut sb) = layout_result
                     .layout_tree
-                    .warm(node_idx)
+                    .warm(LayoutNodeId::new(node_idx))
                     .and_then(|w| w.scrollbar_info)
                 else {
                     continue;
@@ -2952,7 +2953,7 @@ impl Runner {
                         &mut sb,
                     );
                     if raised {
-                        if let Some(warm) = layout_result.layout_tree.warm_mut(node_idx) {
+                        if let Some(warm) = layout_result.layout_tree.warm_mut(LayoutNodeId::new(node_idx)) {
                             warm.scrollbar_info = Some(sb);
                         }
                     }
@@ -2966,7 +2967,7 @@ impl Runner {
                     .copied()
                     .unwrap_or_else(LogicalPosition::zero);
                 let container_rect = LogicalRect { origin: container_origin, size: container_size };
-                let content_size = layout_result.layout_tree.get_content_size(node_idx);
+                let content_size = layout_result.layout_tree.get_content_size(LayoutNodeId::new(node_idx));
                 let thickness = sb.scrollbar_width.max(sb.scrollbar_height);
                 regs.push((
                     *dom_id,

--- a/layout/src/e2e/runner.rs
+++ b/layout/src/e2e/runner.rs
@@ -962,6 +962,30 @@ impl Runner {
             result = result.max(self.process_window_events(depth + 1));
         }
 
+        // TEXT-EDIT NOTIFICATIONS (port of the DLL's drain): edits committed
+        // outside the text-input record pipeline dispatch their Input event
+        // here, so `On::Input` observes deletions and line breaks too.
+        {
+            let pending = self.layout_window.take_text_edit_notifications();
+            if !pending.is_empty() {
+                let now = self.now();
+                let edit_events: Vec<_> = pending
+                    .into_iter()
+                    .map(|host| {
+                        azul_core::events::SyntheticEvent::new(
+                            azul_core::events::EventType::Input,
+                            azul_core::events::EventSource::User,
+                            host,
+                            now.clone(),
+                            azul_core::events::EventData::None,
+                        )
+                    })
+                    .collect();
+                let (edit_result, _edit_update, _) = self.dispatch_events_propagated(&edit_events);
+                result = result.max(edit_result);
+            }
+        }
+
         // Finalize pending focus changes (caret init for contenteditable) —
         // the DLL's end-of-pass `SystemChange::FinalizePendingFocusChanges`.
         self.layout_window.finalize_pending_focus_changes();
@@ -1449,27 +1473,41 @@ impl Runner {
 
             // === Focus ===
             CallbackChange::SetFocusTarget { target } => {
-                use azul_layout::managers::focus_cursor::resolve_focus_target;
+                use azul_layout::managers::focus_cursor::{
+                    resolve_focus_target_or_defer, FocusResolution,
+                };
                 use azul_layout::managers::scroll_into_view::ScrollIntoViewOptions;
 
                 let now = self.now();
                 let window_state = self.window_state.clone();
                 let lw = &mut self.layout_window;
-                let current_focus = lw.focus_manager.get_focused_node().copied();
-                match resolve_focus_target(target, &lw.layout_results, current_focus) {
-                    Ok(Some(new_focus)) => {
+                // `resolve_focus_target` cannot tell "matched nothing" from "no
+                // layout exists to match against yet": both are `Ok(None)`, and
+                // this arm applied that as CLEAR FOCUS. A `set_focus` issued
+                // before the first layout — the ordinary case for a `create`
+                // callback — therefore vanished, which is what apps papered
+                // over with a short timer. `Deferred` means do NOTHING: the
+                // target is parked on the focus manager and re-resolved by
+                // `finalize_pending_focus_changes` after the next layout pass.
+                match resolve_focus_target_or_defer(
+                    &mut lw.focus_manager,
+                    target,
+                    &lw.layout_results,
+                ) {
+                    Ok(FocusResolution::Resolved(Some(new_focus))) => {
                         lw.focus_manager.set_focused_node(Some(new_focus));
                         lw.scroll_node_into_view(new_focus, ScrollIntoViewOptions::nearest(), now);
                         arm_caret_for_focus(lw, Some(new_focus), &window_state);
                         lw.finalize_pending_focus_changes();
                         ProcessEventResult::ShouldReRenderCurrentWindow
                     }
-                    Ok(None) => {
+                    Ok(FocusResolution::Resolved(None)) => {
                         lw.focus_manager.set_focused_node(None);
                         arm_caret_for_focus(lw, None, &window_state);
                         lw.finalize_pending_focus_changes();
                         ProcessEventResult::ShouldReRenderCurrentWindow
                     }
+                    Ok(FocusResolution::Deferred) => ProcessEventResult::DoNothing,
                     Err(_) => ProcessEventResult::DoNothing,
                 }
             }
@@ -2451,8 +2489,14 @@ impl Runner {
                     .collect();
 
                 let mut result = ProcessEventResult::DoNothing;
-                let (text_changes_result, text_update, _) =
+                let (text_changes_result, text_update, text_prevent_default) =
                     self.dispatch_events_propagated(&text_events);
+                // A callback veto kills the recorded edit — same as the DLL:
+                // clearing it also stops any later apply from landing it late.
+                if text_prevent_default {
+                    self.layout_window.text_input_manager.clear_changeset();
+                    return result.max(text_changes_result);
+                }
                 result = result.max(text_changes_result);
                 if matches!(
                     text_update,
@@ -2629,6 +2673,13 @@ impl Runner {
             }
         }
 
+        // Parity with the DLL's `regenerate_layout` tail: a focus parked
+        // before the FIRST layout is applied right after the layout that made
+        // it resolvable, so the caret is seeded in this very frame.
+        if self.layout_window.focus_manager.has_deferred_focus_target() {
+            self.layout_window.finalize_pending_focus_changes();
+        }
+
         self.render_and_record();
     }
 
@@ -2795,6 +2846,49 @@ impl Runner {
                 }
                 (self.set_focus(None, focused), true)
             }
+            DefaultAction::InsertLineBreakAtCursor { target } => {
+                // Same as the DLL shells: plain-text Enter records a literal
+                // "\n" and applies it directly (the apply tail already ran
+                // this pass). Veto is honored by the !prevent_default gate
+                // around default actions.
+                if let Some(node_id) = target.node.into_crate_internal() {
+                    let old_inline = self
+                        .layout_window
+                        .get_text_before_textinput(target.dom, node_id);
+                    let old_text = self
+                        .layout_window
+                        .extract_text_from_inline_content(&old_inline);
+                    use crate::managers::text_input::TextInputSource;
+                    self.layout_window.text_input_manager.record_input(
+                        *target,
+                        "\n".to_string(),
+                        old_text,
+                        TextInputSource::Keyboard,
+                    );
+                    let changeset_result = self.layout_window.apply_text_changeset();
+                    let mut r = ProcessEventResult::DoNothing;
+                    if !changeset_result.dirty_nodes.is_empty() {
+                        r = if changeset_result.needs_relayout {
+                            ProcessEventResult::ShouldIncrementalRelayout
+                        } else {
+                            ProcessEventResult::ShouldUpdateDisplayListCurrentWindow
+                        };
+                        self.layout_window.scroll_selection_into_view(
+                            azul_layout::window::SelectionScrollType::Cursor,
+                            azul_layout::window::ScrollMode::Instant,
+                        );
+                    }
+                    // Applied outside the record pipeline's event window —
+                    // owe the host its Input dispatch (drained at pass tail).
+                    self.layout_window
+                        .text_edit_manager
+                        .pending_edit_notifications
+                        .push(*target);
+                    (r, false)
+                } else {
+                    (ProcessEventResult::DoNothing, false)
+                }
+            }
             DefaultAction::SplitBlockAtCursor { .. }
             | DefaultAction::MergeWithPrevious { .. }
             | DefaultAction::MergeWithNext { .. } => {
@@ -2822,19 +2916,24 @@ impl Runner {
         let lw = &mut self.layout_window;
         let mut regs: Vec<(DomId, NodeId, LogicalRect, LogicalSize, f32, f32, bool, bool)> =
             Vec::new();
-        for (dom_id, layout_result) in &lw.layout_results {
-            for (node_idx, node) in layout_result.layout_tree.nodes.iter().enumerate() {
-                let Some(sb) = layout_result
-                    .layout_tree
-                    .warm(node_idx)
-                    .and_then(|w| w.scrollbar_info.as_ref())
-                else {
+        for (dom_id, layout_result) in &mut lw.layout_results {
+            // Same amendment as the DLL copy (see common/layout.rs): a
+            // VirtualView's scrollable extent is whatever its callback just
+            // published, so the necessity flags are amended here — and stored
+            // back — before the gate below reads them. Without this, no
+            // headless test can ever see an `overflow: auto` VirtualView
+            // scrollbar.
+            let scroll_states = lw.scroll_manager.get_scroll_states_for_dom(*dom_id);
+            for node_idx in 0..layout_result.layout_tree.nodes.len() {
+                let node = &layout_result.layout_tree.nodes[node_idx];
+                let Some(dom_node_id) = node.dom_node_id else {
                     continue;
                 };
-                if !(sb.needs_vertical || sb.needs_horizontal) {
-                    continue;
-                }
-                let Some(dom_node_id) = node.dom_node_id else {
+                let Some(mut sb) = layout_result
+                    .layout_tree
+                    .warm(node_idx)
+                    .and_then(|w| w.scrollbar_info)
+                else {
                     continue;
                 };
                 let border_box_size = node.used_size.unwrap_or_default();
@@ -2844,6 +2943,23 @@ impl Runner {
                     width: (border_box_size.width - border.left - border.right).max(0.0),
                     height: (border_box_size.height - border.top - border.bottom).max(0.0),
                 };
+                if let Some(pos) = scroll_states.get(&dom_node_id) {
+                    let raised = crate::solver3::cache::apply_virtual_scroll_necessity(
+                        &layout_result.styled_dom,
+                        dom_node_id,
+                        pos.children_rect.size,
+                        container_size,
+                        &mut sb,
+                    );
+                    if raised {
+                        if let Some(warm) = layout_result.layout_tree.warm_mut(node_idx) {
+                            warm.scrollbar_info = Some(sb);
+                        }
+                    }
+                }
+                if !(sb.needs_vertical || sb.needs_horizontal) {
+                    continue;
+                }
                 let container_origin = layout_result
                     .calculated_positions
                     .get(node_idx)

--- a/layout/src/headless.rs
+++ b/layout/src/headless.rs
@@ -17,6 +17,7 @@
 //!
 //! Activated with `AZUL_HEADLESS=1` (optionally `AZ_DEBUG=1` for the debug server).
 
+use crate::solver3::layout_tree::LayoutNodeId;
 use std::collections::BTreeMap;
 
 use azul_core::{
@@ -95,7 +96,7 @@ struct ScrollContainerEntry {
     dom_id: DomId,
     node_id: NodeId,
     /// Index of this node in its DOM's layout tree (for content-size lookup).
-    layout_idx: usize,
+    layout_idx: LayoutNodeId,
     scroll_id: u64,
     /// Static viewport box, window space (placement-translated).
     rect: LogicalRect,
@@ -326,7 +327,7 @@ pub fn node_rect_to_screen(
         }
         let Some(anc_node) = nodes.get(anc) else { break };
         if let Some(anid) = anc_node.dom_node_id {
-            if layout_result.scroll_ids.contains_key(&anc) {
+            if layout_result.scroll_ids.contains_key(&LayoutNodeId::new(anc)) {
                 links_rev.push(HitChainLink::Scroll(dom_id, anid));
             }
             if resolve_transform(dom_id, anid).is_some() {
@@ -442,7 +443,7 @@ fn compute_node_chains(
                 } else {
                     chain_of[p]
                 };
-                let is_scroll = scroll_ids.contains_key(&p);
+                let is_scroll = scroll_ids.contains_key(&LayoutNodeId::new(p));
                 let pnid = nodes[p].dom_node_id;
                 let parent_transforms = pnid.is_some_and(has_transform);
                 match (pnid, is_scroll || parent_transforms) {
@@ -710,9 +711,9 @@ impl CpuHitTester {
             // them), but css-overflow-3 disables their user-triggered
             // scrolling, so the hit-tester must not route the wheel there.
             for (&layout_idx, &scroll_id) in scroll_ids {
-                let Some(n) = nodes.get(layout_idx) else { continue };
+                let Some(n) = nodes.get(layout_idx.index()) else { continue };
                 let Some(node_id) = n.dom_node_id else { continue };
-                let (Some(pos), Some(size)) = (positions.get(layout_idx), n.used_size) else {
+                let (Some(pos), Some(size)) = (positions.get(layout_idx.index()), n.used_size) else {
                     continue;
                 };
                 let user_scrollable = styled_dom
@@ -741,7 +742,7 @@ impl CpuHitTester {
                         },
                         size,
                     },
-                    chain: chain_of[layout_idx],
+                    chain: chain_of[layout_idx.index()],
                 });
             }
 
@@ -951,7 +952,7 @@ pub fn convert_cpu_hit_test_to_full(
                     .get(node_id)
                     .and_then(|indices| indices.first())
                     .and_then(|&idx| {
-                        let node_pos = lr.calculated_positions.get(idx)?;
+                        let node_pos = lr.calculated_positions.get(idx.index())?;
                         let node = lr.layout_tree.get(idx)?;
                         let bp = node.box_props.unpack();
                         let content_x =
@@ -1027,7 +1028,7 @@ pub fn convert_cpu_hit_test_to_full(
                 continue;
             }
             let parent_rect = LogicalRect::new(node_pos, node_size);
-            let child_rect = compute_scroll_child_rect(lr, layout_idx, parent_rect);
+            let child_rect = compute_scroll_child_rect(lr, layout_idx.index(), parent_rect);
 
             let scroll_node = OverflowingScrollNode {
                 parent_rect,
@@ -1089,7 +1090,7 @@ pub fn compute_scroll_child_rect(
     layout_idx: usize,
     parent_rect: LogicalRect,
 ) -> LogicalRect {
-    let content_size = layout_result.layout_tree.get_content_size(layout_idx);
+    let content_size = layout_result.layout_tree.get_content_size(LayoutNodeId::new(layout_idx));
     LogicalRect::new(
         parent_rect.origin,
         LogicalSize::new(

--- a/layout/src/icon.rs
+++ b/layout/src/icon.rs
@@ -184,7 +184,7 @@ fn create_font_icon_from_original(
     original: &StyledDom,
     system_style: &SystemStyle,
 ) -> StyledDom {
-    let mut dom = Dom::create_text(font_icon.icon_char.clone());
+    let mut dom = Dom::create_text_do_not_use_without_block_level_wrapper(font_icon.icon_char.clone());
     
     // Add font family
     let font_prop = CssPropertyWithConditions::simple(

--- a/layout/src/lib.rs
+++ b/layout/src/lib.rs
@@ -436,6 +436,11 @@ pub mod glyph_cache;
 pub mod default_actions;
 /// Post-layout developer warnings for raw text nodes used without a
 /// containing block (azul does not auto-wrap them the way browsers do).
+///
+/// Reads computed display through `solver3::getters`, so it exists only
+/// where the layout solver does — same gate as `window` and
+/// `default_actions`, its only caller being inside `window`.
+#[cfg(feature = "text_layout")]
 pub mod dom_lint;
 /// Apply structural `DocumentOperation`s to a plain XML tree.
 ///

--- a/layout/src/lib.rs
+++ b/layout/src/lib.rs
@@ -434,6 +434,9 @@ pub mod glyph_cache;
 /// Default keyboard actions (copy, paste, select-all, undo, etc.).
 #[cfg(feature = "text_layout")]
 pub mod default_actions;
+/// Post-layout developer warnings for raw text nodes used without a
+/// containing block (azul does not auto-wrap them the way browsers do).
+pub mod dom_lint;
 /// Apply structural `DocumentOperation`s to a plain XML tree.
 ///
 /// The Path-2 helper for apps without their own document model (the PDF

--- a/layout/src/managers/a11y.rs
+++ b/layout/src/managers/a11y.rs
@@ -188,7 +188,7 @@ impl A11yManager {
                     .and_then(|&layout_idx| {
                         let hot = layout_result.layout_tree.get(layout_idx)?;
                         let abs_pos = layout_result.calculated_positions
-                            .get(layout_idx).copied();
+                            .get(layout_idx.index()).copied();
                         Some((hot, layout_idx, abs_pos))
                     });
 

--- a/layout/src/managers/a11y_snapshot.rs
+++ b/layout/src/managers/a11y_snapshot.rs
@@ -380,7 +380,7 @@ fn element_bounds(
         return zero;
     };
     let (Some(pos), Some(size)) = (
-        layout_result.calculated_positions.get(layout_idx).copied(),
+        layout_result.calculated_positions.get(layout_idx.index()).copied(),
         hot.used_size,
     ) else {
         return zero;
@@ -410,7 +410,7 @@ fn element_bounds(
     let on_screen = crate::headless::node_rect_to_screen(
         layout_result,
         dom_id,
-        layout_idx,
+        layout_idx.index(),
         local,
         &|d, n| scroll_manager.get_current_offset(d, n),
         &|d, n| {

--- a/layout/src/managers/focus_cursor.rs
+++ b/layout/src/managers/focus_cursor.rs
@@ -62,6 +62,41 @@ pub struct FocusManager {
     pub cursor_needs_initialization: bool,
     /// Information about the pending contenteditable focus
     pub pending_contenteditable_focus: Option<PendingContentEditableFocus>,
+
+    // --- focus-before-first-layout retry queue ---
+
+    /// A [`FocusTarget`] that could not be resolved because no layout existed
+    /// yet, kept so it can be re-resolved as soon as one does.
+    ///
+    /// `resolve_focus_target` answers `Ok(None)` with empty `layout_results`,
+    /// and every caller reads `Ok(None)` as "clear focus" — so a programmatic
+    /// `set_focus` issued from a `create` callback (which runs BEFORE the first
+    /// layout) vanished without a trace, and apps papered over it with a
+    /// short timer. Drained by
+    /// `LayoutWindow::finalize_pending_focus_changes`, which runs after the
+    /// layout pass.
+    pub deferred_focus_target: Option<FocusTarget>,
+    /// How many times the pending contenteditable focus has been re-armed for
+    /// want of a text layout. Bounded so a node that will never have an inline
+    /// layout cannot re-arm forever.
+    pub pending_focus_retries: u8,
+}
+
+/// How many times [`FocusManager::pending_contenteditable_focus`] may be put
+/// back because the text layout was not available yet.
+pub const MAX_PENDING_FOCUS_RETRIES: u8 = 2;
+
+/// Outcome of resolving a [`FocusTarget`] through
+/// [`resolve_focus_target_or_defer`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FocusResolution {
+    /// The target resolved. `None` means "clear focus" (`FocusTarget::NoFocus`,
+    /// or a selector that matched nothing focusable) and MUST be applied.
+    Resolved(Option<DomNodeId>),
+    /// No layout existed yet, so the target was retained on the
+    /// [`FocusManager`] and will be re-resolved after the first layout pass.
+    /// Callers must leave the current focus alone.
+    Deferred,
 }
 
 impl Default for FocusManager {
@@ -78,6 +113,8 @@ impl FocusManager {
             pending_focus_request: None,
             cursor_needs_initialization: false,
             pending_contenteditable_focus: None,
+            deferred_focus_target: None,
+            pending_focus_retries: 0,
         }
     }
 
@@ -137,16 +174,35 @@ impl FocusManager {
         text_node_id: NodeId,
     ) {
         self.cursor_needs_initialization = true;
+        self.pending_focus_retries = 0;
         self.pending_contenteditable_focus = Some(PendingContentEditableFocus {
             dom_id,
             container_node_id,
             text_node_id,
         });
     }
-    
+
+    /// Put a just-taken pending contenteditable focus BACK because the text
+    /// layout it needs did not exist yet. Returns `false` once
+    /// [`MAX_PENDING_FOCUS_RETRIES`] is exhausted, in which case the caller
+    /// must seed the cursor with whatever it has.
+    pub const fn rearm_pending_contenteditable_focus(
+        &mut self,
+        pending: PendingContentEditableFocus,
+    ) -> bool {
+        if self.pending_focus_retries >= MAX_PENDING_FOCUS_RETRIES {
+            return false;
+        }
+        self.pending_focus_retries += 1;
+        self.cursor_needs_initialization = true;
+        self.pending_contenteditable_focus = Some(pending);
+        true
+    }
+
     /// Clear the pending contenteditable focus (when focus moves away or is cleared).
     pub const fn clear_pending_contenteditable_focus(&mut self) {
         self.cursor_needs_initialization = false;
+        self.pending_focus_retries = 0;
         self.pending_contenteditable_focus = None;
     }
     
@@ -168,6 +224,26 @@ impl FocusManager {
         self.cursor_needs_initialization
     }
 
+    // --- focus-before-first-layout retry queue ---
+
+    /// Retain a focus target that had no layout to resolve against.
+    ///
+    /// A later request replaces an earlier one: only the most recent
+    /// programmatic focus can win once layout arrives, exactly as it would if
+    /// both had been resolvable immediately.
+    pub fn defer_focus_target(&mut self, target: FocusTarget) {
+        self.deferred_focus_target = Some(target);
+    }
+
+    /// Whether a focus target is waiting for the first layout.
+    #[must_use] pub const fn has_deferred_focus_target(&self) -> bool {
+        self.deferred_focus_target.is_some()
+    }
+
+    /// Take the deferred focus target (one-shot).
+    pub const fn take_deferred_focus_target(&mut self) -> Option<FocusTarget> {
+        self.deferred_focus_target.take()
+    }
 }
 
 impl crate::managers::NodeIdRemap for FocusManager {
@@ -400,7 +476,40 @@ fn find_first_matching_focusable_node(
     })
 }
 
+/// Resolve a `FocusTarget`, or QUEUE it when there is no layout to resolve
+/// against yet.
+///
+/// This is the entry point every focus-changing caller should use.
+/// [`resolve_focus_target`] cannot tell "nothing matched" from "nothing exists
+/// yet": both are `Ok(None)`, and callers apply that as "clear focus". A
+/// `set_focus` issued from a `create` callback — which runs before the first
+/// layout — was therefore dropped on the floor.
+///
+/// # Errors
+///
+/// Returns an `UpdateFocusWarning` if the focus target cannot be resolved.
+pub fn resolve_focus_target_or_defer(
+    focus_manager: &mut FocusManager,
+    focus_target: &FocusTarget,
+    layout_results: &BTreeMap<DomId, DomLayoutResult>,
+) -> Result<FocusResolution, UpdateFocusWarning> {
+    // `NoFocus` means the app WANTS focus cleared; that is answerable without
+    // any layout and must not be queued (it would then fire later, clearing a
+    // focus the app had meanwhile set).
+    if layout_results.is_empty() && !matches!(focus_target, FocusTarget::NoFocus) {
+        focus_manager.defer_focus_target(focus_target.clone());
+        return Ok(FocusResolution::Deferred);
+    }
+
+    let current_focus = focus_manager.get_focused_node().copied();
+    resolve_focus_target(focus_target, layout_results, current_focus).map(FocusResolution::Resolved)
+}
+
 /// Resolve a `FocusTarget` to an actual `DomNodeId`
+///
+/// Prefer [`resolve_focus_target_or_defer`]: with empty `layout_results` this
+/// answers `Ok(None)`, which is indistinguishable from "clear focus".
+///
 /// # Errors
 ///
 /// Returns an `UpdateFocusWarning` if the focus target cannot be resolved.

--- a/layout/src/managers/gpu_state.rs
+++ b/layout/src/managers/gpu_state.rs
@@ -5,6 +5,7 @@
 //! for scrollbar opacity - as a single source of truth for
 //! the GPU cache.
 
+use crate::solver3::layout_tree::LayoutNodeId;
 use alloc::collections::BTreeMap;
 
 #[cfg(feature = "std")]
@@ -123,7 +124,7 @@ impl GpuStateManager {
         let gpu_cache = self.get_or_create_cache(dom_id);
 
         for (node_idx, node) in layout_tree.nodes.iter().enumerate() {
-            let warm = layout_tree.warm(node_idx);
+            let warm = layout_tree.warm(LayoutNodeId::new(node_idx));
             // The necessity flags are the layout pass's, amended after layout by
             // `cache::apply_virtual_scroll_necessity` (via `register_scroll_nodes`)
             // for a `VirtualView`, whose scrollable extent layout cannot see. This
@@ -164,7 +165,7 @@ impl GpuStateManager {
             let content_size = scroll_manager
                 .get_scroll_state(dom_id, node_id)
                 .and_then(|s| s.virtual_scroll_size)
-                .unwrap_or_else(|| layout_tree.get_content_size(node_idx));
+                .unwrap_or_else(|| layout_tree.get_content_size(LayoutNodeId::new(node_idx)));
 
             if scrollbar_info.needs_vertical {
                 // Use the visual width from the scrollbar style — same value used
@@ -1328,7 +1329,7 @@ mod autotest_generated {
         //    virtual size).
         let states = sm.get_scroll_states_for_dom(dom(0));
         let pos = states.get(&NODE).expect("the callback created a scroll state");
-        let mut info = t.warm(0).and_then(|w| w.scrollbar_info).expect("layout stored one");
+        let mut info = t.warm(LayoutNodeId::new(0)).and_then(|w| w.scrollbar_info).expect("layout stored one");
         assert!(
             apply_virtual_scroll_necessity(
                 &styled_dom,
@@ -1346,7 +1347,7 @@ mod autotest_generated {
             (0.0, 0.0),
             "no layout gutter is reserved after the fact — the bar overlays"
         );
-        t.warm_mut(0).expect("the fixture has a warm node").scrollbar_info = Some(info);
+        t.warm_mut(LayoutNodeId::new(0)).expect("the fixture has a warm node").scrollbar_info = Some(info);
         sm.register_or_update_scroll_node(
             dom(0),
             NODE,

--- a/layout/src/managers/gpu_state.rs
+++ b/layout/src/managers/gpu_state.rs
@@ -124,6 +124,11 @@ impl GpuStateManager {
 
         for (node_idx, node) in layout_tree.nodes.iter().enumerate() {
             let warm = layout_tree.warm(node_idx);
+            // The necessity flags are the layout pass's, amended after layout by
+            // `cache::apply_virtual_scroll_necessity` (via `register_scroll_nodes`)
+            // for a `VirtualView`, whose scrollable extent layout cannot see. This
+            // path deliberately re-derives nothing: it reads the one stored answer,
+            // so a bar that `paint_scrollbars` drew always gets its thumb moved.
             let Some(scrollbar_info) = warm.and_then(|w| w.scrollbar_info.as_ref()) else {
                 continue;
             };
@@ -149,8 +154,17 @@ impl GpuStateManager {
                 size: inner_size,
             };
 
-            // Use get_content_size() as the single source of truth for content dimensions
-            let content_size = layout_tree.get_content_size(node_idx);
+            // `display_list::paint_scrollbars` sizes the thumb from
+            // `ScrollPosition::children_rect.size` — the `VirtualView` virtual size
+            // when the callback reported one, else the laid-out content size. This
+            // path OVERWRITES the transform key that path seeds, so it has to size
+            // from the same number: a `VirtualView` is a replaced element with no
+            // flow content, so `get_content_size` returns roughly the viewport and
+            // the thumb would snap to the full track on the first live scroll.
+            let content_size = scroll_manager
+                .get_scroll_state(dom_id, node_id)
+                .and_then(|s| s.virtual_scroll_size)
+                .unwrap_or_else(|| layout_tree.get_content_size(node_idx));
 
             if scrollbar_info.needs_vertical {
                 // Use the visual width from the scrollbar style — same value used
@@ -320,8 +334,9 @@ fn remap_dom_hashmap<V>(
 #[cfg(test)]
 mod autotest_generated {
     use azul_core::{
-        dom::FormattingContext,
+        dom::{Dom, FormattingContext, IdOrClass, NodeType},
         resources::OpacityKey,
+        styled_dom::StyledDom,
         task::{Instant, SystemTick, SystemTickDiff},
     };
 
@@ -329,6 +344,7 @@ mod autotest_generated {
     use crate::{
         managers::{NodeIdMap, NodeIdRemap},
         solver3::{
+            cache::apply_virtual_scroll_necessity,
             geometry::PackedBoxProps,
             layout_tree::{LayoutNodeCold, LayoutNodeHot, LayoutNodeWarm},
             scrollbar::ScrollbarRequirements,
@@ -378,6 +394,32 @@ mod autotest_generated {
             overflow_content_size: content,
             ..Default::default()
         }
+    }
+
+    /// What layout computes for an `overflow-y: auto` VirtualView: nothing.
+    /// The node is a replaced element with no flow content, so its laid-out
+    /// content never exceeds its box and `check_scrollbar_necessity` finds no
+    /// reason for a bar — only `visual_width_px` survives from the CSS style.
+    fn auto_no_scrollbar() -> ScrollbarRequirements {
+        ScrollbarRequirements {
+            needs_horizontal: false,
+            needs_vertical: false,
+            scrollbar_width: 0.0,
+            scrollbar_height: 0.0,
+            visual_width_px: 16.0,
+        }
+    }
+
+    /// `body(0) > VirtualView(1)` with `overflow-x: hidden; overflow-y: auto`.
+    /// NodeId 1 is the node every fixture in this module registers.
+    fn auto_virtual_view_dom() -> StyledDom {
+        let mut dom = Dom::create_body().with_child(
+            Dom::create_node(NodeType::VirtualView)
+                .with_ids_and_classes(vec![IdOrClass::Class("vv".into())].into()),
+        );
+        let (css, _warnings) =
+            azul_css::parser2::new_from_str(".vv { overflow-x: hidden; overflow-y: auto; }");
+        StyledDom::create(&mut dom, css)
     }
 
     /// A classic (space-reserving) vertical scrollbar with an explicit visual
@@ -1181,9 +1223,10 @@ mod autotest_generated {
     }
 
     #[test]
-    fn a_negative_scroll_offset_is_treated_as_its_absolute_value() {
-        // compute_thumb_geometry uses scroll_offset.abs(), so an overscroll *above*
-        // the top does not produce a negative thumb offset.
+    fn a_negative_overscroll_offset_parks_the_thumb_at_the_top_of_the_track() {
+        // Rubber-banding *above* the top is the only source of a negative offset.
+        // The ratio clamp pins the thumb at 0 — it must not mirror the pull into
+        // the 36.0 that the equivalent positive offset produces.
         let mut m = GpuStateManager::default();
         let mut sm = ScrollManager::new();
         sm.set_scroll_position_unclamped(
@@ -1196,7 +1239,166 @@ mod autotest_generated {
 
         let y = sole_added_y(&m.update_scrollbar_transforms(dom(0), &sm, &t));
         assert!(y >= 0.0, "thumb offset must never go negative, got {y}");
-        assert!((y - 36.0).abs() < 0.01);
+        assert!(
+            y.abs() < 0.01,
+            "an overscroll above the top must leave the thumb at the start, got {y}"
+        );
+    }
+
+    #[test]
+    fn a_virtual_view_thumb_is_sized_from_the_virtual_scroll_size_like_paint_scrollbars() {
+        // A VirtualView is a replaced element with no flow content, so its laid-out
+        // content size IS the viewport and `get_content_size` alone reports "nothing
+        // to scroll" (full-length thumb parked at 0). `paint_scrollbars` seeds the
+        // transform key from `ScrollPosition::children_rect.size`, which carries the
+        // callback's virtual size; this path overwrites that key on every live
+        // scroll, so both must land on the same thumb offset.
+        const NODE: NodeId = NodeId::new(1);
+        let mut m = GpuStateManager::default();
+        let mut sm = ScrollManager::new();
+        sm.register_or_update_scroll_node(
+            dom(0),
+            NODE,
+            LogicalRect::new(
+                LogicalPosition::new(250.0, 120.0),
+                LogicalSize::new(100.0, 100.0),
+            ),
+            LogicalSize::new(100.0, 100.0),
+            t0(),
+            16.0,
+            16.0,
+            false,
+            true,
+        );
+        sm.update_virtual_scroll_bounds(dom(0), NODE, LogicalSize::new(100.0, 1000.0), None);
+        sm.set_scroll_position(dom(0), NODE, LogicalPosition::new(0.0, 450.0), t0());
+
+        // The layout tree only ever saw the viewport-sized content box.
+        let t = one_node_tree(v_scrollbar(), LogicalSize::new(100.0, 100.0));
+        let y = sole_added_y(&m.update_scrollbar_transforms(dom(0), &sm, &t));
+
+        // ...what display_list::paint_scrollbars computes for the same node.
+        let states = sm.get_scroll_states_for_dom(dom(0));
+        let pos = states.get(&NODE).expect("the node must report a scroll state");
+        assert_eq!(pos.children_rect.size, LogicalSize::new(100.0, 1000.0));
+        let painted = compute_scrollbar_geometry_with_button_size(
+            ScrollbarOrientation::Vertical,
+            LogicalRect::new(LogicalPosition::zero(), LogicalSize::new(100.0, 100.0)),
+            pos.children_rect.size,
+            pos.children_rect.origin.y,
+            16.0,
+            false,
+            16.0,
+        );
+        assert!(
+            (y - painted.thumb_offset).abs() < 0.01,
+            "GPU path put the thumb at {y}, the painter at {}",
+            painted.thumb_offset
+        );
+        // usable = 100 - 2*16 = 68, thumb = max(68 * 100/1000, 32) = 32,
+        // max_scroll = 1000 - 100 = 900 -> half scroll = (68 - 32) * 0.5 = 18.
+        // Sizing from the laid-out 100x100 instead gives max_scroll 0 and a
+        // full-track thumb parked at 0.
+        assert!((y - 18.0).abs() < 0.01, "expected the half-track thumb at 18.0, got {y}");
+    }
+
+    #[test]
+    fn an_auto_virtual_view_agrees_on_the_flag_the_painted_thumb_and_the_gpu_thumb() {
+        // The half-landed state this pins: `paint_scrollbars` raised its own
+        // booleans locally and drew a bar, while this path kept gating on the
+        // layout-computed `warm.scrollbar_info.needs_*` — all-false for an
+        // `auto` VirtualView — so the thumb froze at the display list's seed
+        // value on every live scroll. One function now decides, and
+        // `register_scroll_nodes` stores the decision where this path reads it.
+        const NODE: NodeId = NodeId::new(1);
+        let styled_dom = auto_virtual_view_dom();
+
+        // 1. Layout ran: the VirtualView's box is 100x100 and its laid-out
+        //    content is the same 100x100, so no bar is warranted yet.
+        let mut t = one_node_tree(auto_no_scrollbar(), LogicalSize::new(100.0, 100.0));
+
+        // 2. The VirtualView callback published a 100x1000 document.
+        let mut sm = ScrollManager::new();
+        sm.update_virtual_scroll_bounds(dom(0), NODE, LogicalSize::new(100.0, 1000.0), None);
+
+        // 3. What `register_scroll_nodes` then does: amend the flags from the
+        //    virtual size and store the answer back on the node, which is what
+        //    makes the node registrable at all (the old gate skipped it, so its
+        //    container_rect stayed zero and its clamp bound was the whole
+        //    virtual size).
+        let states = sm.get_scroll_states_for_dom(dom(0));
+        let pos = states.get(&NODE).expect("the callback created a scroll state");
+        let mut info = t.warm(0).and_then(|w| w.scrollbar_info).expect("layout stored one");
+        assert!(
+            apply_virtual_scroll_necessity(
+                &styled_dom,
+                NODE,
+                pos.children_rect.size,
+                LogicalSize::new(100.0, 100.0),
+                &mut info,
+            ),
+            "a 1000px document in a 100px auto viewport needs a bar"
+        );
+        assert!(info.needs_vertical, "the amended flag is the one the GPU path gates on");
+        assert!(!info.needs_horizontal, "overflow-x: hidden must not gain a bar");
+        assert_eq!(
+            (info.scrollbar_width, info.scrollbar_height),
+            (0.0, 0.0),
+            "no layout gutter is reserved after the fact — the bar overlays"
+        );
+        t.warm_mut(0).expect("the fixture has a warm node").scrollbar_info = Some(info);
+        sm.register_or_update_scroll_node(
+            dom(0),
+            NODE,
+            LogicalRect::new(
+                LogicalPosition::new(250.0, 120.0),
+                LogicalSize::new(100.0, 100.0),
+            ),
+            LogicalSize::new(100.0, 100.0),
+            t0(),
+            info.scrollbar_width.max(info.scrollbar_height),
+            info.visual_width_px,
+            info.needs_horizontal,
+            info.needs_vertical,
+        );
+
+        // 4. Half a document down.
+        sm.set_scroll_position(dom(0), NODE, LogicalPosition::new(0.0, 450.0), t0());
+
+        let mut m = GpuStateManager::default();
+        let y = sole_added_y(&m.update_scrollbar_transforms(dom(0), &sm, &t));
+
+        // ...and what `paint_scrollbars` computes for the same node from the
+        // same ScrollPosition: overlay bar (scrollbar_height == 0) => no arrow
+        // buttons on either path.
+        let states = sm.get_scroll_states_for_dom(dom(0));
+        let pos = states.get(&NODE).expect("the node is registered now");
+        let painted = compute_scrollbar_geometry_with_button_size(
+            ScrollbarOrientation::Vertical,
+            LogicalRect::new(LogicalPosition::zero(), LogicalSize::new(100.0, 100.0)),
+            pos.children_rect.size,
+            pos.children_rect.origin.y,
+            info.visual_width_px,
+            info.needs_horizontal,
+            0.0,
+        );
+        assert!(
+            (y - painted.thumb_offset).abs() < 0.01,
+            "GPU path put the thumb at {y}, the painter at {}",
+            painted.thumb_offset
+        );
+        // usable track = 100 (no buttons), thumb = max(100 * 100/1000, 2*16) = 32,
+        // max_scroll = 900 -> half travel = (100 - 32) * 0.5 = 34.
+        assert!((y - 34.0).abs() < 0.01, "expected the half-track thumb at 34.0, got {y}");
+
+        // The pre-fix tree — layout's flags, unamended — emits nothing at all,
+        // which is exactly the frozen thumb under a painted bar.
+        let stale = one_node_tree(auto_no_scrollbar(), LogicalSize::new(100.0, 100.0));
+        let mut fresh = GpuStateManager::default();
+        assert!(
+            fresh.update_scrollbar_transforms(dom(0), &sm, &stale).is_empty(),
+            "without the amendment the GPU path never sees the bar"
+        );
     }
 
     #[test]

--- a/layout/src/managers/scroll_into_view.rs
+++ b/layout/src/managers/scroll_into_view.rs
@@ -20,6 +20,7 @@
 //! - `ScrollBehavior`: auto, instant, smooth
 //! - Proper scroll ancestor chain traversal
 
+use crate::solver3::layout_tree::LayoutNodeId;
 use alloc::vec::Vec;
 
 use azul_core::{
@@ -504,7 +505,7 @@ fn get_node_rect(
     // Get position
     let layout_indices = layout_result.layout_tree.dom_to_layout.get(&nid)?;
     let layout_index = *layout_indices.first()?;
-    let position = *layout_result.calculated_positions.get(layout_index)?;
+    let position = *layout_result.calculated_positions.get(layout_index.index())?;
     
     // Get size
     let layout_node = layout_result.layout_tree.get(layout_index)?;
@@ -655,7 +656,7 @@ mod autotest_generated {
         for (layout_index, (node_index, position, used_size)) in boxes.iter().enumerate() {
             lr.layout_tree
                 .dom_to_layout
-                .insert(nid(*node_index), vec![layout_index]);
+                .insert(nid(*node_index), vec![LayoutNodeId::new(layout_index)]);
             lr.layout_tree.nodes.push(LayoutNodeHot {
                 box_props: PackedBoxProps::default(),
                 dom_node_id: Some(nid(*node_index)),
@@ -1318,7 +1319,7 @@ mod autotest_generated {
         );
         // Stale mapping pointing past the end of both `calculated_positions` and
         // `layout_tree.nodes` — must be a None, not an out-of-bounds index panic.
-        lr.layout_tree.dom_to_layout.insert(nid(TARGET), vec![7]);
+        lr.layout_tree.dom_to_layout.insert(nid(TARGET), vec![LayoutNodeId::new(7)]);
         assert!(get_node_rect(dnid(0, TARGET), &window(lr)).is_none());
     }
 

--- a/layout/src/managers/scroll_state.rs
+++ b/layout/src/managers/scroll_state.rs
@@ -542,21 +542,27 @@ impl ScrollManager {
     /// Used by the CPU renderer to look up scroll positions at render time
     /// without embedding them in the display list.
     ///
-    /// `scroll_ids` maps layout-tree node index → `scroll_id`. We need to
-    /// convert our (`DomId`, `NodeId`) keys to `scroll_ids`.
+    /// Takes `DomLayoutResult::scroll_id_to_node_id` — the SAME table the
+    /// `WebRender` path resolves through (`wr_translate2::scroll_all_nodes`) —
+    /// because it is keyed the way this manager is keyed: by DOM `NodeId`.
+    ///
+    /// It used to take the sibling table `scroll_ids` (layout-tree index →
+    /// `scroll_id`) and index it with `node_id.index()`, i.e. it assumed the
+    /// layout tree and the DOM share an index space. They do not: anonymous
+    /// boxes and box splits are inserted during layout-tree construction, so
+    /// any scroll container with a text sibling ahead of it sits at a
+    /// different index. The lookup then missed, the container never appeared
+    /// in this map, the compositor resolved its layer offset as `(0.0, 0.0)`
+    /// and the content stayed frozen — while the scrollbar thumb, driven by
+    /// the `(DomId, NodeId)`-keyed GPU value cache, kept tracking the wheel.
     #[must_use] pub fn build_scroll_offset_map(
         &self,
         dom_id: DomId,
-        scroll_ids: &std::collections::HashMap<usize, u64>,
+        scroll_id_to_node_id: &std::collections::HashMap<u64, NodeId>,
     ) -> std::collections::HashMap<u64, (f32, f32)> {
         let mut map = std::collections::HashMap::new();
-        for ((d, node_id), state) in &self.states {
-            if *d != dom_id { continue; }
-            // Find the scroll_id for this node_id by searching scroll_ids
-            // (scroll_ids maps layout_index → scroll_id, and node_id.index() == layout_index
-            // for the root DOM)
-            let node_idx = node_id.index();
-            if let Some(&scroll_id) = scroll_ids.get(&node_idx) {
+        for (&scroll_id, &node_id) in scroll_id_to_node_id {
+            if let Some(state) = self.states.get(&(dom_id, node_id)) {
                 map.insert(scroll_id, (state.current_offset.x, state.current_offset.y));
             }
         }
@@ -1033,6 +1039,33 @@ impl ScrollManager {
     }
 
     /// Returns all scroll positions for nodes in a specific DOM
+    ///
+    /// # `ScrollPosition` coordinate convention (MIXED — read before consuming)
+    ///
+    /// The two rects of the emitted [`ScrollPosition`] do NOT live in the same
+    /// space, and a consumer that subtracts one origin from the other gets
+    /// garbage:
+    ///
+    /// - `parent_rect` — the container's border box in **absolute window
+    ///   coordinates** (`calculated_positions[node]`, see
+    ///   `shell2::common::layout::register_scroll_nodes`). Only `size` is
+    ///   meaningful to most consumers; the origin exists for `scroll_into_view`.
+    /// - `children_rect.origin` — the **scroll offset itself**, i.e.
+    ///   `current_offset`: the distance already scrolled, measured from the
+    ///   scroll origin, clamped to `[0, content − container]`. It is NOT the
+    ///   absolute position of the scrolled content, and it is NOT relative to
+    ///   `parent_rect.origin`. Content is painted at `position − offset`
+    ///   (`cpurender::raster`), so a positive value means "scrolled down/right".
+    /// - `children_rect.size` — the scrollable content size (the `VirtualView`
+    ///   virtual size when one was reported, else the laid-out content size).
+    ///
+    /// `content_rect.origin` is never carried out of here because it is always
+    /// zero in the state (`register_or_update_scroll_node` builds it that way,
+    /// and `clamp` reads only its size) — the absolute-content-rect reading of
+    /// `children_rect` is not even representable.
+    ///
+    /// The round trip is the identity: `LayoutWindow::set_scroll_position`
+    /// feeds `children_rect.origin` straight back into `set_scroll_position`.
     #[must_use] pub fn get_scroll_states_for_dom(&self, dom_id: DomId) -> BTreeMap<NodeId, ScrollPosition> {
         // M12.7: iterating an EMPTY hashbrown map (RawIterRange) mis-lifts to
         // wasm and loops forever (same class as the font-id / GPU-cache loops).
@@ -3110,6 +3143,105 @@ mod autotest_generated {
         assert_eq!(states.get(&node(0)).unwrap().children_rect.size, size(100.0, 8000.0));
     }
 
+    /// CONVENTION PIN, end to end: `children_rect.origin` is the raw scroll
+    /// offset in a space of its own, and `parent_rect.origin` is an absolute
+    /// window coordinate. Every fixture above registers its container at
+    /// (0, 0), where the two candidate conventions are indistinguishable —
+    /// this one puts the container where the AzWriter document view actually
+    /// sits (below the ribbon, indented from the left) and drives the reported
+    /// offset through the SAME geometry function the scrollbar painter and the
+    /// GPU-only scroll path use.
+    ///
+    /// The consumers used to compute `children_rect.origin - parent_rect.origin`.
+    /// For the vertical leg below that made an UNSCROLLED container report
+    /// -120, which `compute_thumb_geometry` then took by absolute value (an
+    /// `.abs()` since removed — see
+    /// `a_negative_overscroll_offset_pins_the_thumb_to_the_start_of_the_track`)
+    /// — +120 is 15% of the 800px scroll range, so the thumb opened 38.4px
+    /// down its own track instead of at the top.
+    #[test]
+    fn scroll_states_of_a_container_below_the_window_origin_drive_the_thumb_from_zero() {
+        use crate::solver3::scrollbar::{
+            compute_scrollbar_geometry_with_button_size, ScrollbarGeometry,
+        };
+
+        const THICKNESS: f32 = 16.0;
+
+        // A 300x400 viewport at absolute (250, 120) over 900x1200 of content:
+        // max scroll is (600, 800) on the two axes.
+        let mut m = ScrollManager::new();
+        m.register_or_update_scroll_node(
+            DOM,
+            node(0),
+            rect(250.0, 120.0, 300.0, 400.0),
+            size(900.0, 1200.0),
+            at(0),
+            THICKNESS,
+            THICKNESS,
+            true,
+            true,
+        );
+
+        // Exactly what `paint_scrollbars` does: read the state, take the offset
+        // straight out of `children_rect.origin`, feed it to the shared geometry.
+        fn geom(
+            m: &ScrollManager,
+            expected_offset: LogicalPosition,
+            orientation: ScrollbarOrientation,
+        ) -> ScrollbarGeometry {
+            let sp = *m.get_scroll_states_for_dom(DOM).get(&node(0)).unwrap();
+            assert_eq!(
+                sp.parent_rect.origin,
+                pos(250.0, 120.0),
+                "parent_rect keeps the ABSOLUTE container position"
+            );
+            assert_eq!(
+                sp.children_rect.origin, expected_offset,
+                "children_rect.origin is the raw offset, never container-relative"
+            );
+            compute_scrollbar_geometry_with_button_size(
+                orientation,
+                sp.parent_rect,
+                sp.children_rect.size,
+                match orientation {
+                    ScrollbarOrientation::Vertical => sp.children_rect.origin.y,
+                    ScrollbarOrientation::Horizontal => sp.children_rect.origin.x,
+                },
+                THICKNESS,
+                true,
+                0.0,
+            )
+        }
+
+        // --- unscrolled: the thumb sits at the very top / far left ----------
+        let v = geom(&m, pos(0.0, 0.0), ScrollbarOrientation::Vertical);
+        assert_eq!(v.thumb_offset, 0.0, "was 38.4 with the mixed-origin subtraction");
+        let h = geom(&m, pos(0.0, 0.0), ScrollbarOrientation::Horizontal);
+        assert_eq!(h.thumb_offset, 0.0, "was ~78.9 with the mixed-origin subtraction");
+
+        // --- half way: half of the thumb's travel ---------------------------
+        m.set_scroll_position(DOM, node(0), pos(300.0, 400.0), at(1));
+        let v = geom(&m, pos(300.0, 400.0), ScrollbarOrientation::Vertical);
+        let expected = (v.usable_track_length - v.thumb_length) * 0.5;
+        assert!((v.thumb_offset - expected).abs() < 1e-3, "{v:?}");
+        let h = geom(&m, pos(300.0, 400.0), ScrollbarOrientation::Horizontal);
+        let expected = (h.usable_track_length - h.thumb_length) * 0.5;
+        assert!((h.thumb_offset - expected).abs() < 1e-3, "{h:?}");
+
+        // --- bottomed out: the thumb ends flush with the track --------------
+        m.set_scroll_position(DOM, node(0), pos(9_999.0, 9_999.0), at(2));
+        let v = geom(&m, pos(600.0, 800.0), ScrollbarOrientation::Vertical);
+        assert!(
+            (v.thumb_offset - (v.usable_track_length - v.thumb_length)).abs() < 1e-3,
+            "{v:?}"
+        );
+        let h = geom(&m, pos(600.0, 800.0), ScrollbarOrientation::Horizontal);
+        assert!(
+            (h.thumb_offset - (h.usable_track_length - h.thumb_length)).abs() < 1e-3,
+            "{h:?}"
+        );
+    }
+
     #[test]
     fn build_scroll_offset_map_only_emits_nodes_present_in_scroll_ids() {
         let mut m = mgr(size(100.0, 100.0), size(100.0, 500.0));
@@ -3140,13 +3272,68 @@ mod autotest_generated {
         // Empty id map => empty offset map (and no panic).
         assert!(m.build_scroll_offset_map(DOM, &HashMap::new()).is_empty());
 
-        let mut ids: HashMap<usize, u64> = HashMap::new();
-        ids.insert(0, 100); // node index 0 -> scroll id 100
-        ids.insert(7, 700); // an id for a node that has no scroll state
+        let mut ids: HashMap<u64, NodeId> = HashMap::new();
+        ids.insert(100, node(0)); // scroll id 100 -> DOM node 0
+        ids.insert(700, node(7)); // an id for a node that has no scroll state
         let map = m.build_scroll_offset_map(DOM, &ids);
         assert_eq!(map.len(), 1, "node 4 has no scroll_id; DOM1 is a different dom");
         assert_eq!(map.get(&100), Some(&(0.0, 25.0)));
         assert!(!map.contains_key(&700));
+    }
+
+    #[test]
+    fn build_scroll_offset_map_resolves_a_scroller_whose_layout_index_diverges() {
+        // REGRESSION, CPU present path: "the wheel moves the thumb but the
+        // content stays frozen".
+        //
+        // The offset map used to be built by indexing the layout-index-keyed
+        // `scroll_ids` table with `node_id.index()`. That holds only for DOMs
+        // whose layout tree happens to be index-identical to the DOM — which
+        // is exactly what the minimal fixtures above are, and why nothing
+        // caught it. A text run ahead of the scroll container makes layout
+        // insert anonymous boxes, the indices diverge, the lookup misses, the
+        // compositor resolves the layer offset as (0,0) and the scroll-shift
+        // machinery sees no delta. The thumb keeps moving because it rides the
+        // (DomId, NodeId)-keyed GPU value cache, which never had the bug.
+        //
+        // The tables below are shaped exactly as `LayoutWindow::compute_scroll_ids`
+        // emits them for such a tree: the root scroller is DOM node 0 at layout
+        // index 0, the content scroller is DOM node 2 sitting at layout index 5.
+        let mut m = mgr(size(200.0, 200.0), size(200.0, 400.0));
+        m.register_or_update_scroll_node(
+            DOM,
+            node(2),
+            rect(0.0, 0.0, 200.0, 200.0),
+            size(200.0, 2000.0),
+            at(0),
+            16.0,
+            16.0,
+            false,
+            true,
+        );
+        m.set_scroll_position(DOM, node(2), pos(0.0, 300.0), at(1));
+
+        let mut scroll_ids: HashMap<usize, u64> = HashMap::new();
+        scroll_ids.insert(0, 100);
+        scroll_ids.insert(5, 500);
+        let mut scroll_id_to_node_id: HashMap<u64, NodeId> = HashMap::new();
+        scroll_id_to_node_id.insert(100, node(0));
+        scroll_id_to_node_id.insert(500, node(2));
+
+        // The premise, asserted rather than assumed: for this tree the DOM
+        // NodeId is NOT a valid key into the layout-index table.
+        assert!(
+            !scroll_ids.contains_key(&node(2).index()),
+            "fixture must actually diverge, otherwise it re-tests the coinciding case"
+        );
+
+        let map = m.build_scroll_offset_map(DOM, &scroll_id_to_node_id);
+        assert_eq!(
+            map.get(&500),
+            Some(&(0.0, 300.0)),
+            "the scrolled container must reach the renderer, or its content freezes"
+        );
+        assert_eq!(map.get(&100), Some(&(0.0, 0.0)), "the unscrolled root still reports (0,0)");
     }
 
     // ====================================================== find_scroll_parent

--- a/layout/src/managers/scroll_state.rs
+++ b/layout/src/managers/scroll_state.rs
@@ -59,6 +59,7 @@ use azul_core::{
 use std::sync::{Arc, Mutex};
 
 use crate::managers::hover::InputPointId;
+use crate::solver3::layout_tree::LayoutNodeId;
 use crate::solver3::scrollbar::compute_scrollbar_geometry_with_button_size;
 
 /// Minimum change in scroll offset (in logical pixels) to consider the position
@@ -3313,17 +3314,20 @@ mod autotest_generated {
         );
         m.set_scroll_position(DOM, node(2), pos(0.0, 300.0), at(1));
 
-        let mut scroll_ids: HashMap<usize, u64> = HashMap::new();
-        scroll_ids.insert(0, 100);
-        scroll_ids.insert(5, 500);
+        let mut scroll_ids: HashMap<LayoutNodeId, u64> = HashMap::new();
+        scroll_ids.insert(LayoutNodeId::new(0), 100);
+        scroll_ids.insert(LayoutNodeId::new(5), 500);
         let mut scroll_id_to_node_id: HashMap<u64, NodeId> = HashMap::new();
         scroll_id_to_node_id.insert(100, node(0));
         scroll_id_to_node_id.insert(500, node(2));
 
         // The premise, asserted rather than assumed: for this tree the DOM
-        // NodeId is NOT a valid key into the layout-index table.
+        // NodeId is NOT a valid key into the layout-index table. Note the
+        // deliberate cross-space cast: since `LayoutNodeId` landed, this
+        // probe is the ONLY way to even ask the question — the conflation
+        // this test guards against no longer type-checks in production code.
         assert!(
-            !scroll_ids.contains_key(&node(2).index()),
+            !scroll_ids.contains_key(&LayoutNodeId::new(node(2).index())),
             "fixture must actually diverge, otherwise it re-tests the coinciding case"
         );
 

--- a/layout/src/managers/text_edit.rs
+++ b/layout/src/managers/text_edit.rs
@@ -258,6 +258,12 @@ pub struct TextEditManager {
     pub display_list_dirty: bool,
     /// Caret / selection tween bookkeeping (see [`TextTweenState`]).
     pub tween: TextTweenState,
+    /// Editing hosts whose text was mutated OUTSIDE the text-input record
+    /// pipeline this pass (deletions, multi-cursor paste, the Enter line
+    /// break). The host pass drains this and dispatches an `Input` event per
+    /// host, so widget mirrors observe every committed edit, not only
+    /// insertions. Filled by `LayoutWindow::record_text_edit_undo`.
+    pub pending_edit_notifications: Vec<azul_core::dom::DomNodeId>,
 }
 
 impl Default for TextEditManager {
@@ -287,6 +293,7 @@ impl TextEditManager {
             preedit_cursor_end: -1,
             display_list_dirty: false,
             tween: TextTweenState::default(),
+            pending_edit_notifications: Vec::new(),
         }
     }
 

--- a/layout/src/managers/text_edit.rs
+++ b/layout/src/managers/text_edit.rs
@@ -263,7 +263,7 @@ pub struct TextEditManager {
     /// break). The host pass drains this and dispatches an `Input` event per
     /// host, so widget mirrors observe every committed edit, not only
     /// insertions. Filled by `LayoutWindow::record_text_edit_undo`.
-    pub pending_edit_notifications: Vec<azul_core::dom::DomNodeId>,
+    pub pending_edit_notifications: Vec<DomNodeId>,
 }
 
 impl Default for TextEditManager {

--- a/layout/src/overlay.rs
+++ b/layout/src/overlay.rs
@@ -911,9 +911,9 @@ mod tests {
         // exact ids come from creation order; resolve them dynamically).
         let mut dom = Dom::create_div();
         let mut p1 = Dom::create_p();
-        p1.add_child(Dom::create_text("one"));
+        p1.add_child(Dom::create_text_do_not_use_without_block_level_wrapper("one"));
         let mut p2 = Dom::create_p();
-        p2.add_child(Dom::create_text("two"));
+        p2.add_child(Dom::create_text_do_not_use_without_block_level_wrapper("two"));
         dom.add_child(p1);
         dom.add_child(p2);
         let styled = StyledDom::create_from_dom(dom);
@@ -1017,7 +1017,7 @@ mod tests {
 
         // DOM: div > [text "committed"]
         let mut dom = azul_core::dom::Dom::create_div();
-        dom.add_child(azul_core::dom::Dom::create_text("committed"));
+        dom.add_child(azul_core::dom::Dom::create_text_do_not_use_without_block_level_wrapper("committed"));
         let styled = StyledDom::create_from_dom(dom);
         let text_node = NodeId::new(1);
 

--- a/layout/src/solver3/cache.rs
+++ b/layout/src/solver3/cache.rs
@@ -12,6 +12,7 @@
 //! 4. The intrinsic size calculation (bottom-up) can often be skipped, as it's independent of the
 //!    container size, which is a significant optimization.
 
+use crate::solver3::layout_tree::LayoutNodeId;
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap},
     hash::{DefaultHasher, Hash, Hasher},
@@ -476,7 +477,7 @@ pub struct LayoutCache {
     /// The viewport size from the last layout pass, used to detect resizes.
     pub viewport: Option<LogicalRect>,
     /// Stable scroll IDs computed from `node_data_hash` (layout index -> scroll ID)
-    pub scroll_ids: HashMap<usize, u64>,
+    pub scroll_ids: HashMap<LayoutNodeId, u64>,
     /// Mapping from scroll ID to DOM `NodeId` for hit testing
     pub scroll_id_to_node_id: HashMap<u64, NodeId>,
     /// CSS counter values for each node and counter name.
@@ -688,13 +689,13 @@ pub fn reposition_clean_subtrees(
     // where sibling positions need to be adjusted.
     let mut parents_to_reposition = BTreeSet::new();
     for &root_idx in layout_roots {
-        if let Some(parent_idx) = tree.get(root_idx).and_then(|n| n.parent) {
+        if let Some(parent_idx) = tree.get(LayoutNodeId::new(root_idx)).and_then(|n| n.parent) {
             parents_to_reposition.insert(parent_idx);
         }
     }
 
     for parent_idx in parents_to_reposition {
-        let Some(parent_node) = tree.get(parent_idx) else {
+        let Some(parent_node) = tree.get(LayoutNodeId::new(parent_idx)) else {
             continue;
         };
 
@@ -814,7 +815,7 @@ pub fn reposition_block_flow_siblings(
     layout_roots: &BTreeSet<usize>,
     calculated_positions: &mut super::PositionVec,
 ) {
-    let Some(parent_node) = tree.get(parent_idx) else {
+    let Some(parent_node) = tree.get(LayoutNodeId::new(parent_idx)) else {
         return;
     };
     let dom_id = parent_node.dom_node_id.unwrap_or(NodeId::ZERO);
@@ -841,7 +842,7 @@ pub fn reposition_block_flow_siblings(
     let mut main_pen = 0.0;
 
     for &child_idx in tree.children(parent_idx) {
-        let Some(child_node) = tree.get(child_idx) else {
+        let Some(child_node) = tree.get(LayoutNodeId::new(child_idx)) else {
             continue;
         };
 
@@ -877,7 +878,7 @@ pub fn reposition_block_flow_siblings(
 
             let child_main_start = child_bp.margin.main_start(writing_mode);
             let new_main_pos = main_pen + child_main_start;
-            let old_relative_pos = tree.warm(child_idx)
+            let old_relative_pos = tree.warm(LayoutNodeId::new(child_idx))
                 .and_then(|w| w.relative_position)
                 .unwrap_or_default();
             let cross_pos = if writing_mode.is_vertical() {
@@ -918,7 +919,7 @@ fn shift_subtree_position(
         pos.y += delta.y;
     }
 
-    if let Some(node) = tree.get(node_idx) {
+    if let Some(node) = tree.get(LayoutNodeId::new(node_idx)) {
         let children = tree.children(node_idx).to_vec();
         for &child_idx in &children {
             shift_subtree_position(child_idx, delta, tree, calculated_positions);
@@ -1126,7 +1127,7 @@ pub fn reconcile_and_invalidate<T: ParsedFontTrait>(
 fn assert_dom_ids_are_in_range(tree: &LayoutTree, styled_dom: &StyledDom) {
     let dom_len = styled_dom.node_data.as_container().internal.len();
     for idx in 0..tree.nodes.len() {
-        let Some(dom_id) = tree.get(idx).and_then(|n| n.dom_node_id) else {
+        let Some(dom_id) = tree.get(LayoutNodeId::new(idx)).and_then(|n| n.dom_node_id) else {
             continue;
         };
         assert!(
@@ -1251,7 +1252,7 @@ fn try_reuse_anon_wrapper(
         .iter()
         .copied()
         .filter(|&c| {
-            t.cold(c)
+            t.cold(LayoutNodeId::new(c))
                 .is_some_and(|cold| cold.anonymous_type == Some(AnonymousBoxType::InlineWrapper))
         })
         .nth(anon_ordinal)
@@ -1265,11 +1266,11 @@ fn try_reuse_anon_wrapper(
     let ids_match = old_anon_children
         .iter()
         .zip(inline_run.iter())
-        .all(|(&oc, &(_, nid))| t.get(oc).and_then(|n| n.dom_node_id) == Some(nid));
+        .all(|(&oc, &(_, nid))| t.get(LayoutNodeId::new(oc)).and_then(|n| n.dom_node_id) == Some(nid));
     if !ids_match {
         return false;
     }
-    if let (Some(old_warm), Some(new_node)) = (t.warm(old_anon), new_tree_builder.get_mut(anon_idx))
+    if let (Some(old_warm), Some(new_node)) = (t.warm(LayoutNodeId::new(old_anon)), new_tree_builder.get_mut(anon_idx))
     {
         new_node.inline_content_cache.clone_from(&old_warm.inline_content_cache);
         new_node.intrinsic_sizes = old_warm.intrinsic_sizes;
@@ -1305,7 +1306,7 @@ pub fn reconcile_recursive(
         std::sync::OnceLock::new();
     let node_data = &styled_dom.node_data.as_container()[new_dom_id];
 
-    let old_cold = old_tree.and_then(|t| old_tree_idx.and_then(|idx| t.cold(idx)));
+    let old_cold = old_tree.and_then(|t| old_tree_idx.and_then(|idx| t.cold(LayoutNodeId::new(idx))));
     match (old_tree.is_some(), old_tree_idx.is_some(), old_cold.is_some()) {
         (false, _, _) => drop(crate::probe::Probe::span("recon_old_tree_none")),
         (true, false, _) => drop(crate::probe::Probe::span("recon_old_idx_none")),
@@ -1556,8 +1557,8 @@ pub fn reconcile_recursive(
                 // parents re-dirtied per resize on big.md — the whole list
                 // content re-measured each pass); keying them into the by-dom
                 // map could also alias a marker as its own host during lookup.
-                .filter(|&&cidx| t.warm(cidx).is_none_or(|w| w.pseudo_element.is_none()))
-                .filter_map(|&cidx| t.get(cidx).and_then(|n| n.dom_node_id).map(|did| (did, cidx)))
+                .filter(|&&cidx| t.warm(LayoutNodeId::new(cidx)).is_none_or(|w| w.pseudo_element.is_none()))
+                .filter_map(|&cidx| t.get(LayoutNodeId::new(cidx)).and_then(|n| n.dom_node_id).map(|did| (did, cidx)))
                 .collect()
         }))
         .unwrap_or_default();
@@ -1579,14 +1580,14 @@ pub fn reconcile_recursive(
                     .iter()
                     .copied()
                     .filter(|&c| {
-                        t.cold(c).is_some_and(|cold| {
+                        t.cold(LayoutNodeId::new(c)).is_some_and(|cold| {
                             cold.anonymous_type == Some(AnonymousBoxType::InlineWrapper)
                         })
                     })
                     .map(|w| {
                         t.children(w)
                             .iter()
-                            .filter(|&&cc| t.get(cc).and_then(|n| n.dom_node_id).is_some())
+                            .filter(|&&cc| t.get(LayoutNodeId::new(cc)).and_then(|n| n.dom_node_id).is_some())
                             .count()
                     })
                     .sum::<usize>()
@@ -1681,7 +1682,7 @@ pub fn reconcile_recursive(
                 new_child_hashes.push(child_node.subtree_hash.0);
             }
 
-            if old_tree.and_then(|t| t.cold(old_child_idx?).map(|n| n.subtree_hash))
+            if old_tree.and_then(|t| t.cold(LayoutNodeId::new(old_child_idx?)).map(|n| n.subtree_hash))
                 != new_tree_builder
                     .get(reconciled_child_idx)
                     .map(|n| n.subtree_hash)
@@ -1763,7 +1764,7 @@ pub fn reconcile_recursive(
                         let old_child_idx = old_children_by_dom.get(&inline_dom_id).copied()
                             .or_else(|| old_tree
                                 .and_then(|t| t.dom_to_layout.get(&inline_dom_id))
-                                .and_then(|v| v.first().copied()));
+                                .and_then(|v| v.first().copied().map(LayoutNodeId::index)));
                         let reconciled_child_idx = reconcile_recursive(
                             styled_dom,
                             inline_dom_id,
@@ -1821,7 +1822,7 @@ pub fn reconcile_recursive(
                     new_child_hashes.push(child_node.subtree_hash.0);
                 }
 
-                if old_tree.and_then(|t| t.cold(old_child_idx?).map(|n| n.subtree_hash))
+                if old_tree.and_then(|t| t.cold(LayoutNodeId::new(old_child_idx?)).map(|n| n.subtree_hash))
                     != new_tree_builder
                         .get(reconciled_child_idx)
                         .map(|n| n.subtree_hash)
@@ -1833,7 +1834,7 @@ pub fn reconcile_recursive(
                             new_dom_id.index(),
                             old_tree.is_some(),
                             old_child_idx,
-                            old_tree.and_then(|t| t.cold(old_child_idx.unwrap_or(usize::MAX)).map(|n| n.subtree_hash)),
+                            old_tree.and_then(|t| t.cold(LayoutNodeId::new(old_child_idx.unwrap_or(usize::MAX))).map(|n| n.subtree_hash)),
                             new_tree_builder.get(reconciled_child_idx).map(|n| n.subtree_hash),
                         );
                     }
@@ -1972,8 +1973,8 @@ fn prepare_layout_context<'a, T: ParsedFontTrait>(
     node_index: usize,
     containing_block_size: LogicalSize,
 ) -> Result<PreparedLayoutContext<'a>> {
-    let node = tree.get(node_index).ok_or(LayoutError::InvalidTree)?;
-    let warm = tree.warm(node_index).ok_or(LayoutError::InvalidTree)?;
+    let node = tree.get(LayoutNodeId::new(node_index)).ok_or(LayoutError::InvalidTree)?;
+    let warm = tree.warm(LayoutNodeId::new(node_index)).ok_or(LayoutError::InvalidTree)?;
     let dom_id = node.dom_node_id; // Can be None for anonymous boxes
 
     // Phase 1: Calculate this node's provisional used size
@@ -2273,7 +2274,7 @@ fn check_scrollbar_change(
         return false;
     }
 
-    let Some(warm_node) = tree.warm(node_index) else {
+    let Some(warm_node) = tree.warm(LayoutNodeId::new(node_index)) else {
         return false;
     };
 
@@ -2407,7 +2408,7 @@ fn process_inflow_child<T: ParsedFontTrait>(
 ) -> Result<()> {
     // Set relative position on child
     // child_relative_pos is [CoordinateSpace::Parent] - relative to parent's content-box
-    let child_warm = tree.warm_mut(child_index).ok_or(LayoutError::InvalidTree)?;
+    let child_warm = tree.warm_mut(LayoutNodeId::new(child_index)).ok_or(LayoutError::InvalidTree)?;
     child_warm.relative_position = Some(child_relative_pos);
 
     // Calculate absolute position
@@ -2420,7 +2421,7 @@ fn process_inflow_child<T: ParsedFontTrait>(
 
     // Debug logging
     {
-        let child_node = tree.get(child_index).ok_or(LayoutError::InvalidTree)?;
+        let child_node = tree.get(LayoutNodeId::new(child_index)).ok_or(LayoutError::InvalidTree)?;
         log_child_positioning(
             ctx,
             child_index,
@@ -2435,7 +2436,7 @@ fn process_inflow_child<T: ParsedFontTrait>(
     super::pos_set(calculated_positions, child_index, child_absolute_pos);
 
     // Get child's properties for recursion
-    let child_node = tree.get(child_index).ok_or(LayoutError::InvalidTree)?;
+    let child_node = tree.get(LayoutNodeId::new(child_index)).ok_or(LayoutError::InvalidTree)?;
     let child_bp = child_node.box_props.unpack();
     let child_content_box_pos =
         calculate_content_box_pos(child_absolute_pos, &child_bp);
@@ -2482,13 +2483,13 @@ pub(super) fn position_bfc_child_descendants(
     content_box_pos: LogicalPosition,
     calculated_positions: &mut super::PositionVec,
 ) {
-    let Some(node) = tree.get(node_index) else { return };
+    let Some(node) = tree.get(LayoutNodeId::new(node_index)) else { return };
 
     for &child_index in tree.children(node_index) {
-        let Some(child_node) = tree.get(child_index) else { continue };
+        let Some(child_node) = tree.get(LayoutNodeId::new(child_index)) else { continue };
 
         // Use the relative_position that was set during formatting context layout
-        let child_rel_pos = tree.warm(child_index)
+        let child_rel_pos = tree.warm(LayoutNodeId::new(child_index))
             .and_then(|w| w.relative_position)
             .unwrap_or_default();
         let child_abs_pos = LogicalPosition::new(
@@ -2528,14 +2529,14 @@ fn process_out_of_flow_children<T: ParsedFontTrait>(
 ) -> Result<()> {
     // Collect out-of-flow children (those not already positioned)
     let out_of_flow_children: Vec<(usize, Option<NodeId>)> = {
-        let current_node = tree.get(node_index).ok_or(LayoutError::InvalidTree)?;
+        let current_node = tree.get(LayoutNodeId::new(node_index)).ok_or(LayoutError::InvalidTree)?;
         tree.children(node_index)
             .iter()
             .filter_map(|&child_index| {
                 if super::pos_contains(calculated_positions, child_index) {
                     return None;
                 }
-                let child = tree.get(child_index)?;
+                let child = tree.get(LayoutNodeId::new(child_index))?;
                 Some((child_index, child.dom_node_id))
             })
             .collect()
@@ -2708,10 +2709,10 @@ pub fn calculate_layout_for_subtree_fragment<T: ParsedFontTrait>(
                     // SIZING CACHE HIT — set used_size and return immediately.
                     // No child positioning needed in ComputeSize mode.
                     drop(crate::probe::Probe::span("size_cache_hit_sizing"));
-                    if let Some(node) = tree.get_mut(node_index) {
+                    if let Some(node) = tree.get_mut(LayoutNodeId::new(node_index)) {
                         node.used_size = Some(cached_sizing.result_size);
                     }
-                    if let Some(warm) = tree.warm_mut(node_index) {
+                    if let Some(warm) = tree.warm_mut(LayoutNodeId::new(node_index)) {
                         warm.escaped_top_margin = cached_sizing.escaped_top_margin;
                         warm.escaped_bottom_margin = cached_sizing.escaped_bottom_margin;
                         warm.baseline = cached_sizing.baseline;
@@ -2725,10 +2726,10 @@ pub fn calculate_layout_for_subtree_fragment<T: ParsedFontTrait>(
                 if let Some(cached_layout) = layout_hit {
                     // Layout slot hit in ComputeSize mode — extract size only
                     drop(crate::probe::Probe::span("size_cache_hit_layout"));
-                    if let Some(node) = tree.get_mut(node_index) {
+                    if let Some(node) = tree.get_mut(LayoutNodeId::new(node_index)) {
                         node.used_size = Some(cached_layout.result_size);
                     }
-                    if let Some(warm) = tree.warm_mut(node_index) {
+                    if let Some(warm) = tree.warm_mut(LayoutNodeId::new(node_index)) {
                         warm.overflow_content_size = Some(cached_layout.content_size);
                         warm.scrollbar_info = Some(cached_layout.scrollbar_info);
                     }
@@ -2792,19 +2793,19 @@ pub fn calculate_layout_for_subtree_fragment<T: ParsedFontTrait>(
                 if let Some(cached_layout) = layout_hit {
                     drop(crate::probe::Probe::span("pos_cache_hit"));
                     // LAYOUT CACHE HIT — apply cached results with child positions
-                    if let Some(node) = tree.get_mut(node_index) {
+                    if let Some(node) = tree.get_mut(LayoutNodeId::new(node_index)) {
                         node.used_size = Some(cached_layout.result_size);
                     }
-                    if let Some(warm) = tree.warm_mut(node_index) {
+                    if let Some(warm) = tree.warm_mut(LayoutNodeId::new(node_index)) {
                         warm.overflow_content_size = Some(cached_layout.content_size);
                         warm.scrollbar_info = Some(cached_layout.scrollbar_info);
                     }
 
-                    let box_props = tree.get(node_index)
+                    let box_props = tree.get(LayoutNodeId::new(node_index))
                         .map(|n| n.box_props.unpack())
                         .unwrap_or_default();
                     let writing_mode = tree
-                        .warm(node_index)
+                        .warm(LayoutNodeId::new(node_index))
                         .map(|w| w.computed_style.writing_mode)
                         .unwrap_or_default();
                     let self_content_box_pos = calculate_content_box_pos(containing_block_pos, &box_props);
@@ -2880,11 +2881,11 @@ pub fn calculate_layout_for_subtree_fragment<T: ParsedFontTrait>(
     // an incorrect children_containing_block_size. By updating used_size here, we ensure
     // that layout_bfc reads the freshly resolved size from prepare_layout_context.
     {
-        let is_table_cell = tree.get(node_index).is_some_and(|n| {
+        let is_table_cell = tree.get(LayoutNodeId::new(node_index)).is_some_and(|n| {
             matches!(n.formatting_context, FormattingContext::TableCell)
         });
         if !is_table_cell {
-            if let Some(node) = tree.get_mut(node_index) {
+            if let Some(node) = tree.get_mut(LayoutNodeId::new(node_index)) {
                 node.used_size = Some(final_used_size);
             }
         }
@@ -2906,7 +2907,7 @@ pub fn calculate_layout_for_subtree_fragment<T: ParsedFontTrait>(
     // propagate that back into final_used_size so Phase 3 (scrollbars),
     // Phase 4 (final write), and the self_content_box_pos calculation all
     // see the same border-box that the children were laid out inside.
-    if let Some(adjusted) = tree.get(node_index).and_then(|n| n.used_size) {
+    if let Some(adjusted) = tree.get(LayoutNodeId::new(node_index)).and_then(|n| n.used_size) {
         final_used_size = adjusted;
     }
 
@@ -2978,7 +2979,7 @@ pub fn calculate_layout_for_subtree_fragment<T: ParsedFontTrait>(
     // Phase 4: Update this node's state
     let self_content_box_pos = {
         {
-            let current_node = tree.get_mut(node_index).ok_or(LayoutError::InvalidTree)?;
+            let current_node = tree.get_mut(LayoutNodeId::new(node_index)).ok_or(LayoutError::InvalidTree)?;
 
             // Table cells get their size from the table layout algorithm, don't overwrite
             let is_table_cell = matches!(
@@ -2991,7 +2992,7 @@ pub fn calculate_layout_for_subtree_fragment<T: ParsedFontTrait>(
         }
 
         // Update warm fields
-        if let Some(warm) = tree.warm_mut(node_index) {
+        if let Some(warm) = tree.warm_mut(LayoutNodeId::new(node_index)) {
             warm.scrollbar_info = Some(merged_scrollbar_info);
             // Store overflow content size for scroll frame calculation
             // +spec:overflow:f28d6a - hanging glyphs should be ink overflow, not scrollable overflow (not yet subtracted from content_size)
@@ -2999,7 +3000,7 @@ pub fn calculate_layout_for_subtree_fragment<T: ParsedFontTrait>(
         }
 
         // self_content_box_pos is [CoordinateSpace::Window] - the absolute position of this node's content-box
-        let current_node = tree.get(node_index).ok_or(LayoutError::InvalidTree)?;
+        let current_node = tree.get(LayoutNodeId::new(node_index)).ok_or(LayoutError::InvalidTree)?;
         let current_bp = current_node.box_props.unpack();
         let pos = calculate_content_box_pos(containing_block_pos, &current_bp);
         log_content_box_calculation(ctx, node_index, current_node, containing_block_pos, pos);
@@ -3008,7 +3009,7 @@ pub fn calculate_layout_for_subtree_fragment<T: ParsedFontTrait>(
 
     // Phase 5: Determine formatting context type
     let is_flex_or_grid = {
-        let node = tree.get(node_index).ok_or(LayoutError::InvalidTree)?;
+        let node = tree.get(LayoutNodeId::new(node_index)).ok_or(LayoutError::InvalidTree)?;
         matches!(
             node.formatting_context,
             FormattingContext::Flex | FormattingContext::Grid
@@ -3063,7 +3064,7 @@ pub fn calculate_layout_for_subtree_fragment<T: ParsedFontTrait>(
     // Fragment passes never store (NG rule, same as the hit-side gate above:
     // fragment geometry would poison the continuous cache).
     if fragment.is_none() && node_index < ctx.cache_map.entries.len() {
-        let warm_ref = tree.warm(node_index);
+        let warm_ref = tree.warm(LayoutNodeId::new(node_index));
         let baseline = warm_ref.and_then(|n| n.baseline);
         let escaped_top = warm_ref.and_then(|n| n.escaped_top_margin);
         let escaped_bottom = warm_ref.and_then(|n| n.escaped_bottom_margin);
@@ -3114,8 +3115,8 @@ fn position_flex_child_descendants(
     let children: Vec<usize> = tree.children(node_index).to_vec();
 
     for &child_index in &children {
-        let child_node = tree.get(child_index).ok_or(LayoutError::InvalidTree)?;
-        let child_rel_pos = tree.warm(child_index)
+        let child_node = tree.get(LayoutNodeId::new(child_index)).ok_or(LayoutError::InvalidTree)?;
+        let child_rel_pos = tree.warm(LayoutNodeId::new(child_index))
             .and_then(|w| w.relative_position)
             .unwrap_or_default();
         let child_abs_pos = LogicalPosition::new(
@@ -3129,7 +3130,7 @@ fn position_flex_child_descendants(
         // Get child's content box for recursion
         let cbp = child_node.box_props.unpack();
         let child_writing_mode = tree
-            .warm(child_index)
+            .warm(LayoutNodeId::new(child_index))
             .map(|w| w.computed_style.writing_mode)
             .unwrap_or_default();
         let child_content_box = LogicalPosition::new(
@@ -3211,7 +3212,7 @@ fn apply_content_based_height(
     node_index: usize,
     writing_mode: LayoutWritingMode,
 ) -> Result<LogicalSize> {
-    let node_props = tree.get(node_index).ok_or(LayoutError::InvalidTree)?.box_props.unpack();
+    let node_props = tree.get(LayoutNodeId::new(node_index)).ok_or(LayoutError::InvalidTree)?.box_props.unpack();
     let main_axis_padding_border =
         node_props.padding.main_sum(writing_mode) + node_props.border.main_sum(writing_mode);
 
@@ -3279,14 +3280,14 @@ fn compute_counters_recursive(
     counter_stacks: &mut HashMap<String, Vec<i32>>,
     scope_stack: &mut Vec<Vec<String>>,
 ) {
-    let Some(node) = tree.get(node_idx) else {
+    let Some(node) = tree.get(LayoutNodeId::new(node_idx)) else {
         return;
     };
 
     // Skip pseudo-elements (::marker, ::before, ::after) for counter processing
     // Pseudo-elements inherit counter values from their parent element
     // but don't participate in counter-reset or counter-increment themselves
-    if tree.warm(node_idx).and_then(|w| w.pseudo_element.as_ref()).is_some() {
+    if tree.warm(LayoutNodeId::new(node_idx)).and_then(|w| w.pseudo_element.as_ref()).is_some() {
         // Store the parent's counter values for this pseudo-element
         // so it can be looked up during marker text generation
         if let Some(parent_idx) = node.parent {
@@ -4039,7 +4040,7 @@ mod autotest_generated {
         cache.previous_positions = vec![pos(0.0, 0.0)];
         cache.counters.insert((0, "list-item".to_string()), 7);
         cache.float_cache.insert(0, fc::FloatingContext::default());
-        cache.scroll_ids.insert(0, 42);
+        cache.scroll_ids.insert(LayoutNodeId::new(0), 42);
         cache.scroll_id_to_node_id.insert(42, NodeId::ZERO);
         // A DL with one Text item: the walk must count the item slot AND
         // its glyph Vec heap — this was a flat 2048 guess before, which
@@ -4118,7 +4119,7 @@ mod autotest_generated {
         cache.float_cache.insert(0, fc::FloatingContext::default());
         // Not incremental-reuse state — must survive.
         cache.calculated_positions = vec![pos(1.0, 2.0)];
-        cache.scroll_ids.insert(0, 5);
+        cache.scroll_ids.insert(LayoutNodeId::new(0), 5);
         cache.viewport = Some(LogicalRect::new(pos(0.0, 0.0), size(800.0, 600.0)));
 
         cache.reset_incremental();

--- a/layout/src/solver3/cache.rs
+++ b/layout/src/solver3/cache.rs
@@ -2196,7 +2196,7 @@ pub fn apply_virtual_scroll_necessity(
         .node_data
         .as_container()
         .get(dom_id)
-        .is_some_and(|nd| nd.is_virtual_view_node());
+        .is_some_and(azul_core::dom::NodeData::is_virtual_view_node);
     if !is_virtual_view {
         return false;
     }
@@ -2212,22 +2212,19 @@ pub fn apply_virtual_scroll_necessity(
     let overflow_x = raw_overflow_x.resolve_computed(&raw_overflow_y);
     let overflow_y = raw_overflow_y.resolve_computed(&raw_overflow_x);
 
-    let mut raised = false;
-    if !reqs.needs_horizontal
+    let raise_horizontal = !reqs.needs_horizontal
         && overflow_x.allows_user_scrolling()
-        && virtual_content_size.width > padding_box_size.width + EPSILON
-    {
+        && virtual_content_size.width > padding_box_size.width + EPSILON;
+    if raise_horizontal {
         reqs.needs_horizontal = true;
-        raised = true;
     }
-    if !reqs.needs_vertical
+    let raise_vertical = !reqs.needs_vertical
         && overflow_y.allows_user_scrolling()
-        && virtual_content_size.height > padding_box_size.height + EPSILON
-    {
+        && virtual_content_size.height > padding_box_size.height + EPSILON;
+    if raise_vertical {
         reqs.needs_vertical = true;
-        raised = true;
     }
-    raised
+    raise_horizontal || raise_vertical
 }
 
 /// Determines scrollbar requirements for a node based on content overflow.

--- a/layout/src/solver3/cache.rs
+++ b/layout/src/solver3/cache.rs
@@ -2055,9 +2055,12 @@ fn prepare_layout_context<'a, T: ParsedFontTrait>(
 /// Core scrollbar info computation: given pre-computed content and container sizes plus
 /// a DOM node for style look-up, determines whether scrollbars are needed.
 ///
-/// This is the single source of truth for scrollbar detection. Both the BFC path
-/// (`compute_scrollbar_info`) and the Taffy flex/grid path (`compute_child_layout`
-/// in `taffy_bridge.rs`) call this function, ensuring consistent behaviour.
+/// This is the single source of truth for scrollbar detection AT LAYOUT TIME.
+/// Both the BFC path (`compute_scrollbar_info`) and the Taffy flex/grid path
+/// (`compute_child_layout` in `taffy_bridge.rs`) call this function, ensuring
+/// consistent behaviour. A `VirtualView`'s scrollable extent is not known yet
+/// when this runs — [`apply_virtual_scroll_necessity`] amends the result after
+/// layout and is the only other place a necessity flag is ever raised.
 ///
 /// For paged media (PDF), scrollbars are never added since they don't exist in print.
 pub fn compute_scrollbar_info_core<T: ParsedFontTrait>(
@@ -2139,6 +2142,93 @@ pub fn compute_scrollbar_info_core<T: ParsedFontTrait>(
     reqs
 }
 
+/// Amends a node's [`ScrollbarRequirements`] with the `VirtualView` virtual
+/// scroll size — the half of the necessity decision that only exists AFTER
+/// layout.
+///
+/// `compute_scrollbar_info_core` decides from the LAID-OUT content size. A
+/// `VirtualView` is a replaced element with no flow content, so its laid-out
+/// content IS its viewport: `overflow: auto` can never fire for it, and the real
+/// scrollable extent lives in `ScrollManager`'s `virtual_scroll_size`, which the
+/// `VirtualView` callback publishes strictly after the layout pass that would
+/// need to read it.
+///
+/// This is the ONE place that compares the two. Every consumer of
+/// `needs_horizontal` / `needs_vertical` must reach the answer through it, or
+/// the paint side and the GPU thumb updater disagree — a painted bar whose thumb
+/// never moves. Two callers:
+///
+/// * `display_list::paint_scrollbars`, which cannot read a post-layout
+///   write-back: the display list is built inside the very layout pass that
+///   recomputes `warm.scrollbar_info` from scratch; and
+/// * `shell2::common::layout::register_scroll_nodes`, which stores the amended
+///   value back into `warm.scrollbar_info`, so that
+///   `GpuStateManager::update_scrollbar_transforms`, the `ScrollManager`
+///   registration and the hit-test scrollbar states all see the same answer.
+///
+/// `virtual_content_size` is `ScrollPosition::children_rect.size` — the same
+/// number the thumb geometry is built from, so "is there a bar" and "how long is
+/// its thumb" can never come from different sizes. `padding_box_size` is the
+/// node's border box minus its borders: a `VirtualView` renders its child DOM
+/// into its bounds, so that IS its viewport, and there is no flow content to
+/// inset by padding.
+///
+/// Only the two booleans move. Layout has already run, so raising
+/// `scrollbar_width` / `scrollbar_height` here would desync the paint from the
+/// clip rect that reserved no gutter — an `auto` `VirtualView`'s bar overlays the
+/// viewport's inner edge, while `overflow: scroll` keeps reserving its gutter at
+/// layout time. Nothing is ever lowered: a bar layout already asked for stays.
+///
+/// Returns `true` if a flag was raised.
+pub fn apply_virtual_scroll_necessity(
+    styled_dom: &StyledDom,
+    dom_id: NodeId,
+    virtual_content_size: LogicalSize,
+    padding_box_size: LogicalSize,
+    reqs: &mut ScrollbarRequirements,
+) -> bool {
+    // Same tolerance as `check_scrollbar_necessity`: a sub-pixel difference must
+    // not raise a bar.
+    const EPSILON: f32 = 1.0;
+
+    let is_virtual_view = styled_dom
+        .node_data
+        .as_container()
+        .get(dom_id)
+        .is_some_and(|nd| nd.is_virtual_view_node());
+    if !is_virtual_view {
+        return false;
+    }
+
+    let node_state = styled_dom
+        .styled_nodes
+        .as_container()
+        .get(dom_id)
+        .map(|n| n.styled_node_state)
+        .unwrap_or_default();
+    let raw_overflow_x = get_overflow_x(styled_dom, dom_id, &node_state);
+    let raw_overflow_y = get_overflow_y(styled_dom, dom_id, &node_state);
+    let overflow_x = raw_overflow_x.resolve_computed(&raw_overflow_y);
+    let overflow_y = raw_overflow_y.resolve_computed(&raw_overflow_x);
+
+    let mut raised = false;
+    if !reqs.needs_horizontal
+        && overflow_x.allows_user_scrolling()
+        && virtual_content_size.width > padding_box_size.width + EPSILON
+    {
+        reqs.needs_horizontal = true;
+        raised = true;
+    }
+    if !reqs.needs_vertical
+        && overflow_y.allows_user_scrolling()
+        && virtual_content_size.height > padding_box_size.height + EPSILON
+    {
+        reqs.needs_vertical = true;
+        raised = true;
+    }
+    raised
+}
+
 /// Determines scrollbar requirements for a node based on content overflow.
 ///
 /// Convenience wrapper around `compute_scrollbar_info_core` for the BFC layout path,
@@ -2162,6 +2252,17 @@ fn compute_scrollbar_info<T: ParsedFontTrait>(
 /// is prevented by the outer layout loop's iteration limit (`loop_count > 10` in mod.rs),
 /// not by suppressing removal detection here. This allows scrollbars to correctly
 /// disappear when content shrinks or the window is resized larger.
+///
+/// A flip only counts when at least one of the two states RESERVES layout space —
+/// the same criterion the no-previous-info arm has always used
+/// (`ScrollbarRequirements::needs_reflow`). What a reflow buys is a corrected
+/// available width/height (`layout_bfc`'s `scrollbar_reservation`, and
+/// `shrink_size` below), so two zero-reservation states cannot need one. This
+/// keeps overlay scrollbars (macOS-style, `reserve_width_px == 0`) from paying a
+/// full extra layout pass every time a bar appears, and it is what stops
+/// [`apply_virtual_scroll_necessity`]'s post-layout amendment — which raises
+/// flags without reserving anything — from asking for one on every single pass
+/// over an `overflow: auto` `VirtualView`.
 fn check_scrollbar_change(
     tree: &LayoutTree,
     node_index: usize,
@@ -2180,7 +2281,8 @@ fn check_scrollbar_change(
             // Trigger reflow if scrollbar state changed in either direction
             let horizontal_changed = old_info.needs_horizontal != scrollbar_info.needs_horizontal;
             let vertical_changed = old_info.needs_vertical != scrollbar_info.needs_vertical;
-            horizontal_changed || vertical_changed
+            (horizontal_changed || vertical_changed)
+                && (old_info.needs_reflow() || scrollbar_info.needs_reflow())
         })
 }
 
@@ -4546,6 +4648,146 @@ mod autotest_generated {
         // reflow here.
         let tree = tree_with_scrollbar_info(Some(scrollbars(false, true, 16.0)));
         assert!(!check_scrollbar_change(&tree, 0, &scrollbars(false, true, 4.0), false));
+    }
+
+    #[test]
+    fn check_scrollbar_change_ignores_a_flip_between_two_zero_reservation_states() {
+        // Overlay scrollbars reserve nothing, so a bar appearing or vanishing
+        // cannot change the available space a reflow would recompute. Same for
+        // the post-layout `apply_virtual_scroll_necessity` amendment, which
+        // raises a flag without reserving a gutter — without this, an
+        // `overflow: auto` VirtualView asked for a full extra layout pass on
+        // every single pass, forever.
+        let overlay_bar = tree_with_scrollbar_info(Some(scrollbars(false, true, 0.0)));
+        assert!(!check_scrollbar_change(&overlay_bar, 0, &scrollbars(false, false, 0.0), false));
+        let no_bar = tree_with_scrollbar_info(Some(scrollbars(false, false, 0.0)));
+        assert!(!check_scrollbar_change(&no_bar, 0, &scrollbars(false, true, 0.0), false));
+
+        // A space-reserving bar on EITHER side still forces the reflow.
+        assert!(check_scrollbar_change(&no_bar, 0, &scrollbars(false, true, 16.0), false));
+        let classic_bar = tree_with_scrollbar_info(Some(scrollbars(false, true, 16.0)));
+        assert!(check_scrollbar_change(&classic_bar, 0, &scrollbars(false, false, 0.0), false));
+    }
+
+    // ==================================================================
+    // apply_virtual_scroll_necessity
+    // ==================================================================
+
+    /// `body(0) > node(1)`, where node 1 carries `.vv` and the given node type.
+    fn dom_with_styled_child(node_type: NodeType, css_str: &str) -> StyledDom {
+        styled(
+            Dom::create_body().with_child(
+                Dom::create_node(node_type)
+                    .with_ids_and_classes(vec![IdOrClass::Class("vv".into())].into()),
+            ),
+            css_str,
+        )
+    }
+
+    fn no_scrollbars() -> ScrollbarRequirements {
+        scrollbars(false, false, 0.0)
+    }
+
+    #[test]
+    fn apply_virtual_scroll_necessity_raises_the_axis_the_virtual_document_overflows() {
+        let dom = dom_with_styled_child(
+            NodeType::VirtualView,
+            ".vv { overflow-x: hidden; overflow-y: auto; }",
+        );
+        let mut info = no_scrollbars();
+        assert!(apply_virtual_scroll_necessity(
+            &dom,
+            NodeId::new(1),
+            size(100.0, 1000.0),
+            size(100.0, 100.0),
+            &mut info,
+        ));
+        assert!(info.needs_vertical);
+        assert!(!info.needs_horizontal, "the hidden axis never gains a bar");
+        // Layout has already run: no gutter is reserved after the fact.
+        assert_eq!(info.scrollbar_width, 0.0);
+        assert_eq!(info.scrollbar_height, 0.0);
+    }
+
+    #[test]
+    fn apply_virtual_scroll_necessity_ignores_everything_that_is_not_a_virtual_view() {
+        // Same CSS, same overflowing virtual size — a plain div's necessity is
+        // layout's business and must not be second-guessed here.
+        let dom = dom_with_styled_child(NodeType::Div, ".vv { overflow: auto; }");
+        let mut info = no_scrollbars();
+        assert!(!apply_virtual_scroll_necessity(
+            &dom,
+            NodeId::new(1),
+            size(1000.0, 1000.0),
+            size(100.0, 100.0),
+            &mut info,
+        ));
+        assert!(!info.needs_vertical && !info.needs_horizontal);
+
+        // An out-of-range node is inert rather than a panic.
+        let mut info = no_scrollbars();
+        assert!(!apply_virtual_scroll_necessity(
+            &dom,
+            NodeId::new(9_999),
+            size(1000.0, 1000.0),
+            size(100.0, 100.0),
+            &mut info,
+        ));
+    }
+
+    #[test]
+    fn apply_virtual_scroll_necessity_honours_the_one_pixel_epsilon_and_the_overflow_value() {
+        let auto = dom_with_styled_child(NodeType::VirtualView, ".vv { overflow: auto; }");
+        // Exactly at the boundary: 101 is NOT > 100 + 1 — same tolerance as
+        // check_scrollbar_necessity, so sub-pixel noise cannot flicker a bar.
+        let mut info = no_scrollbars();
+        assert!(!apply_virtual_scroll_necessity(
+            &auto,
+            NodeId::new(1),
+            size(101.0, 101.0),
+            size(100.0, 100.0),
+            &mut info,
+        ));
+        // One pixel past it raises both axes.
+        let mut info = no_scrollbars();
+        assert!(apply_virtual_scroll_necessity(
+            &auto,
+            NodeId::new(1),
+            size(102.0, 102.0),
+            size(100.0, 100.0),
+            &mut info,
+        ));
+        assert!(info.needs_horizontal && info.needs_vertical);
+
+        // `hidden` is a scroll container but not a user-scrollable one: no bar,
+        // however large the virtual document is.
+        let hidden = dom_with_styled_child(NodeType::VirtualView, ".vv { overflow: hidden; }");
+        let mut info = no_scrollbars();
+        assert!(!apply_virtual_scroll_necessity(
+            &hidden,
+            NodeId::new(1),
+            size(9999.0, 9999.0),
+            size(100.0, 100.0),
+            &mut info,
+        ));
+        assert!(!info.needs_horizontal && !info.needs_vertical);
+    }
+
+    #[test]
+    fn apply_virtual_scroll_necessity_never_lowers_a_flag_layout_already_raised() {
+        // `overflow: scroll` sets needs_* unconditionally at layout time (and
+        // reserves the gutter). A virtual size that fits must not undo that.
+        let dom = dom_with_styled_child(NodeType::VirtualView, ".vv { overflow-y: scroll; }");
+        let mut info = scrollbars(false, true, 16.0);
+        assert!(!apply_virtual_scroll_necessity(
+            &dom,
+            NodeId::new(1),
+            size(100.0, 10.0),
+            size(100.0, 100.0),
+            &mut info,
+        ));
+        assert!(info.needs_vertical, "the reserved bar survives");
+        assert_eq!(info.scrollbar_width, 16.0, "and keeps its layout reservation");
     }
 
     // ==================================================================

--- a/layout/src/solver3/cache.rs
+++ b/layout/src/solver3/cache.rs
@@ -3587,10 +3587,10 @@ mod autotest_generated {
         styled(
             Dom::create_body().with_child(
                 div_class("p")
-                    .with_child(Dom::create_text(" \n\t"))
-                    .with_child(Dom::create_text("hi"))
+                    .with_child(Dom::create_text_do_not_use_without_block_level_wrapper(" \n\t"))
+                    .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("hi"))
                     .with_child(Dom::create_div())
-                    .with_child(Dom::create_text("\u{00A0}")),
+                    .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("\u{00A0}")),
             ),
             css_str,
         )
@@ -5021,7 +5021,7 @@ mod autotest_generated {
         let sd = styled(
             Dom::create_body()
                 .with_child(Dom::create_div())
-                .with_child(Dom::create_text(" "))
+                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper(" "))
                 .with_child(div_class("hide")),
             ".hide { display: none; }",
         );

--- a/layout/src/solver3/display_list.rs
+++ b/layout/src/solver3/display_list.rs
@@ -3238,6 +3238,21 @@ where
         Ok(())
     }
 
+    /// Does the IFC rooted at `node_index` own the inline content of `dom_id`?
+    ///
+    /// The editing session's text node need not be a DIRECT child of the IFC
+    /// root — `p > span > text` puts it one level deeper — so resolve it through
+    /// `ifc_membership`, which every inline descendant of the root carries,
+    /// instead of scanning the root's children.
+    fn ifc_root_owns_dom_node(&self, node_index: usize, dom_id: NodeId) -> bool {
+        let tree = self.positioned_tree.tree;
+        tree.dom_to_layout.get(&dom_id).is_some_and(|indices| {
+            indices
+                .iter()
+                .any(|&idx| tree.get_ifc_root_layout_index(idx) == node_index)
+        })
+    }
+
     /// Emits drawing commands for all text cursors (carets).
     /// Iterates over `ctx.cursor_locations` to support multi-cursor rendering.
     /// Preedit underline is only rendered for the primary (last) cursor.
@@ -3306,11 +3321,8 @@ where
         let primary_idx_for_this_node = self.ctx.cursor_locations.iter().enumerate()
             .rev()
             .find(|(_, (cd, cn, _))| {
-                *cd == self.ctx.styled_dom.dom_id && (*cn == dom_id || self.positioned_tree.tree.children(node_index).iter().any(|&child_idx| {
-                    self.positioned_tree.tree.get(child_idx)
-                        .and_then(|c| c.dom_node_id)
-                        .is_some_and(|id| id == *cn)
-                }))
+                *cd == self.ctx.styled_dom.dom_id
+                    && (*cn == dom_id || self.ifc_root_owns_dom_node(node_index, *cn))
             })
             .map(|(i, _)| i);
 
@@ -3321,17 +3333,10 @@ where
             }
 
             // Check this node contains the cursor
-            if dom_id != *cursor_node_id {
-                let is_ifc_root_of_cursor = self.positioned_tree.tree.children(node_index)
-                    .iter()
-                    .any(|&child_idx| {
-                        self.positioned_tree.tree.get(child_idx)
-                            .and_then(|c| c.dom_node_id)
-                            .is_some_and(|id| id == *cursor_node_id)
-                    });
-                if !is_ifc_root_of_cursor {
-                    continue;
-                }
+            if dom_id != *cursor_node_id
+                && !self.ifc_root_owns_dom_node(node_index, *cursor_node_id)
+            {
+                continue;
             }
 
             // Get cursor rect from text layout
@@ -3357,12 +3362,60 @@ where
             if is_primary {
                 if let Some(ref preedit) = self.ctx.preedit_text {
                     if !preedit.is_empty() {
-                        let char_count = preedit.chars().count() as f32;
-                        let approx_char_width = style.width.max(8.0);
-                        let preedit_width = char_count * approx_char_width;
+                        // The composition IS in this layout: apply_preedit_to_
+                        // text_cache splices it into the run at the cursor's
+                        // byte offset and re-shapes, so the underline can span
+                        // the MEASURED advance of the composed clusters. The
+                        // old `char_count × max(caret_width, 8px)` guess was
+                        // wrong for every script whose advances aren't ~8px —
+                        // a CJK cluster is roughly double that.
+                        let run = cursor.cluster_id.source_run;
+                        let start_byte = cursor.cluster_id.start_byte_in_run;
+                        let end_byte = start_byte.saturating_add(
+                            u32::try_from(preedit.len()).unwrap_or(u32::MAX),
+                        );
+                        // (line_index, min_x, max_x) of the composed clusters.
+                        // Clusters on a later line belong to a composition that
+                        // wrapped; they would need their own rect, so the span
+                        // stays on the line the caret sits on.
+                        let mut span: Option<(usize, f32, f32)> = None;
+                        for item in &layout.items {
+                            let Some(cluster) = item.item.as_cluster() else {
+                                continue;
+                            };
+                            let id = cluster.source_cluster_id;
+                            if id.source_run != run
+                                || id.start_byte_in_run < start_byte
+                                || id.start_byte_in_run >= end_byte
+                            {
+                                continue;
+                            }
+                            let edge = item.position.x + cluster.advance;
+                            let (lo, hi) =
+                                (item.position.x.min(edge), item.position.x.max(edge));
+                            span = Some(match span {
+                                Some((line, min_x, max_x)) if line == item.line_index => {
+                                    (line, min_x.min(lo), max_x.max(hi))
+                                }
+                                Some(other_line) => other_line,
+                                None => (item.line_index, lo, hi),
+                            });
+                        }
+                        let (underline_x, preedit_width) = match span {
+                            Some((_, lo, hi)) => (lo + content_box_offset_x, hi - lo),
+                            None => {
+                                // Composition not (yet) in the cache — keep the
+                                // old estimate rather than drawing nothing.
+                                let char_count = preedit.chars().count() as f32;
+                                (
+                                    rect.origin.x + rect.size.width,
+                                    char_count * style.width.max(8.0),
+                                )
+                            }
+                        };
                         let underline_bounds = LogicalRect {
                             origin: LogicalPosition {
-                                x: rect.origin.x + rect.size.width,
+                                x: underline_x,
                                 y: rect.origin.y + rect.size.height - 2.0,
                             },
                             size: LogicalSize {
@@ -5297,12 +5350,44 @@ where
         };
 
         // Check if we need to draw scrollbars for this node.
-        let scrollbar_info = self.positioned_tree.tree.warm(node_index)
+        let mut scrollbar_info = self.positioned_tree.tree.warm(node_index)
             .and_then(|w| w.scrollbar_info)
             .unwrap_or_default();
 
         // Get node_id for GPU cache lookup and CSS style lookup
         let node_id = node.dom_node_id;
+
+        // A VirtualView is a replaced element with NO flow content, so the
+        // layout-side necessity test (`check_scrollbar_necessity`: laid-out
+        // content > container) can never fire for it and `overflow: auto` would
+        // stay bar-less no matter how large the virtualized document is. The
+        // virtual size does reach the display list — the ScrollManager puts the
+        // callback's `virtual_scroll_size` into `ScrollPosition::children_rect`,
+        // which the thumb geometry below already prefers — so decide from that,
+        // through the one function that owns the rule.
+        //
+        // The answer cannot simply be read off `warm.scrollbar_info` here:
+        // `register_scroll_nodes` writes the same amendment back into the tree
+        // for the GPU/hit-test consumers, but it runs AFTER this display list is
+        // built, and the layout pass that precedes this one has already
+        // recomputed `warm.scrollbar_info` from the laid-out sizes.
+        if let Some(nid) = node_id {
+            if let Some(pos) = self.scroll_offsets.get(&nid) {
+                let bp = node.box_props.unpack();
+                let border = &bp.border;
+                let padding_box_size = LogicalSize::new(
+                    (paint_rect.size.width - border.left - border.right).max(0.0),
+                    (paint_rect.size.height - border.top - border.bottom).max(0.0),
+                );
+                crate::solver3::cache::apply_virtual_scroll_necessity(
+                    self.ctx.styled_dom,
+                    nid,
+                    pos.children_rect.size,
+                    padding_box_size,
+                    &mut scrollbar_info,
+                );
+            }
+        }
 
         // Get CSS scrollbar style for this node (cached per LayoutContext).
         let scrollbar_style = node_id
@@ -5421,17 +5506,21 @@ where
             ),
         };
 
-        // Get scroll position for thumb calculation
-        // ScrollPosition contains parent_rect and children_rect
-        // The scroll offset is the difference between children_rect.origin and parent_rect.origin
+        // Get scroll position for thumb calculation.
+        // `children_rect.origin` IS the scroll offset (see
+        // `ScrollManager::get_scroll_states_for_dom`); `parent_rect.origin` is
+        // an ABSOLUTE window coordinate, so subtracting it here mixed two
+        // spaces and started the thumb `container.y` px down its own track for
+        // any scroller not at the window origin. The GPU-only scroll path
+        // (`GpuStateManager::update_scrollbar_transforms`) feeds the raw
+        // `current_offset` into the same geometry fn — these two MUST agree,
+        // because the transform written here is the initial value of the key
+        // that path later overwrites.
         let (scroll_offset_x, scroll_offset_y) = node_id
             .and_then(|nid| {
-                self.scroll_offsets.get(&nid).map(|pos| {
-                    (
-                        pos.children_rect.origin.x - pos.parent_rect.origin.x,
-                        pos.children_rect.origin.y - pos.parent_rect.origin.y,
-                    )
-                })
+                self.scroll_offsets
+                    .get(&nid)
+                    .map(|pos| (pos.children_rect.origin.x, pos.children_rect.origin.y))
             })
             .unwrap_or((0.0, 0.0));
 

--- a/layout/src/solver3/display_list.rs
+++ b/layout/src/solver3/display_list.rs
@@ -3402,17 +3402,16 @@ where
                                 None => (item.line_index, lo, hi),
                             });
                         }
-                        let (underline_x, preedit_width) = match span {
-                            Some((_, lo, hi)) => (lo + content_box_offset_x, hi - lo),
-                            None => {
-                                // Composition not (yet) in the cache — keep the
-                                // old estimate rather than drawing nothing.
-                                let char_count = preedit.chars().count() as f32;
-                                (
-                                    rect.origin.x + rect.size.width,
-                                    char_count * style.width.max(8.0),
-                                )
-                            }
+                        let (underline_x, preedit_width) = if let Some((_, lo, hi)) = span {
+                            (lo + content_box_offset_x, hi - lo)
+                        } else {
+                            // Composition not (yet) in the cache — keep the
+                            // old estimate rather than drawing nothing.
+                            let char_count = preedit.chars().count() as f32;
+                            (
+                                rect.origin.x + rect.size.width,
+                                char_count * style.width.max(8.0),
+                            )
                         };
                         let underline_bounds = LogicalRect {
                             origin: LogicalPosition {

--- a/layout/src/solver3/display_list.rs
+++ b/layout/src/solver3/display_list.rs
@@ -13,6 +13,7 @@
 //! Coordinates are in **absolute window-logical pixels** ([`WindowLogicalRect`]).
 //! `HiDPI` scaling and scroll-offset conversion happen in the compositor.
 
+use crate::solver3::layout_tree::LayoutNodeId;
 use std::{collections::{BTreeMap, HashMap}, sync::Arc};
 
 use azul_core::{
@@ -2466,7 +2467,7 @@ pub fn generate_display_list<T: ParsedFontTrait + Sync + 'static>(
     tree: &LayoutTree,
     calculated_positions: &super::PositionVec,
     scroll_offsets: &BTreeMap<NodeId, ScrollPosition>,
-    scroll_ids: &HashMap<usize, u64>,
+    scroll_ids: &HashMap<LayoutNodeId, u64>,
     gpu_value_cache: Option<&GpuValueCache>,
     renderer_resources: &RendererResources,
     id_namespace: IdNamespace,
@@ -2488,7 +2489,7 @@ pub fn generate_display_list_impl<T: ParsedFontTrait + Sync + 'static>(
     tree: &LayoutTree,
     calculated_positions: &super::PositionVec,
     scroll_offsets: &BTreeMap<NodeId, ScrollPosition>,
-    scroll_ids: &HashMap<usize, u64>,
+    scroll_ids: &HashMap<LayoutNodeId, u64>,
     gpu_value_cache: Option<&GpuValueCache>,
     renderer_resources: &RendererResources,
     id_namespace: IdNamespace,
@@ -2539,7 +2540,7 @@ pub fn generate_display_list_impl<T: ParsedFontTrait + Sync + 'static>(
     //    This is critical when <html> doesn't have height:100% — without this,
     //    the body's background only covers the body's content area, not the viewport.
     {
-        let root_node = tree.get(tree.root);
+        let root_node = tree.get(LayoutNodeId::new(tree.root));
         if let Some(root) = root_node {
             if let Some(root_dom_id) = root.dom_node_id {
                 let root_state = generator.get_styled_node_state(root_dom_id);
@@ -2596,7 +2597,7 @@ struct DisplayListGenerator<'a, 'b, T: ParsedFontTrait> {
     ctx: &'a mut LayoutContext<'b, T>,
     scroll_offsets: &'a BTreeMap<NodeId, ScrollPosition>,
     positioned_tree: &'a PositionedTree<'a>,
-    scroll_ids: &'a HashMap<usize, u64>,
+    scroll_ids: &'a HashMap<LayoutNodeId, u64>,
     gpu_value_cache: Option<&'a GpuValueCache>,
     renderer_resources: &'a RendererResources,
     id_namespace: IdNamespace,
@@ -2938,7 +2939,7 @@ where
         ctx: &'a mut LayoutContext<'b, T>,
         scroll_offsets: &'a BTreeMap<NodeId, ScrollPosition>,
         positioned_tree: &'a PositionedTree<'a>,
-        scroll_ids: &'a HashMap<usize, u64>,
+        scroll_ids: &'a HashMap<LayoutNodeId, u64>,
         gpu_value_cache: Option<&'a GpuValueCache>,
         renderer_resources: &'a RendererResources,
         id_namespace: IdNamespace,
@@ -2969,7 +2970,7 @@ where
         source_node_index: usize,
     ) -> Option<(ColorU, WindowLogicalRect)> {
         let tree = self.positioned_tree.tree;
-        let dom_id_opt = tree.get(source_node_index).and_then(|n| n.dom_node_id);
+        let dom_id_opt = tree.get(LayoutNodeId::new(source_node_index)).and_then(|n| n.dom_node_id);
         if let (Some(sel), Some(dom_id)) = (
             self.ctx.text_selections.get(&self.ctx.styled_dom.dom_id),
             dom_id_opt,
@@ -2980,7 +2981,7 @@ where
         }
         let mut cur = Some(source_node_index);
         while let Some(idx) = cur {
-            if let Some(dom_id) = tree.get(idx).and_then(|n| n.dom_node_id) {
+            if let Some(dom_id) = tree.get(LayoutNodeId::new(idx)).and_then(|n| n.dom_node_id) {
                 let state = self.get_styled_node_state(dom_id);
                 let contents = get_background_contents(
                     self.ctx.styled_dom,
@@ -3011,7 +3012,7 @@ where
                 }
                 let _ = saw_any;
             }
-            cur = tree.get(idx).and_then(|n| n.parent);
+            cur = tree.get(LayoutNodeId::new(idx)).and_then(|n| n.parent);
         }
         None
     }
@@ -3080,7 +3081,7 @@ where
     // with visibility:visible inside a hidden parent must still be painted.
     fn is_node_hidden(&self, node_index: usize) -> bool {
         use azul_css::props::style::effects::StyleVisibility;
-        let Some(node) = self.positioned_tree.tree.get(node_index) else {
+        let Some(node) = self.positioned_tree.tree.get(LayoutNodeId::new(node_index)) else {
             return false;
         };
         let Some(dom_id) = node.dom_node_id else {
@@ -3160,7 +3161,7 @@ where
         let node = self
             .positioned_tree
             .tree
-            .get(node_index)
+            .get(LayoutNodeId::new(node_index))
             .ok_or(LayoutError::InvalidTree)?;
         let Some(dom_id) = node.dom_node_id else {
             return Ok(());
@@ -3197,7 +3198,7 @@ where
         let anchor_bp = self
             .positioned_tree
             .tree
-            .get(ifc_root_index).map_or_else(|| node.box_props.unpack(), |n| n.box_props.unpack());
+            .get(LayoutNodeId::new(ifc_root_index)).map_or_else(|| node.box_props.unpack(), |n| n.box_props.unpack());
         let content_box_offset_x = anchor_pos.x + anchor_bp.padding.left + anchor_bp.border.left;
         let content_box_offset_y = anchor_pos.y + anchor_bp.padding.top + anchor_bp.border.top;
 
@@ -3249,7 +3250,7 @@ where
         tree.dom_to_layout.get(&dom_id).is_some_and(|indices| {
             indices
                 .iter()
-                .any(|&idx| tree.get_ifc_root_layout_index(idx) == node_index)
+                .any(|&idx| tree.get_ifc_root_layout_index(idx.index()) == node_index)
         })
     }
 
@@ -3276,7 +3277,7 @@ where
         let node = self
             .positioned_tree
             .tree
-            .get(node_index)
+            .get(LayoutNodeId::new(node_index))
             .ok_or(LayoutError::InvalidTree)?;
         let Some(dom_id) = node.dom_node_id else {
             return Ok(());
@@ -3450,7 +3451,7 @@ where
         let node = self
             .positioned_tree
             .tree
-            .get(node_index)
+            .get(LayoutNodeId::new(node_index))
             .ok_or(LayoutError::InvalidTree)?;
         let z_index = get_z_index(self.ctx.styled_dom, node.dom_node_id);
 
@@ -3528,7 +3529,7 @@ where
         let node = self
             .positioned_tree
             .tree
-            .get(context.node_index)
+            .get(LayoutNodeId::new(context.node_index))
             .ok_or(LayoutError::InvalidTree)?;
 
         if let Some(dom_id) = node.dom_node_id {
@@ -3841,7 +3842,7 @@ where
             let child_node = self
                 .positioned_tree
                 .tree
-                .get(child_index)
+                .get(LayoutNodeId::new(child_index))
                 .ok_or(LayoutError::InvalidTree)?;
 
             // Check if this child is being dragged (paint last for z-order)
@@ -3880,7 +3881,7 @@ where
             let child_node = self
                 .positioned_tree
                 .tree
-                .get(child_index)
+                .get(LayoutNodeId::new(child_index))
                 .ok_or(LayoutError::InvalidTree)?;
 
             // Check if this child has a GPU transform (CSS transform or drag)
@@ -3971,7 +3972,7 @@ where
             let child_node = self
                 .positioned_tree
                 .tree
-                .get(child_index)
+                .get(LayoutNodeId::new(child_index))
                 .ok_or(LayoutError::InvalidTree)?;
 
             // Check if this child has a GPU transform (CSS transform or drag)
@@ -4050,7 +4051,7 @@ where
             let child_node = self
                 .positioned_tree
                 .tree
-                .get(child_index)
+                .get(LayoutNodeId::new(child_index))
                 .ok_or(LayoutError::InvalidTree)?;
 
             // Check if this child has a GPU transform (CSS transform or drag)
@@ -4142,7 +4143,7 @@ where
         builder: &mut DisplayListBuilder,
         node_index: usize,
     ) -> bool {
-        let Some(node) = self.positioned_tree.tree.get(node_index) else {
+        let Some(node) = self.positioned_tree.tree.get(LayoutNodeId::new(node_index)) else {
             return false;
         };
         let Some(dom_id) = node.dom_node_id else {
@@ -4296,7 +4297,7 @@ where
         let border = &bp.border;
 
         // Get scrollbar info to adjust clip rect for content area
-        let scrollbar_info = self.positioned_tree.tree.warm(node_index)
+        let scrollbar_info = self.positioned_tree.tree.warm(LayoutNodeId::new(node_index))
             .and_then(|w| w.scrollbar_info)
             .unwrap_or_default();
 
@@ -4352,8 +4353,8 @@ where
         // VirtualViewPlaceholder emitted after pop_node_clips in
         // generate_for_stacking_context — so VirtualView nodes get only the clip.
         if (overflow_x.is_scroll() || overflow_y.is_scroll()) && !is_virtual_view {
-            let scroll_id = self.scroll_ids.get(&node_index).copied().unwrap_or(0);
-            let content_size = get_scroll_content_size(node, self.positioned_tree.tree.warm(node_index));
+            let scroll_id = self.scroll_ids.get(&LayoutNodeId::new(node_index)).copied().unwrap_or(0);
+            let content_size = get_scroll_content_size(node, self.positioned_tree.tree.warm(LayoutNodeId::new(node_index)));
             builder.push_scroll_frame(clip_rect, content_size, scroll_id);
         }
 
@@ -4454,7 +4455,7 @@ where
     /// transforms handle this. Subtracting here would cause double-offset and
     /// parallax effects (backgrounds and text moving at different speeds).
     fn get_paint_rect(&self, node_index: usize) -> Option<LogicalRect> {
-        let node = self.positioned_tree.tree.get(node_index)?;
+        let node = self.positioned_tree.tree.get(LayoutNodeId::new(node_index))?;
         let pos = self
             .positioned_tree
             .calculated_positions
@@ -4498,7 +4499,7 @@ where
         let node = self
             .positioned_tree
             .tree
-            .get(node_index)
+            .get(LayoutNodeId::new(node_index))
             .ok_or(LayoutError::InvalidTree)?;
 
         // Set current node for node mapping (for pagination break properties)
@@ -4550,7 +4551,7 @@ where
         // IMPORTANT: The parent check must look at the PARENT NODE's formatting_context,
         // not the current node's. If parent is Flex/Grid, we paint this element as a flex/grid item.
         // Also check parent_formatting_context field which stores parent's FC during tree construction.
-        let warm = self.positioned_tree.tree.warm(node_index);
+        let warm = self.positioned_tree.tree.warm(LayoutNodeId::new(node_index));
         let parent_is_flex_or_grid = warm
             .and_then(|w| w.parent_formatting_context.as_ref().map(|fc| matches!(fc, FormattingContext::Flex | FormattingContext::Grid)))
             .unwrap_or(false);
@@ -4732,7 +4733,7 @@ where
         let table_node = self
             .positioned_tree
             .tree
-            .get(table_index)
+            .get(LayoutNodeId::new(table_index))
             .ok_or(LayoutError::InvalidTree)?;
 
         let Some(table_paint_rect) = self.get_paint_rect(table_index) else {
@@ -4763,7 +4764,7 @@ where
         // Layer 2: Column group backgrounds
         // Layer 3: Column backgrounds (columns are children of column groups)
         for &child_idx in self.positioned_tree.tree.children(table_index) {
-            let child_node = self.positioned_tree.tree.get(child_idx);
+            let child_node = self.positioned_tree.tree.get(LayoutNodeId::new(child_idx));
             if let Some(node) = child_node {
                 if matches!(node.formatting_context, FormattingContext::TableColumnGroup) {
                     // Paint column group background
@@ -4781,7 +4782,7 @@ where
         // Layer 5: Row backgrounds
         // Layer 6: Cell backgrounds
         for &child_idx in self.positioned_tree.tree.children(table_index) {
-            let child_node = self.positioned_tree.tree.get(child_idx);
+            let child_node = self.positioned_tree.tree.get(LayoutNodeId::new(child_idx));
             if let Some(node) = child_node {
                 match node.formatting_context {
                     FormattingContext::TableRowGroup => {
@@ -4818,7 +4819,7 @@ where
     /// keep the initial value (separate).
     fn table_is_border_collapsed(&self, table_index: usize) -> bool {
         use azul_css::props::layout::table::StyleBorderCollapse;
-        let Some(node) = self.positioned_tree.tree.get(table_index) else {
+        let Some(node) = self.positioned_tree.tree.get(LayoutNodeId::new(table_index)) else {
             return false;
         };
         let Some(dom_id) = node.dom_node_id else {
@@ -4842,9 +4843,9 @@ where
     /// Whether a node lives inside a `border-collapse: collapse` table
     /// (walks the layout-tree parent chain to the nearest Table node).
     fn is_inside_collapsed_table(&self, node_index: usize) -> bool {
-        let mut cur = self.positioned_tree.tree.get(node_index).and_then(|n| n.parent);
+        let mut cur = self.positioned_tree.tree.get(LayoutNodeId::new(node_index)).and_then(|n| n.parent);
         while let Some(idx) = cur {
-            let Some(node) = self.positioned_tree.tree.get(idx) else {
+            let Some(node) = self.positioned_tree.tree.get(LayoutNodeId::new(idx)) else {
                 return false;
             };
             if matches!(node.formatting_context, FormattingContext::Table) {
@@ -4884,7 +4885,7 @@ where
         // (cell layout-tree index, paint rect, owning row index) per row
         let mut rows: Vec<(usize, Vec<(usize, LogicalRect)>)> = Vec::new();
         for &child_idx in self.positioned_tree.tree.children(table_index) {
-            let Some(child) = self.positioned_tree.tree.get(child_idx) else {
+            let Some(child) = self.positioned_tree.tree.get(LayoutNodeId::new(child_idx)) else {
                 continue;
             };
             match child.formatting_context {
@@ -4905,17 +4906,17 @@ where
         }
 
         let cell_border = |idx: usize| -> Option<[CollapsedBorder; 4]> {
-            let node = self.positioned_tree.tree.get(idx)?;
+            let node = self.positioned_tree.tree.get(LayoutNodeId::new(idx))?;
             Some(collapsed_border_info(self.ctx, node, BorderSource::Cell).into())
         };
         let row_border = |idx: usize| -> Option<[CollapsedBorder; 4]> {
-            let node = self.positioned_tree.tree.get(idx)?;
+            let node = self.positioned_tree.tree.get(LayoutNodeId::new(idx))?;
             Some(collapsed_border_info(self.ctx, node, BorderSource::Row).into())
         };
         let table_border: Option<[CollapsedBorder; 4]> = self
             .positioned_tree
             .tree
-            .get(table_index)
+            .get(LayoutNodeId::new(table_index))
             .map(|node| collapsed_border_info(self.ctx, node, BorderSource::Table).into());
         const TOP: usize = 0;
         const RIGHT: usize = 1;
@@ -5053,7 +5054,7 @@ where
         // Rows don't have entries in calculated_positions (adding them would
         // double-offset cells during position recursion). Compute the row rect
         // from the bounding box of its cell children.
-        if let Some(row_node) = self.positioned_tree.tree.get(row_idx) {
+        if let Some(row_node) = self.positioned_tree.tree.get(LayoutNodeId::new(row_idx)) {
             if let Some(dom_id) = row_node.dom_node_id {
                 let styled_node_state = self.get_styled_node_state(dom_id);
                 let bg_color = get_background_color(self.ctx.styled_dom, dom_id, &styled_node_state);
@@ -5083,7 +5084,7 @@ where
         }
 
         // Layer 6: Paint cell backgrounds (topmost layer)
-        if let Some(_node) = self.positioned_tree.tree.get(row_idx) {
+        if let Some(_node) = self.positioned_tree.tree.get(LayoutNodeId::new(row_idx)) {
             for &cell_idx in self.positioned_tree.tree.children(row_idx) {
                 self.paint_element_background(builder, cell_idx);
             }
@@ -5102,7 +5103,7 @@ where
             return;
         };
 
-        let Some(node) = self.positioned_tree.tree.get(node_index) else {
+        let Some(node) = self.positioned_tree.tree.get(LayoutNodeId::new(node_index)) else {
             return;
         };
         let Some(dom_id) = node.dom_node_id else {
@@ -5163,9 +5164,9 @@ where
         let node = self
             .positioned_tree
             .tree
-            .get(node_index)
+            .get(LayoutNodeId::new(node_index))
             .ok_or(LayoutError::InvalidTree)?;
-        let node_warm = self.positioned_tree.tree.warm(node_index);
+        let node_warm = self.positioned_tree.tree.warm(LayoutNodeId::new(node_index));
 
         // Set current node for node mapping (for pagination break properties)
         builder.set_current_node(node.dom_node_id);
@@ -5342,7 +5343,7 @@ where
         let node = self
             .positioned_tree
             .tree
-            .get(node_index)
+            .get(LayoutNodeId::new(node_index))
             .ok_or(LayoutError::InvalidTree)?;
 
         let Some(paint_rect) = self.get_paint_rect(node_index) else {
@@ -5350,7 +5351,7 @@ where
         };
 
         // Check if we need to draw scrollbars for this node.
-        let mut scrollbar_info = self.positioned_tree.tree.warm(node_index)
+        let mut scrollbar_info = self.positioned_tree.tree.warm(LayoutNodeId::new(node_index))
             .and_then(|w| w.scrollbar_info)
             .unwrap_or_default();
 
@@ -5530,7 +5531,7 @@ where
         // For VirtualView nodes, the virtual_scroll_size (propagated through ScrollPosition.children_rect)
         // is more accurate than the layout-computed content size.
         let content_size = node_id
-            .and_then(|nid| self.scroll_offsets.get(&nid)).map_or_else(|| self.positioned_tree.tree.get_content_size(node_index), |pos| pos.children_rect.size);
+            .and_then(|nid| self.scroll_offsets.get(&nid)).map_or_else(|| self.positioned_tree.tree.get_content_size(LayoutNodeId::new(node_index)), |pos| pos.children_rect.size);
 
         // Calculate thumb border-radius (half the scrollbar width for pill-shaped thumb)
         let thumb_radius = scrollbar_style.visual_width_px / 2.0;
@@ -6246,7 +6247,7 @@ where
         // double-rendering. Skip it.
         if let Some(indices) = self.positioned_tree.tree.dom_to_layout.get(&node_id) {
             if let Some(&idx) = indices.first() {
-                if self.establishes_stacking_context(idx) {
+                if self.establishes_stacking_context(idx.index()) {
                     return;
                 }
             }
@@ -6268,7 +6269,7 @@ where
             crate::solver3::geometry::EdgeSizes::default,
             |indices| indices.first().map_or_else(
                 crate::solver3::geometry::EdgeSizes::default,
-                |&idx| self.positioned_tree.tree.nodes[idx].box_props.unpack().margin,
+                |&idx| self.positioned_tree.tree.nodes[idx.index()].box_props.unpack().margin,
             ),
         );
 
@@ -6328,7 +6329,7 @@ where
     // +spec:positioning:b84cfa - z-index stacking context creation: integer z-index on positioned elements creates SC; auto on fixed/root creates SC
     // +spec:positioning:d06368 - relative/absolute with z-index:auto do not form stacking context but are painted as if they did
     fn establishes_stacking_context(&self, node_index: usize) -> bool {
-        let Some(node) = self.positioned_tree.tree.get(node_index) else {
+        let Some(node) = self.positioned_tree.tree.get(LayoutNodeId::new(node_index)) else {
             return false;
         };
         let Some(dom_id) = node.dom_node_id else {

--- a/layout/src/solver3/fc.rs
+++ b/layout/src/solver3/fc.rs
@@ -10315,7 +10315,7 @@ mod autotest_generated {
             Dom::create_body().with_child(
                 Dom::create_div()
                     .with_ids_and_classes(vec![IdOrClass::Class("p".into())].into())
-                    .with_child(Dom::create_text(text)),
+                    .with_child(Dom::create_text_do_not_use_without_block_level_wrapper(text)),
             ),
             css_str,
         )

--- a/layout/src/solver3/fc.rs
+++ b/layout/src/solver3/fc.rs
@@ -1,5 +1,6 @@
 //! Formatting context layout (block, inline, table, and flex/grid via Taffy)
 
+use crate::solver3::layout_tree::LayoutNodeId;
 use std::{
     collections::{BTreeMap, HashMap},
     sync::Arc,
@@ -413,7 +414,7 @@ pub fn layout_formatting_context<T: ParsedFontTrait>(
     // so it reliably shows whether layout_formatting_context is ENTERED for the nested div nodes 1,2.
     #[cfg(feature = "web_lift")]
     unsafe { crate::az_mark(((0x609E0 + (node_index & 7) * 4)) as u32, (0xC0DE0042) as u32); }
-    let node = tree.get(node_index).ok_or(LayoutError::InvalidTree)?;
+    let node = tree.get(LayoutNodeId::new(node_index)).ok_or(LayoutError::InvalidTree)?;
     // [g147i az-web-lift DIAG] node REFERENCE address (0x60B80+slot) — NOT a field deref, so reliable.
     // If nodes 0,1,2 aren't spaced by sizeof(LayoutNodeHot) → tree.get(index>0) mis-lifts the Vec stride,
     // making nodes 1,2 garbage references (which would explain FC reading garbage + reads destabilizing).
@@ -585,7 +586,7 @@ fn layout_flex_grid<T: ParsedFontTrait>(
         height: AvailableSpace::Definite(constraints.available_size.height),
     };
 
-    let node = tree.get(node_index).ok_or(LayoutError::InvalidTree)?;
+    let node = tree.get(LayoutNodeId::new(node_index)).ok_or(LayoutError::InvalidTree)?;
 
     // from flex line's cross size (clamped by min/max) when align-self:stretch, cross-size:auto,
     // and neither cross-axis margin is auto. Otherwise uses hypothetical cross size.
@@ -766,7 +767,7 @@ fn layout_flex_grid<T: ParsedFontTrait>(
     // children inside a smaller content-box.
     if is_root {
         if let (Some(aw), Some(ah)) = (adjusted_width, adjusted_height) {
-            if let Some(node_mut) = tree.get_mut(node_index) {
+            if let Some(node_mut) = tree.get_mut(LayoutNodeId::new(node_index)) {
                 node_mut.used_size = Some(LogicalSize::new(aw, ah));
             }
         }
@@ -790,7 +791,7 @@ fn layout_flex_grid<T: ParsedFontTrait>(
     // size, so this is a no-op there. The root syncs its own used_size above.
     if !is_root {
         let container_bb = translate_taffy_size_back(taffy_output.size);
-        if let Some(node_mut) = tree.get_mut(node_index) {
+        if let Some(node_mut) = tree.get_mut(LayoutNodeId::new(node_index)) {
             node_mut.used_size = Some(container_bb);
         }
     }
@@ -813,7 +814,7 @@ fn layout_flex_grid<T: ParsedFontTrait>(
 
     let children: Vec<usize> = tree.children(node_index).to_vec();
     for &child_idx in &children {
-        if let Some(warm_node) = tree.warm(child_idx) {
+        if let Some(warm_node) = tree.warm(LayoutNodeId::new(child_idx)) {
             if let Some(pos) = warm_node.relative_position {
                 output.positions.insert(child_idx, pos);
             }
@@ -1117,7 +1118,7 @@ fn layout_bfc<T: ParsedFontTrait>(
     float_cache: &mut HashMap<usize, FloatingContext>,
 ) -> Result<BfcLayoutResult> {
     let node = tree
-        .get(node_index)
+        .get(LayoutNodeId::new(node_index))
         .ok_or(LayoutError::InvalidTree)?
         .clone();
     // +spec:block-formatting-context:4f4ff6 - writing-mode determines block flow direction (main axis) for ordering block-level boxes in BFC
@@ -1169,7 +1170,7 @@ fn layout_bfc<T: ParsedFontTrait>(
             // containing block for percentage-height / indefinite-height semantics.
             let inner = node.box_props.inner_size(used_size, writing_mode);
             let height_is_auto = tree
-                .warm(node_index)
+                .warm(LayoutNodeId::new(node_index))
                 .is_none_or(|w| w.computed_style.height.is_none());
             if height_is_auto {
                 LogicalSize::new(inner.width, constraints.available_size.height)
@@ -1208,7 +1209,7 @@ fn layout_bfc<T: ParsedFontTrait>(
                     crate::solver3::getters::get_layout_scrollbar_width_px(ctx, dom_id, &styled_node_state)
                 }
                 LayoutOverflow::Auto => {
-                    let already_needs = tree.warm(node_index)
+                    let already_needs = tree.warm(LayoutNodeId::new(node_index))
                         .and_then(|w| w.scrollbar_info.as_ref())
                         .is_some_and(|s| s.needs_vertical);
                     if already_needs {
@@ -1255,7 +1256,7 @@ fn layout_bfc<T: ParsedFontTrait>(
         #[cfg(feature = "web_lift")]
         unsafe { crate::az_mark(((0x60A00 + (node_index & 7) * 4)) as u32, (bfc_children.len() as u32 | 0xC0DE0000) as u32); }
         for &child_index in &bfc_children {
-            let child_node = tree.get(child_index).ok_or(LayoutError::InvalidTree)?;
+            let child_node = tree.get(LayoutNodeId::new(child_index)).ok_or(LayoutError::InvalidTree)?;
             let child_dom_id = child_node.dom_node_id;
 
             // +spec:positioning:447b06 - Absolute positioning pulls element out of flow, skip from normal layout
@@ -1324,7 +1325,7 @@ fn layout_bfc<T: ParsedFontTrait>(
     // children's margins. The DOM root is NOT a BFC boundary for this purpose —
     // its first child's margin still collapses through it (then gets absorbed at
     // the root, since there's no grandparent to escape to).
-    let establishes_own_bfc = establishes_new_bfc(ctx, &node, tree.cold(node_index));
+    let establishes_own_bfc = establishes_new_bfc(ctx, &node, tree.cold(LayoutNodeId::new(node_index)));
     let is_bfc_root = node.parent.is_none() || establishes_own_bfc;
 
     // parent_has_*_blocker inhibits parent-child margin collapse per CSS 2.2 §8.3.1.
@@ -1357,7 +1358,7 @@ fn layout_bfc<T: ParsedFontTrait>(
     {
         let root_fs = crate::solver3::layout_tree::get_root_font_size(ctx.styled_dom);
         for &child_index in &pos_children {
-            let Some(child_dom_id) = tree.get(child_index).and_then(|n| n.dom_node_id) else {
+            let Some(child_dom_id) = tree.get(LayoutNodeId::new(child_index)).and_then(|n| n.dom_node_id) else {
                 continue;
             };
             let efs =
@@ -1448,7 +1449,7 @@ fn layout_bfc<T: ParsedFontTrait>(
         // resumed-child continuation) stops sibling consumption here — the
         // rest of the tail is not on this page.
         if fragment_token_out.is_some() {
-            clear_fragment_pos!(child_index);
+            clear_fragment_pos!(LayoutNodeId::new(child_index));
             continue;
         }
         if !fragment_resume_reached {
@@ -1456,7 +1457,7 @@ fn layout_bfc<T: ParsedFontTrait>(
                 fragment_resume_reached = true;
             } else {
                 // Finished on an earlier fragmentainer.
-                clear_fragment_pos!(child_index);
+                clear_fragment_pos!(LayoutNodeId::new(child_index));
                 continue;
             }
         }
@@ -1479,7 +1480,7 @@ fn layout_bfc<T: ParsedFontTrait>(
             && fragment_token_out.is_none()
             && crate::solver3::getters::get_break_before(
                 ctx.styled_dom,
-                tree.get(child_index).and_then(|n| n.dom_node_id),
+                tree.get(LayoutNodeId::new(child_index)).and_then(|n| n.dom_node_id),
             ) != azul_css::props::layout::fragmentation::PageBreak::Auto
         {
             let later: Vec<usize> = pos_children
@@ -1490,7 +1491,7 @@ fn layout_bfc<T: ParsedFontTrait>(
                 .filter(|&c| {
                     let pt = get_position_type(
                         ctx.styled_dom,
-                        tree.get(c).and_then(|n| n.dom_node_id),
+                        tree.get(LayoutNodeId::new(c)).and_then(|n| n.dom_node_id),
                     );
                     pt != LayoutPosition::Absolute && pt != LayoutPosition::Fixed
                 })
@@ -1514,7 +1515,7 @@ fn layout_bfc<T: ParsedFontTrait>(
                     generation: 0,
                 },
             ));
-            clear_fragment_pos!(child_index);
+            clear_fragment_pos!(LayoutNodeId::new(child_index));
             continue;
         }
 
@@ -1561,7 +1562,7 @@ fn layout_bfc<T: ParsedFontTrait>(
                         .filter(|&c| {
                             let pt = get_position_type(
                                 ctx.styled_dom,
-                                tree.get(c).and_then(|n| n.dom_node_id),
+                                tree.get(LayoutNodeId::new(c)).and_then(|n| n.dom_node_id),
                             );
                             pt != LayoutPosition::Absolute && pt != LayoutPosition::Fixed
                         })
@@ -1591,7 +1592,7 @@ fn layout_bfc<T: ParsedFontTrait>(
             }
         }
 
-        let child_node = tree.get(child_index).ok_or(LayoutError::InvalidTree)?;
+        let child_node = tree.get(LayoutNodeId::new(child_index)).ok_or(LayoutError::InvalidTree)?;
         let child_dom_id = child_node.dom_node_id;
 
         // +spec:floats:2cec1b - 'position' and 'float' determine the positioning algorithm
@@ -1610,7 +1611,7 @@ fn layout_bfc<T: ParsedFontTrait>(
             if float_type != LayoutFloat::None {
                 // Calculate float size just-in-time if not already computed
                 let float_size = if let Some(size) = child_node.used_size { size } else {
-                    let intrinsic = tree.warm(child_index).and_then(|w| w.intrinsic_sizes).unwrap_or_default();
+                    let intrinsic = tree.warm(LayoutNodeId::new(child_index)).and_then(|w| w.intrinsic_sizes).unwrap_or_default();
                     let child_bp = child_node.box_props.unpack();
                     let computed_size = crate::solver3::sizing::calculate_used_size_for_node(
                         ctx.styled_dom,
@@ -1620,13 +1621,13 @@ fn layout_bfc<T: ParsedFontTrait>(
                         &child_bp,
                         &ctx.viewport_size,
                     )?;
-                    if let Some(node_mut) = tree.get_mut(child_index) {
+                    if let Some(node_mut) = tree.get_mut(LayoutNodeId::new(child_index)) {
                         node_mut.used_size = Some(computed_size);
                     }
                     computed_size
                 };
                 // Re-borrow after potential mutation
-                let child_node = tree.get(child_index).ok_or(LayoutError::InvalidTree)?;
+                let child_node = tree.get(LayoutNodeId::new(child_index)).ok_or(LayoutError::InvalidTree)?;
                 let child_bp2 = child_node.box_props.unpack();
                 let float_margin = &child_bp2.margin;
 
@@ -1687,7 +1688,7 @@ fn layout_bfc<T: ParsedFontTrait>(
                             .filter(|&c| {
                                 let pt = get_position_type(
                                     ctx.styled_dom,
-                                    tree.get(c).and_then(|n| n.dom_node_id),
+                                    tree.get(LayoutNodeId::new(c)).and_then(|n| n.dom_node_id),
                                 );
                                 pt != LayoutPosition::Absolute
                                     && pt != LayoutPosition::Fixed
@@ -1701,7 +1702,7 @@ fn layout_bfc<T: ParsedFontTrait>(
                                 child_index,
                                 later.into_iter(),
                             ));
-                        clear_fragment_pos!(child_index);
+                        clear_fragment_pos!(LayoutNodeId::new(child_index));
                         continue;
                     }
                     // First content overflowing every page: monolith-place
@@ -1747,7 +1748,7 @@ fn layout_bfc<T: ParsedFontTrait>(
         // This replaces the old "Pass 1" that recursively laid out grandchildren with wrong positions
         let child_size = if let Some(size) = child_node.used_size { size } else {
             // Calculate size without recursive layout
-            let intrinsic = tree.warm(child_index).and_then(|w| w.intrinsic_sizes).unwrap_or_default();
+            let intrinsic = tree.warm(LayoutNodeId::new(child_index)).and_then(|w| w.intrinsic_sizes).unwrap_or_default();
             let child_used_size = crate::solver3::sizing::calculate_used_size_for_node(
                 ctx.styled_dom,
                 child_dom_id,
@@ -1757,13 +1758,13 @@ fn layout_bfc<T: ParsedFontTrait>(
                 &ctx.viewport_size,
             )?;
             // Update the node with computed size (we need to re-borrow mutably)
-            if let Some(node_mut) = tree.get_mut(child_index) {
+            if let Some(node_mut) = tree.get_mut(LayoutNodeId::new(child_index)) {
                 node_mut.used_size = Some(child_used_size);
             }
             child_used_size
         };
         // Re-borrow child_node after potential mutation
-        let child_node = tree.get(child_index).ok_or(LayoutError::InvalidTree)?;
+        let child_node = tree.get(LayoutNodeId::new(child_index)).ok_or(LayoutError::InvalidTree)?;
         let child_bp = child_node.box_props.unpack();
         let child_margin = &child_bp.margin;
 
@@ -1786,10 +1787,10 @@ fn layout_bfc<T: ParsedFontTrait>(
         // collapsed value of (child's margin, child's first child's margin, ...).
         // Use it for sibling collapse instead of the child's own margin.
         let child_escaped_top = if has_margin_collapse_blocker(&child_bp, writing_mode, true) { None } else {
-            tree.warm(child_index).and_then(|w| w.escaped_top_margin)
+            tree.warm(LayoutNodeId::new(child_index)).and_then(|w| w.escaped_top_margin)
         };
         let child_escaped_bottom = if has_margin_collapse_blocker(&child_bp, writing_mode, false) { None } else {
-            tree.warm(child_index).and_then(|w| w.escaped_bottom_margin)
+            tree.warm(LayoutNodeId::new(child_index)).and_then(|w| w.escaped_bottom_margin)
         };
 
         let mut child_margin_top = child_escaped_top.unwrap_or(child_own_margin_top);
@@ -2195,7 +2196,7 @@ fn layout_bfc<T: ParsedFontTrait>(
             let child_fits = main_pen + child_size.main(writing_mode)
                 <= fs.remaining_block_extent + 0.01;
             let container_descend = !child_fits
-                && tree.get(child_index).is_some_and(|n| {
+                && tree.get(LayoutNodeId::new(child_index)).is_some_and(|n| {
                     matches!(n.formatting_context, FormattingContext::Block { .. })
                         && !tree.children(child_index).is_empty()
                 })
@@ -2225,7 +2226,7 @@ fn layout_bfc<T: ParsedFontTrait>(
                     // regenerate page 1's token forever (no-progress halt).
                     let child_is_block_container = !fragment_child_resumed
                         && tree
-                        .get(child_index)
+                        .get(LayoutNodeId::new(child_index))
                         .is_some_and(|n| {
                             matches!(
                                 n.formatting_context,
@@ -2267,7 +2268,7 @@ fn layout_bfc<T: ParsedFontTrait>(
                                 .filter(|&c| {
                                     let pt = get_position_type(
                                         ctx.styled_dom,
-                                        tree.get(c).and_then(|n| n.dom_node_id),
+                                        tree.get(LayoutNodeId::new(c)).and_then(|n| n.dom_node_id),
                                     );
                                     pt != LayoutPosition::Absolute
                                         && pt != LayoutPosition::Fixed
@@ -2308,7 +2309,7 @@ fn layout_bfc<T: ParsedFontTrait>(
                         .filter(|&c| {
                             let pt = get_position_type(
                                 ctx.styled_dom,
-                                tree.get(c).and_then(|n| n.dom_node_id),
+                                tree.get(LayoutNodeId::new(c)).and_then(|n| n.dom_node_id),
                             );
                             pt != LayoutPosition::Absolute && pt != LayoutPosition::Fixed
                         })
@@ -2323,7 +2324,7 @@ fn layout_bfc<T: ParsedFontTrait>(
                     // BreakBefore of part 1.
                     const MIN_DESCEND_EXTENT: f32 = 40.0;
                     let child_is_block_container = tree
-                        .get(child_index)
+                        .get(LayoutNodeId::new(child_index))
                         .is_some_and(|n| {
                             matches!(
                                 n.formatting_context,
@@ -2399,7 +2400,7 @@ fn layout_bfc<T: ParsedFontTrait>(
                             child_index,
                             later.into_iter(),
                         ));
-                        clear_fragment_pos!(child_index);
+                        clear_fragment_pos!(LayoutNodeId::new(child_index));
                         continue;
                     }
                 }
@@ -2410,7 +2411,7 @@ fn layout_bfc<T: ParsedFontTrait>(
         // K30b: a descend/resume re-lay above may have SHORTENED this
         // child's used_size — refresh the local before positioning.
         let child_size = tree
-            .get(child_index)
+            .get(LayoutNodeId::new(child_index))
             .and_then(|n| n.used_size)
             .unwrap_or(child_size);
 
@@ -2433,8 +2434,8 @@ fn layout_bfc<T: ParsedFontTrait>(
         // formatting context as the element itself."
 
         // +spec:floats:a29f70 - BFC roots, tables, and block-level replaced elements must not overlap float margin boxes
-        let child_node = tree.get(child_index).ok_or(LayoutError::InvalidTree)?;
-        let avoids_floats = establishes_new_bfc(ctx, child_node, tree.cold(child_index))
+        let child_node = tree.get(LayoutNodeId::new(child_index)).ok_or(LayoutError::InvalidTree)?;
+        let avoids_floats = establishes_new_bfc(ctx, child_node, tree.cold(LayoutNodeId::new(child_index)))
             || is_block_level_replaced(ctx, child_node);
 
         // Query available space considering floats ONLY if child avoids floats
@@ -2513,7 +2514,7 @@ fn layout_bfc<T: ParsedFontTrait>(
 
         // Get child's margin, margin_auto, size, and formatting context
         let (child_margin_cloned, child_margin_auto, child_used_size, is_inline_fc, child_dom_id_for_debug) = {
-            let child_node = tree.get(child_index).ok_or(LayoutError::InvalidTree)?;
+            let child_node = tree.get(LayoutNodeId::new(child_index)).ok_or(LayoutError::InvalidTree)?;
             let cbp = child_node.box_props.unpack();
             (
                 cbp.margin,
@@ -2625,7 +2626,7 @@ fn layout_bfc<T: ParsedFontTrait>(
                 // +spec:width-calculation:d172a4 - over-constrained: LTR ignores margin-right, RTL ignores margin-left
                 // in LTR, margin-right is ignored (element positioned at margin-left);
                 // in RTL, margin-left is ignored (element positioned from right edge)
-                let is_rtl = tree.get(node_index)
+                let is_rtl = tree.get(LayoutNodeId::new(node_index))
                     .and_then(|n| n.dom_node_id)
                     .is_some_and(|cb_dom_id| {
                         let node_state = ctx.styled_dom.styled_nodes.as_container()
@@ -2710,7 +2711,7 @@ fn layout_bfc<T: ParsedFontTrait>(
             // Translate float coordinates from BFC-relative to IFC-relative
             // The IFC child is positioned at (child_cross_pos, main_pen) in BFC coordinates
             // Floats need to be relative to the IFC's CONTENT-BOX origin (inside padding/border)
-            let child_node = tree.get(child_index).ok_or(LayoutError::InvalidTree)?;
+            let child_node = tree.get(LayoutNodeId::new(child_index)).ok_or(LayoutError::InvalidTree)?;
             let cbp = child_node.box_props.unpack();
             let padding_border_cross = cbp.padding.cross_start(writing_mode)
                 + cbp.border.cross_start(writing_mode);
@@ -2769,7 +2770,7 @@ fn layout_bfc<T: ParsedFontTrait>(
             );
 
             // Get the IFC child's content-box size (after padding/border)
-            let child_node = tree.get(child_index).ok_or(LayoutError::InvalidTree)?;
+            let child_node = tree.get(LayoutNodeId::new(child_index)).ok_or(LayoutError::InvalidTree)?;
             let child_dom_id = child_node.dom_node_id;
 
             // +spec:containing-block:a8ada9 - line box width determined by containing block and floats
@@ -2924,7 +2925,7 @@ fn layout_bfc<T: ParsedFontTrait>(
 
     // Handle bottom margin escape
     if let Some(last_idx) = last_child_index {
-        let last_child = tree.get(last_idx).ok_or(LayoutError::InvalidTree)?;
+        let last_child = tree.get(LayoutNodeId::new(last_idx)).ok_or(LayoutError::InvalidTree)?;
         let last_child_bp = last_child.box_props.unpack();
         let last_has_bottom_blocker =
             has_margin_collapse_blocker(&last_child_bp, writing_mode, false);
@@ -3146,12 +3147,12 @@ fn layout_bfc<T: ParsedFontTrait>(
     output.baseline = None;
 
     // Store escaped margins in the LayoutNode for use by parent
-    if let Some(warm_mut) = tree.warm_mut(node_index) {
+    if let Some(warm_mut) = tree.warm_mut(LayoutNodeId::new(node_index)) {
         warm_mut.escaped_top_margin = escaped_top_margin;
         warm_mut.escaped_bottom_margin = escaped_bottom_margin;
     }
 
-    if let Some(warm_mut) = tree.warm_mut(node_index) {
+    if let Some(warm_mut) = tree.warm_mut(LayoutNodeId::new(node_index)) {
         warm_mut.baseline = output.baseline;
     }
 
@@ -3347,12 +3348,12 @@ fn layout_ifc<T: ParsedFontTrait>(
     // +spec:display-property:5a795c - root inline box: block container generates anonymous inline box holding all inline-level contents, inheriting from parent
     // For anonymous boxes, we need to find the DOM ID from a parent or child
     // CSS 2.2 § 9.2.1.1: Anonymous boxes inherit properties from their enclosing box
-    let node = tree.get(node_index).ok_or(LayoutError::InvalidTree)?;
+    let node = tree.get(LayoutNodeId::new(node_index)).ok_or(LayoutError::InvalidTree)?;
     let ifc_root_dom_id = if let Some(id) = node.dom_node_id { id } else {
         // Anonymous box - get DOM ID from parent or first child with DOM ID
         let parent_dom_id = node
             .parent
-            .and_then(|p| tree.get(p))
+            .and_then(|p| tree.get(LayoutNodeId::new(p)))
             .and_then(|n| n.dom_node_id);
 
         if let Some(id) = parent_dom_id {
@@ -3361,7 +3362,7 @@ fn layout_ifc<T: ParsedFontTrait>(
             // Try to find DOM ID from first child
             tree.children(node_index)
                 .iter()
-                .filter_map(|&child_idx| tree.get(child_idx)).find_map(|n| n.dom_node_id)
+                .filter_map(|&child_idx| tree.get(LayoutNodeId::new(child_idx))).find_map(|n| n.dom_node_id)
                 .ok_or(LayoutError::InvalidTree)?
         }
     };
@@ -3405,7 +3406,7 @@ fn layout_ifc<T: ParsedFontTrait>(
         let compact = ctx.styled_dom.css_property_cache.ptr.compact_cache.as_ref();
         let mut stack = alloc::vec![node_index];
         while let Some(idx) = stack.pop() {
-            if let Some(cold) = tree.cold(idx) {
+            if let Some(cold) = tree.cold(LayoutNodeId::new(idx)) {
                 cold.node_data_fingerprint.hash(&mut h);
                 // NodeDataFingerprint covers the node's own data and INLINE
                 // css — not what the AUTHOR STYLESHEET resolved onto it. Two
@@ -3413,7 +3414,7 @@ fn layout_ifc<T: ParsedFontTrait>(
                 // otherwise share a key and serve each other's styles. The
                 // compact cache holds the RESOLVED values, so folding this
                 // node's entries in makes any cascade change invalidate.
-                let dom_id_opt = tree.get(idx).and_then(|n| n.dom_node_id);
+                let dom_id_opt = tree.get(LayoutNodeId::new(idx)).and_then(|n| n.dom_node_id);
                 if let (Some(cc), Some(dom_id)) = (compact, dom_id_opt) {
                     let i = dom_id.index();
                     if let Some(t1) = cc.tier1_enums.get(i) {
@@ -3444,7 +3445,7 @@ fn layout_ifc<T: ParsedFontTrait>(
     }));
 
     let cached_collection = tree
-        .warm(node_index)
+        .warm(LayoutNodeId::new(node_index))
         .and_then(|w| w.inline_content_cache.as_ref())
         .filter(|c| c.subtree_fingerprint == subtree_fingerprint)
         .map(|c| (c.content.clone(), c.child_map.clone(), c.content_hash_base));
@@ -3474,7 +3475,7 @@ fn layout_ifc<T: ParsedFontTrait>(
                 h.finish()
             };
             base = Some(computed_base);
-            if let Some(w) = tree.warm_mut(node_index) {
+            if let Some(w) = tree.warm_mut(LayoutNodeId::new(node_index)) {
                 w.inline_content_cache =
                     Some(Box::new(crate::solver3::layout_tree::CachedInlineContent {
                         content: content.clone(),
@@ -3581,7 +3582,7 @@ fn layout_ifc<T: ParsedFontTrait>(
         // would re-emit the removed content AND index `styled_nodes` with a
         // `source_node_id` that no longer exists in the new DOM (OOB panic).
         // Clear it so the empty IFC renders nothing.
-        if let Some(warm_node) = tree.warm_mut(node_index) {
+        if let Some(warm_node) = tree.warm_mut(LayoutNodeId::new(node_index)) {
             warm_node.inline_layout_result = None;
         }
         return Ok(LayoutOutput::default());
@@ -3594,7 +3595,7 @@ fn layout_ifc<T: ParsedFontTrait>(
     // back to full layout_flow().
     {
         let cached_ifc = tree
-            .warm(node_index)
+            .warm(LayoutNodeId::new(node_index))
             .and_then(|n| n.inline_layout_result.as_ref());
 
         // Only reuse the cached inline layout when the available WIDTH is unchanged.
@@ -3844,7 +3845,7 @@ fn layout_ifc<T: ParsedFontTrait>(
             return Ok(output);
         }
 
-        let warm_node = tree.warm_mut(node_index).ok_or(LayoutError::InvalidTree)?;
+        let warm_node = tree.warm_mut(LayoutNodeId::new(node_index)).ok_or(LayoutError::InvalidTree)?;
 
         let should_store = match &warm_node.inline_layout_result {
             None => {
@@ -5722,7 +5723,7 @@ fn is_visibility_collapsed<T: ParsedFontTrait>(
 /// Note: Full whitespace detection would require checking text content during rendering.
 /// This function provides a basic check suitable for layout phase.
 fn is_cell_empty(tree: &LayoutTree, cell_index: usize) -> bool {
-    if tree.get(cell_index).is_none() {
+    if tree.get(LayoutNodeId::new(cell_index)).is_none() {
         return true; // Invalid cell is considered empty
     }
 
@@ -5732,7 +5733,7 @@ fn is_cell_empty(tree: &LayoutTree, cell_index: usize) -> bool {
     }
 
     // If cell has an inline layout result, check if it's empty
-    if let Some(warm_node) = tree.warm(cell_index) {
+    if let Some(warm_node) = tree.warm(LayoutNodeId::new(cell_index)) {
         if let Some(ref cached_layout) = warm_node.inline_layout_result {
             // Check if inline layout has any rendered content
             // Empty inline layouts have no items (glyphs/fragments)
@@ -5794,7 +5795,7 @@ pub fn layout_table_fc<T: ParsedFontTrait>(
 
     // Get the table node to read CSS properties
     let table_node = tree
-        .get(node_index)
+        .get(LayoutNodeId::new(node_index))
         .ok_or(LayoutError::InvalidTree)?
         .clone();
 
@@ -5802,7 +5803,7 @@ pub fn layout_table_fc<T: ParsedFontTrait>(
     // This accounts for the table's own width property (e.g., width: 100%)
     let table_border_box_width = if let Some(dom_id) = table_node.dom_node_id {
         // Use calculate_used_size_for_node to resolve table width (respects width:100%)
-        let intrinsic = tree.warm(node_index).and_then(|w| w.intrinsic_sizes).unwrap_or_default();
+        let intrinsic = tree.warm(LayoutNodeId::new(node_index)).and_then(|w| w.intrinsic_sizes).unwrap_or_default();
         let containing_block_size = LogicalSize {
             width: constraints.available_size.width,
             height: constraints.available_size.height,
@@ -6145,13 +6146,13 @@ fn analyze_table_structure<T: ParsedFontTrait>(
 ) -> Result<TableLayoutContext> {
     let mut table_ctx = TableLayoutContext::new();
 
-    let table_node = tree.get(table_index).ok_or(LayoutError::InvalidTree)?;
+    let table_node = tree.get(LayoutNodeId::new(table_index)).ok_or(LayoutError::InvalidTree)?;
 
     // +spec:width-calculation:0a2766 - table internal elements form rectangular grid of rows/columns (CSS 2.2 §17.5)
     // CSS 2.2 Section 17.4: A table may have one table-caption child.
     // Traverse children to find caption, columns/colgroups, rows, and row groups
     for &child_idx in tree.children(table_index) {
-        if let Some(child) = tree.get(child_idx) {
+        if let Some(child) = tree.get(LayoutNodeId::new(child_idx)) {
             // Check if this is a table caption
             if matches!(child.formatting_context, FormattingContext::TableCaption) {
                 debug_log!(ctx, "Found table caption at index {}", child_idx);
@@ -6176,7 +6177,7 @@ fn analyze_table_structure<T: ParsedFontTrait>(
                 FormattingContext::TableRowGroup => {
                     // Process rows within the row group
                     for &row_idx in tree.children(child_idx) {
-                        if let Some(row) = tree.get(row_idx) {
+                        if let Some(row) = tree.get(LayoutNodeId::new(row_idx)) {
                             if matches!(row.formatting_context, FormattingContext::TableRow) {
                                 analyze_table_row(tree, row_idx, &mut table_ctx, ctx)?;
                             }
@@ -6214,7 +6215,7 @@ fn analyze_table_colgroup<T: ParsedFontTrait>(
     table_ctx: &TableLayoutContext,
     ctx: &mut LayoutContext<'_, T>,
 ) -> Result<()> {
-    let colgroup_node = tree.get(colgroup_index).ok_or(LayoutError::InvalidTree)?;
+    let colgroup_node = tree.get(LayoutNodeId::new(colgroup_index)).ok_or(LayoutError::InvalidTree)?;
 
     // Check if the colgroup itself has visibility:collapse
     if is_visibility_collapsed(ctx, colgroup_node) {
@@ -6229,7 +6230,7 @@ fn analyze_table_colgroup<T: ParsedFontTrait>(
 
     // Check for individual column elements within the group
     for &col_idx in tree.children(colgroup_index) {
-        if let Some(col_node) = tree.get(col_idx) {
+        if let Some(col_node) = tree.get(LayoutNodeId::new(col_idx)) {
             // Note: Individual columns don't have a FormattingContext::TableColumn
             // They are represented as children of TableColumnGroup
             // Check visibility:collapse on each column
@@ -6275,7 +6276,7 @@ fn analyze_table_row<T: ParsedFontTrait>(
     ctx: &mut LayoutContext<'_, T>,
 ) -> Result<()> {
     // +spec:inline-formatting-context:3f8091 - table visual layout: cells occupy grid cells, row/column spanning
-    let row_node = tree.get(row_index).ok_or(LayoutError::InvalidTree)?;
+    let row_node = tree.get(LayoutNodeId::new(row_index)).ok_or(LayoutError::InvalidTree)?;
     let row_num = table_ctx.num_rows;
     table_ctx.num_rows += 1;
     // Track the layout tree index for this row (for positioning/painting)
@@ -6293,7 +6294,7 @@ fn analyze_table_row<T: ParsedFontTrait>(
     let mut col_index = 0;
 
     for &cell_idx in tree.children(row_index) {
-        if let Some(cell) = tree.get(cell_idx) {
+        if let Some(cell) = tree.get(LayoutNodeId::new(cell_idx)) {
             if matches!(cell.formatting_context, FormattingContext::TableCell) {
                 // Read colspan/rowspan from the cell's HTML attributes (default 1).
                 let (colspan, rowspan) = cell
@@ -6415,7 +6416,7 @@ fn calculate_column_widths_fixed<T: ParsedFontTrait>(
         }
 
         // Look up the cell's CSS width via its dom_node_id
-        let Some(dom_id) = tree.get(cell_info.node_index).and_then(|n| n.dom_node_id) else {
+        let Some(dom_id) = tree.get(LayoutNodeId::new(cell_info.node_index)).and_then(|n| n.dom_node_id) else {
             continue;
         };
 
@@ -6583,7 +6584,7 @@ fn measure_cell_content_width<T: ParsedFontTrait>(
         crate::solver3::cache::ComputeMode::ComputeSize,
     )?;
 
-    let cell_bp = tree.get(cell_index)
+    let cell_bp = tree.get(LayoutNodeId::new(cell_index))
         .ok_or(LayoutError::InvalidTree)?
         .box_props.unpack();
     let padding = &cell_bp.padding;
@@ -6594,10 +6595,10 @@ fn measure_cell_content_width<T: ParsedFontTrait>(
     // content width) rather than used_size. used_size for auto-width blocks
     // fills the containing block, which is huge (f32::MAX/2) during
     // intrinsic sizing — that would make every column appear infinitely wide.
-    let content_width = tree.warm(cell_index)
+    let content_width = tree.warm(LayoutNodeId::new(cell_index))
         .and_then(|w| w.overflow_content_size)
         .map_or_else(|| {
-            tree.get(cell_index)
+            tree.get(LayoutNodeId::new(cell_index))
                 .and_then(|n| n.used_size)
                 .map_or(0.0, |s| s.width)
         }, |s| s.width);
@@ -6925,7 +6926,7 @@ fn layout_cell_for_height<T: ParsedFontTrait>(
     cell_width: f32,
     constraints: &LayoutConstraints<'_>,
 ) -> Result<f32> {
-    let cell_node = tree.get(cell_index).ok_or(LayoutError::InvalidTree)?;
+    let cell_node = tree.get(LayoutNodeId::new(cell_index)).ok_or(LayoutError::InvalidTree)?;
     let cell_dom_id = cell_node.dom_node_id.ok_or(LayoutError::InvalidTree)?;
 
     // Check if cell has text content directly in DOM (not in LayoutTree)
@@ -6946,7 +6947,7 @@ fn layout_cell_for_height<T: ParsedFontTrait>(
     );
 
     // Get padding and border to calculate content width
-    let cell_node = tree.get(cell_index).ok_or(LayoutError::InvalidTree)?;
+    let cell_node = tree.get(LayoutNodeId::new(cell_index)).ok_or(LayoutError::InvalidTree)?;
     let cell_bp = cell_node.box_props.unpack();
     let padding = &cell_bp.padding;
     let border = &cell_bp.border;
@@ -6994,7 +6995,7 @@ fn layout_cell_for_height<T: ParsedFontTrait>(
         // prior BFC Pass 1 (which ran before layout_cell_for_height).
         let cell_children: Vec<usize> = tree.children(cell_index).to_vec();
         for child_idx in cell_children {
-            if let Some(warm) = tree.warm_mut(child_idx) {
+            if let Some(warm) = tree.warm_mut(LayoutNodeId::new(child_idx)) {
                 warm.inline_layout_result = None;
             }
         }
@@ -7043,12 +7044,12 @@ fn layout_cell_for_height<T: ParsedFontTrait>(
             crate::solver3::cache::ComputeMode::PerformLayout,
         )?;
 
-        let cell_node = tree.get(cell_index).ok_or(LayoutError::InvalidTree)?;
+        let cell_node = tree.get(LayoutNodeId::new(cell_index)).ok_or(LayoutError::InvalidTree)?;
         cell_node.used_size.unwrap_or_default().height
     };
 
     // Add padding and border to get the total height
-    let cell_node = tree.get(cell_index).ok_or(LayoutError::InvalidTree)?;
+    let cell_node = tree.get(LayoutNodeId::new(cell_index)).ok_or(LayoutError::InvalidTree)?;
     let cell_bp = cell_node.box_props.unpack();
     let padding = &cell_bp.padding;
     let border = &cell_bp.border;
@@ -7081,7 +7082,7 @@ fn layout_cell_for_height<T: ParsedFontTrait>(
 // +spec:inline-formatting-context:c4a20d - cell baseline: first in-flow line box or bottom of content edge
 // +spec:inline-formatting-context:17a9c1 - vertical-align baseline/top/bottom/middle for table cells
 fn compute_cell_baseline(cell_index: usize, tree: &LayoutTree) -> f32 {
-    let Some(cell_node) = tree.get(cell_index) else {
+    let Some(cell_node) = tree.get(LayoutNodeId::new(cell_index)) else {
         return 0.0;
     };
 
@@ -7089,7 +7090,7 @@ fn compute_cell_baseline(cell_index: usize, tree: &LayoutTree) -> f32 {
 
     // +spec:inline-formatting-context:27be38 - cell baseline is first in-flow line box or bottom of content edge
     // Check if the cell has inline layout (first in-flow line box)
-    if let Some(warm_node) = tree.warm(cell_index) {
+    if let Some(warm_node) = tree.warm(LayoutNodeId::new(cell_index)) {
         if let Some(ref cached_layout) = warm_node.inline_layout_result {
             // (d6h) Materialized: sentinel-safe first-line baseline.
             let inline_result = cached_layout.materialized();
@@ -7107,7 +7108,7 @@ fn compute_cell_baseline(cell_index: usize, tree: &LayoutTree) -> f32 {
     let children = tree.children(cell_index);
     for &child_idx in children {
         if child_idx < tree.nodes.len() {
-            if let Some(child_warm) = tree.warm(child_idx) {
+            if let Some(child_warm) = tree.warm(LayoutNodeId::new(child_idx)) {
                 if child_warm.inline_layout_result.is_some() {
                     let child_baseline = compute_cell_baseline(child_idx, tree);
                     let padding_top = cell_bp.padding.top;
@@ -7314,7 +7315,7 @@ fn calculate_row_heights<T: ParsedFontTrait>(
             // +spec:box-model:0ab9b0 - empty-cells:hide suppresses borders/backgrounds, row gets zero height if all cells hidden+empty
             // Check if ALL cells in this row have empty-cells:hide and are empty
             let all_hidden_empty = row_cells.iter().all(|&cell_idx| {
-                tree.get(cell_idx).is_none_or(|cell_node| {
+                tree.get(LayoutNodeId::new(cell_idx)).is_none_or(|cell_node| {
                     let ec = get_empty_cells_property(ctx, cell_node);
                     ec == StyleEmptyCells::Hide && is_cell_empty(tree, cell_idx)
                 })
@@ -7436,7 +7437,7 @@ fn position_table_cells<T: ParsedFontTrait>(
         for (i, &row_y) in row_positions.iter().enumerate() {
             if let Some(&row_node_idx) = table_ctx.row_node_indices.get(i) {
                 let row_height = table_ctx.row_heights.get(i).copied().unwrap_or(0.0);
-                if let Some(row_node) = tree.get_mut(row_node_idx) {
+                if let Some(row_node) = tree.get_mut(LayoutNodeId::new(row_node_idx)) {
                     row_node.used_size = Some(LogicalSize {
                         width: total_col_width,
                         height: row_height,
@@ -7454,7 +7455,7 @@ fn position_table_cells<T: ParsedFontTrait>(
         let precomputed_cell_baseline = compute_cell_baseline(cell_info.node_index, tree);
 
         let cell_node = tree
-            .get_mut(cell_info.node_index)
+            .get_mut(LayoutNodeId::new(cell_info.node_index))
             .ok_or(LayoutError::InvalidTree)?;
 
         // Calculate cell position
@@ -7556,7 +7557,7 @@ fn position_table_cells<T: ParsedFontTrait>(
         // +spec:positioning:156e49 - table cell vertical-align ordering and extra padding per CSS 2.2 §17.5.3
         // Apply vertical-align to cell content if it has inline layout
         // We need to compute the y_offset using immutable borrows first, then apply it mutably.
-        let vertical_align_adjustment = if let Some(warm_node) = tree.warm(cell_info.node_index) {
+        let vertical_align_adjustment = if let Some(warm_node) = tree.warm(LayoutNodeId::new(cell_info.node_index)) {
             if let Some(ref cached_layout) = warm_node.inline_layout_result {
                 // (d6h) Materialized: sentinel-safe content measurement.
                 let inline_result = cached_layout.materialized();
@@ -7635,7 +7636,7 @@ fn position_table_cells<T: ParsedFontTrait>(
 
         // Apply the vertical alignment adjustment (requires mutable borrow)
         if let Some((y_offset, available_width, has_floats)) = vertical_align_adjustment {
-            if let Some(warm_mut) = tree.warm_mut(cell_info.node_index) {
+            if let Some(warm_mut) = tree.warm_mut(LayoutNodeId::new(cell_info.node_index)) {
                 if let Some(ref cached_layout) = warm_mut.inline_layout_result {
                     use std::sync::Arc;
                     use crate::text3::cache::{PositionedItem, UnifiedLayout};
@@ -7701,7 +7702,7 @@ fn position_table_cells<T: ParsedFontTrait>(
         // in-flow block children by the same offset so the UA default
         // `vertical-align: middle` actually centers block content, like browsers.
         let cell_has_inline = tree
-            .warm(cell_info.node_index)
+            .warm(LayoutNodeId::new(cell_info.node_index))
             .is_some_and(|w| w.inline_layout_result.is_some());
         if !cell_has_inline {
             let vertical_align = cell_dom_node_id.map_or(StyleVerticalAlign::Baseline, |dom_id| {
@@ -7728,7 +7729,7 @@ fn position_table_cells<T: ParsedFontTrait>(
                 let mut content_height = 0.0f32;
                 let mut inflow: Vec<usize> = Vec::new();
                 for &c in &children {
-                    let dom_id = tree.get(c).and_then(|n| n.dom_node_id);
+                    let dom_id = tree.get(LayoutNodeId::new(c)).and_then(|n| n.dom_node_id);
                     if matches!(
                         get_position_type(ctx.styled_dom, dom_id),
                         LayoutPosition::Absolute | LayoutPosition::Fixed
@@ -7736,10 +7737,10 @@ fn position_table_cells<T: ParsedFontTrait>(
                         continue; // out-of-flow children are unaffected by vertical-align
                     }
                     let top = tree
-                        .warm(c)
+                        .warm(LayoutNodeId::new(c))
                         .and_then(|w| w.relative_position)
                         .map_or(0.0, |p| p.y);
-                    let h = tree.get(c).and_then(|n| n.used_size).map_or(0.0, |s| s.height);
+                    let h = tree.get(LayoutNodeId::new(c)).and_then(|n| n.used_size).map_or(0.0, |s| s.height);
                     content_height = content_height.max(top + h);
                     inflow.push(c);
                 }
@@ -7751,7 +7752,7 @@ fn position_table_cells<T: ParsedFontTrait>(
                 let y_offset = (content_box_height - content_height) * factor;
                 if y_offset > 0.01 {
                     for &c in &inflow {
-                        if let Some(w) = tree.warm_mut(c) {
+                        if let Some(w) = tree.warm_mut(LayoutNodeId::new(c)) {
                             if let Some(pos) = w.relative_position.as_mut() {
                                 pos.y += y_offset;
                             }
@@ -7818,7 +7819,7 @@ fn collect_and_measure_inline_content<T: ParsedFontTrait>(
     // node's content (both parts collect the same full content; the range
     // partitions it — part 1 `[0, at)`, part 2 `[at, ∞)`).
     if let Some((start, end)) = tree
-        .cold(ifc_root_index)
+        .cold(LayoutNodeId::new(ifc_root_index))
         .and_then(|c| c.preview_byte_range)
     {
         content = slice_inline_content_by_bytes(content, start as usize, end as usize);
@@ -7895,7 +7896,7 @@ fn collect_and_measure_inline_content_impl<T: ParsedFontTrait>(
     let ifc_id = IfcId::unique();
 
     // Store IFC ID on the IFC root node
-    if let Some(cold_node) = tree.cold_mut(ifc_root_index) {
+    if let Some(cold_node) = tree.cold_mut(LayoutNodeId::new(ifc_root_index)) {
         cold_node.ifc_id = Some(ifc_id);
     }
 
@@ -7923,7 +7924,7 @@ fn collect_and_measure_inline_content_impl<T: ParsedFontTrait>(
         crate::az_mark(((0x60960 + slot)) as u32, ((&*tree as *const LayoutTree as usize) as u32) as u32);
     }
 
-    let ifc_root_node = tree.get(ifc_root_index).ok_or(LayoutError::InvalidTree)?;
+    let ifc_root_node = tree.get(LayoutNodeId::new(ifc_root_index)).ok_or(LayoutError::InvalidTree)?;
     // [g135] reached past the 6449 tree.get.
     #[cfg(feature = "web_lift")]
     unsafe { crate::az_mark((0x606A4) as u32, (0x0000_6449u32) as u32); }
@@ -7937,7 +7938,7 @@ fn collect_and_measure_inline_content_impl<T: ParsedFontTrait>(
         // Anonymous box - get DOM ID from parent or first child with DOM ID
         let parent_dom_id = ifc_root_node
             .parent
-            .and_then(|p| tree.get(p))
+            .and_then(|p| tree.get(LayoutNodeId::new(p)))
             .and_then(|n| n.dom_node_id);
 
         if let Some(id) = parent_dom_id {
@@ -7946,7 +7947,7 @@ fn collect_and_measure_inline_content_impl<T: ParsedFontTrait>(
             // Try to find DOM ID from first child
             if let Some(id) = tree.children(ifc_root_index)
                 .iter()
-                .filter_map(|&child_idx| tree.get(child_idx)).find_map(|n| n.dom_node_id) { id } else {
+                .filter_map(|&child_idx| tree.get(LayoutNodeId::new(child_idx))).find_map(|n| n.dom_node_id) { id } else {
                 debug_warning!(ctx, "IFC root and all ancestors/children have no DOM ID");
                 return Ok(());
             }
@@ -7975,7 +7976,7 @@ fn collect_and_measure_inline_content_impl<T: ParsedFontTrait>(
                 item_index: item_idx as u32,
             };
 
-            let child_node = tree.get(child_index).ok_or(LayoutError::InvalidTree)?;
+            let child_node = tree.get(LayoutNodeId::new(child_index)).ok_or(LayoutError::InvalidTree)?;
             let Some(dom_id) = child_node.dom_node_id else {
                 debug_warning!(
                     ctx,
@@ -8015,7 +8016,7 @@ fn collect_and_measure_inline_content_impl<T: ParsedFontTrait>(
                 
                 // Set IFC membership on the text node - drop child_node borrow first
                 drop(child_node);
-                if let Some(warm_mut) = tree.warm_mut(child_index) {
+                if let Some(warm_mut) = tree.warm_mut(LayoutNodeId::new(child_index)) {
                     warm_mut.ifc_membership = Some(IfcMembership {
                         ifc_id,
                         ifc_root_layout_index: ifc_root_index,
@@ -8069,7 +8070,7 @@ fn collect_and_measure_inline_content_impl<T: ParsedFontTrait>(
                 // We must determine its size and baseline before passing it to text3.
 
                 // The intrinsic sizing pass has already calculated its preferred size.
-                let intrinsic_size = tree.warm(child_index).and_then(|w| w.intrinsic_sizes).unwrap_or_default();
+                let intrinsic_size = tree.warm(LayoutNodeId::new(child_index)).and_then(|w| w.intrinsic_sizes).unwrap_or_default();
                 let box_props = child_node.box_props.unpack();
 
                 let styled_node_state = ctx
@@ -8152,7 +8153,7 @@ fn collect_and_measure_inline_content_impl<T: ParsedFontTrait>(
                 let final_size = LogicalSize::new(tentative_size.width, final_height);
 
                 // Update the node in the tree with its now-known used size.
-                tree.get_mut(child_index).unwrap().used_size = Some(final_size);
+                tree.get_mut(LayoutNodeId::new(child_index)).unwrap().used_size = Some(final_size);
 
                 // CSS 2.2 § 10.8.1: inline-block baseline fallback
                 // If overflow is not 'visible', use bottom margin edge as baseline
@@ -8208,7 +8209,7 @@ fn collect_and_measure_inline_content_impl<T: ParsedFontTrait>(
     // Check if this IFC root OR its parent is a list-item and needs a marker
     // Case 1: IFC root itself is list-item (e.g., <li> with display: list-item)
     // Case 2: IFC root's parent is list-item (e.g., <li><text>...</text></li>)
-    let ifc_root_node = tree.get(ifc_root_index).ok_or(LayoutError::InvalidTree)?;
+    let ifc_root_node = tree.get(LayoutNodeId::new(ifc_root_index)).ok_or(LayoutError::InvalidTree)?;
     // [g135] reached past the 6706 tree.get.
     #[cfg(feature = "web_lift")]
     unsafe { crate::az_mark((0x606A4) as u32, (0x0000_6706u32) as u32); }
@@ -8229,7 +8230,7 @@ fn collect_and_measure_inline_content_impl<T: ParsedFontTrait>(
     // Check IFC root's parent
     if list_item_dom_id.is_none() {
         if let Some(parent_idx) = ifc_root_node.parent {
-            if let Some(parent_node) = tree.get(parent_idx) {
+            if let Some(parent_node) = tree.get(LayoutNodeId::new(parent_idx)) {
                 if let Some(parent_dom_id) = parent_node.dom_node_id {
                     use crate::solver3::getters::get_display_property;
                     if let MultiValue::Exact(display) = get_display_property(ctx.styled_dom, Some(parent_dom_id)) {
@@ -8262,7 +8263,7 @@ fn collect_and_measure_inline_content_impl<T: ParsedFontTrait>(
             .iter()
             .enumerate()
             .find(|(idx, node)| {
-                node.dom_node_id == Some(list_dom_id) && tree.warm(*idx).and_then(|w| w.pseudo_element).is_none()
+                node.dom_node_id == Some(list_dom_id) && tree.warm(LayoutNodeId::new(*idx)).and_then(|w| w.pseudo_element).is_none()
             })
             .map(|(idx, _)| idx);
 
@@ -8272,7 +8273,7 @@ fn collect_and_measure_inline_content_impl<T: ParsedFontTrait>(
             let marker_idx = tree.children(list_idx)
                 .iter()
                 .find(|&&child_idx| {
-                    tree.warm(child_idx)
+                    tree.warm(LayoutNodeId::new(child_idx))
                         .is_some_and(|w| w.pseudo_element == Some(PseudoElement::Marker))
                 })
                 .copied();
@@ -8283,7 +8284,7 @@ fn collect_and_measure_inline_content_impl<T: ParsedFontTrait>(
                 // Get the DOM ID for style resolution (marker references the same DOM node as
                 // list-item)
                 let list_dom_id_for_style = tree
-                    .get(marker_idx)
+                    .get(LayoutNodeId::new(marker_idx))
                     .and_then(|n| n.dom_node_id)
                     .unwrap_or(list_dom_id);
 
@@ -8505,7 +8506,7 @@ fn collect_and_measure_inline_content_impl<T: ParsedFontTrait>(
         let child_index = children
             .iter()
             .find(|&&idx| {
-                tree.get(idx)
+                tree.get(LayoutNodeId::new(idx))
                     .and_then(|n| n.dom_node_id)
                     .is_some_and(|id| id == dom_child_id)
             })
@@ -8523,7 +8524,7 @@ fn collect_and_measure_inline_content_impl<T: ParsedFontTrait>(
         // [g136] NON-TEXT branch taken (text child mis-classified?) — reached tree.get(child_index).
         #[cfg(feature = "web_lift")]
         unsafe { crate::az_mark((0x606A4) as u32, (0x0000_6942u32) as u32); }
-        let child_node = tree.get(child_index).ok_or(LayoutError::InvalidTree)?;
+        let child_node = tree.get(LayoutNodeId::new(child_index)).ok_or(LayoutError::InvalidTree)?;
         // At this point we have a non-text DOM child with a layout node
         let dom_id = child_node.dom_node_id.unwrap();
 
@@ -8547,7 +8548,7 @@ fn collect_and_measure_inline_content_impl<T: ParsedFontTrait>(
             // We must determine its size and baseline before passing it to text3.
 
             // The intrinsic sizing pass has already calculated its preferred size.
-            let intrinsic_size = tree.warm(child_index).and_then(|w| w.intrinsic_sizes).unwrap_or_default();
+            let intrinsic_size = tree.warm(LayoutNodeId::new(child_index)).and_then(|w| w.intrinsic_sizes).unwrap_or_default();
             let box_props = child_node.box_props.unpack();
 
             let styled_node_state = ctx
@@ -8657,7 +8658,7 @@ fn collect_and_measure_inline_content_impl<T: ParsedFontTrait>(
             let final_size = LogicalSize::new(tentative_size.width, final_height);
 
             // Update the node in the tree with its now-known used size.
-            tree.get_mut(child_index).unwrap().used_size = Some(final_size);
+            tree.get_mut(LayoutNodeId::new(child_index)).unwrap().used_size = Some(final_size);
 
             // CSS 2.2 § 10.8.1: For inline-block elements, the baseline is the baseline of the
             // last line box in the normal flow, unless it has either no in-flow line boxes or
@@ -8745,11 +8746,11 @@ fn collect_and_measure_inline_content_impl<T: ParsedFontTrait>(
             // and CSS width/height can constrain them
             
             // Re-get child_node since we dropped it earlier for the inline-block case
-            let child_node = tree.get(child_index).ok_or(LayoutError::InvalidTree)?;
+            let child_node = tree.get(LayoutNodeId::new(child_index)).ok_or(LayoutError::InvalidTree)?;
             let box_props = child_node.box_props.unpack();
 
             // Get intrinsic size from the image data or fall back to layout node
-            let intrinsic_size = tree.warm(child_index)
+            let intrinsic_size = tree.warm(LayoutNodeId::new(child_index))
                 .and_then(|w| w.intrinsic_sizes)
                 .unwrap_or_else(|| IntrinsicSizes {
                     max_content_width: 50.0,
@@ -8781,7 +8782,7 @@ fn collect_and_measure_inline_content_impl<T: ParsedFontTrait>(
             
             // Set the used_size on the layout node so paint_rect works correctly
             let final_size = LogicalSize::new(tentative_size.width, tentative_size.height);
-            tree.get_mut(child_index).unwrap().used_size = Some(final_size);
+            tree.get_mut(LayoutNodeId::new(child_index)).unwrap().used_size = Some(final_size);
             
             // Calculate display size for text3 (this is what text3 uses for positioning)
             let display_width = if final_size.width > 0.0 { 
@@ -9012,7 +9013,7 @@ fn collect_inline_span_recursive<T: ParsedFontTrait>(
         let child_index = parent_children
             .iter()
             .find(|&&idx| {
-                tree.get(idx)
+                tree.get(LayoutNodeId::new(idx))
                     .and_then(|n| n.dom_node_id)
                     .is_some_and(|id| id == child_dom_id)
             })
@@ -9049,8 +9050,8 @@ fn collect_inline_span_recursive<T: ParsedFontTrait>(
                     continue;
                 };
 
-                let child_node = tree.get(child_index).ok_or(LayoutError::InvalidTree)?;
-                let intrinsic_size = tree.warm(child_index).and_then(|w| w.intrinsic_sizes).unwrap_or_default();
+                let child_node = tree.get(LayoutNodeId::new(child_index)).ok_or(LayoutError::InvalidTree)?;
+                let intrinsic_size = tree.warm(LayoutNodeId::new(child_index)).and_then(|w| w.intrinsic_sizes).unwrap_or_default();
                 let width = intrinsic_size.max_content_width;
 
                 let styled_node_state = ctx
@@ -9095,7 +9096,7 @@ fn collect_inline_span_recursive<T: ParsedFontTrait>(
                 let final_height = layout_result.output.overflow_size.height;
                 let final_size = LogicalSize::new(width, final_height);
 
-                tree.get_mut(child_index).unwrap().used_size = Some(final_size);
+                tree.get_mut(LayoutNodeId::new(child_index)).unwrap().used_size = Some(final_size);
 
                 // CSS 2.2 § 10.8.1: inline-block baseline fallback
                 let overflow_x = get_overflow_x(ctx.styled_dom, child_dom_id, &styled_node_state).unwrap_or_default();
@@ -9439,7 +9440,7 @@ fn has_margin_collapse_blocker(
 ///
 /// `true` if the element is empty and its margins can collapse internally
 fn is_empty_block(tree: &LayoutTree, node_index: usize) -> bool {
-    let Some(node) = tree.get(node_index) else {
+    let Some(node) = tree.get(LayoutNodeId::new(node_index)) else {
         return true;
     };
     // Per CSS 2.2 § 8.3.1: An empty block is one that:
@@ -9454,7 +9455,7 @@ fn is_empty_block(tree: &LayoutTree, node_index: usize) -> bool {
     }
 
     // Check if node has inline content (text)
-    if tree.warm(node_index).and_then(|w| w.inline_layout_result.as_ref()).is_some() {
+    if tree.warm(LayoutNodeId::new(node_index)).and_then(|w| w.inline_layout_result.as_ref()).is_some() {
         return false;
     }
 
@@ -9488,14 +9489,14 @@ fn generate_list_marker_text(
     use crate::solver3::counters::format_counter;
 
     // Get the marker node
-    let Some(marker_node) = tree.get(marker_index) else {
+    let Some(marker_node) = tree.get(LayoutNodeId::new(marker_index)) else {
         return String::new();
     };
 
     // Verify this is actually a ::marker pseudo-element
     // Per spec, markers must be pseudo-elements, not anonymous boxes
-    let marker_pseudo = tree.warm(marker_index).and_then(|w| w.pseudo_element);
-    let marker_anonymous_type = tree.cold(marker_index).and_then(|c| c.anonymous_type);
+    let marker_pseudo = tree.warm(LayoutNodeId::new(marker_index)).and_then(|w| w.pseudo_element);
+    let marker_anonymous_type = tree.cold(LayoutNodeId::new(marker_index)).and_then(|c| c.anonymous_type);
     if marker_pseudo != Some(PseudoElement::Marker) {
         if let Some(msgs) = debug_messages {
             msgs.push(LayoutDebugMessage::warning(format!(
@@ -9519,7 +9520,7 @@ fn generate_list_marker_text(
         return String::new();
     };
 
-    let Some(list_item_node) = tree.get(list_item_index) else {
+    let Some(list_item_node) = tree.get(LayoutNodeId::new(list_item_index)) else {
         return String::new();
     };
 
@@ -9541,7 +9542,7 @@ fn generate_list_marker_text(
 
     // Get list-style-type from the list-item or its container
     let list_container_dom_id = list_item_node.parent.and_then(|grandparent_index| {
-        tree.get(grandparent_index).and_then(|grandparent| grandparent.dom_node_id)
+        tree.get(LayoutNodeId::new(grandparent_index)).and_then(|grandparent| grandparent.dom_node_id)
     });
 
     // Try to get list-style-type from the list container first,

--- a/layout/src/solver3/getters.rs
+++ b/layout/src/solver3/getters.rs
@@ -55,7 +55,11 @@ use crate::{
 
 const DEFAULT_EM_SIZE: f32 = 16.0;
 const DEFAULT_CARET_WIDTH_PX: f32 = 2.0;
-const DEFAULT_CARET_BLINK_MS: u32 = 500;
+// ONE authority for the default blink period: the manager's constant.
+// This and CURSOR_BLINK_INTERVAL_MS disagreeing (500 vs 530) is what made
+// the "which default wins" question unanswerable — do not fork it again.
+#[allow(clippy::cast_possible_truncation)]
+const DEFAULT_CARET_BLINK_MS: u32 = crate::managers::text_edit::CURSOR_BLINK_INTERVAL_MS as u32;
 const DEFAULT_TAB_SIZE: f32 = 8.0;
 const SCROLLBAR_WIDTH_THIN: f32 = 8.0;
 const SCROLLBAR_WIDTH_AUTO: f32 = 12.0;

--- a/layout/src/solver3/getters.rs
+++ b/layout/src/solver3/getters.rs
@@ -6865,7 +6865,7 @@ mod autotest_generated {
 
     /// `<body>` with a single text child.
     fn body_with_text(text: &str) -> StyledDom {
-        let mut dom = Dom::create_body().with_children(vec![Dom::create_text(text)].into());
+        let mut dom = Dom::create_body().with_children(vec![Dom::create_text_do_not_use_without_block_level_wrapper(text)].into());
         StyledDom::create(&mut dom, Css::empty())
     }
 
@@ -9141,9 +9141,9 @@ mod style_interning_tests {
         // Three sibling texts with no styling of their own: identical
         // computed style, three different nodes.
         let dom = Dom::create_body()
-            .with_child(Dom::create_text("one"))
-            .with_child(Dom::create_text("two"))
-            .with_child(Dom::create_text("three"));
+            .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("one"))
+            .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("two"))
+            .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("three"));
         let sd = StyledDom::create_from_dom(dom);
         let viewport = PhysicalSize::new(800.0, 600.0);
 
@@ -9201,7 +9201,7 @@ mod style_interning_tests {
         use azul_core::styled_dom::StyledDom;
 
         let sd = StyledDom::create_from_dom(
-            Dom::create_body().with_child(Dom::create_text("x")),
+            Dom::create_body().with_child(Dom::create_text_do_not_use_without_block_level_wrapper("x")),
         );
         let viewport = PhysicalSize::new(800.0, 600.0);
 

--- a/layout/src/solver3/layout_tree.rs
+++ b/layout/src/solver3/layout_tree.rs
@@ -4116,14 +4116,14 @@ mod autotest_generated {
             Dom::create_body()
                 .with_child(
                     div_class("block")
-                        .with_child(Dom::create_text("hello"))
-                        .with_child(div_class("inline").with_child(Dom::create_text("world"))),
+                        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("hello"))
+                        .with_child(div_class("inline").with_child(Dom::create_text_do_not_use_without_block_level_wrapper("world"))),
                 )
                 .with_child(
                     div_class("mixed")
-                        .with_child(Dom::create_text(" \n\t"))
+                        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper(" \n\t"))
                         .with_child(div_class("block2"))
-                        .with_child(Dom::create_text("tail")),
+                        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("tail")),
                 ),
             ".block { display: block; } .inline { display: inline; } .mixed { display: block; } \
              .block2 { display: block; }",
@@ -5421,7 +5421,7 @@ mod autotest_generated {
     #[test]
     fn the_marker_pseudo_element_is_inserted_as_the_first_child_of_a_list_item() {
         let sd = styled(
-            Dom::create_body().with_child(div_class("li").with_child(Dom::create_text("item"))),
+            Dom::create_body().with_child(div_class("li").with_child(Dom::create_text_do_not_use_without_block_level_wrapper("item"))),
             ".li { display: list-item; }",
         );
         let tree = build_tree(&sd);
@@ -5500,7 +5500,7 @@ mod autotest_generated {
         let sd = styled(
             Dom::create_body().with_child(
                 div_class("t")
-                    .with_child(Dom::create_text("   "))
+                    .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("   "))
                     .with_child(div_class("row")),
             ),
             ".t { display: table; } .row { display: table-row; }",
@@ -6117,7 +6117,7 @@ mod autotest_generated {
     #[test]
     fn is_inline_level_is_always_true_for_text_regardless_of_display() {
         let sd = styled(
-            Dom::create_body().with_child(div_class("b").with_child(Dom::create_text("t"))),
+            Dom::create_body().with_child(div_class("b").with_child(Dom::create_text_do_not_use_without_block_level_wrapper("t"))),
             ".b { display: block; }",
         );
         let t = text_node(&sd, "t");
@@ -6214,7 +6214,7 @@ mod autotest_generated {
 
     fn ws_dom(text: &str, css: &str) -> StyledDom {
         styled(
-            Dom::create_body().with_child(div_class("p").with_child(Dom::create_text(text))),
+            Dom::create_body().with_child(div_class("p").with_child(Dom::create_text_do_not_use_without_block_level_wrapper(text))),
             css,
         )
     }
@@ -6427,7 +6427,7 @@ mod autotest_generated {
             let nd = NodeData::create_node(nt.clone());
             assert!(!is_replaced_element(&nd), "{nt:?} is not replaced");
         }
-        assert!(!is_replaced_element(&NodeData::create_text("hello")));
+        assert!(!is_replaced_element(&NodeData::create_text_do_not_use_without_block_level_wrapper("hello")));
     }
 
     #[test]
@@ -7003,7 +7003,7 @@ mod autotest_generated {
                 ".t { display: table; } .c { display: table-cell; }",
             ),
             styled(
-                Dom::create_body().with_child(div_class("li").with_child(Dom::create_text("x"))),
+                Dom::create_body().with_child(div_class("li").with_child(Dom::create_text_do_not_use_without_block_level_wrapper("x"))),
                 ".li { display: list-item; }",
             ),
         ] {

--- a/layout/src/solver3/layout_tree.rs
+++ b/layout/src/solver3/layout_tree.rs
@@ -1193,7 +1193,7 @@ impl LayoutNode {
 /// them with [`LayoutNodeId::new`] — an explicit, greppable assertion that
 /// the value really is a layout index.
 ///
-/// The raw SoA vectors (`nodes`, `warm`, `cold`, `children_arena`) stay
+/// The raw `SoA` vectors (`nodes`, `warm`, `cold`, `children_arena`) stay
 /// `usize`-indexed for interior arithmetic; the typed boundary is the
 /// accessor surface (`get`/`warm`/`cold`/`get_content_size`/...), which is
 /// what map-derived consumer code calls.

--- a/layout/src/solver3/layout_tree.rs
+++ b/layout/src/solver3/layout_tree.rs
@@ -1181,6 +1181,47 @@ impl LayoutNode {
     }
 }
 
+/// A position in the LAYOUT tree — distinct from a DOM [`NodeId`] BY TYPE.
+///
+/// The layout tree interleaves anonymous boxes and splits during
+/// construction, so layout indices and DOM indices diverge for any real DOM.
+/// Conflating them (`node_id.index()` used as a layout index) froze CPU-path
+/// scrolling once (`build_scroll_offset_map`) and is exactly the mistake this
+/// newtype turns into a compile error: the ONLY sanctioned ways to obtain a
+/// `LayoutNodeId` from a DOM node are [`LayoutTree::dom_to_layout`] and the
+/// scroll-id tables. Solver-interior code that produces indices locally wraps
+/// them with [`LayoutNodeId::new`] — an explicit, greppable assertion that
+/// the value really is a layout index.
+///
+/// The raw SoA vectors (`nodes`, `warm`, `cold`, `children_arena`) stay
+/// `usize`-indexed for interior arithmetic; the typed boundary is the
+/// accessor surface (`get`/`warm`/`cold`/`get_content_size`/...), which is
+/// what map-derived consumer code calls.
+#[repr(transparent)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct LayoutNodeId(pub usize);
+
+impl LayoutNodeId {
+    #[inline]
+    #[must_use]
+    pub const fn new(index: usize) -> Self {
+        Self(index)
+    }
+    /// The raw vector index. Greppable by design: every `.index()` is a
+    /// deliberate exit from the typed space.
+    #[inline]
+    #[must_use]
+    pub const fn index(self) -> usize {
+        self.0
+    }
+}
+
+impl core::fmt::Display for LayoutNodeId {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "L{}", self.0)
+    }
+}
+
 /// The complete layout tree structure.
 ///
 /// Uses a struct-of-arrays (`SoA`) layout for cache performance:
@@ -1203,7 +1244,7 @@ pub struct LayoutTree {
     // silently no-op there — dom_to_layout came back empty (node mapping lost,
     // get_node_size/position returned None → 0-rects). BTreeMap is deterministic,
     // matches the rest of azul-core, and lifts reliably (M12.7).
-    pub dom_to_layout: BTreeMap<NodeId, Vec<usize>>,
+    pub dom_to_layout: BTreeMap<NodeId, Vec<LayoutNodeId>>,
     /// Flat arena holding all children indices contiguously.
     pub children_arena: Vec<usize>,
     /// Per-node (start, len) into `children_arena`. Indexed by node index.
@@ -1426,38 +1467,38 @@ impl LayoutTree {
 
     /// Get hot layout data for a node (`box_props`, `dom_node_id`, `used_size`, etc.)
     #[inline]
-    #[must_use] pub fn get(&self, index: usize) -> Option<&LayoutNodeHot> {
-        self.nodes.get(index)
+    #[must_use] pub fn get(&self, index: LayoutNodeId) -> Option<&LayoutNodeHot> {
+        self.nodes.get(index.index())
     }
 
     /// Get mutable hot layout data for a node.
     #[inline]
-    pub fn get_mut(&mut self, index: usize) -> Option<&mut LayoutNodeHot> {
-        self.nodes.get_mut(index)
+    pub fn get_mut(&mut self, index: LayoutNodeId) -> Option<&mut LayoutNodeHot> {
+        self.nodes.get_mut(index.index())
     }
 
     /// Get warm layout data for a node (`intrinsic_sizes`, baseline, `inline_layout`, etc.)
     #[inline]
-    #[must_use] pub fn warm(&self, index: usize) -> Option<&LayoutNodeWarm> {
-        self.warm.get(index)
+    #[must_use] pub fn warm(&self, index: LayoutNodeId) -> Option<&LayoutNodeWarm> {
+        self.warm.get(index.index())
     }
 
     /// Get mutable warm layout data for a node.
     #[inline]
-    pub fn warm_mut(&mut self, index: usize) -> Option<&mut LayoutNodeWarm> {
-        self.warm.get_mut(index)
+    pub fn warm_mut(&mut self, index: LayoutNodeId) -> Option<&mut LayoutNodeWarm> {
+        self.warm.get_mut(index.index())
     }
 
     /// Get cold layout data for a node (`dirty_flag`, `subtree_hash`, fingerprint, etc.)
     #[inline]
-    #[must_use] pub fn cold(&self, index: usize) -> Option<&LayoutNodeCold> {
-        self.cold.get(index)
+    #[must_use] pub fn cold(&self, index: LayoutNodeId) -> Option<&LayoutNodeCold> {
+        self.cold.get(index.index())
     }
 
     /// Get mutable cold layout data for a node.
     #[inline]
-    pub fn cold_mut(&mut self, index: usize) -> Option<&mut LayoutNodeCold> {
-        self.cold.get_mut(index)
+    pub fn cold_mut(&mut self, index: LayoutNodeId) -> Option<&mut LayoutNodeCold> {
+        self.cold.get_mut(index.index())
     }
 
     fn root_node(&self) -> &LayoutNodeHot {
@@ -1597,7 +1638,7 @@ impl LayoutTree {
         &self,
         layout_index: usize,
     ) -> Option<Arc<UnifiedLayout>> {
-        let warm = self.warm(layout_index)?;
+        let warm = self.warm(LayoutNodeId::new(layout_index))?;
         let cached = warm.inline_layout_result.as_ref()?;
         if cached.layout.items.is_empty() {
             if let Some(d) = cached.dense.as_deref() {
@@ -1649,8 +1690,8 @@ impl LayoutTree {
     }
 
     /// Get the content size of a node (for scrollbar calculations).
-    #[must_use] pub fn get_content_size(&self, index: usize) -> LogicalSize {
-        let Some(warm) = self.warm.get(index) else {
+    #[must_use] pub fn get_content_size(&self, index: LayoutNodeId) -> LogicalSize {
+        let Some(warm) = self.warm.get(index.index()) else {
             return LogicalSize::default();
         };
 
@@ -1658,7 +1699,7 @@ impl LayoutTree {
             return content_size;
         }
 
-        let Some(hot) = self.nodes.get(index) else {
+        let Some(hot) = self.nodes.get(index.index()) else {
             return LogicalSize::default();
         };
 
@@ -3121,7 +3162,11 @@ impl LayoutTreeBuilder {
             warm: warm_nodes,
             cold: cold_nodes,
             root: root_idx,
-            dom_to_layout: self.dom_to_layout,
+            dom_to_layout: self
+                .dom_to_layout
+                .into_iter()
+                .map(|(k, v)| (k, v.into_iter().map(LayoutNodeId::new).collect()))
+                .collect(),
             children_arena: arena,
             children_offsets: offsets,
             // Populated by `generate_layout_tree` after the tree is built,
@@ -4707,7 +4752,7 @@ mod autotest_generated {
             let full = tree.get_full_node(i).expect("in-range node");
             let (h, w, c) = full.split();
 
-            let hot = tree.get(i).unwrap();
+            let hot = tree.get(LayoutNodeId::new(i)).unwrap();
             assert_eq!(h.dom_node_id, hot.dom_node_id, "node {i}");
             assert_eq!(h.parent, hot.parent, "node {i}");
             assert_eq!(h.used_size, hot.used_size, "node {i}");
@@ -4717,7 +4762,7 @@ mod autotest_generated {
             assert_eq!(h.box_props.padding, hot.box_props.padding, "node {i}");
             assert_eq!(h.box_props.border, hot.box_props.border, "node {i}");
 
-            let warm = tree.warm(i).unwrap();
+            let warm = tree.warm(LayoutNodeId::new(i)).unwrap();
             assert_eq!(w.pseudo_element, warm.pseudo_element, "node {i}");
             assert_eq!(w.baseline, warm.baseline, "node {i}");
             assert_eq!(
@@ -4725,7 +4770,7 @@ mod autotest_generated {
                 "node {i}"
             );
 
-            let cold = tree.cold(i).unwrap();
+            let cold = tree.cold(LayoutNodeId::new(i)).unwrap();
             assert_eq!(c.anonymous_type, cold.anonymous_type, "node {i}");
             assert_eq!(c.dirty_flag, cold.dirty_flag, "node {i}");
             assert_eq!(c.subtree_hash, cold.subtree_hash, "node {i}");
@@ -4759,12 +4804,12 @@ mod autotest_generated {
         let mut tree = build_tree(&mixed_dom());
         let n = tree.nodes.len();
         for idx in [n, n + 1, usize::MAX, usize::MAX - 1, usize::MAX / 2] {
-            assert!(tree.get(idx).is_none(), "get({idx})");
-            assert!(tree.warm(idx).is_none(), "warm({idx})");
-            assert!(tree.cold(idx).is_none(), "cold({idx})");
-            assert!(tree.get_mut(idx).is_none(), "get_mut({idx})");
-            assert!(tree.warm_mut(idx).is_none(), "warm_mut({idx})");
-            assert!(tree.cold_mut(idx).is_none(), "cold_mut({idx})");
+            assert!(tree.get(LayoutNodeId::new(idx)).is_none(), "get({idx})");
+            assert!(tree.warm(LayoutNodeId::new(idx)).is_none(), "warm({idx})");
+            assert!(tree.cold(LayoutNodeId::new(idx)).is_none(), "cold({idx})");
+            assert!(tree.get_mut(LayoutNodeId::new(idx)).is_none(), "get_mut({idx})");
+            assert!(tree.warm_mut(LayoutNodeId::new(idx)).is_none(), "warm_mut({idx})");
+            assert!(tree.cold_mut(LayoutNodeId::new(idx)).is_none(), "cold_mut({idx})");
             assert!(tree.get_inline_layout_for_node(idx).is_none());
         }
     }
@@ -4772,13 +4817,13 @@ mod autotest_generated {
     #[test]
     fn tree_accessors_all_resolve_at_index_zero() {
         let mut tree = build_tree(&mixed_dom());
-        assert!(tree.get(0).is_some());
-        assert!(tree.warm(0).is_some());
-        assert!(tree.cold(0).is_some());
-        assert!(tree.get_mut(0).is_some());
-        assert!(tree.warm_mut(0).is_some());
-        assert!(tree.cold_mut(0).is_some());
-        assert_eq!(tree.get(0).unwrap().parent, None, "index 0 is the root");
+        assert!(tree.get(LayoutNodeId::new(0)).is_some());
+        assert!(tree.warm(LayoutNodeId::new(0)).is_some());
+        assert!(tree.cold(LayoutNodeId::new(0)).is_some());
+        assert!(tree.get_mut(LayoutNodeId::new(0)).is_some());
+        assert!(tree.warm_mut(LayoutNodeId::new(0)).is_some());
+        assert!(tree.cold_mut(LayoutNodeId::new(0)).is_some());
+        assert_eq!(tree.get(LayoutNodeId::new(0)).unwrap().parent, None, "index 0 is the root");
     }
 
     #[test]
@@ -4798,7 +4843,7 @@ mod autotest_generated {
             for &child in tree.children(i) {
                 assert!(child < n, "child {child} of {i} is out of range");
                 assert_eq!(
-                    tree.get(child).unwrap().parent,
+                    tree.get(LayoutNodeId::new(child)).unwrap().parent,
                     Some(i),
                     "child {child} does not point back at parent {i}"
                 );
@@ -4829,8 +4874,8 @@ mod autotest_generated {
     #[test]
     fn get_content_size_is_default_for_an_out_of_range_index() {
         let tree = build_tree(&mixed_dom());
-        assert_eq!(tree.get_content_size(usize::MAX), LogicalSize::default());
-        assert_eq!(tree.get_content_size(tree.nodes.len()), LogicalSize::default());
+        assert_eq!(tree.get_content_size(LayoutNodeId::new(usize::MAX)), LogicalSize::default());
+        assert_eq!(tree.get_content_size(LayoutNodeId::new(tree.nodes.len())), LogicalSize::default());
     }
 
     #[test]
@@ -4838,7 +4883,7 @@ mod autotest_generated {
         let mut tree = raw_tree(vec![hot(None)], &[vec![]]);
         tree.nodes[0].used_size = Some(LogicalSize::new(10.0, 10.0));
         tree.warm[0].overflow_content_size = Some(LogicalSize::new(999.0, 888.0));
-        assert_eq!(tree.get_content_size(0), LogicalSize::new(999.0, 888.0));
+        assert_eq!(tree.get_content_size(LayoutNodeId::new(0)), LogicalSize::new(999.0, 888.0));
     }
 
     #[test]
@@ -4851,7 +4896,7 @@ mod autotest_generated {
             false,
         )));
         // item spans x ∈ [25, 55], y ∈ [0, 40]  →  content must cover 55 × 40.
-        let cs = tree.get_content_size(0);
+        let cs = tree.get_content_size(LayoutNodeId::new(0));
         assert_eq!(cs.width, 55.0);
         assert_eq!(cs.height, 40.0);
     }
@@ -4865,13 +4910,13 @@ mod autotest_generated {
             AvailableSpace::MaxContent,
             false,
         )));
-        assert_eq!(tree.get_content_size(0), LogicalSize::new(500.0, 500.0));
+        assert_eq!(tree.get_content_size(LayoutNodeId::new(0)), LogicalSize::new(500.0, 500.0));
     }
 
     #[test]
     fn get_content_size_of_a_node_with_no_used_size_is_zero() {
         let tree = raw_tree(vec![hot(None)], &[vec![]]);
-        assert_eq!(tree.get_content_size(0), LogicalSize::default());
+        assert_eq!(tree.get_content_size(LayoutNodeId::new(0)), LogicalSize::default());
     }
 
     // ==================================================================
@@ -4975,11 +5020,11 @@ mod autotest_generated {
     fn mark_dirty_walks_up_to_the_root() {
         let mut tree = dirty_tree();
         tree.mark_dirty(2, DirtyFlag::Layout);
-        assert_eq!(tree.cold(2).unwrap().dirty_flag, DirtyFlag::Layout);
-        assert_eq!(tree.cold(1).unwrap().dirty_flag, DirtyFlag::Layout);
-        assert_eq!(tree.cold(0).unwrap().dirty_flag, DirtyFlag::Layout);
+        assert_eq!(tree.cold(LayoutNodeId::new(2)).unwrap().dirty_flag, DirtyFlag::Layout);
+        assert_eq!(tree.cold(LayoutNodeId::new(1)).unwrap().dirty_flag, DirtyFlag::Layout);
+        assert_eq!(tree.cold(LayoutNodeId::new(0)).unwrap().dirty_flag, DirtyFlag::Layout);
         assert_eq!(
-            tree.cold(3).unwrap().dirty_flag,
+            tree.cold(LayoutNodeId::new(3)).unwrap().dirty_flag,
             DirtyFlag::None,
             "the sibling is untouched"
         );
@@ -4998,7 +5043,7 @@ mod autotest_generated {
         tree.mark_dirty(2, DirtyFlag::Layout);
         tree.mark_dirty(2, DirtyFlag::Paint);
         assert_eq!(
-            tree.cold(2).unwrap().dirty_flag,
+            tree.cold(LayoutNodeId::new(2)).unwrap().dirty_flag,
             DirtyFlag::Layout,
             "Layout > Paint — a Paint request must not weaken it"
         );
@@ -5008,10 +5053,10 @@ mod autotest_generated {
     fn mark_dirty_upgrades_paint_to_layout_and_keeps_propagating() {
         let mut tree = dirty_tree();
         tree.mark_dirty(2, DirtyFlag::Paint);
-        assert_eq!(tree.cold(0).unwrap().dirty_flag, DirtyFlag::Paint);
+        assert_eq!(tree.cold(LayoutNodeId::new(0)).unwrap().dirty_flag, DirtyFlag::Paint);
         tree.mark_dirty(2, DirtyFlag::Layout);
-        assert_eq!(tree.cold(2).unwrap().dirty_flag, DirtyFlag::Layout);
-        assert_eq!(tree.cold(0).unwrap().dirty_flag, DirtyFlag::Layout);
+        assert_eq!(tree.cold(LayoutNodeId::new(2)).unwrap().dirty_flag, DirtyFlag::Layout);
+        assert_eq!(tree.cold(LayoutNodeId::new(0)).unwrap().dirty_flag, DirtyFlag::Layout);
     }
 
     #[test]
@@ -5019,8 +5064,8 @@ mod autotest_generated {
         let mut tree = dirty_tree();
         tree.mark_dirty(3, DirtyFlag::Layout); // marks 3, 1, 0
         tree.mark_dirty(2, DirtyFlag::Layout); // marks 2, then stops at 1
-        assert_eq!(tree.cold(2).unwrap().dirty_flag, DirtyFlag::Layout);
-        assert_eq!(tree.cold(1).unwrap().dirty_flag, DirtyFlag::Layout);
+        assert_eq!(tree.cold(LayoutNodeId::new(2)).unwrap().dirty_flag, DirtyFlag::Layout);
+        assert_eq!(tree.cold(LayoutNodeId::new(1)).unwrap().dirty_flag, DirtyFlag::Layout);
     }
 
     #[test]
@@ -5037,26 +5082,26 @@ mod autotest_generated {
         // only thing standing between a corrupted parent pointer and a hang.
         let mut tree = raw_tree(vec![hot(Some(1)), hot(Some(0))], &[vec![], vec![]]);
         tree.mark_dirty(0, DirtyFlag::Layout);
-        assert_eq!(tree.cold(0).unwrap().dirty_flag, DirtyFlag::Layout);
-        assert_eq!(tree.cold(1).unwrap().dirty_flag, DirtyFlag::Layout);
+        assert_eq!(tree.cold(LayoutNodeId::new(0)).unwrap().dirty_flag, DirtyFlag::Layout);
+        assert_eq!(tree.cold(LayoutNodeId::new(1)).unwrap().dirty_flag, DirtyFlag::Layout);
     }
 
     #[test]
     fn mark_dirty_terminates_when_a_node_is_its_own_parent() {
         let mut tree = raw_tree(vec![hot(Some(0))], &[vec![]]);
         tree.mark_dirty(0, DirtyFlag::Layout);
-        assert_eq!(tree.cold(0).unwrap().dirty_flag, DirtyFlag::Layout);
+        assert_eq!(tree.cold(LayoutNodeId::new(0)).unwrap().dirty_flag, DirtyFlag::Layout);
     }
 
     #[test]
     fn mark_subtree_dirty_marks_descendants_but_not_ancestors_or_siblings() {
         let mut tree = dirty_tree();
         tree.mark_subtree_dirty(1, DirtyFlag::Layout);
-        assert_eq!(tree.cold(1).unwrap().dirty_flag, DirtyFlag::Layout);
-        assert_eq!(tree.cold(2).unwrap().dirty_flag, DirtyFlag::Layout);
-        assert_eq!(tree.cold(3).unwrap().dirty_flag, DirtyFlag::Layout);
+        assert_eq!(tree.cold(LayoutNodeId::new(1)).unwrap().dirty_flag, DirtyFlag::Layout);
+        assert_eq!(tree.cold(LayoutNodeId::new(2)).unwrap().dirty_flag, DirtyFlag::Layout);
+        assert_eq!(tree.cold(LayoutNodeId::new(3)).unwrap().dirty_flag, DirtyFlag::Layout);
         assert_eq!(
-            tree.cold(0).unwrap().dirty_flag,
+            tree.cold(LayoutNodeId::new(0)).unwrap().dirty_flag,
             DirtyFlag::None,
             "mark_subtree_dirty walks DOWN only"
         );
@@ -5313,7 +5358,7 @@ mod autotest_generated {
             ),
         ] {
             tree.resolve_box_props(1, cb, vp, efs, rfs);
-            let bp = tree.get(1).unwrap().box_props.unpack();
+            let bp = tree.get(LayoutNodeId::new(1)).unwrap().box_props.unpack();
             for v in [
                 bp.margin.top,
                 bp.margin.right,
@@ -5344,7 +5389,7 @@ mod autotest_generated {
         );
         let mut tree = build_tree(&sd);
         tree.resolve_box_props(1, LogicalSize::new(200.0, 100.0), VIEWPORT, 16.0, 16.0);
-        let bp = tree.get(1).unwrap().box_props.unpack();
+        let bp = tree.get(LayoutNodeId::new(1)).unwrap().box_props.unpack();
         assert!(
             (bp.margin.left - 100.0).abs() < 0.2,
             "50% of a 200px containing block ≈ 100px, got {}",
@@ -5377,7 +5422,7 @@ mod autotest_generated {
         let tree = build_tree(&sd);
         let wrappers: Vec<usize> = (0..tree.nodes.len())
             .filter(|&i| {
-                tree.cold(i).unwrap().anonymous_type == Some(AnonymousBoxType::InlineWrapper)
+                tree.cold(LayoutNodeId::new(i)).unwrap().anonymous_type == Some(AnonymousBoxType::InlineWrapper)
             })
             .collect();
         assert_eq!(
@@ -5387,12 +5432,12 @@ mod autotest_generated {
         );
 
         let w = wrappers[0];
-        assert_eq!(tree.get(w).unwrap().dom_node_id, None, "anon boxes have no DOM node");
-        assert_eq!(tree.cold(w).unwrap().dirty_flag, DirtyFlag::Layout);
+        assert_eq!(tree.get(LayoutNodeId::new(w)).unwrap().dom_node_id, None, "anon boxes have no DOM node");
+        assert_eq!(tree.cold(LayoutNodeId::new(w)).unwrap().dirty_flag, DirtyFlag::Layout);
         let tail = text_node(&sd, "tail");
         let kids = tree.children(w);
         assert_eq!(kids.len(), 1);
-        assert_eq!(tree.get(kids[0]).unwrap().dom_node_id, Some(tail));
+        assert_eq!(tree.get(LayoutNodeId::new(kids[0])).unwrap().dom_node_id, Some(tail));
     }
 
     #[test]
@@ -5402,17 +5447,17 @@ mod autotest_generated {
         // `.block` (DOM 1) holds only inline children — the all-inline fast path
         // must hand them straight to the parent, with no wrapper in between.
         let block_idx = (0..tree.nodes.len())
-            .find(|&i| tree.get(i).unwrap().dom_node_id == Some(NodeId::new(1)))
+            .find(|&i| tree.get(LayoutNodeId::new(i)).unwrap().dom_node_id == Some(NodeId::new(1)))
             .expect("the .block layout node");
         let kids = tree.children(block_idx);
         assert_eq!(kids.len(), 2, "the text run and the inline div, unwrapped");
         assert!(
             kids.iter()
-                .all(|&c| tree.cold(c).unwrap().anonymous_type.is_none()),
+                .all(|&c| tree.cold(LayoutNodeId::new(c)).unwrap().anonymous_type.is_none()),
             "an all-inline block container needs no anonymous wrapper"
         );
         assert_eq!(
-            tree.get(block_idx).unwrap().formatting_context,
+            tree.get(LayoutNodeId::new(block_idx)).unwrap().formatting_context,
             FormattingContext::Inline,
             "it establishes an IFC instead"
         );
@@ -5427,22 +5472,22 @@ mod autotest_generated {
         let tree = build_tree(&sd);
 
         let marker = (0..tree.nodes.len())
-            .find(|&i| tree.warm(i).unwrap().pseudo_element == Some(PseudoElement::Marker))
+            .find(|&i| tree.warm(LayoutNodeId::new(i)).unwrap().pseudo_element == Some(PseudoElement::Marker))
             .expect("display:list-item must generate a ::marker");
-        let li = tree.get(marker).unwrap().parent.expect("marker has a parent");
+        let li = tree.get(LayoutNodeId::new(marker)).unwrap().parent.expect("marker has a parent");
         assert_eq!(
             tree.children(li)[0],
             marker,
             "CSS Lists 3 §3.1: ::marker is the FIRST child"
         );
         assert_eq!(
-            tree.get(marker).unwrap().dom_node_id,
-            tree.get(li).unwrap().dom_node_id,
+            tree.get(LayoutNodeId::new(marker)).unwrap().dom_node_id,
+            tree.get(LayoutNodeId::new(li)).unwrap().dom_node_id,
             "the marker shares the list-item's DOM node for counter/style resolution"
         );
-        assert_eq!(tree.get(marker).unwrap().formatting_context, FormattingContext::Inline);
+        assert_eq!(tree.get(LayoutNodeId::new(marker)).unwrap().formatting_context, FormattingContext::Inline);
         assert!(
-            tree.dom_to_layout[&tree.get(li).unwrap().dom_node_id.unwrap()].contains(&marker),
+            tree.dom_to_layout[&tree.get(LayoutNodeId::new(li)).unwrap().dom_node_id.unwrap()].contains(&LayoutNodeId::new(marker)),
             "the marker is registered in dom_to_layout for counter resolution"
         );
     }
@@ -5475,7 +5520,7 @@ mod autotest_generated {
         assert!(
             root_kids
                 .iter()
-                .any(|&i| tree.warm(i).unwrap().computed_style.display == LayoutDisplay::Block),
+                .any(|&i| tree.warm(LayoutNodeId::new(i)).unwrap().computed_style.display == LayoutDisplay::Block),
             "the promoted child must be a direct child of the root"
         );
     }
@@ -5489,7 +5534,7 @@ mod autotest_generated {
         let tree = build_tree(&sd);
         assert!(
             (0..tree.nodes.len()).any(|i| {
-                tree.cold(i).unwrap().anonymous_type == Some(AnonymousBoxType::TableRow)
+                tree.cold(LayoutNodeId::new(i)).unwrap().anonymous_type == Some(AnonymousBoxType::TableRow)
             }),
             "CSS 2.2 §17.2.1 stage 2: a non-proper table child is wrapped in an anonymous row"
         );
@@ -5513,7 +5558,7 @@ mod autotest_generated {
         );
         assert!(
             !(0..tree.nodes.len())
-                .any(|i| tree.cold(i).unwrap().anonymous_type == Some(AnonymousBoxType::TableRow)),
+                .any(|i| tree.cold(LayoutNodeId::new(i)).unwrap().anonymous_type == Some(AnonymousBoxType::TableRow)),
             "and no anonymous row is generated for it"
         );
     }
@@ -5677,7 +5722,7 @@ mod autotest_generated {
         let sd = mixed_dom();
         let tree = build_tree(&sd);
         let anon = (0..tree.nodes.len())
-            .find(|&i| tree.cold(i).unwrap().anonymous_type.is_some())
+            .find(|&i| tree.cold(LayoutNodeId::new(i)).unwrap().anonymous_type.is_some())
             .expect("mixed_dom generates one anonymous wrapper");
         let old = tree.get_full_node(anon).unwrap();
         assert_eq!(old.dom_node_id, None);
@@ -5768,9 +5813,9 @@ mod autotest_generated {
         assert!(tree.children_arena.is_empty());
         assert!(tree.children_offsets.is_empty());
         assert!(tree.subtree_needs_intrinsic.is_empty());
-        assert!(tree.get(0).is_none());
+        assert!(tree.get(LayoutNodeId::new(0)).is_none());
         assert!(tree.children(0).is_empty());
-        assert_eq!(tree.get_content_size(0), LogicalSize::default());
+        assert_eq!(tree.get_content_size(LayoutNodeId::new(0)), LogicalSize::default());
         assert_eq!(tree.memory_report().node_count, 0);
     }
 
@@ -5783,7 +5828,7 @@ mod autotest_generated {
 
         let tree = builder.build(usize::MAX);
         assert_eq!(tree.root, usize::MAX, "build() stores the index verbatim");
-        assert!(tree.get(tree.root).is_none());
+        assert!(tree.get(LayoutNodeId::new(tree.root)).is_none());
         assert!(tree.children(tree.root).is_empty());
         assert_eq!(tree.get_ifc_root_layout_index(tree.root), usize::MAX);
     }
@@ -5926,13 +5971,13 @@ mod autotest_generated {
         );
         let tree = build_tree(&sd);
         assert!(
-            (0..tree.nodes.len()).all(|i| tree.cold(i).unwrap().anonymous_type.is_none()),
+            (0..tree.nodes.len()).all(|i| tree.cold(LayoutNodeId::new(i)).unwrap().anonymous_type.is_none()),
             "no anonymous table boxes for blockified flex items"
         );
         let flex = tree.children(tree.root)[0];
         for &c in tree.children(flex) {
             assert!(matches!(
-                tree.get(c).unwrap().formatting_context,
+                tree.get(LayoutNodeId::new(c)).unwrap().formatting_context,
                 FormattingContext::Block { .. }
             ));
         }
@@ -6052,7 +6097,7 @@ mod autotest_generated {
         let flex = kids
             .iter()
             .copied()
-            .find(|&i| tree.get(i).unwrap().formatting_context == FormattingContext::Flex)
+            .find(|&i| tree.get(LayoutNodeId::new(i)).unwrap().formatting_context == FormattingContext::Flex)
             .expect("the flex child");
         let plain = kids.iter().copied().find(|&i| i != flex).expect("the plain child");
         assert!(bits[flex]);
@@ -6446,13 +6491,13 @@ mod autotest_generated {
             "the <br> must be dropped from its parent's child list"
         );
         let br = (0..tree.nodes.len())
-            .find(|&i| tree.get(i).unwrap().dom_node_id == Some(NodeId::new(1)))
+            .find(|&i| tree.get(LayoutNodeId::new(i)).unwrap().dom_node_id == Some(NodeId::new(1)))
             .expect("the node object still exists, just unparented");
         assert_eq!(
-            tree.warm(br).unwrap().computed_style.display,
+            tree.warm(LayoutNodeId::new(br)).unwrap().computed_style.display,
             LayoutDisplay::None
         );
-        assert_eq!(tree.get(br).unwrap().formatting_context, FormattingContext::None);
+        assert_eq!(tree.get(LayoutNodeId::new(br)).unwrap().formatting_context, FormattingContext::None);
     }
 
     // ==================================================================
@@ -7015,10 +7060,10 @@ mod autotest_generated {
             assert_eq!(tree.children_offsets.len(), n);
             assert_eq!(tree.subtree_needs_intrinsic.len(), n);
             assert!(tree.root < n);
-            assert_eq!(tree.get(tree.root).unwrap().parent, None);
+            assert_eq!(tree.get(LayoutNodeId::new(tree.root)).unwrap().parent, None);
 
             for i in 0..n {
-                if let Some(p) = tree.get(i).unwrap().parent {
+                if let Some(p) = tree.get(LayoutNodeId::new(i)).unwrap().parent {
                     assert!(p < n, "node {i}'s parent {p} is out of range");
                 }
                 for &c in tree.children(i) {
@@ -7028,7 +7073,7 @@ mod autotest_generated {
             }
             for (dom_id, indices) in &tree.dom_to_layout {
                 for &i in indices {
-                    assert!(i < n, "dom_to_layout[{dom_id:?}] points at {i}, out of range");
+                    assert!(i < LayoutNodeId::new(n), "dom_to_layout[{dom_id:?}] points at {i}, out of range");
                     assert_eq!(tree.get(i).unwrap().dom_node_id, Some(*dom_id));
                 }
             }
@@ -7050,7 +7095,7 @@ mod autotest_generated {
     #[test]
     fn the_root_box_always_establishes_a_new_block_formatting_context() {
         let tree = build_tree(&mixed_dom());
-        match tree.get(tree.root).unwrap().formatting_context {
+        match tree.get(LayoutNodeId::new(tree.root)).unwrap().formatting_context {
             FormattingContext::Block {
                 establishes_new_context,
             } => assert!(establishes_new_context, "process_node forces this for the root"),

--- a/layout/src/solver3/mod.rs
+++ b/layout/src/solver3/mod.rs
@@ -10,6 +10,7 @@ pub mod fc;
 pub mod geometry;
 pub mod getters;
 pub mod layout_tree;
+pub use layout_tree::LayoutNodeId;
 pub mod page_breaks;
 pub mod break_token;
 pub mod paged_layout;
@@ -635,7 +636,7 @@ pub fn layout_document<T: ParsedFontTrait + Sync + 'static>(
         &cache.cached_display_list
     {
         let new_root_hash = new_tree
-            .cold(new_tree.root)
+            .cold(LayoutNodeId::new(new_tree.root))
             .map(|c| c.subtree_hash);
         // The GPU-KEY-POPULATION fingerprint is the third key component. The
         // emitted list is a function of which nodes carry transform/opacity
@@ -726,7 +727,7 @@ pub fn layout_document<T: ParsedFontTrait + Sync + 'static>(
             &recon_result.intrinsic_dirty,
         );
         for &node_idx in &closure {
-            if let Some(warm) = new_tree.warm_mut(node_idx) {
+            if let Some(warm) = new_tree.warm_mut(LayoutNodeId::new(node_idx)) {
                 warm.taffy_cache.clear();
                 warm.measured_content_sizes = (None, None);
             }
@@ -779,13 +780,13 @@ pub fn layout_document<T: ParsedFontTrait + Sync + 'static>(
                 let Some(&old_layout_idx) = old_indices.get(pair_idx) else {
                     continue;
                 };
-                if old_layout_idx >= cache_map.entries.len()
-                    || new_layout_idx >= remapped.entries.len()
+                if old_layout_idx >= LayoutNodeId::new(cache_map.entries.len())
+                    || new_layout_idx >= LayoutNodeId::new(remapped.entries.len())
                 {
                     continue;
                 }
-                remapped.entries[new_layout_idx] =
-                    core::mem::take(&mut cache_map.entries[old_layout_idx]);
+                remapped.entries[new_layout_idx.index()] =
+                    core::mem::take(&mut cache_map.entries[old_layout_idx.index()]);
             }
         }
 
@@ -798,7 +799,7 @@ pub fn layout_document<T: ParsedFontTrait + Sync + 'static>(
         // dom-id mapping we just populated, then match anon children
         // positionally within that parent.
         // Build a new→old layout-idx lookup from the primary pass.
-        let mut new_to_old_layout_idx: HashMap<usize, usize> =
+        let mut new_to_old_layout_idx: HashMap<LayoutNodeId, LayoutNodeId> =
             HashMap::new();
         for (dom_id, new_indices) in &new_tree.dom_to_layout {
             let Some(old_indices) = old_tree.dom_to_layout.get(dom_id) else {
@@ -812,10 +813,10 @@ pub fn layout_document<T: ParsedFontTrait + Sync + 'static>(
         }
 
         for (new_parent_idx, new_anon_children) in new_anon_by_parent {
-            let Some(&old_parent_idx) = new_to_old_layout_idx.get(&new_parent_idx) else {
+            let Some(&old_parent_idx) = new_to_old_layout_idx.get(&LayoutNodeId::new(new_parent_idx)) else {
                 continue;
             };
-            let Some(old_anon_children) = old_anon_by_parent.get(&old_parent_idx) else {
+            let Some(old_anon_children) = old_anon_by_parent.get(&old_parent_idx.index()) else {
                 continue;
             };
             for (ord, &new_anon_idx) in new_anon_children.iter().enumerate() {
@@ -920,7 +921,7 @@ pub fn layout_document<T: ParsedFontTrait + Sync + 'static>(
         // leaving the old entry in place would serve STALE PAINT on the next
         // call, and not storing at all would re-emit every frame for the
         // whole life of an animation.
-        let root_hash = tree.cold(tree.root).map(|c| c.subtree_hash);
+        let root_hash = tree.cold(LayoutNodeId::new(tree.root)).map(|c| c.subtree_hash);
         let gpu_fp = gpu_value_cache
             .map_or(0, azul_core::gpu::GpuValueCache::dl_emission_fingerprint);
         if let Some(h) = root_hash {
@@ -1429,7 +1430,7 @@ pub fn layout_document<T: ParsedFontTrait + Sync + 'static>(
             let opaque_bg: Vec<bool> = (0..new_tree.nodes.len())
                 .map(|i| {
                     new_tree
-                        .get(i)
+                        .get(LayoutNodeId::new(i))
                         .and_then(|node| node.dom_node_id)
                         .is_some_and(|dom_id| {
                             let state = &ctx.styled_dom.styled_nodes.as_container()
@@ -1481,7 +1482,7 @@ pub fn layout_document<T: ParsedFontTrait + Sync + 'static>(
     // sees matching values after reconcile, it returns this clone
     // directly and skips all downstream work.
     let root_subtree_hash = new_tree
-        .cold(new_tree.root)
+        .cold(LayoutNodeId::new(new_tree.root))
         .map_or(layout_tree::SubtreeHash(0), |c| c.subtree_hash);
     // The DL is shared, not copied: one allocation serves the cache slot, the
     // caller's `DomLayoutResult`, and any virtual-view snapshot maps. Rare
@@ -1584,8 +1585,8 @@ pub(super) fn get_containing_block_for_node(
     calculated_positions: &PositionVec,
     viewport: LogicalRect,
 ) -> (LogicalPosition, LogicalSize) {
-    if let Some(parent_idx) = tree.get(node_idx).and_then(|n| n.parent) {
-        if let Some(parent_node) = tree.get(parent_idx) {
+    if let Some(parent_idx) = tree.get(LayoutNodeId::new(node_idx)).and_then(|n| n.parent) {
+        if let Some(parent_node) = tree.get(LayoutNodeId::new(parent_idx)) {
             let pos = pos_get(calculated_positions, parent_idx)
                 .unwrap_or(viewport.origin);
             let size = parent_node.used_size.unwrap_or_default();

--- a/layout/src/solver3/mod.rs
+++ b/layout/src/solver3/mod.rs
@@ -3029,8 +3029,8 @@ mod autotest_generated {
             // runs — the empty divs sit BETWEEN anonymous blocks, which is
             // the arrangement that used to skip them.
             let mut dom = Dom::create_body()
-                .with_child(Dom::create_text("azul-self-test"))
-                .with_child(Dom::create_text("probing platform APIs"))
+                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("azul-self-test"))
+                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("probing platform APIs"))
                 .with_child(Dom::create_div())
                 .with_child(Dom::create_div());
             let (css, _warnings) = azul_css::parser2::new_from_str("body { font-size: 14px; }");

--- a/layout/src/solver3/paged_layout.rs
+++ b/layout/src/solver3/paged_layout.rs
@@ -10,6 +10,7 @@
 //! **Note**: Full CSS `@page` rule parsing is not yet implemented. The `FakePageConfig`
 //! provides programmatic control over page decoration as a temporary solution.
 
+use crate::solver3::layout_tree::LayoutNodeId;
 use crate::debug_log;
 use std::collections::BTreeMap;
 
@@ -741,7 +742,7 @@ fn compute_layout_with_fragmentation<T: ParsedFontTrait + Sync + 'static>(
 
     // Step 1.2: Clear Taffy Caches for Dirty Nodes
     for &node_idx in &recon_result.intrinsic_dirty {
-        if let Some(warm) = new_tree.warm_mut(node_idx) {
+        if let Some(warm) = new_tree.warm_mut(LayoutNodeId::new(node_idx)) {
             warm.taffy_cache.clear();
             warm.measured_content_sizes = (None, None);
         }
@@ -974,7 +975,7 @@ pub fn spine_path_at_y(
 
     let mut best: Option<(f32, u32, NodeId)> = None;
     for idx in 0..tree.nodes.len() {
-        let Some(node) = tree.get(idx) else { continue };
+        let Some(node) = tree.get(LayoutNodeId::new(idx)) else { continue };
         let Some(dom_id) = node.dom_node_id else { continue };
         if !crate::solver3::layout_tree::is_block_level(styled_dom, dom_id) {
             continue;
@@ -2112,7 +2113,7 @@ fn spine_layout_hit_at_y(
     };
     let mut best: Option<(u32, usize, f32)> = None;
     for idx in 0..tree.nodes.len() {
-        let Some(node) = tree.get(idx) else { continue };
+        let Some(node) = tree.get(LayoutNodeId::new(idx)) else { continue };
         let Some(dom_id) = node.dom_node_id else { continue };
         if !crate::solver3::layout_tree::is_block_level(styled_dom, dom_id) {
             continue;
@@ -2148,7 +2149,7 @@ fn spine_layout_hit_at_y(
     let hierarchy = styled_dom.node_hierarchy.as_container();
     // Re-find the spine block the path addresses (same selection rule).
     let (layout_idx, node_top) = spine_layout_hit_at_y(tree, positions, styled_dom, y)?;
-    let node = tree.get(layout_idx)?;
+    let node = tree.get(LayoutNodeId::new(layout_idx))?;
     let bp = node.box_props.unpack();
     let content_top = node_top + bp.padding.top + bp.border.top;
     let rel_y = y - content_top;
@@ -2571,7 +2572,7 @@ where
         let content = cache
             .tree
             .as_ref()
-            .and_then(|t| t.get(0))
+            .and_then(|t| t.get(LayoutNodeId::new(0)))
             .and_then(|n| n.used_size)
             .map_or(0.0, |sz| sz.height);
 

--- a/layout/src/solver3/positioning.rs
+++ b/layout/src/solver3/positioning.rs
@@ -1,6 +1,7 @@
 //! Final positioning of layout nodes (relative, absolute, and fixed schemes)
 // +spec:positioning:79d47e - Implements relative, absolute, and fixed positioning schemes
 
+use crate::solver3::layout_tree::LayoutNodeId;
 use crate::debug_log;
 use std::collections::BTreeMap;
 
@@ -168,7 +169,7 @@ pub fn position_out_of_flow_elements<T: ParsedFontTrait>(
             // Same applies to flex containers (Flexbox §4.1).
             {
                 use azul_core::dom::FormattingContext;
-                let parent_is_flex_or_grid = node.parent.and_then(|p| tree.get(p)).is_some_and(|pn| {
+                let parent_is_flex_or_grid = node.parent.and_then(|p| tree.get(LayoutNodeId::new(p))).is_some_and(|pn| {
                     matches!(pn.formatting_context, FormattingContext::Flex | FormattingContext::Grid)
                 });
                 if parent_is_flex_or_grid {
@@ -180,7 +181,7 @@ pub fn position_out_of_flow_elements<T: ParsedFontTrait>(
             let parent_info: Option<(usize, LogicalPosition, f32, f32, f32, f32)> = {
                 let node = &tree.nodes[node_index];
                 node.parent.and_then(|parent_idx| {
-                    let parent_node = tree.get(parent_idx)?;
+                    let parent_node = tree.get(LayoutNodeId::new(parent_idx))?;
                     let parent_dom_id = parent_node.dom_node_id?;
                     let parent_position = get_position_type(ctx.styled_dom, Some(parent_dom_id));
                     if parent_position == LayoutPosition::Absolute
@@ -248,7 +249,7 @@ pub fn position_out_of_flow_elements<T: ParsedFontTrait>(
             // its children disappear. §10.3.7: their used size never depends
             // on in-flow layout, so recomputing is deterministic.
             let element_size = {
-                let intrinsic = tree.warm(node_index).and_then(|w| w.intrinsic_sizes).unwrap_or_default();
+                let intrinsic = tree.warm(LayoutNodeId::new(node_index)).and_then(|w| w.intrinsic_sizes).unwrap_or_default();
                 let Ok(size) = crate::solver3::sizing::calculate_used_size_for_node(
                     ctx.styled_dom,
                     Some(dom_id),
@@ -261,7 +262,7 @@ pub fn position_out_of_flow_elements<T: ParsedFontTrait>(
                 };
 
                 // Store the calculated size in the tree node
-                if let Some(node_mut) = tree.get_mut(node_index) {
+                if let Some(node_mut) = tree.get_mut(LayoutNodeId::new(node_index)) {
                     node_mut.used_size = Some(size);
                 }
 
@@ -417,7 +418,7 @@ pub fn position_out_of_flow_elements<T: ParsedFontTrait>(
                 // else: keep content-based height (max-content) per aspect-ratio exception
                 final_pos.y = containing_block_rect.origin.y + top_val + used_margin_top;
                 // Update the element size with the resolved height
-                if let Some(node_mut) = tree.get_mut(node_index) {
+                if let Some(node_mut) = tree.get_mut(LayoutNodeId::new(node_index)) {
                     if let Some(ref mut size) = node_mut.used_size {
                         size.height = used_height;
                     }
@@ -459,7 +460,7 @@ pub fn position_out_of_flow_elements<T: ParsedFontTrait>(
                         let mut parent = tree.nodes[node_index].parent;
                         let mut found = None;
                         while let Some(pidx) = parent {
-                            if let Some(pnode) = tree.get(pidx) {
+                            if let Some(pnode) = tree.get(LayoutNodeId::new(pidx)) {
                                 if get_position_type(ctx.styled_dom, pnode.dom_node_id).is_positioned() {
                                     found = pnode.dom_node_id;
                                     break;
@@ -585,7 +586,7 @@ pub fn position_out_of_flow_elements<T: ParsedFontTrait>(
                         if !has_aspect_ratio {
                             // width = cb_width - left - margin_left - margin_right - right
                             let used_width = (cb_width - left - m_left - m_right - right).max(0.0);
-                            if let Some(node_mut) = tree.get_mut(node_index) {
+                            if let Some(node_mut) = tree.get_mut(LayoutNodeId::new(node_index)) {
                                 if let Some(ref mut size) = node_mut.used_size {
                                     size.width = used_width;
                                 }
@@ -673,7 +674,7 @@ pub fn position_out_of_flow_elements<T: ParsedFontTrait>(
                     }
                 }
 
-                if let Some(node_mut) = tree.get_mut(node_index) {
+                if let Some(node_mut) = tree.get_mut(LayoutNodeId::new(node_index)) {
                     node_mut.used_size = Some(solved_size);
                 }
                 let bp = tree.nodes[node_index].box_props.unpack();
@@ -756,7 +757,7 @@ pub fn adjust_relative_positions<T: ParsedFontTrait>(
         // Determine the containing block size for resolving percentages.
         // For `position: relative`, this is the parent's content box size.
         let containing_block_size = node.parent
-            .and_then(|parent_idx| tree.get(parent_idx))
+            .and_then(|parent_idx| tree.get(LayoutNodeId::new(parent_idx)))
             .map_or(viewport.size, |parent_node| {
                 // Get parent's writing mode to correctly calculate its inner (content) size.
                 let parent_wm = parent_node.dom_node_id
@@ -813,7 +814,7 @@ pub fn adjust_relative_positions<T: ParsedFontTrait>(
         // Spec: "If the 'direction' property of the containing block is 'ltr', the value of 'left' wins"
         // Get the direction of the containing block (parent), not the element itself
         let cb_direction = node.parent
-            .and_then(|parent_idx| tree.get(parent_idx))
+            .and_then(|parent_idx| tree.get(LayoutNodeId::new(parent_idx)))
             .and_then(|parent_node| {
                 let parent_dom_id = parent_node.dom_node_id?;
                 let parent_state =
@@ -897,10 +898,10 @@ fn find_nearest_scrollport(
     use crate::solver3::getters::{get_overflow_x, get_overflow_y};
     use azul_css::props::layout::LayoutOverflow;
 
-    let mut current_parent_idx = tree.get(node_index).and_then(|n| n.parent);
+    let mut current_parent_idx = tree.get(LayoutNodeId::new(node_index)).and_then(|n| n.parent);
 
     while let Some(parent_index) = current_parent_idx {
-        let Some(parent_node) = tree.get(parent_index) else {
+        let Some(parent_node) = tree.get(LayoutNodeId::new(parent_index)) else {
             break;
         };
         let Some(parent_dom_id) = parent_node.dom_node_id else {
@@ -974,9 +975,9 @@ fn find_nearest_scroll_offset(
     node_index: usize,
     scroll_offsets: &BTreeMap<NodeId, ScrollPosition>,
 ) -> LogicalPosition {
-    let mut parent = tree.get(node_index).and_then(|n| n.parent);
+    let mut parent = tree.get(LayoutNodeId::new(node_index)).and_then(|n| n.parent);
     while let Some(pidx) = parent {
-        if let Some(pnode) = tree.get(pidx) {
+        if let Some(pnode) = tree.get(LayoutNodeId::new(pidx)) {
             if let Some(dom_id) = pnode.dom_node_id {
                 if let Some(scroll_pos) = scroll_offsets.get(&dom_id) {
                     return scroll_pos.children_rect.origin;
@@ -1035,7 +1036,7 @@ pub fn adjust_sticky_positions<T: ParsedFontTrait>(
         // The containing block for percentage resolution is the parent's content box
         let containing_block = node.parent
             .and_then(|parent_idx| {
-                let parent_node = tree.get(parent_idx)?;
+                let parent_node = tree.get(LayoutNodeId::new(parent_idx))?;
                 let parent_pos = calculated_positions.get(parent_idx).copied().unwrap_or_default();
                 let parent_size = parent_node.used_size.unwrap_or_default();
                 let parent_wm = parent_node.dom_node_id
@@ -1186,11 +1187,11 @@ pub(crate) fn find_absolute_containing_block_rect(
     viewport: LogicalRect,
 ) -> Result<LogicalRect> {
     // +spec:positioning:748d87 - walk up to nearest positioned ancestor for CB
-    let mut current_parent_idx = tree.get(node_index).and_then(|n| n.parent);
+    let mut current_parent_idx = tree.get(LayoutNodeId::new(node_index)).and_then(|n| n.parent);
 
     // +spec:positioning:aa361e - values other than static make a box positioned and establish an abspos containing block
     while let Some(parent_index) = current_parent_idx {
-        let parent_node = tree.get(parent_index).ok_or(LayoutError::InvalidTree)?;
+        let parent_node = tree.get(LayoutNodeId::new(parent_index)).ok_or(LayoutError::InvalidTree)?;
 
         if get_position_type(styled_dom, parent_node.dom_node_id).is_positioned() {
             // calculated_positions stores margin-box positions

--- a/layout/src/solver3/positioning.rs
+++ b/layout/src/solver3/positioning.rs
@@ -962,6 +962,13 @@ fn find_nearest_scrollport(
 
 /// Find the scroll offset of the nearest scroll container ancestor.
 /// Returns the scroll offset as a `LogicalPosition` (how far the content has scrolled).
+///
+/// `children_rect.origin` IS that offset (see
+/// `ScrollManager::get_scroll_states_for_dom`), positive meaning "scrolled
+/// down/right". `parent_rect.origin` is an ABSOLUTE window coordinate and must
+/// NOT be subtracted from it — doing so mixed two spaces and reported a
+/// container's own y as a scroll amount for every scroller below the top of
+/// the window.
 fn find_nearest_scroll_offset(
     tree: &LayoutTree,
     node_index: usize,
@@ -972,9 +979,7 @@ fn find_nearest_scroll_offset(
         if let Some(pnode) = tree.get(pidx) {
             if let Some(dom_id) = pnode.dom_node_id {
                 if let Some(scroll_pos) = scroll_offsets.get(&dom_id) {
-                    let offset_x = scroll_pos.children_rect.origin.x - scroll_pos.parent_rect.origin.x;
-                    let offset_y = scroll_pos.children_rect.origin.y - scroll_pos.parent_rect.origin.y;
-                    return LogicalPosition::new(offset_x, offset_y);
+                    return scroll_pos.children_rect.origin;
                 }
             }
             parent = pnode.parent;
@@ -1930,14 +1935,18 @@ mod autotest_generated {
     // find_nearest_scroll_offset (numeric)
     // ==================================================================
 
-    fn scroll_at(parent: (f32, f32), children: (f32, f32)) -> ScrollPosition {
+    /// `container_origin` is the scroller's ABSOLUTE window position, `offset`
+    /// is the scroll amount — the two are deliberately different everywhere
+    /// below, because a fixture with a container at (0, 0) cannot tell the two
+    /// `ScrollPosition` conventions apart.
+    fn scroll_at(container_origin: (f32, f32), offset: (f32, f32)) -> ScrollPosition {
         ScrollPosition {
             parent_rect: LogicalRect::new(
-                LogicalPosition::new(parent.0, parent.1),
+                LogicalPosition::new(container_origin.0, container_origin.1),
                 LogicalSize::new(100.0, 100.0),
             ),
             children_rect: LogicalRect::new(
-                LogicalPosition::new(children.0, children.1),
+                LogicalPosition::new(offset.0, offset.1),
                 LogicalSize::new(100.0, 400.0),
             ),
         }
@@ -1957,7 +1966,7 @@ mod autotest_generated {
     fn find_nearest_scroll_offset_out_of_range_index_is_zero_not_a_panic() {
         let (sd, tree) = two_level("");
         let mut offsets = BTreeMap::new();
-        offsets.insert(node_by_class(&sd, "root"), scroll_at((0.0, 0.0), (0.0, -50.0)));
+        offsets.insert(node_by_class(&sd, "root"), scroll_at((0.0, 120.0), (0.0, 50.0)));
         assert_eq!(
             find_nearest_scroll_offset(&tree, 9_999, &offsets),
             LogicalPosition::zero()
@@ -1972,7 +1981,7 @@ mod autotest_generated {
         let mut offsets = BTreeMap::new();
         offsets.insert(
             node_by_class(&sd, "child"),
-            scroll_at((0.0, 0.0), (0.0, -50.0)),
+            scroll_at((0.0, 120.0), (0.0, 50.0)),
         );
         assert_eq!(
             find_nearest_scroll_offset(&tree, 1, &offsets),
@@ -1981,16 +1990,32 @@ mod autotest_generated {
     }
 
     #[test]
-    fn find_nearest_scroll_offset_is_children_origin_minus_parent_origin() {
+    fn find_nearest_scroll_offset_is_the_raw_offset_not_a_container_relative_one() {
+        // CONVENTION PIN. `children_rect.origin` IS the scroll offset;
+        // `parent_rect.origin` is an absolute window coordinate in a different
+        // space. Subtracting the two (as this used to) reported the AzWriter
+        // document view — a scroller at y = 120, unscrolled — as scrolled by
+        // -120, which then shifted every sticky box inside it by a screenful.
         let (sd, tree) = two_level("");
         let mut offsets = BTreeMap::new();
         offsets.insert(
             node_by_class(&sd, "root"),
-            scroll_at((10.0, 20.0), (-5.0, -80.0)),
+            scroll_at((10.0, 120.0), (0.0, 0.0)),
         );
         assert_eq!(
             find_nearest_scroll_offset(&tree, 1, &offsets),
-            LogicalPosition::new(-15.0, -100.0)
+            LogicalPosition::zero(),
+            "an unscrolled container reports zero wherever it sits"
+        );
+
+        offsets.insert(
+            node_by_class(&sd, "root"),
+            scroll_at((10.0, 120.0), (5.0, 80.0)),
+        );
+        assert_eq!(
+            find_nearest_scroll_offset(&tree, 1, &offsets),
+            LogicalPosition::new(5.0, 80.0),
+            "the offset is reported verbatim, not relative to the container"
         );
     }
 
@@ -1998,11 +2023,11 @@ mod autotest_generated {
     fn find_nearest_scroll_offset_picks_the_nearest_ancestor() {
         let (sd, tree) = three_level("");
         let mut offsets = BTreeMap::new();
-        offsets.insert(node_by_class(&sd, "root"), scroll_at((0.0, 0.0), (0.0, -999.0)));
-        offsets.insert(node_by_class(&sd, "mid"), scroll_at((0.0, 0.0), (0.0, -7.0)));
+        offsets.insert(node_by_class(&sd, "root"), scroll_at((0.0, 40.0), (0.0, 999.0)));
+        offsets.insert(node_by_class(&sd, "mid"), scroll_at((0.0, 120.0), (0.0, 7.0)));
         assert_eq!(
             find_nearest_scroll_offset(&tree, 2, &offsets),
-            LogicalPosition::new(0.0, -7.0),
+            LogicalPosition::new(0.0, 7.0),
             "mid wins over root"
         );
     }
@@ -2012,10 +2037,10 @@ mod autotest_generated {
         let (sd, mut tree) = three_level("");
         tree.nodes[1].dom_node_id = None;
         let mut offsets = BTreeMap::new();
-        offsets.insert(node_by_class(&sd, "root"), scroll_at((0.0, 0.0), (0.0, -30.0)));
+        offsets.insert(node_by_class(&sd, "root"), scroll_at((0.0, 120.0), (0.0, 30.0)));
         assert_eq!(
             find_nearest_scroll_offset(&tree, 2, &offsets),
-            LogicalPosition::new(0.0, -30.0)
+            LogicalPosition::new(0.0, 30.0)
         );
     }
 
@@ -2028,11 +2053,12 @@ mod autotest_generated {
             scroll_at((f32::MAX, f32::MAX), (f32::MIN, f32::MIN)),
         );
         let got = find_nearest_scroll_offset(&tree, 1, &offsets);
-        // MIN - MAX overflows f32 → -inf. It must not be NaN (which would poison
-        // every downstream sticky comparison silently).
+        // No arithmetic is performed any more, so an extreme offset passes
+        // through as-is instead of overflowing to -inf. It must never be NaN
+        // (which would poison every downstream sticky comparison silently).
         assert!(!got.x.is_nan() && !got.y.is_nan());
-        assert_eq!(got.x, f32::NEG_INFINITY);
-        assert_eq!(got.y, f32::NEG_INFINITY);
+        assert_eq!(got.x, f32::MIN);
+        assert_eq!(got.y, f32::MIN);
     }
 
     // ==================================================================
@@ -2622,10 +2648,30 @@ mod autotest_generated {
             );
             let root = node_by_class(&env.styled_dom, "root");
             let mut offsets = BTreeMap::new();
-            offsets.insert(root, scroll_at((0.0, 0.0), (0.0, 50.0)));
+            // The container sits 120px down the window (the AzWriter document
+            // view under the ribbon) — its absolute origin must not leak into
+            // the scroll amount. Scrolled by 50, it must behave exactly like a
+            // container at the window origin scrolled by 50.
+            offsets.insert(root, scroll_at((0.0, 120.0), (0.0, 50.0)));
             run_sticky(&mut env, &tree, &mut pos, &offsets);
             // sticky edge = scrollport.y (0) + scroll (50) + inset (10).
             assert_eq!(pos[1].y, 60.0);
+        }
+
+        #[test]
+        fn sticky_does_not_move_when_a_low_container_is_unscrolled() {
+            // REGRESSION: `find_nearest_scroll_offset` used to return
+            // `children_rect.origin - parent_rect.origin`, so this container —
+            // at y = 120 with the scroll offset still at zero — reported -120
+            // and pushed the sticky box a screenful out of its scrollport.
+            let (mut env, tree, mut pos) = sticky_fixture(
+                ".root { overflow-y: scroll; } .child { position: sticky; top: 10px; }",
+            );
+            let root = node_by_class(&env.styled_dom, "root");
+            let mut offsets = BTreeMap::new();
+            offsets.insert(root, scroll_at((0.0, 120.0), (0.0, 0.0)));
+            run_sticky(&mut env, &tree, &mut pos, &offsets);
+            assert_eq!(pos[1].y, 10.0, "unscrolled: only the inset applies");
         }
 
         #[test]

--- a/layout/src/solver3/scrollbar.rs
+++ b/layout/src/solver3/scrollbar.rs
@@ -108,7 +108,8 @@ impl Default for ScrollbarGeometry {
 /// - `inner_rect`: The padding-box (border-box minus borders) of the scroll container,
 ///   in the container's coordinate space (absolute window coordinates)
 /// - `content_size`: Total content size (from `get_content_size()` or `virtual_scroll_size`)
-/// - `scroll_offset`: Current scroll offset (y for vertical, x for horizontal; positive = scrolled)
+/// - `scroll_offset`: Current scroll offset (y for vertical, x for horizontal; positive = scrolled).
+///   A negative value is overscroll past the scroll origin and pins the thumb at the track start.
 /// - `scrollbar_width_px`: CSS-resolved scrollbar thickness in pixels
 /// - `has_other_scrollbar`: Whether the perpendicular scrollbar is also visible
 ///   (reduces track length by one `scrollbar_width_px` for the corner)
@@ -212,8 +213,13 @@ fn compute_thumb_geometry(
         .min(usable_track_length);
 
     let max_scroll = (content_length - viewport_length).max(0.0);
+    // A negative offset only ever comes from the rubber-band overscroll of
+    // `ScrollManager::set_scroll_position_unclamped` (every other writer clamps to
+    // `[0, max_scroll]`), i.e. the user is pulling *past the scroll origin* — the
+    // clamp below pins the thumb at the start of the track. Taking the absolute
+    // value instead would send it down the track while the pull goes up.
     let scroll_ratio = if max_scroll > 0.0 {
-        (scroll_offset.abs() / max_scroll).clamp(0.0, 1.0)
+        (scroll_offset / max_scroll).clamp(0.0, 1.0)
     } else {
         0.0
     };
@@ -570,15 +576,13 @@ mod autotest_generated {
     }
 
     #[test]
-    fn negative_scroll_offsets_are_taken_by_absolute_value() {
-        let pos = compute_scrollbar_geometry(
-            ScrollbarOrientation::Vertical,
-            rect(0.0, 0.0, 100.0, 200.0),
-            LogicalSize::new(100.0, 400.0),
-            50.0,
-            15.0,
-            false,
-        );
+    fn a_negative_overscroll_offset_pins_the_thumb_to_the_start_of_the_track() {
+        // The only writer that can produce a negative offset is the physics timer's
+        // `set_scroll_position_unclamped` rubber-band, i.e. the user pulling past the
+        // top. The thumb must stay parked at the track start, NOT mirror the pull
+        // downwards the way an `.abs()` on the ratio used to make it.
+        //   usable = 200 - 2*15 = 170, thumb = max(170 * 200/400, 30) = 85,
+        //   max_scroll = 200 -> travel = 85.
         let neg = compute_scrollbar_geometry(
             ScrollbarOrientation::Vertical,
             rect(0.0, 0.0, 100.0, 200.0),
@@ -587,9 +591,21 @@ mod autotest_generated {
             15.0,
             false,
         );
-        approx(neg.scroll_ratio, pos.scroll_ratio);
-        approx(neg.thumb_offset, pos.thumb_offset);
-        assert!(neg.thumb_offset >= 0.0);
+        approx(neg.scroll_ratio, 0.0);
+        approx(neg.thumb_offset, 0.0);
+
+        // ...and the mirrored positive offset is a genuinely different position.
+        let pos = compute_scrollbar_geometry(
+            ScrollbarOrientation::Vertical,
+            rect(0.0, 0.0, 100.0, 200.0),
+            LogicalSize::new(100.0, 400.0),
+            50.0,
+            15.0,
+            false,
+        );
+        approx(pos.scroll_ratio, 0.25);
+        approx(pos.thumb_offset, 21.25);
+        assert!(pos.thumb_offset > neg.thumb_offset);
     }
 
     #[test]
@@ -794,7 +810,11 @@ mod autotest_generated {
 
     #[test]
     fn infinite_scroll_offsets_saturate_the_scroll_ratio() {
-        for offset in [f32::INFINITY, f32::NEG_INFINITY] {
+        // +INF saturates at the END of the track; -INF is an overscroll past
+        // the start and PINS AT 0 (the `.abs()` that used to mirror it down
+        // the track was removed with the origin-convention fix — see
+        // `a_negative_overscroll_offset_pins_the_thumb_to_the_start_of_the_track`).
+        for (offset, want_ratio) in [(f32::INFINITY, 1.0), (f32::NEG_INFINITY, 0.0)] {
             let g = compute_scrollbar_geometry(
                 ScrollbarOrientation::Vertical,
                 rect(0.0, 0.0, 100.0, 200.0),
@@ -803,8 +823,11 @@ mod autotest_generated {
                 15.0,
                 false,
             );
-            approx(g.scroll_ratio, 1.0);
-            approx(g.thumb_offset, g.usable_track_length - g.thumb_length);
+            approx(g.scroll_ratio, want_ratio);
+            approx(
+                g.thumb_offset,
+                (g.usable_track_length - g.thumb_length) * want_ratio,
+            );
         }
     }
 

--- a/layout/src/solver3/sizing.rs
+++ b/layout/src/solver3/sizing.rs
@@ -3316,7 +3316,7 @@ mod autotest_generated {
 
     fn text_dom(text: &str) -> StyledDom {
         styled(
-            Dom::create_body().with_child(div_class("p").with_child(Dom::create_text(text))),
+            Dom::create_body().with_child(div_class("p").with_child(Dom::create_text_do_not_use_without_block_level_wrapper(text))),
             ".p { display: block; }",
         )
     }
@@ -3447,7 +3447,7 @@ mod autotest_generated {
     fn subtree_contains_text_walks_a_deeply_nested_subtree() {
         // The recursion is unbounded in depth — 200 levels must not blow up.
         const DEPTH: usize = 200;
-        let mut inner = Dom::create_div().with_child(Dom::create_text("deep"));
+        let mut inner = Dom::create_div().with_child(Dom::create_text_do_not_use_without_block_level_wrapper("deep"));
         for _ in 0..DEPTH {
             inner = Dom::create_div().with_child(inner);
         }

--- a/layout/src/solver3/sizing.rs
+++ b/layout/src/solver3/sizing.rs
@@ -1,5 +1,6 @@
 //! Intrinsic and used size calculations for layout nodes
 
+use crate::solver3::layout_tree::LayoutNodeId;
 use crate::debug_log;
 use std::{
     collections::BTreeSet,
@@ -197,7 +198,7 @@ pub fn calculate_intrinsic_sizes<T: ParsedFontTrait>(
     unsafe {
         crate::az_mark(0x60730_u32, (tree.root as u32));
         crate::az_mark(0x60734_u32, (tree.nodes.len() as u32));
-        crate::az_mark(0x60738_u32, u32::from(tree.get(tree.root).is_some()));
+        crate::az_mark(0x60738_u32, u32::from(tree.get(LayoutNodeId::new(tree.root)).is_some()));
         // [az-diag g55] 0x4075C = the `tree` ptr the CALLEE sees. Compare with 0x40748
         // (caller's &new_tree). Same → nodes-field-offset mis-lift; differ → &mut arg mis-passed.
         crate::az_mark(0x6075C_u32, ((std::ptr::from_ref::<LayoutTree>(tree) as usize) as u32));
@@ -218,7 +219,7 @@ pub(crate) fn compute_dirty_ancestor_closure(
             if !closure.insert(idx) {
                 break;
             }
-            cur = tree.get(idx).and_then(|n| n.parent);
+            cur = tree.get(LayoutNodeId::new(idx)).and_then(|n| n.parent);
         }
     }
     closure
@@ -268,7 +269,7 @@ impl<'a, 'b, 'c, T: ParsedFontTrait> IntrinsicSizeCalculator<'a, 'b, 'c, T> {
         if let Some(closure) = self.dirty_closure.as_ref() {
             if !closure.contains(&node_index) {
                 if let Some(cached) = tree
-                    .warm(node_index)
+                    .warm(LayoutNodeId::new(node_index))
                     .and_then(|w| w.intrinsic_sizes)
                 {
                     drop(crate::probe::Probe::span("intrinsic_cache_hit"));
@@ -297,7 +298,7 @@ impl<'a, 'b, 'c, T: ParsedFontTrait> IntrinsicSizeCalculator<'a, 'b, 'c, T> {
                 .is_some_and(|v| !v)
         {
             let default = IntrinsicSizes::default();
-            if let Some(n) = tree.warm_mut(node_index) {
+            if let Some(n) = tree.warm_mut(LayoutNodeId::new(node_index)) {
                 n.intrinsic_sizes = Some(default);
             }
             return Ok(default);
@@ -309,7 +310,7 @@ impl<'a, 'b, 'c, T: ParsedFontTrait> IntrinsicSizeCalculator<'a, 'b, 'c, T> {
         // Vec<usize> for children and a TaffyCache on every recursion
         // (~300x on excel.html).
         let dom_node_id = tree
-            .get(node_index)
+            .get(LayoutNodeId::new(node_index))
             .ok_or(LayoutError::InvalidTree)?
             .dom_node_id;
 
@@ -341,7 +342,7 @@ impl<'a, 'b, 'c, T: ParsedFontTrait> IntrinsicSizeCalculator<'a, 'b, 'c, T> {
         // Propagate STF flag: children inherit `ancestor_is_stf=true` if any
         // ancestor up to and including self is STF.
         let self_is_stf = tree
-            .get(node_index)
+            .get(LayoutNodeId::new(node_index))
             .is_some_and(|n| {
                 crate::solver3::layout_tree::is_shrink_to_fit_context(
                     self.ctx.styled_dom,
@@ -361,7 +362,7 @@ impl<'a, 'b, 'c, T: ParsedFontTrait> IntrinsicSizeCalculator<'a, 'b, 'c, T> {
             // at line ~226 and abort the WHOLE intrinsic-sizing pass. Skip gracefully so
             // measurement continues — mirrors process_layout_children's guard (line ~1079).
             // REAL fix = reconcile not listing the stray child.
-            if tree.get(child_index).is_none() {
+            if tree.get(LayoutNodeId::new(child_index)).is_none() {
                 continue;
             }
             let child_intrinsic =
@@ -374,7 +375,7 @@ impl<'a, 'b, 'c, T: ParsedFontTrait> IntrinsicSizeCalculator<'a, 'b, 'c, T> {
         let mut intrinsic = self.calculate_node_intrinsic_sizes(tree, node_index, &child_intrinsics)?;
 
         // +spec:min-max-sizing:970fef - if min-width/min-height is a <length>, use as floor for intrinsic sizes
-        if let Some(dom_id) = tree.get(node_index).and_then(|n| n.dom_node_id) {
+        if let Some(dom_id) = tree.get(LayoutNodeId::new(node_index)).and_then(|n| n.dom_node_id) {
             use crate::solver3::getters::{get_css_min_width, get_css_min_height, MultiValue};
 
             let node_state = &self.ctx.styled_dom.styled_nodes.as_container()[dom_id].styled_node_state;
@@ -400,7 +401,7 @@ impl<'a, 'b, 'c, T: ParsedFontTrait> IntrinsicSizeCalculator<'a, 'b, 'c, T> {
                     _ => LayoutBoxSizing::ContentBox,
                 };
                 let bp = tree
-                    .get(node_index)
+                    .get(LayoutNodeId::new(node_index))
                     .map(|n| n.box_props.unpack())
                     .unwrap_or_default();
                 if let MultiValue::Exact(LayoutWidth::Px(px)) =
@@ -446,7 +447,7 @@ impl<'a, 'b, 'c, T: ParsedFontTrait> IntrinsicSizeCalculator<'a, 'b, 'c, T> {
             }
         }
 
-        if let Some(n) = tree.warm_mut(node_index) {
+        if let Some(n) = tree.warm_mut(LayoutNodeId::new(node_index)) {
             n.intrinsic_sizes = Some(intrinsic);
         }
 
@@ -467,7 +468,7 @@ impl<'a, 'b, 'c, T: ParsedFontTrait> IntrinsicSizeCalculator<'a, 'b, 'c, T> {
         node_index: usize,
         child_intrinsics: &[(usize, IntrinsicSizes)],
     ) -> Result<IntrinsicSizes> {
-        let node = tree.get(node_index).ok_or(LayoutError::InvalidTree)?;
+        let node = tree.get(LayoutNodeId::new(node_index)).ok_or(LayoutError::InvalidTree)?;
 
         // +spec:block-formatting-context:30def2 - replaced elements use physical 300x150 default, not re-oriented by writing-mode
         // +spec:display-property:015c41 - replaced elements default to 300x150 intrinsic size per css-sizing-3 §5.1
@@ -562,7 +563,7 @@ impl<'a, 'b, 'c, T: ParsedFontTrait> IntrinsicSizeCalculator<'a, 'b, 'c, T> {
                 // FormattingContext::Inline (meaning "establishes IFC for its children"),
                 // which is different from being an inline element itself.
                 let has_block_child = tree.children(node_index).iter().any(|&child_idx| {
-                    tree.get(child_idx)
+                    tree.get(LayoutNodeId::new(child_idx))
                         .and_then(|c| c.dom_node_id)
                         .is_some_and(|dom_id| {
                             let node_data = &self.ctx.styled_dom.node_data.as_container()[dom_id];
@@ -576,7 +577,7 @@ impl<'a, 'b, 'c, T: ParsedFontTrait> IntrinsicSizeCalculator<'a, 'b, 'c, T> {
                 });
 
                 let has_inline_child = tree.children(node_index).iter().any(|&child_idx| {
-                    tree.get(child_idx)
+                    tree.get(LayoutNodeId::new(child_idx))
                         .and_then(|c| c.dom_node_id)
                         .is_some_and(|dom_id| {
                             let node_data = &self.ctx.styled_dom.node_data.as_container()[dom_id];
@@ -664,7 +665,7 @@ impl<'a, 'b, 'c, T: ParsedFontTrait> IntrinsicSizeCalculator<'a, 'b, 'c, T> {
                 // Check layout tree children AND direct DOM text children (text nodes
                 // are not in the layout tree, only in the DOM).
                 let has_inline_children = tree.children(node_index).iter().any(|&child_idx| {
-                    tree.get(child_idx)
+                    tree.get(LayoutNodeId::new(child_idx))
                         .is_some_and(|c| matches!(c.formatting_context, FormattingContext::Inline))
                 });
 
@@ -765,7 +766,7 @@ impl<'a, 'b, 'c, T: ParsedFontTrait> IntrinsicSizeCalculator<'a, 'b, 'c, T> {
         // element reports a min-content SMALLER than its true unbreakable width and
         // the flex/shrink-to-fit algorithm clips it.
         let mut constraints = UnifiedConstraints::default();
-        if let Some(dom_id) = tree.get(node_index).and_then(|n| n.dom_node_id) {
+        if let Some(dom_id) = tree.get(LayoutNodeId::new(node_index)).and_then(|n| n.dom_node_id) {
             use crate::solver3::getters::{get_white_space_property, MultiValue};
             use azul_css::props::style::text::StyleWhiteSpace;
             let node_state =
@@ -865,7 +866,7 @@ impl<'a, 'b, 'c, T: ParsedFontTrait> IntrinsicSizeCalculator<'a, 'b, 'c, T> {
         node_index: usize,
         child_intrinsics: &[(usize, IntrinsicSizes)],
     ) -> Result<IntrinsicSizes> {
-        let node = tree.get(node_index).ok_or(LayoutError::InvalidTree)?;
+        let node = tree.get(LayoutNodeId::new(node_index)).ok_or(LayoutError::InvalidTree)?;
         let writing_mode = node.dom_node_id.map_or_else(LayoutWritingMode::default, |dom_id| {
             let node_state =
                 &self.ctx.styled_dom.styled_nodes.as_container()[dom_id].styled_node_state;
@@ -889,7 +890,7 @@ impl<'a, 'b, 'c, T: ParsedFontTrait> IntrinsicSizeCalculator<'a, 'b, 'c, T> {
         for &child_index in tree.children(node_index) {
             if let Some(child_intrinsic) = child_intrinsics.iter().find(|(k, _)| k == &child_index).map(|(_, v)| v) {
                 // +spec:intrinsic-sizing:ed72bb - intrinsic contributions based on outer size, auto margins as zero
-                let child_node = tree.get(child_index);
+                let child_node = tree.get(LayoutNodeId::new(child_index));
                 let (cross_extras, main_border_padding, main_margin_start, main_margin_end) =
                     child_node.map_or((0.0, 0.0, 0.0, 0.0), |cn| {
                         let bp = cn.box_props.unpack();
@@ -977,7 +978,7 @@ impl<'a, 'b, 'c, T: ParsedFontTrait> IntrinsicSizeCalculator<'a, 'b, 'c, T> {
         node_index: usize,
         child_intrinsics: &[(usize, IntrinsicSizes)],
     ) -> Result<IntrinsicSizes> {
-        let node = tree.get(node_index).ok_or(LayoutError::InvalidTree)?;
+        let node = tree.get(LayoutNodeId::new(node_index)).ok_or(LayoutError::InvalidTree)?;
 
         // Determine flex-direction to know if main axis is horizontal or vertical
         let is_row = node.dom_node_id.is_none_or(|dom_id| {
@@ -1082,13 +1083,13 @@ impl<'a, 'b, 'c, T: ParsedFontTrait> IntrinsicSizeCalculator<'a, 'b, 'c, T> {
         // Iterate rows — children may be row groups (thead/tbody/tfoot) or direct rows
         let mut rows: Vec<usize> = Vec::new();
         for &child_idx in tree.children(node_index) {
-            let Some(child) = tree.get(child_idx) else { continue };
+            let Some(child) = tree.get(LayoutNodeId::new(child_idx)) else { continue };
             match child.formatting_context {
                 FormattingContext::TableRow => rows.push(child_idx),
                 FormattingContext::TableRowGroup => {
                     // Row group contains rows
                     for &row_idx in tree.children(child_idx) {
-                        if let Some(row) = tree.get(row_idx) {
+                        if let Some(row) = tree.get(LayoutNodeId::new(row_idx)) {
                             if matches!(row.formatting_context, FormattingContext::TableRow) {
                                 rows.push(row_idx);
                             }
@@ -1114,7 +1115,7 @@ impl<'a, 'b, 'c, T: ParsedFontTrait> IntrinsicSizeCalculator<'a, 'b, 'c, T> {
                 };
 
                 // Add cell box-model extras
-                let cell_node = tree.get(cell_idx);
+                let cell_node = tree.get(LayoutNodeId::new(cell_idx));
                 let (h_extras, v_extras) = cell_node.map_or((0.0, 0.0), |cn| {
                     let bp = cn.box_props.unpack();
                     (bp.padding.left + bp.padding.right + bp.border.left + bp.border.right,
@@ -1207,7 +1208,7 @@ fn collect_inline_content_recursive<T: ParsedFontTrait>(
     // visible even though a PRIOR successful call already wrote B8. This is the suspected
     // InvalidTree site (phase stuck at 0xA0 + B8 reached ⇒ a 2nd IFC call fails at this get).
     unsafe { crate::az_mark(0x60754_u32, (node_index as u32)); }
-    let Some(node) = tree.get(node_index) else {
+    let Some(node) = tree.get(LayoutNodeId::new(node_index)) else {
         unsafe { crate::az_mark(0x6071C_u32, (0xBADu32)); }
         return Err(LayoutError::InvalidTree);
     };
@@ -1298,7 +1299,7 @@ fn process_layout_children<T: ParsedFontTrait>(
         // InvalidTree BEFORE the inline text got measured → label height 0. Skip gracefully so
         // measurement continues (the inline text is collected separately above, at the
         // collect_inline_content_recursive DOM-children loop). REAL fix = reconcile not listing it.
-        let Some(child_node) = tree.get(child_index) else { continue; };
+        let Some(child_node) = tree.get(LayoutNodeId::new(child_index)) else { continue; };
         let Some(child_dom_id) = child_node.dom_node_id else {
             continue;
         };
@@ -1315,7 +1316,7 @@ fn process_layout_children<T: ParsedFontTrait>(
             // Non-inline children are treated as atomic inline-level boxes
             // (e.g., inline-block, images, floats)
             // Their intrinsic size must have been calculated in the bottom-up pass
-            let intrinsic_sizes = tree.warm(child_index).and_then(|w| w.intrinsic_sizes).unwrap_or_default();
+            let intrinsic_sizes = tree.warm(LayoutNodeId::new(child_index)).and_then(|w| w.intrinsic_sizes).unwrap_or_default();
 
             // CSS 2.2 § 10.3.9: For inline-block elements with explicit CSS width/height,
             // use the CSS-defined values instead of intrinsic sizes.
@@ -2500,11 +2501,11 @@ mod autotest_generated {
 
     /// The single layout index of a DOM node (fixtures never produce splits).
     fn layout_index(tree: &LayoutTree, dom_id: NodeId) -> usize {
-        *tree
-            .dom_to_layout
+        tree.dom_to_layout
             .get(&dom_id)
             .and_then(|v| v.first())
             .expect("DOM node has a layout node")
+            .index()
     }
 
     // ==================================================================
@@ -2891,14 +2892,14 @@ mod autotest_generated {
         let r = calc.calculate_intrinsic_recursive(&mut tree, 0, false);
         let sizes = r.expect("a stray child index must be skipped, not fatal");
         assert!(sizes.min_content_width.is_finite());
-        assert!(tree.warm(0).and_then(|w| w.intrinsic_sizes).is_some());
+        assert!(tree.warm(LayoutNodeId::new(0)).and_then(|w| w.intrinsic_sizes).is_some());
     }
 
     #[test]
     fn calculate_intrinsic_recursive_reuses_the_cache_for_nodes_outside_the_dirty_closure() {
         let mut tree = chain_tree();
         let cached = isz(11.0, 22.0, 33.0, 44.0);
-        tree.warm_mut(0)
+        tree.warm_mut(LayoutNodeId::new(0))
             .expect("root warm slot")
             .intrinsic_sizes = Some(cached);
 
@@ -2918,7 +2919,7 @@ mod autotest_generated {
         assert_eq!(sizes.min_content_height, 33.0);
         assert_eq!(sizes.max_content_height, 44.0);
         // Children were never visited, so their warm slots stay empty.
-        assert!(tree.warm(1).and_then(|w| w.intrinsic_sizes).is_none());
+        assert!(tree.warm(LayoutNodeId::new(1)).and_then(|w| w.intrinsic_sizes).is_none());
     }
 
     // ==================================================================
@@ -3254,7 +3255,7 @@ mod autotest_generated {
         // max-content (+spec:min-max-sizing:970fef).
         let a = layout_index(&tree, NodeId::new(2));
         let a_sizes = tree
-            .warm(a)
+            .warm(LayoutNodeId::new(a))
             .and_then(|w| w.intrinsic_sizes)
             .expect("`.a` was measured");
         assert_eq!(a_sizes.min_content_width, 120.0);
@@ -3265,7 +3266,7 @@ mod autotest_generated {
         // The flex container aggregates its single item on both axes.
         let f = layout_index(&tree, NodeId::new(1));
         let f_sizes = tree
-            .warm(f)
+            .warm(LayoutNodeId::new(f))
             .and_then(|w| w.intrinsic_sizes)
             .expect("`.flex` was measured");
         assert_eq!(f_sizes.min_content_width, 120.0);
@@ -3285,7 +3286,7 @@ mod autotest_generated {
 
         calculate_intrinsic_sizes(&mut ctx, &mut tree, &mut text_cache, &dirty)
             .expect("stale dirty ids must be ignored, not fatal");
-        let root = tree.warm(tree.root).and_then(|w| w.intrinsic_sizes);
+        let root = tree.warm(LayoutNodeId::new(tree.root)).and_then(|w| w.intrinsic_sizes);
         assert!(root.is_some(), "the root is still measured");
     }
 
@@ -3299,10 +3300,10 @@ mod autotest_generated {
 
         calculate_intrinsic_sizes(&mut ctx, &mut tree, &mut text_cache, &dirty).expect("pass 1");
         let a = layout_index(&tree, NodeId::new(2));
-        let first = tree.warm(a).and_then(|w| w.intrinsic_sizes).expect("measured");
+        let first = tree.warm(LayoutNodeId::new(a)).and_then(|w| w.intrinsic_sizes).expect("measured");
 
         calculate_intrinsic_sizes(&mut ctx, &mut tree, &mut text_cache, &dirty).expect("pass 2");
-        let second = tree.warm(a).and_then(|w| w.intrinsic_sizes).expect("measured");
+        let second = tree.warm(LayoutNodeId::new(a)).and_then(|w| w.intrinsic_sizes).expect("measured");
 
         assert_eq!(first.min_content_width, second.min_content_width);
         assert_eq!(first.max_content_width, second.max_content_width);
@@ -3340,7 +3341,7 @@ mod autotest_generated {
             .get(&text_dom)
             .and_then(|v| v.first())
             .copied()
-            .unwrap_or_else(|| layout_index(tree, block_dom))
+            .unwrap_or_else(|| LayoutNodeId::new(layout_index(tree, block_dom))).index()
     }
 
     #[test]

--- a/layout/src/solver3/taffy_bridge.rs
+++ b/layout/src/solver3/taffy_bridge.rs
@@ -7,6 +7,7 @@
 //! which is called from `fc.rs` when a flex or grid formatting context is
 //! encountered during layout.
 
+use crate::solver3::layout_tree::LayoutNodeId;
 use crate::solver3::calc::CalcResolveContext;
 use crate::solver3::getters::{get_overflow_x, get_overflow_y};
 use azul_core::dom::FormattingContext;
@@ -383,7 +384,7 @@ fn compute_taffy_scrollbar_info<T: ParsedFontTrait>(
 ) -> (crate::solver3::scrollbar::ScrollbarRequirements, f32, f32) {
     use crate::solver3::scrollbar::ScrollbarRequirements;
 
-    let node = tree.get(node_idx);
+    let node = tree.get(LayoutNodeId::new(node_idx));
     let dom_id = node.and_then(|n| n.dom_node_id);
 
     let Some(dom_id) = dom_id else {
@@ -400,7 +401,7 @@ fn compute_taffy_scrollbar_info<T: ParsedFontTrait>(
 
     // Compute padding + border from the node's box_props
     let (padding_width, padding_height, border_width, border_height, border_left, border_top) = tree
-        .get(node_idx)
+        .get(LayoutNodeId::new(node_idx))
         .map_or((0.0, 0.0, 0.0, 0.0, 0.0, 0.0), |node| {
             let bp = node.box_props.unpack();
             (
@@ -1216,7 +1217,7 @@ impl<'a, 'b, T: ParsedFontTrait> TaffyBridge<'a, 'b, T> {
 
     /// Gets or computes the Taffy style for a given node index.
     fn get_taffy_style(&self, node_idx: usize) -> Style {
-        let dom_id = self.tree.get(node_idx).and_then(|n| n.dom_node_id);
+        let dom_id = self.tree.get(LayoutNodeId::new(node_idx)).and_then(|n| n.dom_node_id);
         let mut style = self.translate_style_to_taffy_cached(dom_id);
         
         // CSS 2.1 § 10.3.3: Root element margin handling for Flex/Grid.
@@ -1234,7 +1235,7 @@ impl<'a, 'b, T: ParsedFontTrait> TaffyBridge<'a, 'b, T> {
         // Zeroing the style margin for root nodes prevents this double-subtraction.
         // This is NOT a hack — it's the correct integration point between Azul's
         // BFC-level sizing and Taffy's Flex/Grid algorithm.
-        let is_root = self.tree.get(node_idx).is_some_and(|n| n.parent.is_none());
+        let is_root = self.tree.get(LayoutNodeId::new(node_idx)).is_some_and(|n| n.parent.is_none());
         if is_root {
             style.margin = Rect::zero();
         }
@@ -1267,12 +1268,12 @@ impl<'a, 'b, T: ParsedFontTrait> TaffyBridge<'a, 'b, T> {
     /// Returns (`suppress_width`, `suppress_height`) booleans.
     #[allow(clippy::match_same_arms)] // enum/value mapping/dispatch table: one arm per input variant (or cross-type bindings that can't merge)
     fn should_suppress_cross_intrinsic(&self, node_idx: usize, style: &Style) -> (bool, bool) {
-        let Some(node) = self.tree.get(node_idx) else {
+        let Some(node) = self.tree.get(LayoutNodeId::new(node_idx)) else {
             return (false, false);
         };
 
         // Check if parent is a flex or grid container
-        let Some(parent_fc) = self.tree.warm(node_idx).and_then(|w| w.parent_formatting_context) else {
+        let Some(parent_fc) = self.tree.warm(LayoutNodeId::new(node_idx)).and_then(|w| w.parent_formatting_context) else {
             return (false, false);
         };
 
@@ -1282,7 +1283,7 @@ impl<'a, 'b, T: ParsedFontTrait> TaffyBridge<'a, 'b, T> {
                 let Some(parent_idx) = node.parent else {
                     return (false, false);
                 };
-                let parent_dom_id = self.tree.get(parent_idx).and_then(|n| n.dom_node_id);
+                let parent_dom_id = self.tree.get(LayoutNodeId::new(parent_idx)).and_then(|n| n.dom_node_id);
                 let parent_style = self.translate_style_to_taffy_cached(parent_dom_id);
 
                 // Determine if flex container is row or column
@@ -1339,14 +1340,14 @@ impl<'a, 'b, T: ParsedFontTrait> TaffyBridge<'a, 'b, T> {
     /// Helper to get children that participate in layout (i.e., not `display: none`).
     fn get_layout_children(&self, node_idx: usize) -> Vec<usize> {
         use crate::solver3::getters::{get_display_property, MultiValue};
-        let Some(node) = self.tree.get(node_idx) else {
+        let Some(node) = self.tree.get(LayoutNodeId::new(node_idx)) else {
             return Vec::new();
         };
 
         self.tree.children(node_idx)
             .iter()
             .filter(|&&child_idx| {
-                let Some(child_node) = self.tree.get(child_idx) else {
+                let Some(child_node) = self.tree.get(LayoutNodeId::new(child_idx)) else {
                     return false;
                 };
                 let Some(child_dom_id) = child_node.dom_node_id else {
@@ -1416,7 +1417,7 @@ pub fn layout_taffy_subtree<T: ParsedFontTrait>(
     let text_cache_ptr = core::ptr::from_mut::<crate::font_traits::TextLayoutCache>(text_cache);
 
     let mut bridge = TaffyBridge::new(ctx, tree, text_cache_ptr);
-    let node = bridge.tree.get(node_idx).unwrap();
+    let node = bridge.tree.get(LayoutNodeId::new(node_idx)).unwrap();
 
     let output = match node.formatting_context {
         FormattingContext::Flex => compute_flexbox_layout(&mut bridge, node_idx.into(), inputs),
@@ -1433,10 +1434,10 @@ pub fn layout_taffy_subtree<T: ParsedFontTrait>(
 
         // Log child layout results
         for &child_idx in &children {
-            if let Some(child) = bridge.tree.get(child_idx) {
+            if let Some(child) = bridge.tree.get(LayoutNodeId::new(child_idx)) {
                 bridge.ctx.debug_info_inner(format!(
                     "[TAFFY CHILD RESULT] child_idx={} used_size={:?} relative_pos={:?}",
-                    child_idx, child.used_size, bridge.tree.warm(child_idx).and_then(|w| w.relative_position)
+                    child_idx, child.used_size, bridge.tree.warm(LayoutNodeId::new(child_idx)).and_then(|w| w.relative_position)
                 ));
             }
         }
@@ -1496,9 +1497,9 @@ impl<T: ParsedFontTrait> LayoutPartialTree for TaffyBridge<'_, '_, T> {
         // Azul expects positions relative to the parent's Content Box origin.
         // We must subtract the parent's border and padding from the Taffy-returned position.
         let (parent_border_left, parent_border_top, parent_padding_left, parent_padding_top) = {
-            if let Some(child) = self.tree.get(node_idx) {
+            if let Some(child) = self.tree.get(LayoutNodeId::new(node_idx)) {
                 if let Some(parent_idx) = child.parent {
-                    self.tree.get(parent_idx).map_or((0.0, 0.0, 0.0, 0.0), |parent| {
+                    self.tree.get(LayoutNodeId::new(parent_idx)).map_or((0.0, 0.0, 0.0, 0.0), |parent| {
                         let pbp = parent.box_props.unpack();
                         (
                             pbp.border.left,
@@ -1515,7 +1516,7 @@ impl<T: ParsedFontTrait> LayoutPartialTree for TaffyBridge<'_, '_, T> {
             }
         };
 
-        if let Some(node) = self.tree.get_mut(node_idx) {
+        if let Some(node) = self.tree.get_mut(LayoutNodeId::new(node_idx)) {
             let size = translate_taffy_size_back(layout.size);
             let mut pos = translate_taffy_point_back(layout.location);
 
@@ -1544,7 +1545,7 @@ impl<T: ParsedFontTrait> LayoutPartialTree for TaffyBridge<'_, '_, T> {
 
             node.used_size = Some(size);
         }
-        if let Some(warm) = self.tree.warm_mut(node_idx) {
+        if let Some(warm) = self.tree.warm_mut(LayoutNodeId::new(node_idx)) {
             let mut pos = translate_taffy_point_back(layout.location);
             pos.x -= parent_border_left + parent_padding_left;
             pos.y -= parent_border_top + parent_padding_top;
@@ -1587,7 +1588,7 @@ impl<T: ParsedFontTrait> LayoutPartialTree for TaffyBridge<'_, '_, T> {
         // Get formatting context
         let fc = self
             .tree
-            .get(node_idx)
+            .get(LayoutNodeId::new(node_idx))
             .map(|s| s.formatting_context)
             .unwrap_or_default();
 
@@ -1620,7 +1621,7 @@ impl<T: ParsedFontTrait> LayoutPartialTree for TaffyBridge<'_, '_, T> {
             None
         };
         if let Some(slot) = pure_measure_slot {
-            if let Some(warm) = self.tree.warm(node_idx) {
+            if let Some(warm) = self.tree.warm(LayoutNodeId::new(node_idx)) {
                 let cached = match slot {
                     0 => warm.measured_content_sizes.0,
                     _ => warm.measured_content_sizes.1,
@@ -1637,7 +1638,7 @@ impl<T: ParsedFontTrait> LayoutPartialTree for TaffyBridge<'_, '_, T> {
             let node_idx: usize = node_id.into();
             let fc = tree
                 .tree
-                .get(node_idx)
+                .get(LayoutNodeId::new(node_idx))
                 .map(|s| s.formatting_context)
                 .unwrap_or_default();
 
@@ -1652,7 +1653,7 @@ impl<T: ParsedFontTrait> LayoutPartialTree for TaffyBridge<'_, '_, T> {
 
         // Populate the pure-measure cache from the result we just computed.
         if let Some(slot) = pure_measure_slot {
-            if let Some(warm) = self.tree.warm_mut(node_idx) {
+            if let Some(warm) = self.tree.warm_mut(LayoutNodeId::new(node_idx)) {
                 match slot {
                     0 => warm.measured_content_sizes.0 = Some(result),
                     _ => warm.measured_content_sizes.1 = Some(result),
@@ -1661,7 +1662,7 @@ impl<T: ParsedFontTrait> LayoutPartialTree for TaffyBridge<'_, '_, T> {
         }
 
         // Store layout for container nodes - Taffy only calls set_unrounded_layout for leaf nodes
-        if let Some(node) = self.tree.get_mut(node_idx) {
+        if let Some(node) = self.tree.get_mut(LayoutNodeId::new(node_idx)) {
             let size = translate_taffy_size_back(result.size);
             node.used_size = Some(size);
         }
@@ -1697,7 +1698,7 @@ impl<T: ParsedFontTrait> LayoutPartialTree for TaffyBridge<'_, '_, T> {
                     ContentSizeOrigin::BorderBox,
                 );
 
-            if let Some(warm) = self.tree.warm_mut(node_idx) {
+            if let Some(warm) = self.tree.warm_mut(LayoutNodeId::new(node_idx)) {
                 warm.scrollbar_info = Some(scrollbar_info);
                 // eff_content_w/h are already in content-box coordinates
                 // (the border+padding inset is subtracted in
@@ -1729,7 +1730,7 @@ impl<T: ParsedFontTrait> TaffyBridge<'_, '_, T> {
         // Get padding/border early so we can convert border-box → content-box.
         let (node_padding_width, node_padding_height, node_border_width, node_border_height) = self
             .tree
-            .get(node_idx)
+            .get(LayoutNodeId::new(node_idx))
             .map_or((0.0, 0.0, 0.0, 0.0), |node| {
                 let bp = node.box_props.unpack();
                 (
@@ -1794,7 +1795,7 @@ impl<T: ParsedFontTrait> TaffyBridge<'_, '_, T> {
         // Get text-align from CSS for this node (important for centering content in flex items)
         let text_align = self
             .tree
-            .get(node_idx)
+            .get(LayoutNodeId::new(node_idx))
             .and_then(|node| node.dom_node_id)
             .map(|dom_id| {
                 let node_state =
@@ -1843,7 +1844,7 @@ impl<T: ParsedFontTrait> TaffyBridge<'_, '_, T> {
         // content). Reset `used_size` to the border-box dims Taffy fixed for THIS
         // measure. When width is unknown (an intrinsic pass), clear it so layout_bfc
         // falls back to `constraints.available_size` (INFINITY → true intrinsic).
-        if let Some(n) = self.tree.get_mut(node_idx) {
+        if let Some(n) = self.tree.get_mut(LayoutNodeId::new(node_idx)) {
             n.used_size = match (inputs.known_dimensions.width, inputs.known_dimensions.height) {
                 (Some(w), Some(h)) => Some(LogicalSize {
                     width: w,
@@ -1899,7 +1900,7 @@ impl<T: ParsedFontTrait> TaffyBridge<'_, '_, T> {
                 // Get intrinsic sizes for min/max-content queries
                 let intrinsic = self
                     .tree
-                    .warm(node_idx)
+                    .warm(LayoutNodeId::new(node_idx))
                     .and_then(|w| w.intrinsic_sizes)
                     .unwrap_or_default();
 
@@ -1916,7 +1917,7 @@ impl<T: ParsedFontTrait> TaffyBridge<'_, '_, T> {
                 // shrink-to-fit its content. This is per CSS 2.1 § 10.3.9: "shrink-to-fit width".
                 let fc = self
                     .tree
-                    .get(node_idx)
+                    .get(LayoutNodeId::new(node_idx))
                     .map(|s| s.formatting_context)
                     .unwrap_or_default();
                 
@@ -1957,7 +1958,7 @@ impl<T: ParsedFontTrait> TaffyBridge<'_, '_, T> {
                 // calculate_used_size_for_node (border-box) — strip padding+border back
                 // to content-box. Fixes blank / 0-height images as flex/grid items.
                 let (effective_content_width, content_height) = {
-                    let dom_id = self.tree.get(node_idx).and_then(|n| n.dom_node_id);
+                    let dom_id = self.tree.get(LayoutNodeId::new(node_idx)).and_then(|n| n.dom_node_id);
                     let is_replaced = dom_id
                         .is_some_and(|id| {
                             let nd = &self.ctx.styled_dom.node_data.as_container()[id];
@@ -1966,7 +1967,7 @@ impl<T: ParsedFontTrait> TaffyBridge<'_, '_, T> {
                         });
                     match (is_replaced, dom_id) {
                         (true, Some(id)) => {
-                            let bp = self.tree.get(node_idx).unwrap().box_props.unpack();
+                            let bp = self.tree.get(LayoutNodeId::new(node_idx)).unwrap().box_props.unpack();
                             crate::solver3::sizing::calculate_used_size_for_node(
                                 self.ctx.styled_dom,
                                 Some(id),
@@ -2003,9 +2004,9 @@ impl<T: ParsedFontTrait> TaffyBridge<'_, '_, T> {
                     // Check if parent is a grid container and available_space is definite
                     let parent_is_grid = self
                         .tree
-                        .get(node_idx)
+                        .get(LayoutNodeId::new(node_idx))
                         .and_then(|n| n.parent)
-                        .and_then(|p| self.tree.get(p))
+                        .and_then(|p| self.tree.get(LayoutNodeId::new(p)))
                         .is_some_and(|p| matches!(p.formatting_context, FormattingContext::Grid));
 
                     if parent_is_grid {
@@ -2027,7 +2028,7 @@ impl<T: ParsedFontTrait> TaffyBridge<'_, '_, T> {
                 // Without this, children of flex items won't have their relative_position set,
                 // causing them to all render at (0,0) relative to their parent.
                 for (child_idx, child_pos) in &output.positions {
-                    if let Some(child_warm) = self.tree.warm_mut(*child_idx) {
+                    if let Some(child_warm) = self.tree.warm_mut(LayoutNodeId::new(*child_idx)) {
                         child_warm.relative_position = Some(*child_pos);
                     }
                 }
@@ -2051,13 +2052,13 @@ impl<T: ParsedFontTrait> TaffyBridge<'_, '_, T> {
                 );
 
                 // Store the border-box size and scrollbar_info on the node for display list generation
-                if let Some(node) = self.tree.get_mut(node_idx) {
+                if let Some(node) = self.tree.get_mut(LayoutNodeId::new(node_idx)) {
                     node.used_size = Some(LogicalSize {
                         width: final_width,
                         height: final_height,
                     });
                 }
-                if let Some(warm) = self.tree.warm_mut(node_idx) {
+                if let Some(warm) = self.tree.warm_mut(LayoutNodeId::new(node_idx)) {
                     warm.scrollbar_info = Some(scrollbar_info);
                     // Store the actual content size for scroll calculations
                     warm.overflow_content_size = Some(LogicalSize {
@@ -2087,7 +2088,7 @@ impl<T: ParsedFontTrait> TaffyBridge<'_, '_, T> {
             }
             Err(_e) => {
                 // Fallback to intrinsic sizes if layout fails
-                let intrinsic = self.tree.warm(node_idx).and_then(|w| w.intrinsic_sizes).unwrap_or_default();
+                let intrinsic = self.tree.warm(LayoutNodeId::new(node_idx)).and_then(|w| w.intrinsic_sizes).unwrap_or_default();
 
                 let width = inputs
                     .known_dimensions
@@ -2119,7 +2120,7 @@ impl<T: ParsedFontTrait> CacheTree for TaffyBridge<'_, '_, T> {
     ) -> Option<LayoutOutput> {
         let node_idx: usize = node_id.into();
         let hit = self.tree
-            .warm(node_idx)?
+            .warm(LayoutNodeId::new(node_idx))?
             .taffy_cache
             .get(input);
         drop(crate::probe::Probe::span(if hit.is_some() {
@@ -2153,7 +2154,7 @@ impl<T: ParsedFontTrait> CacheTree for TaffyBridge<'_, '_, T> {
         layout_output: LayoutOutput,
     ) {
         let node_idx: usize = node_id.into();
-        if let Some(warm) = self.tree.warm_mut(node_idx) {
+        if let Some(warm) = self.tree.warm_mut(LayoutNodeId::new(node_idx)) {
             warm.taffy_cache
                 .store(input, layout_output);
         }
@@ -2162,7 +2163,7 @@ impl<T: ParsedFontTrait> CacheTree for TaffyBridge<'_, '_, T> {
     fn cache_clear(&mut self, node_id: taffy::NodeId) {
         drop(crate::probe::Probe::span("taffy_cache_clear"));
         let node_idx: usize = node_id.into();
-        if let Some(warm) = self.tree.warm_mut(node_idx) {
+        if let Some(warm) = self.tree.warm_mut(LayoutNodeId::new(node_idx)) {
             warm.taffy_cache.clear();
             warm.measured_content_sizes = (None, None);
         }

--- a/layout/src/solver3/taffy_bridge.rs
+++ b/layout/src/solver3/taffy_bridge.rs
@@ -350,6 +350,18 @@ use crate::{
     },
 };
 
+/// Coordinate space the `taffy_content_*` arguments of
+/// [`compute_taffy_scrollbar_info`] are measured in.
+#[derive(Copy, Clone, PartialEq, Eq)]
+enum ContentSizeOrigin {
+    /// Taffy's `LayoutOutput::content_size`: child extents measured from the
+    /// BORDER-BOX origin, so the leading border + padding ride along as an
+    /// offset and the flex path adds the trailing padding on top.
+    BorderBox,
+    /// Our own BFC/IFC `overflow_size`, already relative to the content box.
+    ContentBox,
+}
+
 /// Shared scrollbar detection for Taffy-managed flex/grid nodes.
 ///
 /// When Taffy lays out a flex/grid container, it may expand the container
@@ -367,6 +379,7 @@ fn compute_taffy_scrollbar_info<T: ParsedFontTrait>(
     result_height: f32,
     taffy_content_width: f32,
     taffy_content_height: f32,
+    content_origin: ContentSizeOrigin,
 ) -> (crate::solver3::scrollbar::ScrollbarRequirements, f32, f32) {
     use crate::solver3::scrollbar::ScrollbarRequirements;
 
@@ -421,21 +434,35 @@ fn compute_taffy_scrollbar_info<T: ParsedFontTrait>(
         .unwrap_or(result_content_h)
         .max(0.0);
 
-    // Content size: use Taffy's content_size if non-zero,
+    // Content size: use the caller's content_size if non-zero,
     // else result size minus padding/border (Taffy expanded to fit).
     //
-    // IMPORTANT: Taffy's content_size is measured from (0,0) of the border-box,
-    // so it includes border.left/border.top as a leading offset. The container_size
-    // is in content-box coordinates (result_width - padding - border). We must
-    // subtract border.left/top from content_size to align coordinate spaces,
-    // otherwise we get spurious horizontal scrollbars from the border offset.
+    // IMPORTANT: Taffy's content_size is measured from (0,0) of the BORDER box.
+    // Child positions therefore carry border.left/top AND the leading padding as
+    // an offset, and the flex path adds the TRAILING padding on top
+    // (`content_size.height += content_box_inset.bottom - border.bottom`).
+    // container_size below is a content-box size, so the whole inset has to come
+    // off to align the coordinate spaces: subtracting only the border left a
+    // `padding-top: 18px` container reporting content = viewport + 18px, i.e. a
+    // phantom `overflow: auto` scrollbar whose thumb spans ~98% of the track and
+    // whose max_scroll is 18px. Subtracting the padding SUM (leading + trailing)
+    // leaves the pure child extent, so a container whose children fit reports
+    // content == container (no bar) and a genuinely overflowing one keeps
+    // max_scroll = children − content box.
+    //
+    // Our own BFC/IFC overflow_size is already content-box relative and must not
+    // be adjusted at all — hence `content_origin`.
+    let (inset_w, inset_h) = match content_origin {
+        ContentSizeOrigin::BorderBox => (border_left + padding_width, border_top + padding_height),
+        ContentSizeOrigin::ContentBox => (0.0, 0.0),
+    };
     let content_w = if taffy_content_width > 0.0 {
-        (taffy_content_width - border_left).max(0.0)
+        (taffy_content_width - inset_w).max(0.0)
     } else {
         result_content_w.max(0.0)
     };
     let content_h = if taffy_content_height > 0.0 {
-        (taffy_content_height - border_top).max(0.0)
+        (taffy_content_height - inset_h).max(0.0)
     } else {
         result_content_h.max(0.0)
     };
@@ -1667,13 +1694,15 @@ impl<T: ParsedFontTrait> LayoutPartialTree for TaffyBridge<'_, '_, T> {
                     result.size.height,
                     taffy_content_width,
                     taffy_content_height,
+                    ContentSizeOrigin::BorderBox,
                 );
 
             if let Some(warm) = self.tree.warm_mut(node_idx) {
                 warm.scrollbar_info = Some(scrollbar_info);
                 // eff_content_w/h are already in content-box coordinates
-                // (border.left/top subtracted in compute_taffy_scrollbar_info),
-                // so store directly without further subtraction.
+                // (the border+padding inset is subtracted in
+                // compute_taffy_scrollbar_info), so store directly without
+                // further subtraction.
                 warm.overflow_content_size = Some(LogicalSize::new(
                     eff_content_w,
                     eff_content_h,
@@ -2006,6 +2035,10 @@ impl<T: ParsedFontTrait> TaffyBridge<'_, '_, T> {
                 // Compute scrollbar_info for this node (it's a child of a Flex/Grid container,
                 // so calculate_layout_for_subtree won't be called for it).
                 // Uses the unified compute_scrollbar_info_core path.
+                //
+                // content_width/height come from our own BFC/IFC overflow_size,
+                // which is already content-box relative — unlike Taffy's
+                // border-box-origin content_size.
                 let (scrollbar_info, _, _) = compute_taffy_scrollbar_info(
                     self.ctx,
                     self.tree,
@@ -2014,6 +2047,7 @@ impl<T: ParsedFontTrait> TaffyBridge<'_, '_, T> {
                     final_height,
                     content_width,
                     content_height,
+                    ContentSizeOrigin::ContentBox,
                 );
 
                 // Store the border-box size and scrollbar_info on the node for display list generation
@@ -3798,8 +3832,16 @@ mod autotest_generated {
             let tree = generate_layout_tree(&mut ctx).expect("a plain body dom builds");
 
             for idx in [usize::MAX, tree.nodes.len(), tree.nodes.len() + 1] {
-                let (info, w, h) =
-                    compute_taffy_scrollbar_info(&ctx, &tree, idx, 100.0, 100.0, 500.0, 500.0);
+                let (info, w, h) = compute_taffy_scrollbar_info(
+                    &ctx,
+                    &tree,
+                    idx,
+                    100.0,
+                    100.0,
+                    500.0,
+                    500.0,
+                    ContentSizeOrigin::BorderBox,
+                );
                 assert!(!info.needs_horizontal, "#{idx}");
                 assert!(!info.needs_vertical, "#{idx}");
                 assert_eq!(w, 0.0);
@@ -3825,8 +3867,16 @@ mod autotest_generated {
             ];
             for v in extremes {
                 for c in extremes {
-                    let (_info, w, h) =
-                        compute_taffy_scrollbar_info(&ctx, &tree, root, v, v, c, c);
+                    let (_info, w, h) = compute_taffy_scrollbar_info(
+                        &ctx,
+                        &tree,
+                        root,
+                        v,
+                        v,
+                        c,
+                        c,
+                        ContentSizeOrigin::BorderBox,
+                    );
                     assert!(
                         !w.is_nan() && w >= 0.0,
                         "result={v} content={c} → content width {w}"
@@ -3848,8 +3898,16 @@ mod autotest_generated {
 
             // Content far larger than the box: `overflow: visible` still must not
             // ask for scrollbars (only `auto`/`scroll` do).
-            let (info, w, h) =
-                compute_taffy_scrollbar_info(&ctx, &tree, root, 100.0, 100.0, 10_000.0, 10_000.0);
+            let (info, w, h) = compute_taffy_scrollbar_info(
+                &ctx,
+                &tree,
+                root,
+                100.0,
+                100.0,
+                10_000.0,
+                10_000.0,
+                ContentSizeOrigin::BorderBox,
+            );
             assert!(!info.needs_horizontal);
             assert!(!info.needs_vertical);
             assert_eq!(info.scrollbar_width, 0.0);

--- a/layout/src/widgets/accordion.rs
+++ b/layout/src/widgets/accordion.rs
@@ -694,7 +694,7 @@ mod autotest_generated {
 
     #[test]
     fn section_new_stores_args_and_starts_closed() {
-        let content = Dom::create_div().with_child(Dom::create_text("body"));
+        let content = Dom::create_div().with_child(Dom::create_text_do_not_use_without_block_level_wrapper("body"));
         let sec = AccordionSection::new("Title", content.clone());
 
         assert_eq!(sec.title.as_str(), "Title");
@@ -729,7 +729,7 @@ mod autotest_generated {
 
     #[test]
     fn section_with_open_sets_flag_without_touching_other_fields() {
-        let content = Dom::create_text("x");
+        let content = Dom::create_text_do_not_use_without_block_level_wrapper("x");
         let base = AccordionSection::new("t", content.clone());
 
         let opened = base.clone().with_open(true);
@@ -855,8 +855,8 @@ mod autotest_generated {
     #[test]
     fn dom_display_follows_is_open() {
         let acc = Accordion::new(AccordionSectionVec::from_vec(alloc::vec![
-            AccordionSection::new("closed", Dom::create_text("c0")),
-            AccordionSection::new("open", Dom::create_text("c1")).with_open(true),
+            AccordionSection::new("closed", Dom::create_text_do_not_use_without_block_level_wrapper("c0")),
+            AccordionSection::new("open", Dom::create_text_do_not_use_without_block_level_wrapper("c1")).with_open(true),
         ]));
         let dom = acc.dom();
         assert_eq!(dom.children.as_ref().len(), 2);
@@ -926,7 +926,7 @@ mod autotest_generated {
         // deeply nested content + many sections: `estimated_total_children` must
         // still equal the real descendant count, otherwise the compact-DOM arena
         // under-allocates and panics later.
-        let mut deep = Dom::create_text("leaf");
+        let mut deep = Dom::create_text_do_not_use_without_block_level_wrapper("leaf");
         for _ in 0..64 {
             deep = Dom::create_div().with_child(deep);
         }

--- a/layout/src/widgets/accordion.rs
+++ b/layout/src/widgets/accordion.rs
@@ -340,7 +340,7 @@ impl Accordion {
         let mut section_doms: Vec<Dom> = Vec::with_capacity(sections.as_ref().len());
 
         for (index, section) in sections.as_ref().iter().enumerate() {
-            let title = Dom::create_text(section.title.clone())
+            let title = Dom::create_p_with_text(section.title.clone())
                 .with_ids_and_classes(IdOrClassVec::from_const_slice(ACCORDION_TITLE_CLASS))
                 .with_css_props(CssPropertyWithConditionsVec::from_const_slice(
                     ACCORDION_TITLE_STYLE,
@@ -510,10 +510,18 @@ mod autotest_generated {
             .any(|c| matches!(c, Class(s) if s.as_str() == name))
     }
 
-    /// The text of a `NodeType::Text` node (`None` for any other node type).
+    /// The text of a text node, looking through the `<p>` block wrapper the
+    /// label convention mandates (`p > text`).
     fn text_of(node: &Dom) -> Option<&str> {
         match node.root.get_node_type() {
             NodeType::Text(s) => Some(s.as_ref().as_str()),
+            NodeType::P => match node.children.as_ref() {
+                [only] => match only.root.get_node_type() {
+                    NodeType::Text(s) => Some(s.as_ref().as_str()),
+                    _ => None,
+                },
+                _ => None,
+            },
             _ => None,
         }
     }

--- a/layout/src/widgets/alert.rs
+++ b/layout/src/widgets/alert.rs
@@ -360,14 +360,14 @@ impl Alert {
             refany::OptionRefAny,
         };
 
-        let message = Dom::create_text(self.message)
+        let message = Dom::create_p_with_text(self.message)
             .with_ids_and_classes(IdOrClassVec::from_const_slice(ALERT_MESSAGE_CLASS))
             .with_css_props(CssPropertyWithConditionsVec::from_const_slice(ALERT_MESSAGE_STYLE));
 
         let mut children = alloc::vec![message];
 
         if self.dismissible {
-            let close = Dom::create_text(AzString::from_const_str("\u{00D7}"))
+            let close = Dom::create_p_with_text(AzString::from_const_str("\u{00D7}"))
                 .with_ids_and_classes(IdOrClassVec::from_const_slice(ALERT_CLOSE_CLASS))
                 .with_css_props(CssPropertyWithConditionsVec::from_const_slice(ALERT_CLOSE_STYLE))
                 .with_tab_index(TabIndex::Auto)
@@ -477,10 +477,18 @@ mod autotest_generated {
         AlertKind::Danger,
     ];
 
-    /// The text of a `NodeType::Text` node (`None` for any other node type).
+    /// The text of a text node, looking through the `<p>` block wrapper the
+    /// label convention mandates (`p > text`).
     fn text_of(node: &Dom) -> Option<&str> {
         match node.root.get_node_type() {
             NodeType::Text(s) => Some(s.as_ref().as_str()),
+            NodeType::P => match node.children.as_ref() {
+                [only] => match only.root.get_node_type() {
+                    NodeType::Text(s) => Some(s.as_ref().as_str()),
+                    _ => None,
+                },
+                _ => None,
+            },
             _ => None,
         }
     }
@@ -595,8 +603,8 @@ mod autotest_generated {
         let styled = StyledDom::create_from_dom(alert.dom());
         assert_eq!(
             styled.node_hierarchy.as_ref().len(),
-            3,
-            "fixture must flatten to exactly container/message/close"
+            5,
+            "fixture must flatten to container / message <p> + text / close <p> + text"
         );
         styled
     }
@@ -1287,6 +1295,11 @@ mod autotest_generated {
         );
     }
 
+    /// Flat index of the close button in `dismissible_styled_dom`: the tree is
+    /// `0 container / 1 message <p> / 2 message text / 3 close <p> / 4 close text`
+    /// in depth-first pre-order, and the callback sits on the `<p>`.
+    const CLOSE_NODE: usize = 3;
+
     #[test]
     fn dom_is_stable_across_kinds_and_only_the_container_style_changes() {
         for kind in ALL_KINDS {
@@ -1313,8 +1326,8 @@ mod autotest_generated {
     fn dismiss_hides_the_container_and_flips_visible() {
         let mut data = RefAny::new(AlertStateWrapper::default());
 
-        // node 2 == the close button, its parent (node 0) is the container
-        let (update, changes) = run_dismiss(Some(dismissible_styled_dom()), 2, data.clone());
+        // CLOSE_NODE == the close button <p>, its parent (node 0) is the container
+        let (update, changes) = run_dismiss(Some(dismissible_styled_dom()), CLOSE_NODE, data.clone());
 
         assert_eq!(update, Update::DoNothing, "no user callback -> DoNothing");
         assert_eq!(
@@ -1337,7 +1350,7 @@ mod autotest_generated {
             .into(),
         });
 
-        let (update, changes) = run_dismiss(Some(dismissible_styled_dom()), 2, data.clone());
+        let (update, changes) = run_dismiss(Some(dismissible_styled_dom()), CLOSE_NODE, data.clone());
 
         assert_eq!(update, Update::RefreshDom, "the user callback's Update is returned");
         assert_eq!(
@@ -1366,7 +1379,7 @@ mod autotest_generated {
         });
 
         for _ in 0..2 {
-            let (update, changes) = run_dismiss(Some(dismissible_styled_dom()), 2, data.clone());
+            let (update, changes) = run_dismiss(Some(dismissible_styled_dom()), CLOSE_NODE, data.clone());
             assert_eq!(update, Update::RefreshDom);
             assert_eq!(display_writes(&changes), alloc::vec![(0usize, LayoutDisplay::None)]);
         }
@@ -1419,7 +1432,7 @@ mod autotest_generated {
         // the callback-bearing node carries a RefAny of the *wrong* type
         let data = RefAny::new(0xdead_beef_u64);
 
-        let (update, changes) = run_dismiss(Some(dismissible_styled_dom()), 2, data.clone());
+        let (update, changes) = run_dismiss(Some(dismissible_styled_dom()), CLOSE_NODE, data.clone());
 
         assert_eq!(update, Update::DoNothing);
         assert!(
@@ -1440,7 +1453,7 @@ mod autotest_generated {
         let mut payload = entry.refany.clone();
 
         let styled = StyledDom::create_from_dom(dom);
-        let (update, changes) = run_dismiss(Some(styled), 2, payload.clone());
+        let (update, changes) = run_dismiss(Some(styled), CLOSE_NODE, payload.clone());
 
         assert_eq!(update, Update::DoNothing);
         assert_eq!(

--- a/layout/src/widgets/avatar.rs
+++ b/layout/src/widgets/avatar.rs
@@ -242,7 +242,10 @@ impl Avatar {
             Some(image) => Dom::create_image(image)
                 .with_ids_and_classes(IdOrClassVec::from_const_slice(AVATAR_IMAGE_CLASS))
                 .with_css_props(build_image_style(size)),
-            None => Dom::create_text(self.initials)
+            // The initials are a `<p>` for the same reason the image branch is a
+            // replaced node: a raw text child would be a rect-less anonymous box,
+            // so the initials class could never be styled by the author.
+            None => Dom::create_p_with_text(self.initials)
                 .with_ids_and_classes(IdOrClassVec::from_const_slice(AVATAR_INITIALS_CLASS)),
         };
 
@@ -389,11 +392,27 @@ mod autotest_generated {
     }
 
     /// The single child of a rendered avatar DOM (the widget is always
-    /// `container -> [image | text]`).
+    /// `container -> [image | p > text]`).
     fn only_child(dom: &Dom) -> &Dom {
         let children = dom.children.as_ref();
         assert_eq!(children.len(), 1, "an avatar renders exactly one child");
         &children[0]
+    }
+
+    /// The text carried by a text node, looking through the `<p>` block
+    /// wrapper the label convention mandates (`p > text`).
+    fn text_of(node: &Dom) -> Option<&str> {
+        match node.root.get_node_type() {
+            NodeType::Text(s) => Some(s.as_ref().as_str()),
+            NodeType::P => match node.children.as_ref() {
+                [only] => match only.root.get_node_type() {
+                    NodeType::Text(s) => Some(s.as_ref().as_str()),
+                    _ => None,
+                },
+                _ => None,
+            },
+            _ => None,
+        }
     }
 
     // ------------------------------------------------------------------
@@ -872,10 +891,7 @@ mod autotest_generated {
 
             let child = only_child(&dom);
             assert!(has_class(child, "__azul-native-avatar-initials"));
-            match child.root.get_node_type() {
-                NodeType::Text(s) => assert_eq!(s.as_ref().as_str(), "AB"),
-                other => panic!("{size:?}: expected a text child, got {other:?}"),
-            }
+            assert_eq!(text_of(child), Some("AB"), "{size:?}: expected `p > text`");
         }
     }
 
@@ -915,12 +931,15 @@ mod autotest_generated {
         for s in ["", "\0", "e\u{0301}", "\u{5E9}\u{5DC}", long.as_str()] {
             let dom = Avatar::create(AzString::from(s.to_string())).dom();
             let child = only_child(&dom);
-            match child.root.get_node_type() {
-                NodeType::Text(t) => {
-                    assert_eq!(t.as_ref().as_str(), s, "text node mangled the initials");
-                    assert_eq!(t.as_ref().len(), s.len(), "text node changed the byte length");
-                }
-                other => panic!("expected a text child, got {other:?}"),
+            match child.children.as_ref() {
+                [only] => match only.root.get_node_type() {
+                    NodeType::Text(t) => {
+                        assert_eq!(t.as_ref().as_str(), s, "text node mangled the initials");
+                        assert_eq!(t.as_ref().len(), s.len(), "text node changed the byte length");
+                    }
+                    other => panic!("expected a text child, got {other:?}"),
+                },
+                other => panic!("expected `p > text`, got {} grandchildren", other.len()),
             }
         }
     }

--- a/layout/src/widgets/backstage.rs
+++ b/layout/src/widgets/backstage.rs
@@ -660,10 +660,14 @@ impl Backstage {
             if item.gap_before {
                 part_style = merged_style(&part_style, &style.nav_item_gap_style);
             }
+            // The nav item div is display:flex — a raw text run cannot be a
+            // flex item (no anonymous-block wrapping in azul), so the label
+            // gets its `<p>` per the label convention. Caught by `dom_lint`
+            // on its very first run.
             let mut d = Dom::create_div()
                 .with_ids_and_classes(IdOrClassVec::from_const_slice(classes))
                 .with_css_props(part_style)
-                .with_children(DomVec::from_vec(vec![Dom::create_text(item.label)]));
+                .with_children(DomVec::from_vec(vec![Dom::create_p_with_text(item.label)]));
             if let Some(cb) = on_nav_select.as_ref() {
                 d = d.with_callbacks(vec![CoreCallbackData {
                     event: EventFilter::Hover(HoverEventFilter::MouseUp),

--- a/layout/src/widgets/badge.rs
+++ b/layout/src/widgets/badge.rs
@@ -174,13 +174,18 @@ impl Badge {
         s
     }
 
-    /// Converts this badge into a DOM text node with the `__azul-native-badge` class.
+    /// Converts this badge into a `<p>` pill carrying the
+    /// `__azul-native-badge` class and wrapping a bare text node.
+    ///
+    /// The pill's background, padding and border-radius live on the `<p>`: a
+    /// `NodeType::Text` node is always inline-level and owns no rect, so those
+    /// properties would never paint on a raw text node.
     #[inline]
     #[must_use] pub fn dom(self) -> Dom {
         static BADGE_CLASS: &[IdOrClass] =
             &[Class(AzString::from_const_str("__azul-native-badge"))];
 
-        Dom::create_text(self.string)
+        Dom::create_p_with_text(self.string)
             .with_ids_and_classes(IdOrClassVec::from_const_slice(BADGE_CLASS))
             .with_css_props(self.badge_style)
     }
@@ -341,6 +346,22 @@ mod autotest_generated {
     /// The properties of a rendered node's *inline* style, in declaration order.
     fn inline_properties(node: &Dom) -> Vec<CssProperty> {
         node.root.style.iter_inline_properties().map(|(p, _)| p.clone()).collect()
+    }
+
+    /// The text carried by a text node, looking through the `<p>` block
+    /// wrapper the label convention mandates (`p > text`).
+    fn text_of(node: &Dom) -> Option<&str> {
+        match node.root.get_node_type() {
+            NodeType::Text(s) => Some(s.as_ref().as_str()),
+            NodeType::P => match node.children.as_ref() {
+                [only] => match only.root.get_node_type() {
+                    NodeType::Text(s) => Some(s.as_ref().as_str()),
+                    _ => None,
+                },
+                _ => None,
+            },
+            _ => None,
+        }
     }
 
     /// Adversarial badge texts: empty, whitespace, combining marks, ZWJ emoji,
@@ -791,20 +812,25 @@ mod autotest_generated {
     // ------------------------------------------------------------------
 
     #[test]
-    fn dom_is_a_single_classed_text_node_carrying_the_computed_style() {
+    fn dom_is_a_single_classed_pill_carrying_the_computed_style() {
         for kind in ALL_KINDS {
             let badge = Badge::with_kind(AzString::from_const_str("99+"), kind);
             let expected = properties(&badge.badge_style);
             let dom = badge.dom();
 
             assert!(has_class(&dom, "__azul-native-badge"), "{kind:?}: missing the widget class");
-            assert!(dom.children.as_ref().is_empty(), "{kind:?}: a badge is a single text node, not a subtree");
+            assert!(
+                matches!(dom.root.get_node_type(), NodeType::P),
+                "{kind:?}: the pill box must be the <p>, not a rect-less text node"
+            );
+            assert_eq!(dom.children.as_ref().len(), 1, "{kind:?}: a badge is one <p> wrapping one text node");
             assert_eq!(inline_properties(&dom), expected, "{kind:?}: the pill lost its computed style");
+            assert!(
+                inline_properties(&dom.children.as_ref()[0]).is_empty(),
+                "{kind:?}: styling belongs on the <p>, not on the text node"
+            );
 
-            match dom.root.get_node_type() {
-                NodeType::Text(s) => assert_eq!(s.as_ref().as_str(), "99+", "{kind:?}: the label was mangled"),
-                other => panic!("{kind:?}: expected a text node, got {other:?}"),
-            }
+            assert_eq!(text_of(&dom), Some("99+"), "{kind:?}: the label was mangled");
         }
     }
 
@@ -825,12 +851,15 @@ mod autotest_generated {
     fn dom_preserves_adversarial_labels_verbatim() {
         for s in adversarial_strings() {
             let dom = Badge::create(AzString::from(s.clone())).dom();
-            match dom.root.get_node_type() {
-                NodeType::Text(t) => {
-                    assert_eq!(t.as_ref().as_str(), s.as_str(), "the label changed on its way into the DOM");
-                    assert_eq!(t.as_ref().len(), s.len(), "byte length changed (NUL truncation?)");
-                }
-                other => panic!("expected a text node, got {other:?}"),
+            match dom.children.as_ref() {
+                [only] => match only.root.get_node_type() {
+                    NodeType::Text(t) => {
+                        assert_eq!(t.as_ref().as_str(), s.as_str(), "the label changed on its way into the DOM");
+                        assert_eq!(t.as_ref().len(), s.len(), "byte length changed (NUL truncation?)");
+                    }
+                    other => panic!("expected a text node, got {other:?}"),
+                },
+                other => panic!("expected exactly one text child, got {} children", other.len()),
             }
             assert!(has_class(&dom, "__azul-native-badge"));
         }

--- a/layout/src/widgets/breadcrumb.rs
+++ b/layout/src/widgets/breadcrumb.rs
@@ -216,7 +216,7 @@ impl Breadcrumb {
             if is_last {
                 // The current page: muted + bold, non-clickable (no callback).
                 children.push(
-                    Dom::create_text(label.clone())
+                    Dom::create_p_with_text(label.clone())
                         .with_ids_and_classes(IdOrClassVec::from_const_slice(
                             BREADCRUMB_CURRENT_CLASS,
                         ))
@@ -227,7 +227,7 @@ impl Breadcrumb {
             } else {
                 // A clickable crumb link.
                 children.push(
-                    Dom::create_text(label.clone())
+                    Dom::create_p_with_text(label.clone())
                         .with_ids_and_classes(IdOrClassVec::from_const_slice(BREADCRUMB_ITEM_CLASS))
                         .with_css_props(CssPropertyWithConditionsVec::from_const_slice(
                             BREADCRUMB_ITEM_STYLE,
@@ -247,7 +247,7 @@ impl Breadcrumb {
                 );
                 // Separator after every non-last crumb.
                 children.push(
-                    Dom::create_text(SEPARATOR_GLYPH)
+                    Dom::create_p_with_text(SEPARATOR_GLYPH)
                         .with_ids_and_classes(IdOrClassVec::from_const_slice(
                             BREADCRUMB_SEPARATOR_CLASS,
                         ))
@@ -359,10 +359,18 @@ mod autotest_generated {
         StringVec::from_vec((0..n).map(|i| AzString::from(format!("c{i}"))).collect::<Vec<_>>())
     }
 
-    /// The text of a `NodeType::Text` node (`None` for any other node type).
+    /// The text of a text node, looking through the `<p>` block wrapper the
+    /// label convention mandates (`p > text`).
     fn text_of(node: &Dom) -> Option<&str> {
         match node.root.get_node_type() {
             NodeType::Text(s) => Some(s.as_ref().as_str()),
+            NodeType::P => match node.children.as_ref() {
+                [only] => match only.root.get_node_type() {
+                    NodeType::Text(s) => Some(s.as_ref().as_str()),
+                    _ => None,
+                },
+                _ => None,
+            },
             _ => None,
         }
     }
@@ -847,9 +855,12 @@ mod autotest_generated {
         // `convert_dom_into_compact_dom` under-allocates and panics.
         for n in [0usize, 1, 2, 3, 5, 64, 257] {
             let dom = Breadcrumb::create(n_labels(n)).dom();
-            let expected = if n == 0 { 0 } else { 2 * n - 1 };
+            let children = if n == 0 { 0 } else { 2 * n - 1 };
+            // Every child is a styled `<p>` wrapping its bare text leaf per
+            // the label convention, so descendants = 2 x children.
+            let expected = 2 * children;
 
-            assert_eq!(dom.children.as_ref().len(), expected, "child count for n={n}");
+            assert_eq!(dom.children.as_ref().len(), children, "child count for n={n}");
             assert_eq!(
                 dom.estimated_total_children,
                 recursive_descendants(&dom),
@@ -865,8 +876,8 @@ mod autotest_generated {
         let styled = StyledDom::create_from_dom(Breadcrumb::create(n_labels(n)).dom());
         assert_eq!(
             styled.node_hierarchy.as_ref().len(),
-            2 * n,
-            "root + (2n-1) children"
+            4 * n - 1,
+            "root + (2n-1) children, each a <p> + its text leaf"
         );
     }
 
@@ -1022,15 +1033,16 @@ mod autotest_generated {
 
     #[test]
     fn click_reports_the_index_of_each_crumb() {
-        // children: crumb0(1) sep(2) crumb1(3) sep(4) crumb2(5) sep(6) current(7)
+        // Flat DFS with the label convention (<p> + text leaf per child):
+        // crumb0(1) sep(3) crumb1(5) sep(7) crumb2(9) sep(11) current(13)
         let (styled, state) = flatten(Breadcrumb::create(labels(&["a", "b", "c", "d"])));
         assert_eq!(
             styled.node_hierarchy.as_ref().len(),
-            8,
-            "fixture must flatten to root + 7 children"
+            15,
+            "fixture must flatten to root + 7 children + their 7 text leaves"
         );
 
-        for (hit, expected) in [(1usize, 0usize), (3, 1), (5, 2)] {
+        for (hit, expected) in [(1usize, 0usize), (5, 1), (9, 2)] {
             let mut state = state.clone();
             let (update, changes) = run_click(Some(styled.clone()), hit, state.clone());
 
@@ -1043,7 +1055,7 @@ mod autotest_generated {
                 selected_index_of(&mut state),
                 expected,
                 "node {hit} sits at sibling position {} => index {expected}",
-                hit - 1
+                (hit - 1) / 2
             );
             assert!(
                 changes.is_empty(),
@@ -1059,7 +1071,7 @@ mod autotest_generated {
             .with_on_navigate(log.clone(), nav_cb(record_nav));
         let (styled, state) = flatten(bc);
 
-        let (update, _) = run_click(Some(styled.clone()), 5, state.clone());
+        let (update, _) = run_click(Some(styled.clone()), 9, state.clone());
         assert_eq!(update, Update::RefreshDom, "the user's Update must propagate");
         assert_eq!(log_indices(&mut log), vec![2]);
 
@@ -1161,7 +1173,7 @@ mod autotest_generated {
         // if the handler is ever invoked on one.
         let (styled, state) = flatten(Breadcrumb::create(labels(&["a", "b", "c", "d"])));
 
-        for (hit, expected) in [(2usize, 0usize), (4, 1), (6, 2), (7, 3)] {
+        for (hit, expected) in [(3usize, 0usize), (7, 1), (11, 2), (13, 3)] {
             let mut state = state.clone();
             let (update, _) = run_click(Some(styled.clone()), hit, state.clone());
             assert_eq!(update, Update::DoNothing);
@@ -1169,7 +1181,7 @@ mod autotest_generated {
                 selected_index_of(&mut state),
                 expected,
                 "node {hit} => position {} => index {expected}",
-                hit - 1
+                (hit - 1) / 2
             );
         }
     }
@@ -1178,10 +1190,12 @@ mod autotest_generated {
     fn click_indices_stay_in_range_for_a_long_trail() {
         let n = 64;
         let (styled, state) = flatten(Breadcrumb::create(n_labels(n)));
-        assert_eq!(styled.node_hierarchy.as_ref().len(), 2 * n);
+        assert_eq!(styled.node_hierarchy.as_ref().len(), 4 * n - 1);
 
-        // Last clickable crumb: index n-2, at child position 2*(n-2) => node 2n-3.
-        let hit = 2 * n - 3;
+        // Last clickable crumb: index n-2, at child position 2*(n-2); flat id
+        // of the child at position p is 1 + 2p (each earlier child is a <p>
+        // plus its text leaf) => node 4n-7.
+        let hit = 4 * n - 7;
         let mut state = state;
         let (_, _) = run_click(Some(styled), hit, state.clone());
 

--- a/layout/src/widgets/button.rs
+++ b/layout/src/widgets/button.rs
@@ -493,7 +493,7 @@ impl Button {
             button = button.with_child(
                 Dom::create_p()
                     .with_css_props(self.label_style)
-                    .with_children(azul_core::dom::DomVec::from_vec(vec![Dom::create_text(self.label)])),
+                    .with_children(azul_core::dom::DomVec::from_vec(vec![Dom::create_text_do_not_use_without_block_level_wrapper(self.label)])),
             );
         }
 

--- a/layout/src/widgets/card.rs
+++ b/layout/src/widgets/card.rs
@@ -467,7 +467,7 @@ mod autotest_generated {
     #[test]
     fn create_stores_pathological_content_verbatim() {
         for t in ADVERSARIAL_TEXT {
-            let c = Card::create(Dom::create_text(t));
+            let c = Card::create(Dom::create_text_do_not_use_without_block_level_wrapper(t));
             assert_eq!(
                 text_of(&c.content),
                 Some(t),
@@ -508,7 +508,7 @@ mod autotest_generated {
 
     #[test]
     fn swap_with_default_moves_every_field_out_and_leaves_a_default() {
-        let mut c = Card::create(Dom::create_text("payload")).with_flex_grow(2.5);
+        let mut c = Card::create(Dom::create_text_do_not_use_without_block_level_wrapper("payload")).with_flex_grow(2.5);
         c.set_on_click(RefAny::new(7u32), click_a as CardOnClickCallbackType);
 
         let taken = c.swap_with_default();
@@ -524,7 +524,7 @@ mod autotest_generated {
 
     #[test]
     fn repeated_swap_with_default_never_accumulates_state() {
-        let mut c = Card::create(Dom::create_text("x")).with_flex_grow(1.0);
+        let mut c = Card::create(Dom::create_text_do_not_use_without_block_level_wrapper("x")).with_flex_grow(1.0);
         let _first = c.swap_with_default();
 
         for i in 0..8 {
@@ -545,9 +545,9 @@ mod autotest_generated {
 
     #[test]
     fn set_content_replaces_rather_than_appends() {
-        let mut c = Card::create(Dom::create_text("first"));
-        c.set_content(Dom::create_text("second"));
-        c.set_content(Dom::create_text("third"));
+        let mut c = Card::create(Dom::create_text_do_not_use_without_block_level_wrapper("first"));
+        c.set_content(Dom::create_text_do_not_use_without_block_level_wrapper("second"));
+        c.set_content(Dom::create_text_do_not_use_without_block_level_wrapper("third"));
 
         assert_eq!(text_of(&c.content), Some("third"), "the last content did not win");
 
@@ -562,8 +562,8 @@ mod autotest_generated {
 
     #[test]
     fn with_content_touches_only_the_content_field() {
-        let base = Card::create(Dom::create_text("old")).with_flex_grow(3.0);
-        let c = base.with_content(Dom::create_text("new"));
+        let base = Card::create(Dom::create_text_do_not_use_without_block_level_wrapper("old")).with_flex_grow(3.0);
+        let c = base.with_content(Dom::create_text_do_not_use_without_block_level_wrapper("new"));
 
         assert_eq!(text_of(&c.content), Some("new"));
         assert_eq!(c.flex_grow, 3.0, "with_content clobbered flex_grow");
@@ -574,7 +574,7 @@ mod autotest_generated {
     fn with_content_preserves_an_already_installed_callback() {
         let c = Card::default()
             .with_on_click(RefAny::new(1u8), click_a as CardOnClickCallbackType)
-            .with_content(Dom::create_text("late content"));
+            .with_content(Dom::create_text_do_not_use_without_block_level_wrapper("late content"));
 
         assert!(c.on_click.is_some(), "with_content dropped the callback");
         let dom = c.dom();
@@ -618,7 +618,7 @@ mod autotest_generated {
 
     #[test]
     fn with_flex_grow_touches_only_the_numeric_field() {
-        let c = Card::create(Dom::create_text("body"))
+        let c = Card::create(Dom::create_text_do_not_use_without_block_level_wrapper("body"))
             .with_on_click(RefAny::new(1u8), click_a as CardOnClickCallbackType)
             .with_flex_grow(f32::NAN);
 
@@ -767,7 +767,7 @@ mod autotest_generated {
         let cb: CardOnClickCallbackType = click_a;
         let expected_ptr = cb as *const () as usize;
 
-        let dom = Card::create(Dom::create_text("clickable"))
+        let dom = Card::create(Dom::create_text_do_not_use_without_block_level_wrapper("clickable"))
             .with_on_click(RefAny::new(0xDEAD_BEEF_u32), cb)
             .dom();
 
@@ -817,7 +817,7 @@ mod autotest_generated {
 
     #[test]
     fn a_card_without_a_callback_registers_no_callbacks() {
-        let dom = Card::create(Dom::create_text("inert")).with_flex_grow(1.0).dom();
+        let dom = Card::create(Dom::create_text_do_not_use_without_block_level_wrapper("inert")).with_flex_grow(1.0).dom();
         assert!(
             dom.root.callbacks.as_ref().is_empty(),
             "a callback appeared on a card that was never given one",
@@ -826,7 +826,7 @@ mod autotest_generated {
 
     #[test]
     fn set_on_click_does_not_disturb_the_other_fields() {
-        let mut c = Card::create(Dom::create_text("body")).with_flex_grow(2.0);
+        let mut c = Card::create(Dom::create_text_do_not_use_without_block_level_wrapper("body")).with_flex_grow(2.0);
         c.set_on_click(RefAny::new("payload".to_string()), click_a as CardOnClickCallbackType);
 
         assert_eq!(text_of(&c.content), Some("body"), "set_on_click clobbered the content");
@@ -845,7 +845,7 @@ mod autotest_generated {
 
     #[test]
     fn dom_builds_a_single_card_div_holding_the_content_as_its_only_child() {
-        let dom = Card::create(Dom::create_text("body")).dom();
+        let dom = Card::create(Dom::create_text_do_not_use_without_block_level_wrapper("body")).dom();
 
         assert_eq!(*dom.root.get_node_type(), NodeType::Div, "the card container must be a div");
         assert_eq!(
@@ -979,7 +979,7 @@ mod autotest_generated {
         // would be a use-after-free (and the third a double-free). Build, drop, re-read.
         let survivor = Card::default().dom();
         for _ in 0..64 {
-            drop(Card::create(Dom::create_text("throwaway")).with_flex_grow(1.0).dom());
+            drop(Card::create(Dom::create_text_do_not_use_without_block_level_wrapper("throwaway")).with_flex_grow(1.0).dom());
         }
 
         assert_eq!(CARD_SHADOW.offset_y.inner.number.get(), 2.0, "the static shadow was mutated or freed");
@@ -1014,13 +1014,13 @@ mod autotest_generated {
 
     #[test]
     fn from_card_for_dom_is_exactly_dom() {
-        let c = Card::create(Dom::create_text("body")).with_flex_grow(1.5);
+        let c = Card::create(Dom::create_text_do_not_use_without_block_level_wrapper("body")).with_flex_grow(1.5);
         assert_eq!(Dom::from(c.clone()), c.dom(), "the From impl diverged from Card::dom");
     }
 
     #[test]
     fn cards_nest_without_desyncing_the_child_counts() {
-        let inner = Card::create(Dom::create_text("inner")).with_flex_grow(1.0).dom();
+        let inner = Card::create(Dom::create_text_do_not_use_without_block_level_wrapper("inner")).with_flex_grow(1.0).dom();
         let outer = Card::create(inner).with_flex_grow(2.0).dom();
 
         assert_eq!(

--- a/layout/src/widgets/chip.rs
+++ b/layout/src/widgets/chip.rs
@@ -364,7 +364,7 @@ impl Chip {
         // RefAny so both handlers observe the same ChipState.
         let state_ref = RefAny::new(self.chip_state);
 
-        let mut label = Dom::create_text(self.label)
+        let mut label = Dom::create_p_with_text(self.label)
             .with_ids_and_classes(IdOrClassVec::from_const_slice(CHIP_LABEL_CLASS))
             .with_css_props(CssPropertyWithConditionsVec::from_const_slice(CHIP_LABEL_STYLE));
 
@@ -391,7 +391,7 @@ impl Chip {
         let mut children = alloc::vec![label];
 
         if self.removable {
-            let remove = Dom::create_text(AzString::from_const_str("\u{00D7}"))
+            let remove = Dom::create_p_with_text(AzString::from_const_str("\u{00D7}"))
                 .with_ids_and_classes(IdOrClassVec::from_const_slice(CHIP_REMOVE_CLASS))
                 .with_css_props(CssPropertyWithConditionsVec::from_const_slice(CHIP_REMOVE_STYLE))
                 .with_tab_index(TabIndex::Auto)
@@ -638,10 +638,18 @@ mod autotest_generated {
         0.2126 * f32::from(c.r) + 0.7152 * f32::from(c.g) + 0.0722 * f32::from(c.b)
     }
 
-    /// The text of a `NodeType::Text` node (`None` for any other node type).
+    /// The text of a text node, looking through the `<p>` block wrapper the
+    /// label convention mandates (`p > text`).
     fn text_of(node: &Dom) -> Option<&str> {
         match node.root.get_node_type() {
             NodeType::Text(s) => Some(s.as_ref().as_str()),
+            NodeType::P => match node.children.as_ref() {
+                [only] => match only.root.get_node_type() {
+                    NodeType::Text(s) => Some(s.as_ref().as_str()),
+                    _ => None,
+                },
+                _ => None,
+            },
             _ => None,
         }
     }
@@ -780,16 +788,22 @@ mod autotest_generated {
         }
     }
 
-    /// The flattened DOM of a removable chip: `container(0)`, `label(1)`,
-    /// `remove(2)` — i.e. exactly the hierarchy `default_on_chip_remove` walks
-    /// (hit node -> parent).
+    /// Flat indices of a removable chip in depth-first pre-order:
+    /// `0 container / 1 label <p> / 2 label text / 3 remove <p> / 4 remove text`.
+    /// Both callbacks sit on the `<p>`s — a text node owns no rect and could
+    /// never be hit-tested.
+    const LABEL_NODE: usize = 1;
+    const REMOVE_NODE: usize = 3;
+
+    /// The flattened DOM of a removable chip — exactly the hierarchy
+    /// `default_on_chip_remove` walks (hit node -> parent).
     fn removable_styled_dom() -> StyledDom {
         let chip = Chip::create(AzString::from("tag")).with_removable(true);
         let styled = StyledDom::create_from_dom(chip.dom());
         assert_eq!(
             styled.node_hierarchy.as_ref().len(),
-            3,
-            "fixture must flatten to exactly container/label/remove"
+            5,
+            "fixture must flatten to container / label <p> + text / remove <p> + text"
         );
         styled
     }
@@ -1844,7 +1858,11 @@ mod autotest_generated {
                 label.root.get_tab_index().is_none(),
                 "{kind:?}: an inert label must not be keyboard-focusable"
             );
-            assert!(label.children.as_ref().is_empty(), "{kind:?}: the label is a leaf text node");
+            assert_eq!(
+                label.children.as_ref().len(),
+                1,
+                "{kind:?}: the label is a <p> wrapping exactly one bare text node"
+            );
         }
     }
 
@@ -2021,9 +2039,9 @@ mod autotest_generated {
         // container". That only holds while the x is a *direct* child.
         let styled = removable_styled_dom();
         let hierarchy = styled.node_hierarchy.as_ref();
-        assert_eq!(hierarchy.len(), 3, "container(0), label(1), remove(2)");
+        assert_eq!(hierarchy.len(), 5, "container(0), label <p>(1)+text(2), remove <p>(3)+text(4)");
         assert_eq!(
-            hierarchy[2].parent_id(),
+            hierarchy[REMOVE_NODE].parent_id(),
             Some(NodeId::new(0)),
             "the x's parent must be the pill container"
         );
@@ -2038,8 +2056,8 @@ mod autotest_generated {
     fn remove_hides_the_container_and_flips_visible() {
         let mut data = RefAny::new(ChipStateWrapper::default());
 
-        // node 2 == the x, its parent (node 0) is the container
-        let (update, changes) = run_remove(Some(removable_styled_dom()), 2, data.clone());
+        // REMOVE_NODE == the x <p>, its parent (node 0) is the container
+        let (update, changes) = run_remove(Some(removable_styled_dom()), REMOVE_NODE, data.clone());
 
         assert_eq!(update, Update::DoNothing, "no user callback -> DoNothing");
         assert_eq!(
@@ -2055,7 +2073,7 @@ mod autotest_generated {
     fn remove_invokes_the_user_callback_with_the_already_flipped_state() {
         let (mut data, mut log) = state_with_remove_log();
 
-        let (update, changes) = run_remove(Some(removable_styled_dom()), 2, data.clone());
+        let (update, changes) = run_remove(Some(removable_styled_dom()), REMOVE_NODE, data.clone());
 
         assert_eq!(update, Update::RefreshDom, "the user callback's Update is returned");
         assert_eq!(
@@ -2076,7 +2094,7 @@ mod autotest_generated {
         let (mut data, mut log) = state_with_remove_log();
 
         for _ in 0..2 {
-            let (update, changes) = run_remove(Some(removable_styled_dom()), 2, data.clone());
+            let (update, changes) = run_remove(Some(removable_styled_dom()), REMOVE_NODE, data.clone());
             assert_eq!(update, Update::RefreshDom);
             assert_eq!(display_writes(&changes), alloc::vec![(0usize, LayoutDisplay::None)]);
         }
@@ -2118,7 +2136,7 @@ mod autotest_generated {
     fn remove_without_any_layout_result_is_a_noop() {
         let mut data = RefAny::new(ChipStateWrapper::default());
 
-        let (update, changes) = run_remove(None, 2, data.clone());
+        let (update, changes) = run_remove(None, REMOVE_NODE, data.clone());
 
         assert_eq!(update, Update::DoNothing);
         assert!(changes.is_empty());
@@ -2130,7 +2148,7 @@ mod autotest_generated {
         // the callback-bearing node carries a RefAny of the *wrong* type
         let data = RefAny::new(0xdead_beef_u64);
 
-        let (update, changes) = run_remove(Some(removable_styled_dom()), 2, data.clone());
+        let (update, changes) = run_remove(Some(removable_styled_dom()), REMOVE_NODE, data.clone());
 
         assert_eq!(update, Update::DoNothing);
         assert!(changes.is_empty(), "a foreign payload must not hide the container");
@@ -2140,11 +2158,11 @@ mod autotest_generated {
     fn remove_fired_from_the_label_still_hides_the_container() {
         // Current behaviour, pinned: the handler trusts its wiring — it hides
         // whatever the hit node's parent is and never checks that the hit node is
-        // actually the x. Firing it from node 1 (the label) therefore hides the
+        // actually the x. Firing it from the label <p> therefore hides the
         // container just the same.
         let mut data = RefAny::new(ChipStateWrapper::default());
 
-        let (update, changes) = run_remove(Some(removable_styled_dom()), 1, data.clone());
+        let (update, changes) = run_remove(Some(removable_styled_dom()), LABEL_NODE, data.clone());
 
         assert_eq!(update, Update::DoNothing);
         assert_eq!(display_writes(&changes), alloc::vec![(0usize, LayoutDisplay::None)]);
@@ -2179,7 +2197,7 @@ mod autotest_generated {
             p.state = state.clone();
         }
 
-        let (update, changes) = run_remove(Some(removable_styled_dom()), 2, state.clone());
+        let (update, changes) = run_remove(Some(removable_styled_dom()), REMOVE_NODE, state.clone());
 
         assert_eq!(update, Update::DoNothing);
         assert_eq!(display_writes(&changes), alloc::vec![(0usize, LayoutDisplay::None)]);
@@ -2204,7 +2222,7 @@ mod autotest_generated {
         let mut payload = entry.refany.clone();
 
         let styled = StyledDom::create_from_dom(dom);
-        let (update, changes) = run_remove(Some(styled), 2, payload.clone());
+        let (update, changes) = run_remove(Some(styled), REMOVE_NODE, payload.clone());
 
         assert_eq!(update, Update::DoNothing);
         assert_eq!(display_writes(&changes), alloc::vec![(0usize, LayoutDisplay::None)]);
@@ -2222,7 +2240,7 @@ mod autotest_generated {
     fn click_without_a_user_callback_is_a_noop() {
         let mut data = RefAny::new(ChipStateWrapper::default());
 
-        let (update, changes) = run_click(Some(removable_styled_dom()), 1, data.clone());
+        let (update, changes) = run_click(Some(removable_styled_dom()), LABEL_NODE, data.clone());
 
         assert_eq!(update, Update::DoNothing);
         assert!(changes.is_empty(), "a click must never restyle anything");
@@ -2233,7 +2251,7 @@ mod autotest_generated {
     fn click_invokes_the_user_callback_with_the_current_state() {
         let (mut data, mut log) = state_with_click_log(true);
 
-        let (update, changes) = run_click(Some(removable_styled_dom()), 1, data.clone());
+        let (update, changes) = run_click(Some(removable_styled_dom()), LABEL_NODE, data.clone());
 
         assert_eq!(update, Update::RefreshDom, "the user callback's Update is returned");
         assert_eq!(
@@ -2251,7 +2269,7 @@ mod autotest_generated {
         // observe `visible == false`.
         let (data, mut log) = state_with_click_log(false);
 
-        let (update, _) = run_click(Some(removable_styled_dom()), 1, data);
+        let (update, _) = run_click(Some(removable_styled_dom()), LABEL_NODE, data);
 
         assert_eq!(update, Update::RefreshDom);
         assert_eq!(log_calls(&mut log), alloc::vec![false, false]);
@@ -2274,7 +2292,7 @@ mod autotest_generated {
     fn click_with_a_foreign_payload_is_a_noop() {
         let data = RefAny::new(0xdead_beef_u64);
 
-        let (update, changes) = run_click(Some(removable_styled_dom()), 1, data);
+        let (update, changes) = run_click(Some(removable_styled_dom()), LABEL_NODE, data);
 
         assert_eq!(update, Update::DoNothing);
         assert!(changes.is_empty());
@@ -2285,7 +2303,7 @@ mod autotest_generated {
         let (mut data, mut log) = state_with_click_log(true);
 
         for _ in 0..3 {
-            let (update, changes) = run_click(Some(removable_styled_dom()), 1, data.clone());
+            let (update, changes) = run_click(Some(removable_styled_dom()), LABEL_NODE, data.clone());
             assert_eq!(update, Update::RefreshDom);
             assert!(changes.is_empty());
         }
@@ -2309,7 +2327,7 @@ mod autotest_generated {
         let mut payload = entry.refany.clone();
 
         let styled = StyledDom::create_from_dom(dom);
-        let (update, changes) = run_click(Some(styled), 1, payload.clone());
+        let (update, changes) = run_click(Some(styled), LABEL_NODE, payload.clone());
 
         assert_eq!(update, Update::RefreshDom);
         assert!(changes.is_empty());
@@ -2332,10 +2350,10 @@ mod autotest_generated {
         let remove_payload = dom.children.as_ref()[1].root.get_callbacks().as_ref()[0].refany.clone();
 
         let styled = StyledDom::create_from_dom(dom);
-        let (_, changes) = run_remove(Some(styled), 2, remove_payload);
+        let (_, changes) = run_remove(Some(styled), REMOVE_NODE, remove_payload);
         assert_eq!(display_writes(&changes), alloc::vec![(0usize, LayoutDisplay::None)]);
 
-        let (update, _) = run_click(Some(removable_styled_dom()), 1, click_payload);
+        let (update, _) = run_click(Some(removable_styled_dom()), LABEL_NODE, click_payload);
         assert_eq!(update, Update::RefreshDom);
         assert_eq!(
             log_calls(&mut log_handle),

--- a/layout/src/widgets/combobox.rs
+++ b/layout/src/widgets/combobox.rs
@@ -543,7 +543,7 @@ impl ComboBox {
         // pattern), so open/selected/text stay in sync across interactions.
         let state_ref = RefAny::new(self.combo_state);
 
-        let text_node = Dom::create_text(field_text)
+        let text_node = Dom::create_p_with_text(field_text)
             .with_ids_and_classes(IdOrClassVec::from_const_slice(COMBOBOX_TEXT_CLASS))
             .with_css_props(self.text_style);
 
@@ -594,7 +594,7 @@ impl ComboBox {
         let mut option_doms: Vec<Dom> = Vec::with_capacity(items.as_ref().len());
         for option in items.as_ref() {
             option_doms.push(
-                Dom::create_text(option.clone())
+                Dom::create_p_with_text(option.clone())
                     .with_ids_and_classes(IdOrClassVec::from_const_slice(COMBOBOX_OPTION_CLASS))
                     .with_css_props(self.option_style.clone())
                     .with_tab_index(TabIndex::Auto)
@@ -678,7 +678,9 @@ extern "C" fn on_combobox_text_input(data: RefAny, info: CallbackInfo) -> Update
 
 fn on_combobox_text_input_inner(mut data: RefAny, mut info: CallbackInfo) -> Option<Update> {
     let field = info.get_hit_node();
-    let text_node = info.get_first_child(field)?;
+    // field -> label `<p>` -> bare text leaf: the label convention keeps the
+    // styling on the block box, so the re-textable node is one level deeper.
+    let text_node = info.get_first_child(info.get_first_child(field)?)?;
 
     let changeset = info.get_text_changeset()?;
     let inserted_text = changeset.inserted_text.as_str().to_string();
@@ -705,7 +707,8 @@ extern "C" fn on_combobox_key_down(data: RefAny, info: CallbackInfo) -> Update {
 
 fn on_combobox_key_down_inner(mut data: RefAny, mut info: CallbackInfo) -> Option<Update> {
     let field = info.get_hit_node();
-    let text_node = info.get_first_child(field)?;
+    // field -> label `<p>` -> bare text leaf (see `on_combobox_text_input_inner`).
+    let text_node = info.get_first_child(info.get_first_child(field)?)?;
 
     let keyboard_state = info.get_current_keyboard_state();
     let c = keyboard_state.current_virtual_keycode.into_option()?;
@@ -725,9 +728,10 @@ fn on_combobox_key_down_inner(mut data: RefAny, mut info: CallbackInfo) -> Optio
     Some(Update::DoNothing)
 }
 
-/// Option click handler. The hit node is the clicked option; its index is the
-/// number of previous siblings. Its parent is the list; the list's parent is the
-/// wrapper, whose first child is the field, whose first child is the text node.
+/// Option click handler. The hit node is the clicked option's `<p>`; its index is
+/// the number of previous siblings. Its parent is the list; the list's parent is
+/// the wrapper, whose first child is the field, whose first child is the label
+/// `<p>`, whose only child is the text node.
 /// Fills the field with the option's label, sets `selected`, closes the list, and
 /// invokes the optional user callback.
 extern "C" fn on_combobox_option_click(mut data: RefAny, mut info: CallbackInfo) -> Update {
@@ -750,7 +754,10 @@ extern "C" fn on_combobox_option_click(mut data: RefAny, mut info: CallbackInfo)
     let Some(field) = info.get_first_child(wrapper) else {
         return Update::DoNothing;
     };
-    let Some(text_node) = info.get_first_child(field) else {
+    let Some(text_box) = info.get_first_child(field) else {
+        return Update::DoNothing;
+    };
+    let Some(text_node) = info.get_first_child(text_box) else {
         return Update::DoNothing;
     };
 
@@ -846,10 +853,18 @@ mod autotest_generated {
             .any(|c| matches!(c, Class(s) if s.as_str() == name))
     }
 
-    /// The text of a `NodeType::Text` node (`None` for any other node type).
+    /// The text of a text node, looking through the `<p>` block wrapper the
+    /// label convention mandates (`p > text`).
     fn text_of(node: &Dom) -> Option<&str> {
         match node.root.get_node_type() {
             NodeType::Text(s) => Some(s.as_ref().as_str()),
+            NodeType::P => match node.children.as_ref() {
+                [only] => match only.root.get_node_type() {
+                    NodeType::Text(s) => Some(s.as_ref().as_str()),
+                    _ => None,
+                },
+                _ => None,
+            },
             _ => None,
         }
     }
@@ -937,7 +952,14 @@ mod autotest_generated {
 
         let wrapper = one(&styled, "__azul-native-combobox");
         let field = one(&styled, "__azul-native-combobox-input");
-        let text = one(&styled, "__azul-native-combobox-text");
+        // The class sits on the label `<p>`; the node the handlers re-text is
+        // the bare text leaf inside it, which pre-order flattening puts next.
+        let text_box = one(&styled, "__azul-native-combobox-text");
+        let text = text_box + 1;
+        assert!(
+            matches!(styled.node_data.as_ref()[text].get_node_type(), NodeType::Text(_)),
+            "the combobox field label must be `p > text`"
+        );
         let list = one(&styled, "__azul-native-combobox-list");
         let options = nodes_with_class(&styled, "__azul-native-combobox-option");
         assert_eq!(options.len(), items.len());
@@ -1844,8 +1866,8 @@ mod autotest_generated {
 
     #[test]
     fn text_input_on_a_childless_node_is_a_noop() {
-        // An option row is a leaf: `get_first_child` returns None before any
-        // state is touched.
+        // A bare text leaf has no children of its own: `get_first_child`
+        // returns None before any state is touched.
         let fx = fixture(&["a"]);
         let mut data = state(&["a"], "abc", false, 0);
 
@@ -1859,7 +1881,7 @@ mod autotest_generated {
                 }),
                 ..Env::default()
             },
-            fx.options[0],
+            fx.text,
             data.clone(),
             |r, ci| on_combobox_text_input(r, ci),
         );
@@ -1893,7 +1915,7 @@ mod autotest_generated {
         assert_eq!(
             text_writes(&changes),
             alloc::vec![(fx.text, String::from("abc"))],
-            "the field's first child is the node that is re-texted"
+            "the text leaf inside the field's label <p> is the node that is re-texted"
         );
         assert_eq!(inner_of(&mut data).text.as_str(), "abc");
         // selection/open state is not disturbed by typing

--- a/layout/src/widgets/date_picker.rs
+++ b/layout/src/widgets/date_picker.rs
@@ -493,7 +493,7 @@ fn build_header(year: u32, month: u32, shared: RefAny) -> Dom {
     use azul_core::dom::{EventFilter, HoverEventFilter};
 
     let nav = |arrow: AzString, cb: usize, refany: RefAny| -> Dom {
-        Dom::create_text(arrow)
+        Dom::create_p_with_text(arrow)
             .with_ids_and_classes(IdOrClassVec::from_const_slice(NAV_BTN_CLASS))
             .with_css_props(CssPropertyWithConditionsVec::from_const_slice(NAV_BTN_STYLE))
             .with_callbacks(
@@ -518,7 +518,7 @@ fn build_header(year: u32, month: u32, shared: RefAny) -> Dom {
         .with_children(
             alloc::vec![
                 nav(PREV_ARROW, on_prev_month as usize, shared.clone()),
-                Dom::create_text(label)
+                Dom::create_p_with_text(label)
                     .with_ids_and_classes(IdOrClassVec::from_const_slice(HEADER_LABEL_CLASS))
                     .with_css_props(CssPropertyWithConditionsVec::from_const_slice(
                         HEADER_LABEL_STYLE,
@@ -533,7 +533,7 @@ fn build_weekday_row() -> Dom {
     let cells: Vec<Dom> = WEEKDAY_NAMES
         .iter()
         .map(|n| {
-            Dom::create_text(n.clone())
+            Dom::create_p_with_text(n.clone())
                 .with_ids_and_classes(IdOrClassVec::from_const_slice(WEEKDAY_CELL_CLASS))
                 .with_css_props(CssPropertyWithConditionsVec::from_const_slice(
                     WEEKDAY_CELL_STYLE,
@@ -589,7 +589,7 @@ fn build_blank_cell() -> Dom {
 fn build_day_cell(day: u32, selected: bool, shared: RefAny) -> Dom {
     use azul_core::dom::{EventFilter, HoverEventFilter};
 
-    Dom::create_text(AzString::from(format!("{day}")))
+    Dom::create_p_with_text(AzString::from(format!("{day}")))
         .with_ids_and_classes(IdOrClassVec::from_const_slice(DAY_CELL_CLASS))
         .with_css_props(build_day_cell_style(selected))
         .with_callbacks(
@@ -919,9 +919,16 @@ mod autotest_generated {
             .collect()
     }
 
-    /// The text a node renders, or `None` for a non-text node (a blank cell).
+    /// The text a node renders, looking through the `<p>` block wrapper the
+    /// label convention mandates; `None` for a non-text node (a blank cell).
     fn text_of(dom: &Dom) -> Option<String> {
-        dom.root.get_node_type().format()
+        match dom.root.get_node_type() {
+            NodeType::P => match dom.children.as_ref() {
+                [only] => only.root.get_node_type().format(),
+                _ => None,
+            },
+            other => other.format(),
+        }
     }
 
     /// The day numbers of a grid in reading order; `None` marks a blank cell.
@@ -2142,12 +2149,16 @@ mod autotest_generated {
                 "{y}-{m}: the cached descendant count is wrong",
             );
 
-            let rows = dom.children.as_ref()[2].children.as_ref().len();
+            // The flatten must agree with the (just-verified) descendant
+            // cache: root + descendants. A per-month closed formula stopped
+            // being practical once day/label cells became <p> + text leaf
+            // pairs whose count varies with the month's blank cells.
+            let expected = 1 + dom.estimated_total_children;
             let styled = StyledDom::create_from_dom(dom);
             assert_eq!(
                 styled.node_data.as_ref().len(),
-                14 + 8 * rows,
-                "{y}-{m}: container + header(3) + weekdays(7) + grid of {rows} weeks did not flatten as expected",
+                expected,
+                "{y}-{m}: the flatten disagrees with the descendant cache",
             );
         }
     }

--- a/layout/src/widgets/drop_down.rs
+++ b/layout/src/widgets/drop_down.rs
@@ -322,7 +322,7 @@ impl DropDown {
                 Dom::create_p()
                     .with_css_props(label_style)
                     .with_children(DomVec::from_vec(vec![
-                        Dom::create_text(selected_text),
+                        Dom::create_text_do_not_use_without_block_level_wrapper(selected_text),
                     ])),
                 // Arrow icon (resolved via Material Icons)
                 Dom::create_icon(AzString::from_const_str("arrow_drop_down"))

--- a/layout/src/widgets/frame.rs
+++ b/layout/src/widgets/frame.rs
@@ -662,7 +662,7 @@ mod autotest_generated {
 
     #[test]
     fn create_zeroes_flex_grow_and_stores_both_arguments_verbatim() {
-        let f = frame("Settings", Dom::create_text("body"));
+        let f = frame("Settings", Dom::create_text_do_not_use_without_block_level_wrapper("body"));
 
         // Positive zero, not -0.0: a negative zero would flip the sign of the encoded
         // isize on some paths and is not what "no growth" means.
@@ -756,7 +756,7 @@ mod autotest_generated {
 
     #[test]
     fn swap_with_default_moves_every_field_out_and_leaves_a_default() {
-        let mut f = frame("payload", Dom::create_text("body")).with_flex_grow(2.5);
+        let mut f = frame("payload", Dom::create_text_do_not_use_without_block_level_wrapper("body")).with_flex_grow(2.5);
 
         let taken = f.swap_with_default();
 
@@ -775,7 +775,7 @@ mod autotest_generated {
 
     #[test]
     fn repeated_swap_with_default_never_accumulates_state() {
-        let mut f = frame("x", Dom::create_text("y")).with_flex_grow(1.0);
+        let mut f = frame("x", Dom::create_text_do_not_use_without_block_level_wrapper("y")).with_flex_grow(1.0);
         let first = f.swap_with_default();
         assert_eq!(first.title.as_str(), "x");
 
@@ -873,7 +873,7 @@ mod autotest_generated {
 
     #[test]
     fn with_flex_grow_touches_only_the_numeric_field() {
-        let f = frame("title", Dom::create_text("body")).with_flex_grow(f32::NAN);
+        let f = frame("title", Dom::create_text_do_not_use_without_block_level_wrapper("body")).with_flex_grow(f32::NAN);
 
         assert_eq!(f.title.as_str(), "title", "with_flex_grow clobbered the title");
         assert_eq!(text_of(&f.content), Some("body"), "with_flex_grow clobbered the content");
@@ -1016,7 +1016,7 @@ mod autotest_generated {
 
     #[test]
     fn dom_has_the_documented_shape() {
-        let dom = frame("Title", Dom::create_text("content")).dom();
+        let dom = frame("Title", Dom::create_text_do_not_use_without_block_level_wrapper("content")).dom();
 
         assert_eq!(kids(&dom).len(), 2, "a frame is a header plus a content area");
         assert_eq!(kids(header(&dom)).len(), 3, "the header is rule / title / rule");
@@ -1283,8 +1283,8 @@ mod autotest_generated {
                 "user-content",
             ))]))
             .with_children(DomVec::from_vec(vec![
-                Dom::create_text("a"),
-                Dom::create_text("b"),
+                Dom::create_text_do_not_use_without_block_level_wrapper("a"),
+                Dom::create_text_do_not_use_without_block_level_wrapper("b"),
             ]));
         let expected = content.clone();
 
@@ -1300,8 +1300,8 @@ mod autotest_generated {
     fn dom_is_deterministic_for_equal_inputs() {
         for t in ADVERSARIAL_TEXT {
             for v in ADVERSARIAL_FLOATS {
-                let a = frame(t, Dom::create_text(t)).with_flex_grow(v).dom();
-                let b = frame(t, Dom::create_text(t)).with_flex_grow(v).dom();
+                let a = frame(t, Dom::create_text_do_not_use_without_block_level_wrapper(t)).with_flex_grow(v).dom();
+                let b = frame(t, Dom::create_text_do_not_use_without_block_level_wrapper(t)).with_flex_grow(v).dom();
                 assert_eq!(a, b, "two identical frames rendered differently for {t:?} / {v}");
             }
         }

--- a/layout/src/widgets/frame.rs
+++ b/layout/src/widgets/frame.rs
@@ -374,7 +374,8 @@ impl Frame {
                                 IdOrClassVec::from_const_slice(IDS_AND_CLASSES_15264202958442287530)
                             })
                             .with_children(DomVec::from_vec(vec![Dom::create_div()])),
-                        Dom::create_text(self.title).with_css_props(CSS_MATCH_4236783900531286611),
+                        Dom::create_p_with_text(self.title)
+                            .with_css_props(CSS_MATCH_4236783900531286611),
                         Dom::create_div()
                             .with_css_props(CSS_MATCH_9156589477016488419)
                             .with_ids_and_classes({
@@ -489,7 +490,7 @@ mod autotest_generated {
         &kids(header(dom))[0]
     }
 
-    /// The title text node, wedged between the two header rules.
+    /// The title `<p>` box, wedged between the two header rules.
     fn title_node(dom: &Dom) -> &Dom {
         &kids(header(dom))[1]
     }
@@ -529,9 +530,18 @@ mod autotest_generated {
             .collect()
     }
 
+    /// The text of a text node, looking through the `<p>` block wrapper the
+    /// label convention mandates (`p > text`).
     fn text_of(dom: &Dom) -> Option<&str> {
         match dom.root.get_node_type() {
             NodeType::Text(s) => Some(s.as_ref().as_str()),
+            NodeType::P => match dom.children.as_ref() {
+                [only] => match only.root.get_node_type() {
+                    NodeType::Text(s) => Some(s.as_ref().as_str()),
+                    _ => None,
+                },
+                _ => None,
+            },
             _ => None,
         }
     }
@@ -709,7 +719,7 @@ mod autotest_generated {
             count_descendants(&deep),
             "the cached child count desynced for deeply nested content",
         );
-        assert_eq!(deep.estimated_total_children, 8 + 64, "frame chrome is 8 nodes + the content");
+        assert_eq!(deep.estimated_total_children, 9 + 64, "frame chrome is 8 nodes + the content");
 
         let wide = frame(
             "wide",
@@ -723,13 +733,13 @@ mod autotest_generated {
             count_descendants(&wide),
             "the cached child count desynced for very wide content",
         );
-        assert_eq!(wide.estimated_total_children, 8 + 2000);
+        assert_eq!(wide.estimated_total_children, 9 + 2000);
     }
 
     #[test]
     fn frames_nest_without_desyncing_the_child_count_cache() {
         let inner = frame("inner", Dom::create_div()).dom();
-        assert_eq!(inner.estimated_total_children, 8, "a bare frame is 8 nodes below the root");
+        assert_eq!(inner.estimated_total_children, 9, "a bare frame is 9 nodes below the root");
 
         let outer = frame("outer", inner).dom();
         assert_eq!(
@@ -737,7 +747,7 @@ mod autotest_generated {
             count_descendants(&outer),
             "nesting a frame inside a frame desynced the cached child count",
         );
-        assert_eq!(outer.estimated_total_children, 16);
+        assert_eq!(outer.estimated_total_children, 18);
     }
 
     // ------------------------------------------------------------------
@@ -806,8 +816,8 @@ mod autotest_generated {
 
         assert_eq!(text_of(title_node(&left_behind)), Some(""));
         assert_eq!(text_of(title_node(&moved_out)), Some("original"));
-        assert_eq!(left_behind.estimated_total_children, 8);
-        assert_eq!(moved_out.estimated_total_children, 8 + 8);
+        assert_eq!(left_behind.estimated_total_children, 9);
+        assert_eq!(moved_out.estimated_total_children, 9 + 8);
     }
 
     // ------------------------------------------------------------------
@@ -1012,7 +1022,15 @@ mod autotest_generated {
         assert_eq!(kids(header(&dom)).len(), 3, "the header is rule / title / rule");
         assert_eq!(kids(rule_before(&dom)).len(), 1, "the left rule wraps exactly one div");
         assert_eq!(kids(rule_after(&dom)).len(), 1, "the right rule wraps exactly one div");
-        assert!(kids(title_node(&dom)).is_empty(), "the title node must be a leaf");
+        assert_eq!(
+            kids(title_node(&dom)).len(),
+            1,
+            "the title is a <p> wrapping exactly one bare text node"
+        );
+        assert!(
+            kids(&kids(title_node(&dom))[0]).is_empty(),
+            "the text node itself must be a leaf"
+        );
         assert_eq!(kids(content_area(&dom)).len(), 1, "the content area holds exactly one child");
 
         assert_eq!(text_of(title_node(&dom)), Some("Title"));
@@ -1314,7 +1332,7 @@ mod autotest_generated {
                 "the title style changed for input {t:?}",
             );
             assert_eq!(kids(header(&dom)).len(), 3, "the header shape changed for input {t:?}");
-            assert_eq!(dom.estimated_total_children, 8, "the node count changed for {t:?}");
+            assert_eq!(dom.estimated_total_children, 9, "the node count changed for {t:?}");
         }
     }
 }

--- a/layout/src/widgets/label.rs
+++ b/layout/src/widgets/label.rs
@@ -101,13 +101,18 @@ impl Label {
         s
     }
 
-    /// Converts this label into a DOM text node with the `__azul-native-label` class.
+    /// Converts this label into a `<p>` block carrying the
+    /// `__azul-native-label` class and wrapping a bare text node.
+    ///
+    /// The `<p>` is the styled box: a `NodeType::Text` node is always
+    /// inline-level and owns no rect, so every box-model property here would
+    /// be inert on a raw text node.
     #[inline]
     #[must_use] pub fn dom(self) -> Dom {
         static LABEL_CLASS: &[IdOrClass] =
             &[Class(AzString::from_const_str("__azul-native-label"))];
 
-        Dom::create_text(self.string)
+        Dom::create_p_with_text(self.string)
             .with_ids_and_classes(IdOrClassVec::from_const_slice(LABEL_CLASS))
             .with_css_props(self.label_style)
     }
@@ -135,7 +140,7 @@ mod autotest_generated {
     /// The number of declarations each *populated* platform table carries.
     const DECL_COUNT: usize = 9;
 
-    /// The class `dom()` stamps onto the text node.
+    /// The class `dom()` stamps onto the label `<p>`.
     const LABEL_CLASS_NAME: &str = "__azul-native-label";
 
     /// The style table `Label::create` is expected to pick on *this* target.
@@ -225,10 +230,18 @@ mod autotest_generated {
         node.root.style.iter_inline_properties().map(|(p, _)| p.clone()).collect()
     }
 
-    /// The text carried by a `NodeType::Text` node (`None` for any other type).
+    /// The text carried by a text node, looking through the `<p>` block
+    /// wrapper the label convention mandates (`p > text`).
     fn text_of(node: &Dom) -> Option<&str> {
         match node.root.get_node_type() {
             NodeType::Text(s) => Some(s.as_ref().as_str()),
+            NodeType::P => match node.children.as_ref() {
+                [only] => match only.root.get_node_type() {
+                    NodeType::Text(s) => Some(s.as_ref().as_str()),
+                    _ => None,
+                },
+                _ => None,
+            },
             _ => None,
         }
     }
@@ -647,8 +660,16 @@ mod autotest_generated {
             1,
             "expected exactly one class and no ids"
         );
-        assert!(dom.children.as_ref().is_empty(), "a label is a leaf, not a subtree");
-        assert_eq!(dom.estimated_total_children, 0, "a leaf must not claim descendants");
+        assert_eq!(
+            dom.children.as_ref().len(),
+            1,
+            "a label is a <p> wrapping exactly one bare text node"
+        );
+        assert!(
+            dom.children.as_ref()[0].children.as_ref().is_empty(),
+            "the text node itself is a leaf, not a subtree"
+        );
+        assert_eq!(dom.estimated_total_children, 1, "the <p> owns exactly its text node");
         assert!(dom.css.as_ref().is_empty(), "a label must not attach a scoped stylesheet");
         assert!(dom.root.callbacks.as_ref().is_empty(), "a static widget must not bind callbacks");
         assert_eq!(inline_properties(&dom), expected, "the label lost its computed style");

--- a/layout/src/widgets/list_view.rs
+++ b/layout/src/widgets/list_view.rs
@@ -1906,7 +1906,7 @@ mod autotest_generated {
         ListViewRow {
             cells: DomVec::from_vec(
                 (0..n)
-                    .map(|i| Dom::create_text(format!("c{i}")))
+                    .map(|i| Dom::create_text_do_not_use_without_block_level_wrapper(format!("c{i}")))
                     .collect::<Vec<_>>(),
             ),
             height: None.into(),

--- a/layout/src/widgets/list_view.rs
+++ b/layout/src/widgets/list_view.rs
@@ -1696,7 +1696,7 @@ impl ListView {
                                     .with_css_props(CSS_MATCH_12498280255863106397)
                                     .with_ids_and_classes(COLUMN_NAME_CLASS)
                                     .with_child({
-                                        Dom::create_text(col.clone())
+                                        Dom::create_p_with_text(col.clone())
                                             .with_css_props(CSS_MATCH_15673486787900743642)
                                     });
                                 // Wire the click only when the app set a handler.
@@ -1934,9 +1934,15 @@ mod autotest_generated {
         (&ch[0], &ch[1])
     }
 
+    /// The text of a text node, looking through the `<p>` block wrapper the
+    /// label convention mandates (`p > text`).
     fn text_of(dom: &Dom) -> &str {
         match &dom.root.node_type {
             NodeType::Text(s) => s.as_ref().as_str(),
+            NodeType::P => match dom.children.as_ref() {
+                [only] => text_of(only),
+                _ => panic!("a label <p> must wrap exactly one text node"),
+            },
             _ => panic!("expected a text node"),
         }
     }

--- a/layout/src/widgets/map.rs
+++ b/layout/src/widgets/map.rs
@@ -1523,7 +1523,7 @@ extern "C" fn map_widget_render(
                     }
                     None => {
                         tile_div = tile_div.with_child(
-                            Dom::create_text(alloc::format!("✓? z{z_int}/{x}/{y}"))
+                            Dom::create_p_with_text(alloc::format!("✓? z{z_int}/{x}/{y}"))
                                 .with_css("position: absolute; left: 4px; top: 4px; font-size: 11px; color: #888;"),
                         );
                     }
@@ -1534,7 +1534,7 @@ extern "C" fn map_widget_render(
                         _ => "",
                     };
                     tile_div = tile_div.with_child(
-                        Dom::create_text(alloc::format!("{state_tag} z{z_int}/{x}/{y}"))
+                        Dom::create_p_with_text(alloc::format!("{state_tag} z{z_int}/{x}/{y}"))
                             .with_css("position: absolute; left: 4px; top: 4px; font-size: 11px; color: #888;"),
                     );
                 }

--- a/layout/src/widgets/menubar.rs
+++ b/layout/src/widgets/menubar.rs
@@ -102,7 +102,7 @@ fn build_menubar_item(item: &StringMenuItem) -> Dom {
     Dom::create_div()
         .with_ids_and_classes(IdOrClassVec::from_vec(vec![Class(MENUBAR_ITEM_CLASS.into())]))
         .with_css(MENUBAR_ITEM_CSS)
-        .with_child(Dom::create_text(item.label.clone()))
+        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper(item.label.clone()))
         .with_callbacks(
             vec![CoreCallbackData {
                 event: EventFilter::Hover(HoverEventFilter::MouseUp),

--- a/layout/src/widgets/mod.rs
+++ b/layout/src/widgets/mod.rs
@@ -311,6 +311,14 @@ pub mod date_picker;
 // /// Spreadsheet (virtualized view) widget
 // pub mod spreadsheet;
 
+/// Every shipped widget's `dom()` with reasonable defaults, for lints that
+/// must hold across the whole widget set (the label-convention test below and
+/// `dom_lint`'s runtime-warning twin). Test-only.
+#[cfg(test)]
+pub(crate) fn all_widget_doms_for_lint() -> Vec<(&'static str, azul_core::dom::Dom)> {
+    label_convention::every_widget_dom()
+}
+
 #[cfg(test)]
 #[allow(clippy::too_many_lines)]
 mod label_convention {
@@ -325,7 +333,7 @@ mod label_convention {
     //! no hit area, and a dataset has no node to be found on.
     //!
     //! The canonical shape is `Dom::create_p_with_text(label)` (or
-    //! `create_p().with_children([create_text(label)])`) with every property on
+    //! `create_p().with_children([create_text_do_not_use_without_block_level_wrapper(label)])`) with every property on
     //! the `<p>`, or — where a dedicated styled `<div>` already is the box — a
     //! bare `create_text` leaf with the properties on that `<div>`.
     //!
@@ -454,7 +462,7 @@ mod label_convention {
     /// * `map`'s tile labels — emitted from the `VirtualView` render callback,
     ///   not from `dom()`, so the walk cannot reach them; they were converted by
     ///   hand and are pinned by the map widget's own tests.
-    fn every_widget_dom() -> Vec<(&'static str, Dom)> {
+    pub(super) fn every_widget_dom() -> Vec<(&'static str, Dom)> {
         use super::{
             accordion::{Accordion, AccordionSection, AccordionSectionVec},
             alert::Alert,
@@ -663,7 +671,7 @@ mod label_convention {
     fn the_walk_reports_a_deliberately_broken_text_node() {
         use azul_core::dom::TabIndex;
 
-        let mut leaf = Dom::create_text(AzString::from("bare"));
+        let mut leaf = Dom::create_text_do_not_use_without_block_level_wrapper(AzString::from("bare"));
         leaf.root.set_css("width: 10px;");
         let broken = Dom::create_div().with_child(leaf.with_tab_index(TabIndex::Auto));
 

--- a/layout/src/widgets/mod.rs
+++ b/layout/src/widgets/mod.rs
@@ -310,3 +310,368 @@ pub mod time_picker;
 pub mod date_picker;
 // /// Spreadsheet (virtualized view) widget
 // pub mod spreadsheet;
+
+#[cfg(test)]
+#[allow(clippy::too_many_lines)]
+mod label_convention {
+    //! Workspace-level enforcement of the widget label convention (USER ruling,
+    //! 2026-08-12): a widget must never attach state to a raw text node.
+    //!
+    //! `NodeType::Text` is unconditionally inline-level
+    //! (`solver3::layout_tree`): it is given no rect and no `UnifiedLayout` of
+    //! its own — the wrapping block box carries those. Anything attached to a
+    //! text node is therefore attached to a box-less node and is silently
+    //! INERT: box-model properties never paint, callbacks and `tab_index` have
+    //! no hit area, and a dataset has no node to be found on.
+    //!
+    //! The canonical shape is `Dom::create_p_with_text(label)` (or
+    //! `create_p().with_children([create_text(label)])`) with every property on
+    //! the `<p>`, or — where a dedicated styled `<div>` already is the box — a
+    //! bare `create_text` leaf with the properties on that `<div>`.
+    //!
+    //! This generalises `ribbon`'s per-widget invariant test to every widget in
+    //! the crate. Widgets that emit no text at all are still instantiated, so
+    //! the list doubles as a smoke test that every `dom()` builds.
+
+    use azul_core::dom::{Dom, NodeType};
+    use azul_css::{props::basic::color::ColorU, AzString, OptionString, StringVec};
+
+    /// Everything a node can carry that only a real box can honour, in the
+    /// order the failure message lists it.
+    fn inert_state_on(node: &Dom) -> Vec<&'static str> {
+        let mut found = Vec::new();
+        if !node.root.style.rules.as_ref().is_empty() {
+            found.push("css props");
+        }
+        // A subtree stylesheet on a childless text node can only target the text
+        // node itself (`with_css("width: …")` parses to `* { … }`), so it is the
+        // same violation wearing the other API.
+        if !node.css.as_ref().is_empty() {
+            found.push("subtree css");
+        }
+        if !node.root.get_callbacks().as_ref().is_empty() {
+            found.push("callbacks");
+        }
+        if node.root.get_tab_index().is_some() {
+            found.push("tab_index");
+        }
+        if node.root.get_dataset().is_some() {
+            found.push("dataset");
+        }
+        if !node.children.as_ref().is_empty() {
+            found.push("children");
+        }
+        found
+    }
+
+    fn walk(node: &Dom, widget: &str, bad: &mut Vec<String>) {
+        if let NodeType::Text(text) = node.root.get_node_type() {
+            let found = inert_state_on(node);
+            if !found.is_empty() {
+                bad.push(format!(
+                    "{widget}: text node {:?} carries {} — move it onto a wrapping <p> \
+                     (or onto the styled <div> that already boxes it)",
+                    text.as_ref().as_str(),
+                    found.join(" + "),
+                ));
+            }
+        }
+        for child in node.children.as_ref() {
+            walk(child, widget, bad);
+        }
+    }
+
+    fn labels(items: &[&str]) -> StringVec {
+        StringVec::from_vec(items.iter().map(|s| AzString::from(*s)).collect::<Vec<_>>())
+    }
+
+    /// A user-content placeholder for the widgets that embed an arbitrary
+    /// caller-supplied `Dom`. Deliberately property-free: this test governs
+    /// what *widgets* emit, not what an application passes in.
+    fn user_content() -> Dom {
+        Dom::create_div()
+    }
+
+    fn node_graph_fixture() -> super::node_graph::NodeGraph {
+        use super::node_graph::{
+            InputConnectionVec, InputOutputInfo, InputOutputTypeId, InputOutputTypeIdInfoMap,
+            InputOutputTypeIdInfoMapVec, InputOutputTypeIdVec, Node, NodeGraph, NodeGraphNodeId,
+            NodeGraphNodePosition, NodeIdNodeMap, NodeIdNodeMapVec, NodeTypeField,
+            NodeTypeFieldValue, NodeTypeFieldVec, NodeTypeId, NodeTypeIdInfoMap,
+            NodeTypeIdInfoMapVec, NodeTypeInfo, OutputConnectionVec,
+        };
+
+        const TYPE_A: NodeTypeId = NodeTypeId { inner: 1 };
+        const IO_A: InputOutputTypeId = InputOutputTypeId { inner: 1 };
+
+        NodeGraph {
+            node_types: NodeTypeIdInfoMapVec::from_vec(vec![NodeTypeIdInfoMap {
+                node_type_id: TYPE_A,
+                node_type_info: NodeTypeInfo {
+                    is_root: true,
+                    node_type_name: AzString::from("Add"),
+                    inputs: InputOutputTypeIdVec::from_vec(vec![IO_A]),
+                    outputs: InputOutputTypeIdVec::from_vec(vec![IO_A]),
+                },
+            }]),
+            input_output_types: InputOutputTypeIdInfoMapVec::from_vec(vec![
+                InputOutputTypeIdInfoMap {
+                    io_type_id: IO_A,
+                    io_info: InputOutputInfo {
+                        data_type: AzString::from("number"),
+                        color: ColorU { r: 0, g: 0, b: 0, a: 255 },
+                    },
+                },
+            ]),
+            nodes: NodeIdNodeMapVec::from_vec(vec![NodeIdNodeMap {
+                node_id: NodeGraphNodeId { inner: 1 },
+                node: Node {
+                    node_type: TYPE_A,
+                    position: NodeGraphNodePosition { x: 0.0, y: 0.0 },
+                    fields: NodeTypeFieldVec::from_vec(vec![NodeTypeField {
+                        key: AzString::from("enabled"),
+                        value: NodeTypeFieldValue::CheckBox(false),
+                    }]),
+                    connect_in: InputConnectionVec::from_const_slice(&[]),
+                    connect_out: OutputConnectionVec::from_const_slice(&[]),
+                },
+            }]),
+            add_node_str: AzString::from("Add node"),
+            ..NodeGraph::default()
+        }
+    }
+
+    /// Every widget in the crate, built with defaults that actually exercise
+    /// its label paths (a widget with no labels proves nothing).
+    ///
+    /// NOT in this list, and why:
+    /// * `camera` / `microphone` / `screencap` / `video` — each `dom()` emits a
+    ///   single replaced `<img>` (or nothing) fed by a background worker and
+    ///   needs a device/GL config to construct; they contain no text node at
+    ///   all, so there is nothing for this convention to govern.
+    /// * `menubar` — a free function over a window `Menu`, not a `dom()` widget;
+    ///   its bar items are already `div > bare text`.
+    /// * `map`'s tile labels — emitted from the `VirtualView` render callback,
+    ///   not from `dom()`, so the walk cannot reach them; they were converted by
+    ///   hand and are pinned by the map widget's own tests.
+    fn every_widget_dom() -> Vec<(&'static str, Dom)> {
+        use super::{
+            accordion::{Accordion, AccordionSection, AccordionSectionVec},
+            alert::Alert,
+            avatar::Avatar,
+            backstage::{Backstage, BackstageNavItem, BackstageNavItemVec},
+            badge::Badge,
+            breadcrumb::Breadcrumb,
+            button::Button,
+            card::Card,
+            check_box::CheckBox,
+            chip::Chip,
+            color_input::ColorInput,
+            combobox::ComboBox,
+            date_picker::DatePicker,
+            divider::Divider,
+            drop_down::DropDown,
+            file_input::FileInput,
+            frame::Frame,
+            label::Label,
+            list_view::ListView,
+            map::{MapTileLayer, MapWidget},
+            modal::Modal,
+            number_input::NumberInput,
+            pagination::Pagination,
+            popover::Popover,
+            progressbar::ProgressBar,
+            quick_access::QuickAccessBar,
+            radio_group::RadioGroup,
+            ribbon::{Ribbon, RibbonAppButton, RibbonButton, RibbonGroup, RibbonItem, RibbonTab, RibbonTabVec},
+            segmented::Segmented,
+            slider::Slider,
+            spinner::Spinner,
+            split_pane::{SplitDirection, SplitPane},
+            statusbar::{StatusBar, StatusBarSegment, StatusBarSegmentVec},
+            stepper::Stepper,
+            switch::Switch,
+            tabs::{TabContent, TabHeader},
+            text_area::TextArea,
+            text_input::TextInput,
+            time_picker::TimePicker,
+            titlebar::Titlebar,
+            toast::Toast,
+            tooltip::Tooltip,
+            tree_view::{TreeView, TreeViewNode},
+        };
+
+        vec![
+            (
+                "accordion",
+                Accordion::new(AccordionSectionVec::from_vec(vec![
+                    AccordionSection::new("Open section", user_content()).with_open(true),
+                    AccordionSection::new("Closed section", user_content()),
+                ]))
+                .dom(),
+            ),
+            (
+                "alert",
+                Alert::create(AzString::from("Something happened"))
+                    .with_dismissible(true)
+                    .dom(),
+            ),
+            ("avatar", Avatar::create(AzString::from("AB")).dom()),
+            (
+                "backstage",
+                Backstage::new(BackstageNavItemVec::from_vec(vec![
+                    BackstageNavItem::new(AzString::from("Info")),
+                    BackstageNavItem::new(AzString::from("Save")),
+                ]))
+                .dom(),
+            ),
+            ("badge", Badge::create(AzString::from("99+")).dom()),
+            (
+                "breadcrumb",
+                Breadcrumb::create(labels(&["Home", "Docs", "Page"])).dom(),
+            ),
+            ("button", Button::create(AzString::from("Click me")).dom()),
+            ("card", Card::create(user_content()).dom()),
+            ("check_box", CheckBox::create(true).dom()),
+            (
+                "chip",
+                Chip::create(AzString::from("tag")).with_removable(true).dom(),
+            ),
+            (
+                "color_input",
+                ColorInput::create(ColorU { r: 1, g: 2, b: 3, a: 255 }).dom(),
+            ),
+            ("combobox", ComboBox::new(labels(&["one", "two"])).dom()),
+            ("date_picker", DatePicker::create(2024, 2, 15).dom()),
+            ("divider", Divider::create().dom()),
+            ("drop_down", DropDown::new(labels(&["one", "two"])).dom()),
+            ("file_input", FileInput::create(OptionString::None).dom()),
+            (
+                "frame",
+                Frame::create(AzString::from("Frame title"), user_content()).dom(),
+            ),
+            ("label", Label::create(AzString::from("A label")).dom()),
+            ("list_view", ListView::create(labels(&["Name", "Size"])).dom()),
+            ("map", MapWidget::create(MapTileLayer::default()).dom()),
+            (
+                "modal",
+                Modal::create(user_content())
+                    .with_title(AzString::from("Dialog"))
+                    .with_open(true)
+                    .dom(),
+            ),
+            ("node_graph", node_graph_fixture().dom()),
+            ("number_input", NumberInput::create(4.0).dom()),
+            ("pagination", Pagination::create(2, 5).dom()),
+            (
+                "popover",
+                Popover::new(user_content(), user_content()).with_open(true).dom(),
+            ),
+            ("progressbar", ProgressBar::create(40.0).dom()),
+            (
+                "quick_access",
+                QuickAccessBar::new(AzString::from("Document1")).dom(),
+            ),
+            (
+                "radio_group",
+                RadioGroup::create(labels(&["First", "Second"])).dom(),
+            ),
+            (
+                "ribbon",
+                Ribbon::new(RibbonTabVec::from_vec(vec![
+                    RibbonTab::new(AzString::from("HOME")).with_group(
+                        RibbonGroup::new(AzString::from("Clipboard")).with_item(
+                            RibbonItem::LargeButton(RibbonButton::new(
+                                AzString::from("content_paste"),
+                                AzString::from("Paste"),
+                            )),
+                        ),
+                    ),
+                    RibbonTab::new(AzString::from("PAGE LAYOUT")),
+                ]))
+                .with_app_button(RibbonAppButton::new(AzString::from("FILE")))
+                .dom(),
+            ),
+            (
+                "segmented",
+                Segmented::create(labels(&["Day", "Week", "Month"])).dom(),
+            ),
+            ("slider", Slider::create(0.5, 0.0, 1.0).dom()),
+            ("spinner", Spinner::create().dom()),
+            (
+                "split_pane",
+                SplitPane::create(SplitDirection::Horizontal, user_content(), user_content()).dom(),
+            ),
+            (
+                "statusbar",
+                StatusBar::new(StatusBarSegmentVec::from_vec(vec![
+                    StatusBarSegment::new(AzString::from("Page 1 of 3")),
+                ]))
+                .dom(),
+            ),
+            (
+                "stepper",
+                Stepper::create(labels(&["Start", "Details", "Done"])).dom(),
+            ),
+            ("switch", Switch::create(true).dom()),
+            ("tabs (header)", TabHeader::create(labels(&["One", "Two"])).dom()),
+            ("tabs (content)", TabContent::new(user_content()).dom()),
+            ("text_area", TextArea::create().dom()),
+            ("text_input", TextInput::create().dom()),
+            (
+                "time_picker",
+                TimePicker::create(9, 30).with_24h(false).dom(),
+            ),
+            ("titlebar", Titlebar::create(AzString::from("Window")).dom()),
+            ("toast", Toast::create(AzString::from("Saved")).dom()),
+            (
+                "tooltip",
+                Tooltip::new(user_content(), AzString::from("Explains it")).dom(),
+            ),
+            (
+                "tree_view",
+                TreeView::new(
+                    TreeViewNode::new("root")
+                        .with_expanded(true)
+                        .with_child(TreeViewNode::new("child")),
+                )
+                .dom(),
+            ),
+        ]
+    }
+
+    /// THE convention. A widget that trips this has attached box-model CSS, a
+    /// callback, a `tab_index`, a dataset or children to a node that owns no
+    /// rect — all of which the layout engine silently discards.
+    #[test]
+    fn no_widget_attaches_state_to_a_rect_less_text_node() {
+        let mut bad = Vec::new();
+        for (name, dom) in every_widget_dom() {
+            walk(&dom, name, &mut bad);
+        }
+        assert!(
+            bad.is_empty(),
+            "widget label convention violated ({} site(s)):\n{}",
+            bad.len(),
+            bad.join("\n"),
+        );
+    }
+
+    /// A guard on the guard: the walk must be able to SEE a violation, or the
+    /// test above would pass vacuously the day someone breaks `inert_state_on`.
+    #[test]
+    fn the_walk_reports_a_deliberately_broken_text_node() {
+        use azul_core::dom::TabIndex;
+
+        let mut leaf = Dom::create_text(AzString::from("bare"));
+        leaf.root.set_css("width: 10px;");
+        let broken = Dom::create_div().with_child(leaf.with_tab_index(TabIndex::Auto));
+
+        let mut bad = Vec::new();
+        walk(&broken, "fixture", &mut bad);
+
+        assert_eq!(bad.len(), 1, "the walk missed a hand-broken text node");
+        assert!(bad[0].contains("css props"), "{}", bad[0]);
+        assert!(bad[0].contains("tab_index"), "{}", bad[0]);
+    }
+}

--- a/layout/src/widgets/modal.rs
+++ b/layout/src/widgets/modal.rs
@@ -410,7 +410,7 @@ impl Modal {
         let mut panel_children = Vec::new();
 
         if self.show_close_button {
-            let close = Dom::create_text(AzString::from_const_str("\u{00D7}"))
+            let close = Dom::create_p_with_text(AzString::from_const_str("\u{00D7}"))
                 .with_ids_and_classes(IdOrClassVec::from_const_slice(MODAL_CLOSE_CLASS))
                 .with_css_props(CssPropertyWithConditionsVec::from_const_slice(MODAL_CLOSE_STYLE))
                 .with_tab_index(TabIndex::Auto)
@@ -431,7 +431,7 @@ impl Modal {
         }
 
         if !self.title.as_str().is_empty() {
-            let title = Dom::create_text(self.title)
+            let title = Dom::create_p_with_text(self.title)
                 .with_ids_and_classes(IdOrClassVec::from_const_slice(MODAL_TITLE_CLASS))
                 .with_css_props(CssPropertyWithConditionsVec::from_const_slice(MODAL_TITLE_STYLE));
             panel_children.push(title);
@@ -560,10 +560,18 @@ mod autotest_generated {
             .any(|c| matches!(c, Class(s) if s.as_str() == name))
     }
 
-    /// The text of a `NodeType::Text` node (`None` for any other node type).
+    /// The text of a text node, looking through the `<p>` block wrapper the
+    /// label convention mandates (`p > text`).
     fn text_of(node: &Dom) -> Option<&str> {
         match node.root.get_node_type() {
             NodeType::Text(s) => Some(s.as_ref().as_str()),
+            NodeType::P => match node.children.as_ref() {
+                [only] => match only.root.get_node_type() {
+                    NodeType::Text(s) => Some(s.as_ref().as_str()),
+                    _ => None,
+                },
+                _ => None,
+            },
             _ => None,
         }
     }
@@ -758,14 +766,15 @@ mod autotest_generated {
     }
 
     /// The flattened DOM of a default modal: `backdrop(0)`, `panel(1)`,
-    /// `close(2)`, `content-wrapper(3)`, `content(4)` — i.e. exactly the
-    /// hierarchy `on_modal_close` walks (hit node -> parent -> parent).
+    /// `close <p>(2)`, `close text(3)`, `content-wrapper(4)`, `content(5)` —
+    /// i.e. exactly the hierarchy `on_modal_close` walks (hit node -> parent ->
+    /// parent). The callback lives on the `<p>`, never on the text node.
     fn modal_styled_dom() -> StyledDom {
         let styled = StyledDom::create_from_dom(Modal::create(Dom::create_div()).dom());
         assert_eq!(
             styled.node_hierarchy.as_ref().len(),
-            5,
-            "fixture must flatten to backdrop/panel/close/wrapper/content"
+            6,
+            "fixture must flatten to backdrop/panel/close <p> + text/wrapper/content"
         );
         styled
     }
@@ -1362,7 +1371,7 @@ mod autotest_generated {
         assert_eq!(kids.len(), 2, "no title -> [close, content]");
         assert!(has_class(&kids[0], "__azul-native-modal-close"));
         assert!(has_class(&kids[1], "__azul-native-modal-content"));
-        assert_eq!(node_count(&dom), 5);
+        assert_eq!(node_count(&dom), 6); // close "x" is a <p> + its text leaf
     }
 
     #[test]
@@ -1379,7 +1388,7 @@ mod autotest_generated {
         assert!(has_class(&kids[1], "__azul-native-modal-title"));
         assert!(has_class(&kids[2], "__azul-native-modal-content"));
         assert_eq!(text_of(&kids[1]), Some("Title"));
-        assert_eq!(node_count(&dom), 6);
+        assert_eq!(node_count(&dom), 8); // close + title each: <p> + text leaf
     }
 
     #[test]
@@ -1529,8 +1538,9 @@ mod autotest_generated {
             .with_open(true)
             .dom();
 
-        // backdrop + panel + close + title + wrapper + content root + 2000*5
-        assert_eq!(node_count(&dom), 6 + 2_000 * 5);
+        // backdrop + panel + close(<p>+text) + title(<p>+text) + wrapper +
+        // content root + 2000*5
+        assert_eq!(node_count(&dom), 8 + 2_000 * 5);
         assert_eq!(count_callbacks(&dom), 1);
     }
 
@@ -1684,7 +1694,7 @@ mod autotest_generated {
 
     #[test]
     fn close_with_a_stale_hit_node_is_a_noop() {
-        // node 999 does not exist in the 5-node fixture
+        // node 999 does not exist in the 6-node fixture
         let mut data = RefAny::new(ModalStateWrapper {
             inner: ModalState { open: true },
             on_close: OptionModalOnClose::None,
@@ -1773,8 +1783,9 @@ mod autotest_generated {
         assert!(wrapper_open(&mut payload), "the snapshot starts open");
 
         let styled = StyledDom::create_from_dom(dom);
-        // backdrop(0), panel(1), close(2), title(3), wrapper(4), content(5)
-        assert_eq!(styled.node_hierarchy.as_ref().len(), 6);
+        // backdrop(0), panel(1), close <p>(2) + text(3), title <p>(4) + text(5),
+        // wrapper(6), content(7)
+        assert_eq!(styled.node_hierarchy.as_ref().len(), 8);
 
         let (update, changes) = run_close(Some(styled), 2, payload.clone());
 

--- a/layout/src/widgets/modal.rs
+++ b/layout/src/widgets/modal.rs
@@ -948,7 +948,7 @@ mod autotest_generated {
 
     #[test]
     fn create_is_a_closed_modal_with_a_close_button_and_no_title() {
-        let content = Dom::create_div().with_child(Dom::create_text("hi"));
+        let content = Dom::create_div().with_child(Dom::create_text_do_not_use_without_block_level_wrapper("hi"));
         let m = Modal::create(content.clone());
 
         assert!(!m.modal_state.inner.open, "a fresh modal must start closed");
@@ -1036,7 +1036,7 @@ mod autotest_generated {
 
     #[test]
     fn set_title_touches_nothing_else() {
-        let content = Dom::create_div().with_child(Dom::create_text("body"));
+        let content = Dom::create_div().with_child(Dom::create_text_do_not_use_without_block_level_wrapper("body"));
         let mut m = Modal::create(content.clone()).with_open(true);
         let before = m.backdrop_style.clone();
 
@@ -1082,8 +1082,8 @@ mod autotest_generated {
 
     #[test]
     fn set_content_replaces_and_last_write_wins() {
-        let a = Dom::create_div().with_child(Dom::create_text("a"));
-        let b = Dom::create_text("b");
+        let a = Dom::create_div().with_child(Dom::create_text_do_not_use_without_block_level_wrapper("a"));
+        let b = Dom::create_text_do_not_use_without_block_level_wrapper("b");
 
         let mut m = Modal::create(a.clone());
         assert_eq!(m.content, a);
@@ -1317,7 +1317,7 @@ mod autotest_generated {
 
     #[test]
     fn swap_with_default_returns_the_original_and_resets_self() {
-        let content = Dom::create_div().with_child(Dom::create_text("body"));
+        let content = Dom::create_div().with_child(Dom::create_text_do_not_use_without_block_level_wrapper("body"));
         let mut m = Modal::create(content.clone())
             .with_title(AzString::from("Title"))
             .with_open(true)
@@ -1771,7 +1771,7 @@ mod autotest_generated {
     fn close_end_to_end_through_the_real_dom_payload() {
         // Take the *actual* RefAny the widget wired into its close button and
         // drive the *actual* handler the widget registered against it.
-        let modal = Modal::create(Dom::create_text("body"))
+        let modal = Modal::create(Dom::create_text_do_not_use_without_block_level_wrapper("body"))
             .with_title(AzString::from("Title"))
             .with_open(true);
         let dom = modal.dom();

--- a/layout/src/widgets/node_graph.rs
+++ b/layout/src/widgets/node_graph.rs
@@ -2296,7 +2296,7 @@ fn render_node(
            IdOrClassVec::from_const_slice(IDS_AND_CLASSES_4480169002427296613)
         })
         .with_children(DomVec::from_vec(vec![
-           Dom::create_text(AzString::from_const_str("X"))
+           Dom::create_p_with_text(AzString::from_const_str("X"))
                .with_css_props(CSS_MATCH_7395766480280098891)
                .with_callbacks(vec![
                    CoreCallbackData {
@@ -2310,7 +2310,7 @@ fn render_node(
                        &[Class(AzString::from_const_str("node_close_button"))];
                    IdOrClassVec::from_const_slice(IDS_AND_CLASSES_7122017923389407516)
                }),
-           Dom::create_text(node_info.node_type_name.clone())
+           Dom::create_p_with_text(node_info.node_type_name.clone())
                .with_css_props(CSS_MATCH_1739273067404038547)
                .with_ids_and_classes({
                    const IDS_AND_CLASSES_15777790571346582635: &[IdOrClass] =
@@ -2374,7 +2374,7 @@ fn render_node(
                                                        IDS_AND_CLASSES_9154857442066749879,
                                                    )
                                                })
-                                               .with_children(DomVec::from_vec(vec![Dom::create_text(
+                                               .with_children(DomVec::from_vec(vec![Dom::create_p_with_text(
                                                    input_label,
                                                )
                                                .with_css_props(
@@ -2468,7 +2468,7 @@ fn render_node(
                                    )
                                })
                                .with_children(DomVec::from_vec(vec![
-                                   Dom::create_text(field.key.clone())
+                                   Dom::create_p_with_text(field.key.clone())
                                    .with_css_props(CSS_MATCH_1198521124955124418)
                                    .with_ids_and_classes({
                                        const IDS_AND_CLASSES_12334207996395559585:
@@ -2616,7 +2616,7 @@ fn render_node(
                                                        IDS_AND_CLASSES_1667960214206134147,
                                                    )
                                                })
-                                               .with_children(DomVec::from_vec(vec![Dom::create_text(
+                                               .with_children(DomVec::from_vec(vec![Dom::create_p_with_text(
                                                    output_label,
                                                )
                                                .with_css_props(

--- a/layout/src/widgets/number_input.rs
+++ b/layout/src/widgets/number_input.rs
@@ -767,13 +767,18 @@ mod autotest_generated {
         wrapper.inner.get_text()
     }
 
-    /// The text actually *rendered* into the label node.
+    /// The text actually *rendered* into the label node (a styled `<p>`
+    /// wrapping its bare text leaf per the label convention).
     fn displayed_text(dom: &Dom) -> String {
-        dom.children.as_ref()[LABEL]
+        let label = &dom.children.as_ref()[LABEL];
+        label
             .root
             .get_node_type()
             .format()
-            .expect("the label child must be a text node")
+            .or_else(|| {
+                label.children.as_ref().first().and_then(|c| c.root.get_node_type().format())
+            })
+            .expect("the label child must wrap a text node")
     }
 
     fn cursor_pos(dom: &Dom) -> usize {
@@ -1101,11 +1106,12 @@ mod autotest_generated {
         );
         assert!(
             dom.children.as_ref()[PLACEHOLDER]
-                .root
-                .get_node_type()
-                .format()
+                .children
+                .as_ref()
+                .first()
+                .and_then(|c| c.root.get_node_type().format())
                 .is_some(),
-            "the placeholder child must be a text node",
+            "the placeholder child must wrap a text node",
         );
         assert_eq!(buffer_text(&dom), "-12.5");
         assert_eq!(displayed_text(&dom), "-12.5");

--- a/layout/src/widgets/pagination.rs
+++ b/layout/src/widgets/pagination.rs
@@ -353,7 +353,7 @@ impl Pagination {
 
         let make_button =
             |label: AzString, class: &'static [IdOrClass], style: CssPropertyWithConditionsVec| {
-                Dom::create_text(label)
+                Dom::create_p_with_text(label)
                     .with_ids_and_classes(IdOrClassVec::from_const_slice(class))
                     .with_css_props(style)
                     .with_callbacks(
@@ -572,6 +572,13 @@ mod autotest_generated {
     fn text_of(node: &Dom) -> Option<&str> {
         match node.root.get_node_type() {
             NodeType::Text(s) => Some(s.as_ref().as_str()),
+            NodeType::P => match node.children.as_ref() {
+                [only] => match only.root.get_node_type() {
+                    NodeType::Text(s) => Some(s.as_ref().as_str()),
+                    _ => None,
+                },
+                _ => None,
+            },
             _ => None,
         }
     }
@@ -762,15 +769,18 @@ mod autotest_generated {
             .clone()
     }
 
-    /// Flattened node id of the `Prev` button (root is 0, children follow in order).
+    /// Flattened node ids. Every button is a `<p>` wrapping one bare text node,
+    /// so depth-first pre-order lays them out as
+    /// `0 root / 1 Prev <p> / 2 Prev text / 3 page1 <p> / 4 page1 text / …`.
+    /// The callbacks sit on the `<p>`s.
     const PREV_NODE: usize = 1;
     /// Flattened node id of page `p` (1-based).
     const fn page_node(p: usize) -> usize {
-        p + 1
+        2 * p + 1
     }
     /// Flattened node id of the `Next` button for a `total`-page pager.
     const fn next_node(total: usize) -> usize {
-        total + 2
+        2 * total + 3
     }
 
     /// A `DomLayoutResult` with an *empty* layout tree: `on_page_click` only walks
@@ -1614,7 +1624,7 @@ mod autotest_generated {
             assert_eq!(dom.children.as_ref().len(), total + 2);
             assert_eq!(
                 dom.estimated_total_children,
-                total + 2,
+                2 * (total + 2),
                 "cached descendant count desynced for total={total}"
             );
         }
@@ -1669,8 +1679,8 @@ mod autotest_generated {
         let styled = StyledDom::create_from_dom(Pagination::create(250, total).dom());
         assert_eq!(
             styled.node_hierarchy.as_ref().len(),
-            total + 3,
-            "root + Prev + {total} pages + Next"
+            2 * total + 5,
+            "root + (Prev + {total} pages + Next), each a <p> wrapping one text node"
         );
     }
 
@@ -1882,7 +1892,7 @@ mod autotest_generated {
         assert_eq!(pass.len(), total + 2, "one pair of writes per button");
 
         for (i, (node, bg, fg)) in pass.iter().enumerate() {
-            assert_eq!(*node, i + 1, "buttons must be restyled in document order");
+            assert_eq!(*node, 2 * i + 1, "buttons must be restyled in document order");
             let (want_bg, want_fg) = if i == 0 {
                 // Prev: live, because the new page is not 1.
                 (NEUTRAL_BG_COLOR, NEUTRAL_TEXT)

--- a/layout/src/widgets/popover.rs
+++ b/layout/src/widgets/popover.rs
@@ -750,8 +750,8 @@ mod autotest_generated {
 
     #[test]
     fn new_stores_both_doms_and_starts_closed() {
-        let anchor = Dom::create_div().with_child(Dom::create_text("anchor"));
-        let content = Dom::create_text("panel");
+        let anchor = Dom::create_div().with_child(Dom::create_text_do_not_use_without_block_level_wrapper("anchor"));
+        let content = Dom::create_text_do_not_use_without_block_level_wrapper("panel");
         let pop = Popover::new(anchor.clone(), content.clone());
 
         assert_eq!(pop.anchor, anchor, "the anchor must be stored verbatim");
@@ -788,12 +788,12 @@ mod autotest_generated {
     fn new_survives_extreme_doms() {
         // a 128-deep anchor and a 2000-sibling panel: nothing may be truncated,
         // reordered or recursed into during construction.
-        let mut deep = Dom::create_text("leaf");
+        let mut deep = Dom::create_text_do_not_use_without_block_level_wrapper("leaf");
         for _ in 0..128 {
             deep = Dom::create_div().with_child(deep);
         }
         let wide_children: Vec<Dom> = (0..2000)
-            .map(|i| Dom::create_text(alloc::format!("{i}")))
+            .map(|i| Dom::create_text_do_not_use_without_block_level_wrapper(alloc::format!("{i}")))
             .collect();
         let wide = Dom::create_div().with_children(wide_children.clone().into());
 
@@ -809,7 +809,7 @@ mod autotest_generated {
     fn new_accepts_the_same_dom_as_anchor_and_content() {
         // aliasing the two arguments must produce two independent subtrees, not
         // one shared (and later doubly-mounted) node.
-        let shared = Dom::create_div().with_child(Dom::create_text("x"));
+        let shared = Dom::create_div().with_child(Dom::create_text_do_not_use_without_block_level_wrapper("x"));
         let pop = Popover::new(shared.clone(), shared.clone());
 
         assert_eq!(pop.anchor, shared);
@@ -827,7 +827,7 @@ mod autotest_generated {
 
     #[test]
     fn set_open_round_trips_state_and_style() {
-        let mut pop = Popover::new(Dom::create_text("a"), Dom::create_text("c"));
+        let mut pop = Popover::new(Dom::create_text_do_not_use_without_block_level_wrapper("a"), Dom::create_text_do_not_use_without_block_level_wrapper("c"));
 
         // repeats and flips: the style must follow the flag on every write,
         // including redundant ones.
@@ -850,16 +850,16 @@ mod autotest_generated {
         }
 
         // the restyle must not touch the payload doms
-        assert_eq!(pop.anchor, Dom::create_text("a"));
-        assert_eq!(pop.content, Dom::create_text("c"));
+        assert_eq!(pop.anchor, Dom::create_text_do_not_use_without_block_level_wrapper("a"));
+        assert_eq!(pop.content, Dom::create_text_do_not_use_without_block_level_wrapper("c"));
     }
 
     #[test]
     fn with_open_matches_set_open() {
         for open in [false, true] {
-            let mut mutated = Popover::new(Dom::create_text("a"), Dom::create_text("c"));
+            let mut mutated = Popover::new(Dom::create_text_do_not_use_without_block_level_wrapper("a"), Dom::create_text_do_not_use_without_block_level_wrapper("c"));
             mutated.set_open(open);
-            let built = Popover::new(Dom::create_text("a"), Dom::create_text("c")).with_open(open);
+            let built = Popover::new(Dom::create_text_do_not_use_without_block_level_wrapper("a"), Dom::create_text_do_not_use_without_block_level_wrapper("c")).with_open(open);
             assert_eq!(built, mutated, "builder and setter must agree (open = {open})");
         }
     }
@@ -923,15 +923,15 @@ mod autotest_generated {
 
     #[test]
     fn set_on_toggle_does_not_disturb_state_style_or_doms() {
-        let mut pop = Popover::new(Dom::create_text("a"), Dom::create_text("c")).with_open(true);
+        let mut pop = Popover::new(Dom::create_text_do_not_use_without_block_level_wrapper("a"), Dom::create_text_do_not_use_without_block_level_wrapper("c")).with_open(true);
         let style_before = pop.content_style.clone();
 
         pop.set_on_toggle(RefAny::new(0u8), toggle_cb(toggle_do_nothing));
 
         assert!(pop.popover_state.inner.open, "open flag must survive");
         assert_eq!(pop.content_style, style_before, "style must survive");
-        assert_eq!(pop.anchor, Dom::create_text("a"));
-        assert_eq!(pop.content, Dom::create_text("c"));
+        assert_eq!(pop.anchor, Dom::create_text_do_not_use_without_block_level_wrapper("a"));
+        assert_eq!(pop.content, Dom::create_text_do_not_use_without_block_level_wrapper("c"));
     }
 
     #[test]
@@ -980,14 +980,14 @@ mod autotest_generated {
 
     #[test]
     fn swap_with_default_moves_all_state_out() {
-        let mut pop = Popover::new(Dom::create_text("a"), Dom::create_text("c"))
+        let mut pop = Popover::new(Dom::create_text_do_not_use_without_block_level_wrapper("a"), Dom::create_text_do_not_use_without_block_level_wrapper("c"))
             .with_open(true)
             .with_on_toggle(RefAny::new(5u8), toggle_cb(record_toggle));
 
         let original = pop.swap_with_default();
 
-        assert_eq!(original.anchor, Dom::create_text("a"));
-        assert_eq!(original.content, Dom::create_text("c"));
+        assert_eq!(original.anchor, Dom::create_text_do_not_use_without_block_level_wrapper("a"));
+        assert_eq!(original.content, Dom::create_text_do_not_use_without_block_level_wrapper("c"));
         assert!(original.popover_state.inner.open);
         assert!(original.popover_state.on_toggle.is_some());
         assert_eq!(original.content_style, build_content_style(true));
@@ -1018,7 +1018,7 @@ mod autotest_generated {
 
     #[test]
     fn dom_structure_classes_and_callback() {
-        let dom = Popover::new(Dom::create_text("anchor"), Dom::create_text("panel")).dom();
+        let dom = Popover::new(Dom::create_text_do_not_use_without_block_level_wrapper("anchor"), Dom::create_text_do_not_use_without_block_level_wrapper("panel")).dom();
 
         assert!(has_class(&dom, "__azul-native-popover"));
         let children = dom.children.as_ref();
@@ -1135,7 +1135,7 @@ mod autotest_generated {
         // deep + wide payloads: `estimated_total_children` must still equal the
         // real descendant count, otherwise the compact-DOM arena under-allocates
         // and panics later.
-        let mut deep = Dom::create_text("leaf");
+        let mut deep = Dom::create_text_do_not_use_without_block_level_wrapper("leaf");
         for _ in 0..64 {
             deep = Dom::create_div().with_child(deep);
         }
@@ -1172,7 +1172,7 @@ mod autotest_generated {
         // `Dom::from(p) == p.dom()` cannot be asserted directly: every `dom()`
         // call mints a fresh `RefAny` for the trigger payload, and two distinct
         // `RefAny`s never compare equal. Compare the observable structure.
-        let make = || Popover::new(Dom::create_text("a"), Dom::create_text("c")).with_open(true);
+        let make = || Popover::new(Dom::create_text_do_not_use_without_block_level_wrapper("a"), Dom::create_text_do_not_use_without_block_level_wrapper("c")).with_open(true);
         let via_from = Dom::from(make());
         let via_dom = make().dom();
 

--- a/layout/src/widgets/quick_access.rs
+++ b/layout/src/widgets/quick_access.rs
@@ -551,7 +551,7 @@ impl QuickAccessBar {
         }
 
         children.push(
-            Dom::create_text(title)
+            Dom::create_p_with_text(title)
                 .with_ids_and_classes(IdOrClassVec::from_const_slice(CLS_TITLE))
                 .with_css_props(style.title_style.clone()),
         );

--- a/layout/src/widgets/radio_group.rs
+++ b/layout/src/widgets/radio_group.rs
@@ -408,7 +408,7 @@ impl RadioGroup {
                     .into(),
                 );
 
-            let label_node = Dom::create_text(label.clone())
+            let label_node = Dom::create_p_with_text(label.clone())
                 .with_ids_and_classes(IdOrClassVec::from_const_slice(RADIO_GROUP_LABEL_CLASS))
                 .with_css_props(CssPropertyWithConditionsVec::from_const_slice(
                     RADIO_GROUP_LABEL_STYLE,
@@ -719,10 +719,18 @@ mod autotest_generated {
             .collect()
     }
 
-    /// The text of a `NodeType::Text` node (`None` for any other node type).
+    /// The text of a text node, looking through the `<p>` block wrapper the
+    /// label convention mandates (`p > text`).
     fn text_of(node: &Dom) -> Option<&str> {
         match node.root.get_node_type() {
             NodeType::Text(s) => Some(s.as_ref().as_str()),
+            NodeType::P => match node.children.as_ref() {
+                [only] => match only.root.get_node_type() {
+                    NodeType::Text(s) => Some(s.as_ref().as_str()),
+                    _ => None,
+                },
+                _ => None,
+            },
             _ => None,
         }
     }
@@ -758,14 +766,15 @@ mod autotest_generated {
     // ------------------------------------------------------------------
 
     /// Flattened (pre-order) node id of option row `i`: the tree is
-    /// `root, [row, circle, dot, label] * n`.
+    /// `root, [row, circle, dot, label <p>, label text] * n` — the label is a
+    /// `<p>` wrapping a bare text node, per the widget label convention.
     fn row_node(i: usize) -> DomNodeId {
-        node(1 + 4 * i)
+        node(1 + 5 * i)
     }
 
     /// Flattened node id of option `i`'s indicator dot.
     fn dot_node(i: usize) -> NodeId {
-        NodeId::new(3 + 4 * i)
+        NodeId::new(3 + 5 * i)
     }
 
     fn node(idx: usize) -> DomNodeId {
@@ -1722,15 +1731,15 @@ mod autotest_generated {
     }
 
     #[test]
-    fn dom_flattens_to_four_nodes_per_option() {
-        // root + (row, circle, dot, label) per option. The click handler's live
-        // restyle walks exactly this shape, and the callback tests below address
-        // nodes by this formula.
+    fn dom_flattens_to_five_nodes_per_option() {
+        // root + (row, circle, dot, label <p>, label text) per option. The click
+        // handler's live restyle walks exactly this shape, and the callback tests
+        // below address nodes by this formula.
         for n in [0, 1, 2, 7] {
             let styled = StyledDom::create_from_dom(RadioGroup::create(n_labels(n)).dom());
             assert_eq!(
                 styled.node_hierarchy.as_ref().len(),
-                1 + 4 * n,
+                1 + 5 * n,
                 "an {n}-option group flattened to an unexpected node count",
             );
         }
@@ -2004,9 +2013,9 @@ mod autotest_generated {
         // the callback is registered on, and only rows carry callbacks. Should an
         // inner node ever reach it anyway, it must stay memory-safe and push no
         // half-finished restyle — the sibling walk simply finds no dots to update.
-        // (`dot` is its circle's only child -> position 0; `label` is its row's
-        // second child -> position 1, regardless of which row it belongs to.)
-        for (hit, expected) in [(node(3), 0usize), (node(11), 0), (node(4), 1), (node(12), 1)] {
+        // (`dot` is its circle's only child -> position 0; the label `<p>` is its
+        // row's second child -> position 1, regardless of which row it belongs to.)
+        for (hit, expected) in [(node(3), 0usize), (node(13), 0), (node(4), 1), (node(14), 1)] {
             let (styled, state) = flatten(group(&["a", "b", "c"]));
             let mut probe = state.clone();
 

--- a/layout/src/widgets/ribbon.rs
+++ b/layout/src/widgets/ribbon.rs
@@ -2117,7 +2117,7 @@ impl Ribbon {
             .with_children(DomVec::from_vec(vec![
                 Dom::create_p()
                     .with_css_props(style.mobile_tab_label_style.clone())
-                    .with_children(DomVec::from_vec(vec![Dom::create_text(active_label)])),
+                    .with_children(DomVec::from_vec(vec![Dom::create_text_do_not_use_without_block_level_wrapper(active_label)])),
                 Dom::create_icon(AzString::from_const_str("expand_more"))
                     .with_css_props(style.mobile_tab_arrow_style.clone()),
             ]));
@@ -2440,7 +2440,7 @@ fn group_dom(group: RibbonGroup, s: &RibbonStyle, b: RibbonBehavior) -> Dom {
         Dom::create_p()
             .with_ids_and_classes(IdOrClassVec::from_const_slice(CLS_GROUP_LABEL))
             .with_css_props(s.group_label_style.clone())
-            .with_children(DomVec::from_vec(vec![Dom::create_text(label)])),
+            .with_children(DomVec::from_vec(vec![Dom::create_text_do_not_use_without_block_level_wrapper(label)])),
     );
     if let Some(l) = launcher.into_option() {
         footer_children.push(styled_button(
@@ -2494,7 +2494,7 @@ fn gallery_dom(gallery: RibbonGallery, s: &RibbonStyle, b: RibbonBehavior) -> Do
             };
             let label = Dom::create_p()
                 .with_css_props(s.gallery_cell_label_style.clone())
-                .with_children(DomVec::from_vec(vec![Dom::create_text(cell.label.clone())]));
+                .with_children(DomVec::from_vec(vec![Dom::create_text_do_not_use_without_block_level_wrapper(cell.label.clone())]));
             let mut d = Dom::create_div()
                 .with_ids_and_classes(IdOrClassVec::from_const_slice(classes))
                 .with_css_props(cell_style)
@@ -3682,7 +3682,7 @@ mod tests {
 
     #[test]
     fn custom_items_pass_through_verbatim() {
-        let custom = Dom::create_text("¶");
+        let custom = Dom::create_text_do_not_use_without_block_level_wrapper("¶");
         let node = render_item(RibbonItem::Custom(custom.clone()));
         assert_eq!(node, custom);
     }
@@ -3695,7 +3695,7 @@ mod tests {
         let v: Vec<RibbonGalleryCell> = (0..cells)
             .map(|i| {
                 RibbonGalleryCell::new(
-                    Dom::create_text(format!("AaBbCc{i}")),
+                    Dom::create_text_do_not_use_without_block_level_wrapper(format!("AaBbCc{i}")),
                     AzString::from(format!("Style {i}")),
                 )
             })

--- a/layout/src/widgets/segmented.rs
+++ b/layout/src/widgets/segmented.rs
@@ -345,7 +345,7 @@ impl Segmented {
             let seg_style = build_segment_style(i == selected, is_first, is_last);
 
             children.push(
-                Dom::create_text(label.clone())
+                Dom::create_p_with_text(label.clone())
                     .with_ids_and_classes(IdOrClassVec::from_const_slice(SEGMENT_ITEM_CLASS))
                     .with_css_props(seg_style)
                     .with_callbacks(
@@ -647,10 +647,18 @@ mod autotest_generated {
         0.2126 * f32::from(c.r) + 0.7152 * f32::from(c.g) + 0.0722 * f32::from(c.b)
     }
 
-    /// The text of a `NodeType::Text` node (`None` for any other node type).
+    /// The text of a text node, looking through the `<p>` block wrapper the
+    /// label convention mandates (`p > text`).
     fn text_of(node: &Dom) -> Option<&str> {
         match node.root.get_node_type() {
             NodeType::Text(s) => Some(s.as_ref().as_str()),
+            NodeType::P => match node.children.as_ref() {
+                [only] => match only.root.get_node_type() {
+                    NodeType::Text(s) => Some(s.as_ref().as_str()),
+                    _ => None,
+                },
+                _ => None,
+            },
             _ => None,
         }
     }
@@ -813,6 +821,14 @@ mod autotest_generated {
         let dom = seg.dom();
         let state = segment_state(&dom, 0);
         (StyledDom::create_from_dom(dom), state)
+    }
+
+    /// Flattened (pre-order) node id of segment `i`. Every segment is a `<p>`
+    /// wrapping one bare text node, so the tree is
+    /// `0 root / 1 seg0 <p> / 2 seg0 text / 3 seg1 <p> / …` and the callback
+    /// sits on the `<p>`.
+    const fn seg_node(i: usize) -> usize {
+        2 * i + 1
     }
 
     /// Invokes `on_segment_click` against a `LayoutWindow` holding `styled` (or
@@ -1727,12 +1743,15 @@ mod autotest_generated {
             let dom = Segmented::create(labels(&[s.as_str(), "other"])).dom();
             let children = dom.children.as_ref();
             assert_eq!(children.len(), 2);
-            match children[0].root.get_node_type() {
-                NodeType::Text(t) => {
-                    assert_eq!(t.as_ref().as_str(), s.as_str(), "the caption changed inside dom()");
-                    assert_eq!(t.as_ref().len(), s.len(), "byte length changed (NUL truncation?)");
-                }
-                other => panic!("expected a text node, got {other:?}"),
+            match children[0].children.as_ref() {
+                [only] => match only.root.get_node_type() {
+                    NodeType::Text(t) => {
+                        assert_eq!(t.as_ref().as_str(), s.as_str(), "the caption changed inside dom()");
+                        assert_eq!(t.as_ref().len(), s.len(), "byte length changed (NUL truncation?)");
+                    }
+                    other => panic!("expected a text node, got {other:?}"),
+                },
+                other => panic!("expected `p > text`, got {} children", other.len()),
             }
         }
     }
@@ -1749,7 +1768,11 @@ mod autotest_generated {
                 recursive_descendants(&dom),
                 "cached descendant count desynced for n={n}"
             );
-            assert_eq!(dom.estimated_total_children, n, "for n={n}");
+            assert_eq!(
+                dom.estimated_total_children,
+                2 * n,
+                "for n={n} (each segment is a <p> wrapping one text node)"
+            );
         }
     }
 
@@ -1757,7 +1780,11 @@ mod autotest_generated {
     fn dom_of_many_segments_flattens_without_panicking() {
         let n = 512;
         let styled = StyledDom::create_from_dom(Segmented::create(n_labels(n)).dom());
-        assert_eq!(styled.node_hierarchy.as_ref().len(), n + 1, "root + n segments");
+        assert_eq!(
+            styled.node_hierarchy.as_ref().len(),
+            2 * n + 1,
+            "root + n segments, each a <p> wrapping one text node"
+        );
     }
 
     #[test]
@@ -1805,18 +1832,27 @@ mod autotest_generated {
     fn click_selects_the_segment_at_the_clicked_position() {
         let n = 4;
         let (styled, state) = flatten(Segmented::create(n_labels(n)));
-        assert_eq!(styled.node_hierarchy.as_ref().len(), n + 1, "fixture: root + n segments");
+        assert_eq!(
+            styled.node_hierarchy.as_ref().len(),
+            2 * n + 1,
+            "fixture: root + n segments, each a <p> wrapping one text node"
+        );
 
         for i in 0..n {
             let mut state = state.clone();
-            let (update, changes) = run_click(Some(styled.clone()), i + 1, state.clone());
+            let (update, changes) = run_click(Some(styled.clone()), seg_node(i), state.clone());
 
             assert_eq!(
                 update,
                 Update::DoNothing,
                 "with no on_change installed the handler reports nothing to redraw"
             );
-            assert_eq!(selected_index_of(&mut state), i, "node {} must select segment {i}", i + 1);
+            assert_eq!(
+                selected_index_of(&mut state),
+                i,
+                "node {} must select segment {i}",
+                seg_node(i)
+            );
             assert_eq!(restyle_writes(&changes).len(), 2 * n, "every segment must be restyled");
         }
     }
@@ -1829,7 +1865,7 @@ mod autotest_generated {
         let (styled, state) = flatten(Segmented::create(n_labels(n)));
 
         for clicked in 0..n {
-            let (_, changes) = run_click(Some(styled.clone()), clicked + 1, state.clone());
+            let (_, changes) = run_click(Some(styled.clone()), seg_node(clicked), state.clone());
             let writes = restyle_writes(&changes);
             assert_eq!(writes.len(), 2 * n);
 
@@ -1837,12 +1873,12 @@ mod autotest_generated {
                 let fresh = build_segment_style(i == clicked, i == 0, i + 1 == n);
                 assert_eq!(
                     writes[2 * i],
-                    (i + 1, "bg", background_color(&fresh).expect("background")),
+                    (seg_node(i), "bg", background_color(&fresh).expect("background")),
                     "clicked={clicked}: segment {i} background"
                 );
                 assert_eq!(
                     writes[2 * i + 1],
-                    (i + 1, "text", text_color(&fresh).expect("text colour")),
+                    (seg_node(i), "text", text_color(&fresh).expect("text colour")),
                     "clicked={clicked}: segment {i} text colour"
                 );
             }
@@ -1856,13 +1892,13 @@ mod autotest_generated {
             .with_on_change(log.clone(), change_cb(record_index));
         let (styled, state) = flatten(seg);
 
-        let (update, changes) = run_click(Some(styled.clone()), 3, state.clone());
+        let (update, changes) = run_click(Some(styled.clone()), seg_node(2), state.clone());
         assert_eq!(update, Update::RefreshDom, "the user's Update must propagate");
         assert_eq!(log_indices(&mut log), vec![2], "the callback sees the *new* index");
         assert_eq!(restyle_writes(&changes).len(), 8, "the restyle must still run");
 
         // A second click updates the shared state again — the index is not sticky.
-        let (_, _) = run_click(Some(styled), 1, state.clone());
+        let (_, _) = run_click(Some(styled), seg_node(0), state.clone());
         assert_eq!(log_indices(&mut log), vec![2, 0]);
 
         let mut state = state;
@@ -1878,7 +1914,7 @@ mod autotest_generated {
             let seg =
                 Segmented::create(labels(&["a", "b"])).with_on_change(RefAny::new(0u8), cb);
             let (styled, state) = flatten(seg);
-            let (update, changes) = run_click(Some(styled), 2, state);
+            let (update, changes) = run_click(Some(styled), seg_node(1), state);
             assert_eq!(update, expected);
             assert_eq!(
                 restyle_writes(&changes).len(),
@@ -1891,16 +1927,16 @@ mod autotest_generated {
     #[test]
     fn click_restyles_even_without_a_user_callback() {
         let (styled, state) = flatten(Segmented::create(labels(&["a", "b"])));
-        let (update, changes) = run_click(Some(styled), 1, state);
+        let (update, changes) = run_click(Some(styled), seg_node(0), state);
 
         assert_eq!(update, Update::DoNothing);
         assert_eq!(
             restyle_writes(&changes),
             vec![
-                (1, "bg", SEG_SELECTED_BG_COLOR),
-                (1, "text", SEG_SELECTED_TEXT),
-                (2, "bg", SEG_UNSELECTED_BG_COLOR),
-                (2, "text", SEG_UNSELECTED_TEXT),
+                (seg_node(0), "bg", SEG_SELECTED_BG_COLOR),
+                (seg_node(0), "text", SEG_SELECTED_TEXT),
+                (seg_node(1), "bg", SEG_UNSELECTED_BG_COLOR),
+                (seg_node(1), "text", SEG_UNSELECTED_TEXT),
             ],
             "selection feedback must not depend on the user wiring a callback"
         );
@@ -1910,13 +1946,16 @@ mod autotest_generated {
     fn click_on_a_single_segment_control_stays_at_zero() {
         let (styled, state) = flatten(Segmented::create(labels(&["only"])));
         let mut probe = state.clone();
-        let (update, changes) = run_click(Some(styled), 1, state);
+        let (update, changes) = run_click(Some(styled), seg_node(0), state);
 
         assert_eq!(update, Update::DoNothing);
         assert_eq!(selected_index_of(&mut probe), 0);
         assert_eq!(
             restyle_writes(&changes),
-            vec![(1, "bg", SEG_SELECTED_BG_COLOR), (1, "text", SEG_SELECTED_TEXT)]
+            vec![
+                (seg_node(0), "bg", SEG_SELECTED_BG_COLOR),
+                (seg_node(0), "text", SEG_SELECTED_TEXT)
+            ]
         );
     }
 
@@ -2012,7 +2051,7 @@ mod autotest_generated {
         }
 
         let styled = StyledDom::create_from_dom(Segmented::create(labels(&["a", "b"])).dom());
-        let (update, changes) = run_click(Some(styled), 2, state.clone());
+        let (update, changes) = run_click(Some(styled), seg_node(1), state.clone());
 
         assert_eq!(update, Update::DoNothing);
         assert_eq!(restyle_writes(&changes).len(), 4, "the restyle must still run afterwards");
@@ -2029,11 +2068,11 @@ mod autotest_generated {
         let n = 128;
         let (styled, state) = flatten(Segmented::create(n_labels(n)));
 
-        for hit in [1usize, 2, n / 2, n - 1, n] {
+        for i in [0usize, 1, n / 2 - 1, n - 2, n - 1] {
             let mut probe = state.clone();
-            let (_, changes) = run_click(Some(styled.clone()), hit, state.clone());
+            let (_, changes) = run_click(Some(styled.clone()), seg_node(i), state.clone());
             let idx = selected_index_of(&mut probe);
-            assert_eq!(idx, hit - 1, "node {hit} sits at sibling position {}", hit - 1);
+            assert_eq!(idx, i, "node {} sits at sibling position {i}", seg_node(i));
             assert!(idx < n, "the reported index must always address a real label");
             assert_eq!(restyle_writes(&changes).len(), 2 * n);
         }
@@ -2047,18 +2086,18 @@ mod autotest_generated {
         let (styled, state) = flatten(seg);
         let mut probe = state.clone();
 
-        let (_, changes) = run_click(Some(styled), 2, state);
+        let (_, changes) = run_click(Some(styled), seg_node(1), state);
 
         assert_eq!(selected_index_of(&mut probe), 1);
         assert_eq!(
             restyle_writes(&changes),
             vec![
-                (1, "bg", SEG_UNSELECTED_BG_COLOR),
-                (1, "text", SEG_UNSELECTED_TEXT),
-                (2, "bg", SEG_SELECTED_BG_COLOR),
-                (2, "text", SEG_SELECTED_TEXT),
-                (3, "bg", SEG_UNSELECTED_BG_COLOR),
-                (3, "text", SEG_UNSELECTED_TEXT),
+                (seg_node(0), "bg", SEG_UNSELECTED_BG_COLOR),
+                (seg_node(0), "text", SEG_UNSELECTED_TEXT),
+                (seg_node(1), "bg", SEG_SELECTED_BG_COLOR),
+                (seg_node(1), "text", SEG_SELECTED_TEXT),
+                (seg_node(2), "bg", SEG_UNSELECTED_BG_COLOR),
+                (seg_node(2), "text", SEG_UNSELECTED_TEXT),
             ]
         );
     }

--- a/layout/src/widgets/slider.rs
+++ b/layout/src/widgets/slider.rs
@@ -11,6 +11,7 @@
 //!
 //! Key types: [`Slider`], [`SliderState`], [`SliderOnValueChange`].
 
+use crate::solver3::layout_tree::LayoutNodeId;
 use azul_core::{
     callbacks::{CoreCallbackData, Update},
     dom::{Dom, IdOrClass, IdOrClass::Class, IdOrClassVec, TabIndex},
@@ -676,8 +677,8 @@ mod autotest_generated {
             parent,
         };
         let mut dom_to_layout = BTreeMap::new();
-        dom_to_layout.insert(NodeId::new(0), vec![0usize]);
-        dom_to_layout.insert(NodeId::new(1), vec![1usize]);
+        dom_to_layout.insert(NodeId::new(0), vec![LayoutNodeId::new(0)]);
+        dom_to_layout.insert(NodeId::new(1), vec![LayoutNodeId::new(1)]);
 
         let mut result = unlaid(styled_dom);
         result.layout_tree.nodes = vec![

--- a/layout/src/widgets/split_pane.rs
+++ b/layout/src/widgets/split_pane.rs
@@ -39,6 +39,7 @@
 //! Key types: [`SplitPane`], [`SplitPaneState`], [`SplitDirection`],
 //! [`SplitPaneOnResize`].
 
+use crate::solver3::layout_tree::LayoutNodeId;
 use std::vec::Vec;
 
 use azul_core::{
@@ -819,7 +820,7 @@ mod autotest_generated {
         for (layout_index, (node_index, used)) in boxes.iter().enumerate() {
             lr.layout_tree
                 .dom_to_layout
-                .insert(NodeId::new(*node_index), vec![layout_index]);
+                .insert(NodeId::new(*node_index), vec![LayoutNodeId::new(layout_index)]);
             lr.layout_tree.nodes.push(LayoutNodeHot {
                 box_props: PackedBoxProps::default(),
                 dom_node_id: Some(NodeId::new(*node_index)),

--- a/layout/src/widgets/statusbar.rs
+++ b/layout/src/widgets/statusbar.rs
@@ -936,7 +936,9 @@ fn segment_dom(seg: StatusBarSegment, style: &StatusBarStyle) -> Dom {
         .with_ids_and_classes(IdOrClassVec::from_const_slice(CLS_SEGMENT))
         .with_css_props(style.segment_style.clone())
         .with_children(DomVec::from_vec(vec![
-            Dom::create_text(label).with_css_props(style.segment_label_style.clone()),
+            // `<p>` so the inert segment has the same `div > p > text` shape as
+            // the clickable one (Button puts `label_style` on a `<p>` too).
+            Dom::create_p_with_text(label).with_css_props(style.segment_label_style.clone()),
         ]))
 }
 

--- a/layout/src/widgets/statusbar.rs
+++ b/layout/src/widgets/statusbar.rs
@@ -1035,7 +1035,7 @@ fn zoom_dom(zoom: StatusBarZoom, style: &StatusBarStyle) -> Dom {
             Dom::create_div()
                 .with_ids_and_classes(IdOrClassVec::from_const_slice(CLS_ZOOM_LABEL))
                 .with_css_props(style.zoom_label_style.clone())
-                .with_children(DomVec::from_vec(vec![Dom::create_text(AzString::from(
+                .with_children(DomVec::from_vec(vec![Dom::create_text_do_not_use_without_block_level_wrapper(AzString::from(
                     label,
                 ))])),
         );

--- a/layout/src/widgets/stepper.rs
+++ b/layout/src/widgets/stepper.rs
@@ -397,7 +397,7 @@ impl Stepper {
                                 STEPPER_CONNECTOR_CLASS,
                             ))
                             .with_css_props(connector_style(conn_left_fill(i, current))),
-                        Dom::create_text(AzString::from(format!("{}", i + 1).as_str()))
+                        Dom::create_p_with_text(AzString::from(format!("{}", i + 1).as_str()))
                             .with_ids_and_classes(IdOrClassVec::from_const_slice(
                                 STEPPER_CIRCLE_CLASS,
                             ))
@@ -431,7 +431,7 @@ impl Stepper {
                 .with_children(
                     vec![
                         row,
-                        Dom::create_text(label.clone())
+                        Dom::create_p_with_text(label.clone())
                             .with_ids_and_classes(IdOrClassVec::from_const_slice(
                                 STEPPER_LABEL_CLASS,
                             ))
@@ -618,15 +618,16 @@ mod autotest_generated {
     // Flattened node layout
     //
     // `convert_dom_into_compact_dom` walks the tree in pre-order, and one step
-    // cell contributes exactly six nodes:
+    // cell contributes exactly eight nodes — the circle and the label are both
+    // `<p>` boxes wrapping one bare text node each (the widget label convention):
     //
-    //     cell → row → [conn-left, circle, conn-right] , label
+    //     cell → row → [conn-left, circle <p> → text, conn-right] , label <p> → text
     //
-    // so step `i` occupies `1 + 6*i ..= 6 + 6*i`. `flattened_layout_is_six_nodes_per_step`
+    // so step `i` occupies `1 + 8*i ..= 8 + 8*i`. `flattened_layout_is_eight_nodes_per_step`
     // pins this against the real hierarchy so the click tests below cannot drift.
     // ------------------------------------------------------------------
 
-    const NODES_PER_STEP: usize = 6;
+    const NODES_PER_STEP: usize = 8;
 
     fn cell_node(i: usize) -> usize {
         1 + NODES_PER_STEP * i
@@ -637,14 +638,16 @@ mod autotest_generated {
     fn conn_left_node(i: usize) -> usize {
         3 + NODES_PER_STEP * i
     }
+    /// The circle's `<p>` box — the node the restyle writes to.
     fn circle_node(i: usize) -> usize {
         4 + NODES_PER_STEP * i
     }
     fn conn_right_node(i: usize) -> usize {
-        5 + NODES_PER_STEP * i
-    }
-    fn label_node(i: usize) -> usize {
         6 + NODES_PER_STEP * i
+    }
+    /// The label's `<p>` box — the node the restyle writes to.
+    fn label_node(i: usize) -> usize {
+        7 + NODES_PER_STEP * i
     }
 
     // ------------------------------------------------------------------
@@ -826,10 +829,18 @@ mod autotest_generated {
         0.2126 * f32::from(c.r) + 0.7152 * f32::from(c.g) + 0.0722 * f32::from(c.b)
     }
 
-    /// The text of a `NodeType::Text` node (`None` for any other node type).
+    /// The text of a text node, looking through the `<p>` block wrapper the
+    /// label convention mandates (`p > text`).
     fn text_of(node: &Dom) -> Option<&str> {
         match node.root.get_node_type() {
             NodeType::Text(s) => Some(s.as_ref().as_str()),
+            NodeType::P => match node.children.as_ref() {
+                [only] => match only.root.get_node_type() {
+                    NodeType::Text(s) => Some(s.as_ref().as_str()),
+                    _ => None,
+                },
+                _ => None,
+            },
             _ => None,
         }
     }
@@ -2469,12 +2480,15 @@ mod autotest_generated {
             let dom = Stepper::create(labels(&[s.as_str(), "other"])).dom();
             let children = dom.children.as_ref();
             assert_eq!(children.len(), 2);
-            match label_of(&children[0]).root.get_node_type() {
-                NodeType::Text(t) => {
-                    assert_eq!(t.as_ref().as_str(), s.as_str(), "the caption changed inside dom()");
-                    assert_eq!(t.as_ref().len(), s.len(), "byte length changed (NUL truncation?)");
-                }
-                other => panic!("expected a text node, got {other:?}"),
+            match label_of(&children[0]).children.as_ref() {
+                [only] => match only.root.get_node_type() {
+                    NodeType::Text(t) => {
+                        assert_eq!(t.as_ref().as_str(), s.as_str(), "the caption changed inside dom()");
+                        assert_eq!(t.as_ref().len(), s.len(), "byte length changed (NUL truncation?)");
+                    }
+                    other => panic!("expected a text node, got {other:?}"),
+                },
+                other => panic!("expected `p > text`, got {} children", other.len()),
             }
             // The circle number must not be affected by the caption next to it.
             assert_eq!(text_of(circle_of(row_of(&children[0]))), Some("1"));
@@ -2508,12 +2522,12 @@ mod autotest_generated {
         assert_eq!(
             styled.node_hierarchy.as_ref().len(),
             NODES_PER_STEP * n + 1,
-            "root + six nodes per step"
+            "root + eight nodes per step"
         );
     }
 
     #[test]
-    fn flattened_layout_is_six_nodes_per_step() {
+    fn flattened_layout_is_eight_nodes_per_step() {
         // Pins the pre-order node numbering the click tests below depend on.
         let n = 4;
         let styled = StyledDom::create_from_dom(Stepper::create(n_labels(n)).dom());
@@ -2539,12 +2553,20 @@ mod autotest_generated {
                     .unwrap_or_else(|| panic!("step {i}: node {idx} is missing"));
                 assert!(nd.has_class(class), "step {i}: node {idx} is not a {class}");
             }
+            assert!(
+                matches!(
+                    data.get(NodeId::new(circle_node(i))).expect("circle").get_node_type(),
+                    NodeType::P
+                ),
+                "step {i}: the circle box must be a <p> — a text node owns no rect, so \
+                 width/height/border-radius could never make it a circle"
+            );
             let want = format!("{}", i + 1);
-            match data.get(NodeId::new(circle_node(i))).expect("circle").get_node_type() {
+            match data.get(NodeId::new(circle_node(i) + 1)).expect("circle text").get_node_type() {
                 NodeType::Text(t) => {
                     assert_eq!(t.as_ref().as_str(), want.as_str(), "step {i}: circle number");
                 }
-                other => panic!("step {i}: the circle is not a text node: {other:?}"),
+                other => panic!("step {i}: the circle does not wrap a text node: {other:?}"),
             }
         }
     }

--- a/layout/src/widgets/tabs.rs
+++ b/layout/src/widgets/tabs.rs
@@ -1342,7 +1342,7 @@ impl TabHeader {
                     let dataset = RefAny::new(dataset);
 
                     tab_items.push(
-                        Dom::create_text(tab.clone())
+                        Dom::create_p_with_text(tab.clone())
                             .with_callbacks(if on_click_is_some {
                                 vec![CoreCallbackData {
                                     event: EventFilter::Hover(HoverEventFilter::MouseUp),
@@ -1525,10 +1525,18 @@ mod autotest_generated {
         StringVec::from_vec((0..n).map(|i| AzString::from(format!("tab {i}"))).collect())
     }
 
-    /// The text of a `NodeType::Text` node (`None` for any other node type).
+    /// The text of a text node, looking through the `<p>` block wrapper the
+    /// label convention mandates (`p > text`).
     fn text_of(node: &Dom) -> Option<&str> {
         match node.root.get_node_type() {
             NodeType::Text(s) => Some(s.as_ref().as_str()),
+            NodeType::P => match node.children.as_ref() {
+                [only] => match only.root.get_node_type() {
+                    NodeType::Text(s) => Some(s.as_ref().as_str()),
+                    _ => None,
+                },
+                _ => None,
+            },
             _ => None,
         }
     }
@@ -2498,12 +2506,16 @@ mod autotest_generated {
                 dom.recompute_estimated_total_children(),
                 "n={n}: cached descendant count desynced"
             );
-            assert_eq!(dom.node_count(), n + 3, "header + spacer + {n} tabs + spacer");
+            assert_eq!(
+                dom.node_count(),
+                2 * n + 3,
+                "header + spacer + {n} tabs (each a <p> wrapping one text node) + spacer"
+            );
 
             let styled = StyledDom::create_from_dom(dom);
             assert_eq!(
                 styled.node_hierarchy.as_ref().len(),
-                n + 3,
+                2 * n + 3,
                 "n={n}: the flattened arena must match node_count()"
             );
         }

--- a/layout/src/widgets/tabs.rs
+++ b/layout/src/widgets/tabs.rs
@@ -2567,7 +2567,7 @@ mod autotest_generated {
     // ==================================================================
 
     fn nested(depth: usize) -> Dom {
-        let mut dom = Dom::create_text("leaf");
+        let mut dom = Dom::create_text_do_not_use_without_block_level_wrapper("leaf");
         for _ in 0..depth {
             dom = Dom::create_div().with_child(dom);
         }

--- a/layout/src/widgets/text_area.rs
+++ b/layout/src/widgets/text_area.rs
@@ -1,25 +1,31 @@
 //! Multi-line text input (text area) widget.
 //!
-//! A multi-line sibling of [`crate::widgets::text_input::TextInput`]: it reuses
-//! the same editable-state / cursor / focus-callback machinery but stores and
-//! renders multiple lines. Pressing Return/Enter inserts a newline; Backspace
-//! deletes the last character; typed/pasted text (including embedded newlines)
-//! is appended. The buffer is a `Vec<char>` (as `U32Vec`) exactly like
-//! `TextInput`, so the `'\n'` characters round-trip through
-//! [`TextAreaState::get_text`].
+//! A multi-line sibling of [`crate::widgets::text_input::TextInput`], built on
+//! the same flow: the container is a `contenteditable` host carrying the tab
+//! index and the focus callbacks, so the engine's `TextEditManager` owns the
+//! caret, the selection and the buffer, and edits run through
+//! `record_text_input` / `apply_text_changeset`. Caret and selection are
+//! display-list items driven by that manager; the widget emits no cursor node.
 //!
-//! The widget reuses [`TextInput`]'s [`OnTextInputReturn`] / [`TextInputValid`]
-//! return types for its `on_text_input` callback so existing host bindings and
-//! validation logic apply unchanged.
+//! Value and placeholder are `<p>` blocks wrapping a bare text node — a
+//! [`NodeType::Text`](azul_core::dom::NodeType::Text) node is always
+//! inline-level and owns no rect, so box-model properties on one are inert.
+//! Line wrapping relies on the text layout honouring `white-space: pre-wrap`.
 //!
-//! TODO2: this implements the *core* of multi-line editing — multi-line value,
-//! newline insertion, append/backspace, `on_text_input` (a.k.a. on_change) and
-//! `on_focus_lost`. Advanced editing is intentionally NOT implemented and is
-//! not verifiable without a live window: the blinking cursor is a static child
-//! and does not track the caret across lines, there is no selection/range
-//! editing, no mid-buffer insertion (edits append/truncate at the end), and no
-//! vertical (up/down) caret navigation. Line wrapping relies on the text
-//! layout honouring `white-space: pre-wrap`.
+//! [`TextAreaState`] is a *mirror* of the engine's state, refreshed from its
+//! changesets so the public callbacks keep the shape existing hosts bind
+//! against. The widget reuses [`TextInput`]'s [`OnTextInputReturn`] /
+//! [`TextInputValid`] return types for its `on_text_input` callback so existing
+//! host bindings and validation logic apply unchanged; a `TextInputValid::No`
+//! answer turns into `CallbackInfo::prevent_default`, which stops the engine
+//! from applying the edit it recorded.
+//!
+//! KNOWN GAP: caret-relative *deletion* (Backspace/Delete) and Enter are engine
+//! default actions and the mirror cannot see their result, because the engine
+//! exposes no post-apply text for a node whose value sits under a block
+//! wrapper. Enter in a contenteditable host records a structural block split
+//! rather than inserting a `'\n'` into the buffer, so a multi-paragraph value
+//! no longer round-trips through [`TextAreaState::get_text`] as newlines.
 //!
 //! Key types: [`TextArea`], [`TextAreaState`], [`TextAreaOnTextInput`],
 //! [`TextAreaOnVirtualKeyDown`], [`TextAreaOnFocusLost`].
@@ -28,13 +34,12 @@ use alloc::{string::String, vec::Vec};
 
 use azul_core::{
     callbacks::{CoreCallback, CoreCallbackData, Update},
-    dom::Dom,
+    dom::{Dom, DomNodeId},
     refany::RefAny,
-    window::VirtualKeyCode,
 };
 use azul_css::{
     dynamic_selector::{CssPropertyWithConditions, CssPropertyWithConditionsVec},
-    props::{basic::{ColorU, StyleFontFamily, StyleFontFamilyVec, StyleFontSize}, layout::{LayoutPosition, LayoutWidth, LayoutHeight, LayoutBoxSizing, LayoutFlexGrow, LayoutMinHeight, LayoutPaddingLeft, LayoutPaddingRight, LayoutPaddingTop, LayoutPaddingBottom, LayoutOverflow, LayoutDisplay, LayoutTop, LayoutLeft}, property::{CssProperty, StyleWhiteSpaceValue}, style::{StyleBackgroundContent, StyleBackgroundContentVec, StyleOpacity, StyleCursor, StyleTextColor, LayoutBorderTopWidth, LayoutBorderBottomWidth, LayoutBorderLeftWidth, LayoutBorderRightWidth, StyleBorderTopStyle, BorderStyle, StyleBorderBottomStyle, StyleBorderLeftStyle, StyleBorderRightStyle, StyleBorderTopColor, StyleBorderBottomColor, StyleBorderLeftColor, StyleBorderRightColor, StyleTextAlign, StyleWhiteSpace}},
+    props::{basic::{ColorU, StyleFontFamily, StyleFontFamilyVec, StyleFontSize}, layout::{LayoutPosition, LayoutBoxSizing, LayoutFlexGrow, LayoutMinHeight, LayoutPaddingLeft, LayoutPaddingRight, LayoutPaddingTop, LayoutPaddingBottom, LayoutOverflow, LayoutDisplay, LayoutTop, LayoutLeft}, property::{CssProperty, StyleWhiteSpaceValue}, style::{StyleBackgroundContent, StyleBackgroundContentVec, StyleOpacity, StyleCursor, StyleTextColor, LayoutBorderTopWidth, LayoutBorderBottomWidth, LayoutBorderLeftWidth, LayoutBorderRightWidth, StyleBorderTopStyle, BorderStyle, StyleBorderBottomStyle, StyleBorderLeftStyle, StyleBorderRightStyle, StyleBorderTopColor, StyleBorderBottomColor, StyleBorderLeftColor, StyleBorderRightColor, StyleTextAlign, StyleWhiteSpace}},
     impl_option_inner, AzString, U32Vec, OptionString,
 };
 
@@ -48,7 +53,6 @@ const BACKGROUND_COLOR: ColorU = ColorU {
     b: 255,
     a: 255,
 }; // white
-const BLACK: ColorU = ColorU { r: 0, g: 0, b: 0, a: 255 };
 const COLOR_9B9B9B: ColorU = ColorU {
     r: 155,
     g: 155,
@@ -68,10 +72,6 @@ const COLOR_4C4C4C: ColorU = ColorU {
     a: 255,
 }; // #4C4C4C text
 
-const CURSOR_COLOR_BLACK: &[StyleBackgroundContent] = &[StyleBackgroundContent::Color(BLACK)];
-const CURSOR_COLOR: StyleBackgroundContentVec =
-    StyleBackgroundContentVec::from_const_slice(CURSOR_COLOR_BLACK);
-
 const BACKGROUND_THEME_LIGHT: &[StyleBackgroundContent] =
     &[StyleBackgroundContent::Color(BACKGROUND_COLOR)];
 const BACKGROUND_COLOR_LIGHT: StyleBackgroundContentVec =
@@ -85,15 +85,6 @@ const SANS_SERIF_FAMILY: StyleFontFamilyVec =
 
 /// Minimum height of the editable area (~4 lines).
 const MIN_HEIGHT_PX: isize = 64;
-
-// -- cursor style (a static child; does not track the caret — see module TODO2) --
-static TEXT_CURSOR_PROPS: &[CssPropertyWithConditions] = &[
-    CssPropertyWithConditions::simple(CssProperty::const_position(LayoutPosition::Absolute)),
-    CssPropertyWithConditions::simple(CssProperty::const_width(LayoutWidth::const_px(1))),
-    CssPropertyWithConditions::simple(CssProperty::const_height(LayoutHeight::const_px(11))),
-    CssPropertyWithConditions::simple(CssProperty::const_background_content(CURSOR_COLOR)),
-    CssPropertyWithConditions::simple(CssProperty::const_opacity(StyleOpacity::const_new(0))),
-];
 
 // -- container style (cross-platform single style) --
 static TEXT_AREA_CONTAINER_PROPS: &[CssPropertyWithConditions] = &[
@@ -207,7 +198,7 @@ static TEXT_AREA_CONTAINER_PROPS: &[CssPropertyWithConditions] = &[
     )),
 ];
 
-// -- label style (the rendered multi-line text) --
+// -- label style (the `<p>` block wrapping the multi-line value) --
 static TEXT_AREA_LABEL_PROPS: &[CssPropertyWithConditions] = &[
     CssPropertyWithConditions::simple(CssProperty::const_display(LayoutDisplay::Block)),
     CssPropertyWithConditions::simple(CssProperty::const_flex_grow(LayoutFlexGrow::const_new(0))),
@@ -223,6 +214,14 @@ static TEXT_AREA_LABEL_PROPS: &[CssPropertyWithConditions] = &[
 ];
 
 // -- placeholder style --
+//
+// An absolutely-positioned `<p>` overlay inside the editable container. It is
+// marked `contenteditable="false"` so the engine's inheritance walk stops at it
+// and the prompt never becomes part of the buffer, and it is toggled with
+// `display` as well as `opacity`: a hidden-but-laid-out overlay would still own
+// the container's first inline layout, which is what
+// `LayoutWindow::reshape_text_node` picks up when it looks for the IFC to write
+// an edit into.
 static TEXT_AREA_PLACEHOLDER_PROPS: &[CssPropertyWithConditions] = &[
     CssPropertyWithConditions::simple(CssProperty::const_display(LayoutDisplay::Block)),
     CssPropertyWithConditions::simple(CssProperty::const_flex_grow(LayoutFlexGrow::const_new(0))),
@@ -499,8 +498,15 @@ impl TextArea {
         s
     }
 
+    /// Renders the widget.
+    ///
+    /// The container is the `contenteditable` host — the flag, the tab index and
+    /// the focus callbacks all sit on it, because focus events do not bubble and
+    /// the engine records an edit against the *focused* node. Its two children
+    /// are `<p>` blocks wrapping a bare text node each; nothing else is emitted,
+    /// in particular no caret node.
     #[must_use] pub fn dom(mut self) -> Dom {
-        use azul_core::dom::{EventFilter, FocusEventFilter, HoverEventFilter, IdOrClass::Class, TabIndex};
+        use azul_core::dom::{AttributeType, DomVec, EventFilter, FocusEventFilter, IdOrClass::Class, TabIndex};
 
         self.text_area_state.inner.cursor_pos = self.text_area_state.inner.text.len();
 
@@ -520,12 +526,18 @@ impl TextArea {
             .map(|s| s.as_str().to_string())
             .unwrap_or_default();
 
+        let mut placeholder_style = self.placeholder_style;
+        if !self.text_area_state.inner.text.is_empty() {
+            placeholder_style = hidden_placeholder_style(&placeholder_style);
+        }
+
         let state_ref = RefAny::new(self.text_area_state);
 
         Dom::create_div()
             .with_ids_and_classes(vec![Class("__azul-native-text-area-container".into())].into())
             .with_css_props(self.container_style)
             .with_tab_index(TabIndex::Auto)
+            .with_contenteditable(true)
             .with_dataset(Some(state_ref.clone()).into())
             .with_callbacks(
                 vec![
@@ -566,30 +578,105 @@ impl TextArea {
             )
             .with_children(
                 vec![
-                    Dom::create_text(placeholder)
+                    Dom::create_p()
                         .with_ids_and_classes(
                             vec![Class("__azul-native-text-area-placeholder".into())].into(),
                         )
-                        .with_css_props(self.placeholder_style),
-                    Dom::create_text(label_text)
+                        .with_css_props(placeholder_style)
+                        // appended, never `with_attributes`: that one replaces the
+                        // whole vector, classes included
+                        .with_attribute(AttributeType::ContentEditable(false))
+                        .with_children(DomVec::from_vec(vec![Dom::create_text(placeholder)])),
+                    Dom::create_p()
                         .with_ids_and_classes(
                             vec![Class("__azul-native-text-area-label".into())].into(),
                         )
                         .with_css_props(self.label_style)
-                        .with_children(
-                            vec![Dom::create_div()
-                                .with_ids_and_classes(
-                                    vec![Class("__azul-native-text-area-cursor".into())].into(),
-                                )
-                                .with_css_props(CssPropertyWithConditionsVec::from_const_slice(
-                                    TEXT_CURSOR_PROPS,
-                                ))]
-                            .into(),
-                        ),
+                        .with_children(DomVec::from_vec(vec![Dom::create_text(label_text)])),
                 ]
                 .into(),
             )
     }
+}
+
+/// `style` with the placeholder taken out of the flow: `display: none` on top
+/// of `opacity: 0`, so a hidden prompt owns neither pixels nor an inline layout.
+fn hidden_placeholder_style(
+    style: &CssPropertyWithConditionsVec,
+) -> CssPropertyWithConditionsVec {
+    let mut props = style.as_ref().to_vec();
+    props.push(CssPropertyWithConditions::simple(CssProperty::const_display(
+        LayoutDisplay::None,
+    )));
+    props.push(CssPropertyWithConditions::simple(CssProperty::const_opacity(
+        StyleOpacity::const_new(0),
+    )));
+    CssPropertyWithConditionsVec::from_vec(props)
+}
+
+/// The placeholder `<p>` and the value `<p>`, in that order.
+///
+/// Both handlers and tests resolve them through the same hierarchy hops the
+/// container's own layout guarantees; a subtree of any other shape yields
+/// `None` and every handler bails out.
+fn label_nodes(info: &CallbackInfo) -> Option<(DomNodeId, DomNodeId)> {
+    let placeholder = info.get_first_child(info.get_hit_node())?;
+    let label = info.get_next_sibling(placeholder)?;
+    Some((placeholder, label))
+}
+
+/// Shows or hides the placeholder prompt.
+fn set_placeholder_visible(info: &mut CallbackInfo, placeholder: DomNodeId, visible: bool) {
+    let (display, opacity) = if visible {
+        (LayoutDisplay::Block, StyleOpacity::const_new(100))
+    } else {
+        (LayoutDisplay::None, StyleOpacity::const_new(0))
+    };
+    info.set_css_property(placeholder, CssProperty::const_opacity(opacity));
+    info.set_css_property(placeholder, CssProperty::const_display(display));
+}
+
+/// Adopts the engine's text for `node` into the widget's mirror.
+///
+/// The engine owns the buffer, so its answer wins — except that an empty answer
+/// is ambiguous: `get_text_before_textinput` also yields nothing for a node
+/// whose text sits under a block wrapper it does not descend into. An empty
+/// read therefore never clears a non-empty mirror.
+fn adopt_engine_text(state: &mut TextAreaState, info: &CallbackInfo, node: DomNodeId) {
+    let Some(text) = info.get_node_text_content(node) else {
+        return;
+    };
+    if text.is_empty() && !state.text.is_empty() {
+        return;
+    }
+    state.text = text.chars().map(|c| c as u32).collect::<Vec<_>>().into();
+}
+
+/// Mirrors the insertion the engine is about to apply.
+///
+/// The engine inserts at the caret, so the mirror does too whenever the caret
+/// is readable and lands on a character boundary; otherwise it appends, which
+/// is where the caret sits for every append-only path. `cursor_pos` stays a
+/// byte offset, as it has always been.
+fn mirror_insertion(state: &mut TextAreaState, inserted: &str, caret: Option<usize>) {
+    let text = state.get_text();
+    let at = caret
+        .filter(|at| *at <= text.len() && text.is_char_boundary(*at))
+        .unwrap_or(text.len());
+
+    let mut next = String::with_capacity(text.len() + inserted.len());
+    next.push_str(&text[..at]);
+    next.push_str(inserted);
+    next.push_str(&text[at..]);
+
+    state.text = next.chars().map(|c| c as u32).collect::<Vec<_>>().into();
+    state.cursor_pos = at.saturating_add(inserted.len());
+}
+
+/// The caret's byte offset inside the edited node, if the engine has one.
+fn engine_caret(info: &CallbackInfo, node: DomNodeId) -> Option<usize> {
+    info.get_node_cursor_position(node)
+        .map(|c| c.cluster_id.start_byte_in_run as usize)
 }
 
 extern "C" fn default_on_focus_received(mut text_area: RefAny, mut info: CallbackInfo) -> Update {
@@ -603,15 +690,18 @@ extern "C" fn default_on_focus_received(mut text_area: RefAny, mut info: Callbac
         return Update::DoNothing;
     };
 
+    let container = info.get_hit_node();
+    adopt_engine_text(&mut text_area.inner, &info, container);
+
     // hide the placeholder text
     if text_area.inner.text.is_empty() {
-        info.set_css_property(
-            placeholder_text_node_id,
-            CssProperty::const_opacity(StyleOpacity::const_new(0)),
-        );
+        set_placeholder_visible(&mut info, placeholder_text_node_id, false);
     }
 
-    text_area.inner.cursor_pos = text_area.inner.text.len();
+    // The engine seeds the caret at the end of the value when focus lands on a
+    // contenteditable host; the mirror follows it.
+    let end_of_text = text_area.inner.text.len();
+    text_area.inner.cursor_pos = engine_caret(&info, container).unwrap_or(end_of_text);
 
     Update::DoNothing
 }
@@ -627,12 +717,12 @@ extern "C" fn default_on_focus_lost(mut text_area: RefAny, mut info: CallbackInf
         return Update::DoNothing;
     };
 
+    let container = info.get_hit_node();
+    adopt_engine_text(&mut text_area.inner, &info, container);
+
     // show the placeholder text
     if text_area.inner.text.is_empty() {
-        info.set_css_property(
-            placeholder_text_node_id,
-            CssProperty::const_opacity(StyleOpacity::const_new(100)),
-        );
+        set_placeholder_visible(&mut info, placeholder_text_node_id, true);
     }
 
     let text_area = &mut *text_area;
@@ -652,16 +742,48 @@ extern "C" fn default_on_text_input(text_area: RefAny, info: CallbackInfo) -> Up
 fn default_on_text_input_inner(mut text_area: RefAny, mut info: CallbackInfo) -> Option<Update> {
     let mut text_area = text_area.downcast_mut::<TextAreaStateWrapper>()?;
 
-    let changeset = info.get_text_changeset()?;
-    let inserted_text = changeset.inserted_text.as_str().to_string();
+    // The engine records the edit before the callbacks run and applies it after
+    // them; this handler only observes it and mirrors it into the widget state.
+    // An `Input` WITHOUT a pending record is a post-edit NOTIFICATION: an edit
+    // committed outside the record pipeline (deletion, the Enter line break,
+    // programmatic edit) that is already applied — adopt it and inform the
+    // user hook; `valid` cannot veto what already happened.
+    let inserted_text = info
+        .get_text_changeset()
+        .map(|c| c.inserted_text.as_str().to_string())
+        .unwrap_or_default();
+
+    let (placeholder_node_id, _label_node_id) = label_nodes(&info)?;
+    let container = info.get_hit_node();
 
     if inserted_text.is_empty() {
-        return None;
+        // Idempotent: a notification that changed nothing observable stays a
+        // strict no-op, so the no-changeset pins keep holding.
+        let before = text_area.inner.get_text();
+        adopt_engine_text(&mut text_area.inner, &info, container);
+        if text_area.inner.get_text() == before {
+            return None;
+        }
+        let empty = text_area.inner.get_text().is_empty();
+        set_placeholder_visible(&mut info, placeholder_node_id, empty);
+        let result = {
+            let text_area = &mut *text_area;
+            let inner_clone = text_area.inner.clone();
+            match text_area.on_text_input.as_mut() {
+                Some(TextAreaOnTextInput { callback, refany }) => {
+                    (callback.cb)(refany.clone(), info, inner_clone)
+                }
+                None => OnTextInputReturn {
+                    update: Update::DoNothing,
+                    valid: TextInputValid::Yes,
+                },
+            }
+        };
+        return Some(result.update);
     }
 
-    let placeholder_node_id = info.get_first_child(info.get_hit_node())?;
-    let label_node_id = info.get_next_sibling(placeholder_node_id)?;
-    let _cursor_node_id = info.get_first_child(label_node_id)?;
+    let caret = engine_caret(&info, container);
+    adopt_engine_text(&mut text_area.inner, &info, container);
 
     let result = {
         let text_area = &mut *text_area;
@@ -669,12 +791,7 @@ fn default_on_text_input_inner(mut text_area: RefAny, mut info: CallbackInfo) ->
 
         // inner_clone has the new (would-be) text
         let mut inner_clone = text_area.inner.clone();
-        inner_clone.cursor_pos = inner_clone.cursor_pos.saturating_add(inserted_text.len());
-        inner_clone.text = {
-            let mut internal = inner_clone.text.clone().into_library_owned_vec();
-            internal.extend(inserted_text.chars().map(|c| c as u32));
-            internal.into()
-        };
+        mirror_insertion(&mut inner_clone, &inserted_text, caret);
 
         match ontextinput.as_mut() {
             Some(TextAreaOnTextInput { callback, refany }) => {
@@ -689,23 +806,13 @@ fn default_on_text_input_inner(mut text_area: RefAny, mut info: CallbackInfo) ->
 
     if result.valid == TextInputValid::Yes {
         // hide the placeholder text
-        info.set_css_property(
-            placeholder_node_id,
-            CssProperty::const_opacity(StyleOpacity::const_new(0)),
-        );
+        set_placeholder_visible(&mut info, placeholder_node_id, false);
 
-        // append to the text
-        text_area.inner.text = {
-            let mut internal = text_area.inner.text.clone().into_library_owned_vec();
-            internal.extend(inserted_text.chars().map(|c| c as u32));
-            internal.into()
-        };
-        text_area.inner.cursor_pos = text_area
-            .inner
-            .cursor_pos
-            .saturating_add(inserted_text.len());
-
-        info.change_node_text(label_node_id, text_area.inner.get_text().into());
+        mirror_insertion(&mut text_area.inner, &inserted_text, caret);
+    } else {
+        // The engine applies the recorded changeset once the callbacks return,
+        // unless one of them vetoes it.
+        info.prevent_default();
     }
 
     Some(result.update)
@@ -722,13 +829,15 @@ fn default_on_virtual_key_down_inner(
     let mut text_area = text_area.downcast_mut::<TextAreaStateWrapper>()?;
     let keyboard_state = info.get_current_keyboard_state();
 
-    let c = keyboard_state.current_virtual_keycode.into_option()?;
-    let placeholder_node_id = info.get_first_child(info.get_hit_node())?;
-    let label_node_id = info.get_next_sibling(placeholder_node_id)?;
-    let _cursor_node_id = info.get_first_child(label_node_id)?;
+    let _keycode = keyboard_state.current_virtual_keycode.into_option()?;
+    let (_placeholder_node_id, _label_node_id) = label_nodes(&info)?;
 
-    // Dispatch to the user's on_virtual_key_down callback first; a
-    // TextInputValid::No return suppresses the built-in editing behavior.
+    let container = info.get_hit_node();
+    adopt_engine_text(&mut text_area.inner, &info, container);
+
+    // Editing keys (Backspace, Delete, the arrows, Enter) are the engine's
+    // default actions; this handler only forwards the key to the user's hook
+    // and lets a rejection stop the default from running.
     let result = {
         // rustc doesn't understand the borrowing lifetime here
         let text_area = &mut *text_area;
@@ -745,43 +854,7 @@ fn default_on_virtual_key_down_inner(
     };
 
     if result.valid == TextInputValid::No {
-        return Some(result.update);
-    }
-
-    match c {
-        VirtualKeyCode::Back => {
-            text_area.inner.text = {
-                let mut internal = text_area.inner.text.clone().into_library_owned_vec();
-                internal.pop();
-                internal.into()
-            };
-            text_area.inner.cursor_pos = text_area.inner.cursor_pos.saturating_sub(1);
-            info.change_node_text(label_node_id, text_area.inner.get_text().into());
-
-            // re-show placeholder if the buffer is now empty
-            if text_area.inner.text.is_empty() {
-                info.set_css_property(
-                    placeholder_node_id,
-                    CssProperty::const_opacity(StyleOpacity::const_new(100)),
-                );
-            }
-        }
-        VirtualKeyCode::Return | VirtualKeyCode::NumpadEnter => {
-            // insert a newline
-            text_area.inner.text = {
-                let mut internal = text_area.inner.text.clone().into_library_owned_vec();
-                internal.push('\n' as u32);
-                internal.into()
-            };
-            text_area.inner.cursor_pos = text_area.inner.cursor_pos.saturating_add(1);
-            info.change_node_text(label_node_id, text_area.inner.get_text().into());
-            // hide placeholder (buffer is non-empty now)
-            info.set_css_property(
-                placeholder_node_id,
-                CssProperty::const_opacity(StyleOpacity::const_new(0)),
-            );
-        }
-        _ => return Some(result.update),
+        info.prevent_default();
     }
 
     Some(result.update)
@@ -808,14 +881,17 @@ mod autotest_generated {
     };
 
     use azul_core::{
-        dom::{DomId, DomNodeId, EventFilter, FocusEventFilter, NodeId, NodeType},
+        dom::{
+            AttributeType, DomId, DomNodeId, EventFilter, FocusEventFilter, NodeId, NodeType,
+            TabIndex,
+        },
         geom::{LogicalRect, OptionLogicalPosition},
         gl::OptionGlContextPtr,
         hit_test::ScrollPosition,
         refany::OptionRefAny,
         resources::RendererResources,
         styled_dom::{NodeHierarchyItemId, StyledDom},
-        window::{MonitorVec, RawWindowHandle},
+        window::{MonitorVec, RawWindowHandle, VirtualKeyCode},
     };
     use rust_fontconfig::FcFontCache;
 
@@ -923,10 +999,18 @@ mod autotest_generated {
         CssPropertyWithConditionsVec::from_vec(all.into_iter().take(n).collect())
     }
 
-    /// The text of a `NodeType::Text` node (`None` for any other node type).
+    /// The text a node carries, looking through the `<p>` block wrapper the
+    /// widget convention mandates (`p > text`).
     fn text_of(node: &Dom) -> Option<&str> {
         match node.root.get_node_type() {
             NodeType::Text(s) => Some(s.as_ref().as_str()),
+            NodeType::P => match node.children.as_ref() {
+                [only] => match only.root.get_node_type() {
+                    NodeType::Text(s) => Some(s.as_ref().as_str()),
+                    _ => None,
+                },
+                _ => None,
+            },
             _ => None,
         }
     }
@@ -1044,7 +1128,7 @@ mod autotest_generated {
         container: usize,
         placeholder: usize,
         label: usize,
-        cursor: usize,
+        label_text: usize,
     }
 
     /// Which node the event hit.
@@ -1054,8 +1138,9 @@ mod autotest_generated {
         Nothing,
         Container,
         Placeholder,
-        /// A leaf: it has no children, so every handler must bail out.
-        Cursor,
+        /// The value's bare text leaf: it has no children, so every handler
+        /// must bail out.
+        TextLeaf,
     }
 
     /// Flattened indices of every node carrying `class`, in tree order.
@@ -1083,13 +1168,25 @@ mod autotest_generated {
             found[0]
         }
 
+        let label = one(&styled, "__azul-native-text-area-label");
         let nodes = Nodes {
             container: one(&styled, "__azul-native-text-area-container"),
             placeholder: one(&styled, "__azul-native-text-area-placeholder"),
-            label: one(&styled, "__azul-native-text-area-label"),
-            cursor: one(&styled, "__azul-native-text-area-cursor"),
+            label,
+            label_text: first_child(&styled, label),
         };
         (styled, nodes)
+    }
+
+    /// The flattened index of `node`'s first child.
+    fn first_child(styled: &StyledDom, node: usize) -> usize {
+        styled
+            .node_hierarchy
+            .as_ref()
+            .get(node)
+            .and_then(|item| item.first_child_id(NodeId::new(node)))
+            .expect("expected a child node")
+            .index()
     }
 
     fn dom_node(idx: usize) -> DomNodeId {
@@ -1218,7 +1315,7 @@ mod autotest_generated {
             },
             Hit::Container => dom_node(nodes.container),
             Hit::Placeholder => dom_node(nodes.placeholder),
-            Hit::Cursor => dom_node(nodes.cursor),
+            Hit::TextLeaf => dom_node(nodes.label_text),
         };
 
         let changes: Arc<Mutex<Vec<CallbackChange>>> = Arc::new(Mutex::new(Vec::new()));
@@ -1783,13 +1880,90 @@ mod autotest_generated {
         assert!(children[0].root.has_class("__azul-native-text-area-placeholder"));
         assert!(children[1].root.has_class("__azul-native-text-area-label"));
 
-        let label_children = children[1].children.as_ref();
-        assert_eq!(label_children.len(), 1, "the label owns exactly the cursor");
-        assert!(label_children[0].root.has_class("__azul-native-text-area-cursor"));
+        for block in children {
+            assert!(matches!(block.root.get_node_type(), NodeType::P));
+            assert_eq!(block.children.as_ref().len(), 1, "a label wraps one text node");
+            let leaf = &block.children.as_ref()[0];
+            assert!(matches!(leaf.root.get_node_type(), NodeType::Text(_)));
+            assert!(leaf.children.as_ref().is_empty(), "the text node is a leaf");
+        }
+    }
+
+    #[test]
+    fn dom_emits_no_cursor_node() {
+        // The caret and the selection are display-list items driven by the
+        // engine's TextEditManager; a widget-owned cursor div resolved against
+        // the container and never tracked the caret.
+        let styled = StyledDom::create_from_dom(TextArea::create().dom());
+        assert!(nodes_with_class(&styled, "__azul-native-text-area-cursor").is_empty());
+    }
+
+    #[test]
+    fn dom_carries_no_state_on_any_text_node() {
+        // A NodeType::Text node is unconditionally inline-level and owns no
+        // rect, so css props / callbacks / a tab index / a dataset / children on
+        // one are all inert. Every text node must be a bare leaf under a <p>.
+        fn walk(node: &Dom, parent_is_p: bool, bad: &mut Vec<String>) {
+            if let NodeType::Text(t) = node.root.get_node_type() {
+                let carries = !node.root.get_style().is_empty()
+                    || !node.root.get_callbacks().as_ref().is_empty()
+                    || node.root.get_tab_index().is_some()
+                    || node.root.get_dataset().is_some()
+                    || !node.children.as_ref().is_empty()
+                    || !parent_is_p;
+                if carries {
+                    bad.push(t.as_ref().as_str().to_string());
+                }
+            }
+            let is_p = matches!(node.root.get_node_type(), NodeType::P);
+            for c in node.children.as_ref() {
+                walk(c, is_p, bad);
+            }
+        }
+
+        for area in [
+            TextArea::create(),
+            TextArea::create()
+                .with_text(AzString::from("a\nb"))
+                .with_placeholder(AzString::from("hint")),
+        ] {
+            let mut bad = Vec::new();
+            walk(&area.dom(), false, &mut bad);
+            assert!(bad.is_empty(), "text nodes carrying inert state: {bad:?}");
+        }
+    }
+
+    #[test]
+    fn dom_marks_the_container_as_keyboard_focusable_and_editable() {
+        // Focus events do not bubble and the engine records an edit against the
+        // FOCUSED node, so the tab index and the contenteditable flag have to
+        // sit on the same node the handlers are attached to.
+        let dom = TextArea::create().dom();
+        assert_eq!(dom.root.get_tab_index(), Some(TabIndex::Auto));
+        assert!(dom.root.is_contenteditable());
+    }
+
+    #[test]
+    fn dom_keeps_the_placeholder_out_of_the_editable_content() {
+        // Everything inside a contenteditable host is editable content unless a
+        // node blocks the inheritance walk; the prompt must never be typed into.
+        let dom = TextArea::create().with_placeholder(AzString::from("hint")).dom();
+        let children = dom.children.as_ref();
         assert!(
-            label_children[0].children.as_ref().is_empty(),
-            "the cursor is a leaf"
+            children[0]
+                .root
+                .attributes()
+                .as_ref()
+                .iter()
+                .any(|a| matches!(a, AttributeType::ContentEditable(false))),
+            "the placeholder is inside the editable host and does not opt out",
         );
+        assert!(!children[1]
+            .root
+            .attributes()
+            .as_ref()
+            .iter()
+            .any(|a| matches!(a, AttributeType::ContentEditable(_))));
     }
 
     #[test]
@@ -1915,9 +2089,9 @@ mod autotest_generated {
 
     #[test]
     fn styled_dom_navigation_matches_what_the_handlers_assume() {
-        // The three handlers all walk container -> first child (placeholder)
-        // -> next sibling (label) -> first child (cursor). If that walk ever
-        // stops matching the DOM, every one of them silently no-ops.
+        // Every handler walks container -> first child (placeholder) -> next
+        // sibling (label). If that walk ever stops matching the DOM, all of
+        // them silently no-op.
         let (styled, nodes) = skeleton();
         let hierarchy = styled.node_hierarchy.as_container();
 
@@ -1931,10 +2105,11 @@ mod autotest_generated {
             .expect("the placeholder must have a next sibling");
         assert_eq!(label.index(), nodes.label);
 
-        let cursor = hierarchy[label]
+        let leaf = hierarchy[label]
             .first_child_id(label)
-            .expect("the label must have a first child");
-        assert_eq!(cursor.index(), nodes.cursor);
+            .expect("the value block must wrap a text node");
+        assert_eq!(leaf.index(), nodes.label_text);
+        assert!(hierarchy[leaf].first_child_id(leaf).is_none(), "the text node is a leaf");
     }
 
     // ==================================================================
@@ -1974,7 +2149,7 @@ mod autotest_generated {
     fn focus_received_bails_out_on_a_childless_hit_node() {
         let data = RefAny::new(wrapper("text"));
         let (update, changes, _) = run(
-            Env::default().hitting(Hit::Cursor),
+            Env::default().hitting(Hit::TextLeaf),
             &data,
             |r, ci| default_on_focus_received(r, ci),
         );
@@ -2089,7 +2264,7 @@ mod autotest_generated {
         let data = RefAny::new(state);
 
         let (update, changes, _) = run(
-            Env::default().hitting(Hit::Cursor),
+            Env::default().hitting(Hit::TextLeaf),
             &data,
             |r, ci| default_on_focus_lost(r, ci),
         );
@@ -2178,7 +2353,7 @@ mod autotest_generated {
     fn text_input_bails_out_on_a_childless_hit_node() {
         let data = RefAny::new(wrapper("abc"));
         let (out, changes, _) = run(
-            Env::typed("x").hitting(Hit::Cursor),
+            Env::typed("x").hitting(Hit::TextLeaf),
             &data,
             default_on_text_input_inner,
         );
@@ -2190,8 +2365,8 @@ mod autotest_generated {
 
     #[test]
     fn text_input_bails_out_when_the_hit_node_has_no_sibling_chain() {
-        // Hitting the placeholder: it has no children at all, so the walk stops
-        // at the very first step.
+        // Hitting the placeholder: its own text leaf has no next sibling, so
+        // the walk stops one step in.
         let data = RefAny::new(wrapper("abc"));
         let (out, changes, _) = run(
             Env::typed("x").hitting(Hit::Placeholder),
@@ -2205,7 +2380,7 @@ mod autotest_generated {
     }
 
     #[test]
-    fn text_input_appends_and_repaints() {
+    fn text_input_mirrors_the_insertion_and_hides_the_placeholder() {
         let data = RefAny::new(wrapper("ab"));
         let (out, changes, nodes) = run(Env::typed("cd"), &data, default_on_text_input_inner);
 
@@ -2216,24 +2391,20 @@ mod autotest_generated {
             vec![(nodes.placeholder, 0.0)],
             "typing hides the placeholder"
         );
-        assert_eq!(
-            text_writes(&changes),
-            vec![(nodes.label, "abcd".to_string())],
-            "the label is rewritten with the *whole* buffer, not the delta"
+        assert!(
+            text_writes(&changes).is_empty(),
+            "the widget repainted the value itself; the engine owns the buffer"
         );
     }
 
     #[test]
     fn text_input_preserves_embedded_newlines() {
         let data = RefAny::new(wrapper("first"));
-        let (out, changes, nodes) = run(Env::typed("\nsecond\n"), &data, default_on_text_input_inner);
+        let (out, changes, _) = run(Env::typed("\nsecond\n"), &data, default_on_text_input_inner);
 
         assert_eq!(out, Some(Update::DoNothing));
         assert_eq!(read(&data).get_text(), "first\nsecond\n");
-        assert_eq!(
-            text_writes(&changes),
-            vec![(nodes.label, "first\nsecond\n".to_string())]
-        );
+        assert!(text_writes(&changes).is_empty());
     }
 
     #[test]
@@ -2333,7 +2504,12 @@ mod autotest_generated {
             Some(Update::RefreshDomAllWindows),
             "a rejected edit still returns the hook's Update"
         );
-        assert!(changes.is_empty(), "a rejected edit must not repaint");
+        assert_eq!(
+            changes.len(),
+            1,
+            "a rejected edit must push nothing but the preventDefault: {changes:?}"
+        );
+        assert!(matches!(changes[0], CallbackChange::PreventDefault));
         let state = read(&data);
         assert_eq!(state.get_text(), "locked");
         assert_eq!(state.cursor_pos, 0, "and must not move the cursor");
@@ -2354,9 +2530,10 @@ mod autotest_generated {
     }
 
     #[test]
-    fn text_input_writes_the_filtered_text_not_the_raw_buffer() {
-        // Non-scalar units already in the buffer survive the edit but never
-        // reach the label, so the rendered string is shorter than the buffer.
+    fn text_input_drops_non_scalar_units_the_engine_could_never_hold() {
+        // The mirror is rebuilt from the *string* the engine works in, so
+        // non-scalar units planted directly into the buffer do not survive an
+        // edit. Nothing can render them either, so there is nothing to lose.
         let data = RefAny::new(wrapper("a"));
         poke(&data, |w| {
             let mut units = w.inner.text.clone().into_library_owned_vec();
@@ -2364,19 +2541,12 @@ mod autotest_generated {
             w.inner.text = units.into();
         });
 
-        let (out, changes, nodes) = run(Env::typed("b"), &data, default_on_text_input_inner);
+        let (out, changes, _) = run(Env::typed("b"), &data, default_on_text_input_inner);
 
         assert_eq!(out, Some(Update::DoNothing));
-        assert_eq!(
-            text_writes(&changes),
-            vec![(nodes.label, "ab".to_string())],
-            "only the scalars are rendered"
-        );
-        assert_eq!(
-            read(&data).text.len(),
-            NON_SCALAR.len() + 2,
-            "the raw buffer keeps everything"
-        );
+        assert!(text_writes(&changes).is_empty());
+        assert_eq!(read(&data).get_text(), "ab");
+        assert_eq!(read(&data).text.len(), 2);
     }
 
     #[test]
@@ -2393,11 +2563,12 @@ mod autotest_generated {
         let big: String = "chunk 😀\n".repeat(10_000);
         let data = RefAny::new(wrapper(""));
 
-        let (out, changes, nodes) = run(Env::typed(&big), &data, default_on_text_input_inner);
+        let (out, changes, _) = run(Env::typed(&big), &data, default_on_text_input_inner);
 
         assert_eq!(out, Some(Update::DoNothing));
         assert_eq!(read(&data).text.len(), big.chars().count());
-        assert_eq!(text_writes(&changes), vec![(nodes.label, big)]);
+        assert_eq!(read(&data).get_text(), big);
+        assert!(text_writes(&changes).is_empty());
     }
 
     // ==================================================================
@@ -2439,7 +2610,7 @@ mod autotest_generated {
         let data = RefAny::new(state);
 
         let (out, changes, _) = run(
-            Env::key(VirtualKeyCode::Back).hitting(Hit::Cursor),
+            Env::key(VirtualKeyCode::Back).hitting(Hit::TextLeaf),
             &data,
             default_on_virtual_key_down_inner,
         );
@@ -2454,186 +2625,32 @@ mod autotest_generated {
     }
 
     #[test]
-    fn backspace_on_an_empty_buffer_does_not_underflow() {
-        let data = RefAny::new(wrapper(""));
-        let (out, changes, nodes) = run(
-            Env::key(VirtualKeyCode::Back),
-            &data,
-            default_on_virtual_key_down_inner,
-        );
-
-        assert_eq!(out, Some(Update::DoNothing));
-        let state = read(&data);
-        assert!(state.text.is_empty());
-        assert_eq!(state.cursor_pos, 0, "saturating_sub must hold the floor");
-        // It still repaints: an empty buffer re-shows the placeholder.
-        assert_eq!(text_writes(&changes), vec![(nodes.label, String::new())]);
-        assert_eq!(opacity_writes(&changes), vec![(nodes.placeholder, 1.0)]);
-    }
-
-    #[test]
-    fn backspace_removes_exactly_one_char() {
-        for (before, after) in [
-            ("abc", "ab"),
-            ("a", ""),
-            ("a\n", "a"),
-            ("😀😀", "😀"),        // astral chars are one buffer slot each
-            ("e\u{301}", "e"),     // a combining mark is its own char
-            ("日本語", "日本"),
-        ] {
-            let data = RefAny::new(wrapper(before));
-            let (out, changes, nodes) = run(
-                Env::key(VirtualKeyCode::Back),
-                &data,
-                default_on_virtual_key_down_inner,
-            );
-
-            assert_eq!(out, Some(Update::DoNothing));
-            let state = read(&data);
-            assert_eq!(state.get_text(), after, "backspace on {before:?}");
-            assert_eq!(state.text.len(), after.chars().count());
-            assert_eq!(text_writes(&changes), vec![(nodes.label, after.to_string())]);
-        }
-    }
-
-    #[test]
-    fn backspace_re_shows_the_placeholder_only_once_the_buffer_empties() {
-        let data = RefAny::new(wrapper("ab"));
-
-        let (_, changes, _) = run(
-            Env::key(VirtualKeyCode::Back),
-            &data,
-            default_on_virtual_key_down_inner,
-        );
-        assert!(
-            opacity_writes(&changes).is_empty(),
-            "still one char left — the placeholder stays hidden"
-        );
-
-        let (_, changes, nodes) = run(
-            Env::key(VirtualKeyCode::Back),
-            &data,
-            default_on_virtual_key_down_inner,
-        );
-        assert_eq!(opacity_writes(&changes), vec![(nodes.placeholder, 1.0)]);
-    }
-
-    #[test]
-    fn backspace_clamps_the_cursor_instead_of_wrapping() {
-        let data = RefAny::new(wrapper("abc"));
-        poke(&data, |w| w.inner.cursor_pos = 0);
-
-        let (_, _, _) = run(
-            Env::key(VirtualKeyCode::Back),
-            &data,
-            default_on_virtual_key_down_inner,
-        );
-
-        assert_eq!(
-            read(&data).cursor_pos,
-            0,
-            "0 - 1 must saturate, never wrap to usize::MAX"
-        );
-    }
-
-    #[test]
-    fn backspace_pops_a_non_scalar_unit_too() {
-        let data = RefAny::new(wrapper("ab"));
-        poke(&data, |w| {
-            let mut units = w.inner.text.clone().into_library_owned_vec();
-            units.push(0xD800); // a lone surrogate, invisible to get_text
-            w.inner.text = units.into();
-        });
-
-        let (_, changes, nodes) = run(
-            Env::key(VirtualKeyCode::Back),
-            &data,
-            default_on_virtual_key_down_inner,
-        );
-
-        let state = read(&data);
-        assert_eq!(state.text.len(), 2, "the surrogate was the unit popped");
-        assert_eq!(state.get_text(), "ab");
-        assert_eq!(text_writes(&changes), vec![(nodes.label, "ab".to_string())]);
-    }
-
-    #[test]
-    fn return_inserts_a_newline() {
-        let data = RefAny::new(wrapper("line"));
-        let (out, changes, nodes) = run(
-            Env::key(VirtualKeyCode::Return),
-            &data,
-            default_on_virtual_key_down_inner,
-        );
-
-        assert_eq!(out, Some(Update::DoNothing));
-        let state = read(&data);
-        assert_eq!(state.get_text(), "line\n");
-        assert_eq!(state.cursor_pos, 1, "cursor_pos started at 0 and moved by one");
-        assert_eq!(text_writes(&changes), vec![(nodes.label, "line\n".to_string())]);
-        assert_eq!(
-            opacity_writes(&changes),
-            vec![(nodes.placeholder, 0.0)],
-            "the buffer is non-empty, so the placeholder must be hidden"
-        );
-    }
-
-    #[test]
-    fn numpad_enter_behaves_exactly_like_return() {
-        let via_return = RefAny::new(wrapper("x"));
-        let (a_out, a_changes, _) = run(
-            Env::key(VirtualKeyCode::Return),
-            &via_return,
-            default_on_virtual_key_down_inner,
-        );
-
-        let via_numpad = RefAny::new(wrapper("x"));
-        let (b_out, b_changes, _) = run(
-            Env::key(VirtualKeyCode::NumpadEnter),
-            &via_numpad,
-            default_on_virtual_key_down_inner,
-        );
-
-        assert_eq!(a_out, b_out);
-        assert_eq!(read(&via_return), read(&via_numpad));
-        assert_eq!(text_writes(&a_changes), text_writes(&b_changes));
-        assert_eq!(opacity_writes(&a_changes), opacity_writes(&b_changes));
-    }
-
-    #[test]
-    fn repeated_returns_accumulate_blank_lines() {
-        let data = RefAny::new(wrapper(""));
-        for _ in 0..5 {
-            let (out, _, _) = run(
-                Env::key(VirtualKeyCode::Return),
-                &data,
-                default_on_virtual_key_down_inner,
-            );
-            assert_eq!(out, Some(Update::DoNothing));
-        }
-
-        let state = read(&data);
-        assert_eq!(state.get_text(), "\n\n\n\n\n");
-        assert_eq!(state.cursor_pos, 5);
-    }
-
-    #[test]
-    fn a_plain_character_key_is_left_to_the_text_input_path() {
-        // Printable keys arrive through `default_on_text_input`; the key handler
-        // must not double-insert them.
+    fn no_key_edits_the_buffer_behind_the_engine() {
+        // Backspace, Delete and the arrows are `SystemChange::ApplySelectionOp`
+        // and Enter records a structural block split — all of them engine
+        // default actions. A widget that also edited its own buffer would
+        // double-apply every one of them.
         for key in [
+            VirtualKeyCode::Back,
+            VirtualKeyCode::Delete,
+            VirtualKeyCode::Return,
+            VirtualKeyCode::NumpadEnter,
+            VirtualKeyCode::Left,
             VirtualKeyCode::A,
             VirtualKeyCode::Space,
             VirtualKeyCode::Tab,
             VirtualKeyCode::Escape,
-            VirtualKeyCode::Left,
         ] {
-            let data = RefAny::new(wrapper("abc"));
-            let (out, changes, _) = run(Env::key(key), &data, default_on_virtual_key_down_inner);
+            for text in ["", "abc", "a\nb"] {
+                let data = RefAny::new(wrapper(text));
+                let before = read(&data);
+                let (out, changes, _) =
+                    run(Env::key(key), &data, default_on_virtual_key_down_inner);
 
-            assert_eq!(out, Some(Update::DoNothing), "{key:?}");
-            assert!(changes.is_empty(), "{key:?} must not repaint");
-            assert_eq!(read(&data).get_text(), "abc", "{key:?} must not edit");
+                assert_eq!(out, Some(Update::DoNothing), "{key:?} on {text:?}");
+                assert!(changes.is_empty(), "{key:?} on {text:?} mutated the DOM: {changes:?}");
+                assert_eq!(read(&data), before, "{key:?} on {text:?} edited the mirror");
+            }
         }
     }
 
@@ -2662,7 +2679,7 @@ mod autotest_generated {
     }
 
     #[test]
-    fn a_rejecting_hook_suppresses_the_built_in_editing() {
+    fn a_rejecting_hook_vetoes_the_engines_default_action() {
         for key in [VirtualKeyCode::Back, VirtualKeyCode::Return] {
             let log = edit_log(REJECT);
             let mut state = wrapper("frozen");
@@ -2676,14 +2693,15 @@ mod autotest_generated {
             let (out, changes, _) = run(Env::key(key), &data, default_on_virtual_key_down_inner);
 
             assert_eq!(out, Some(Update::RefreshDomAllWindows), "{key:?}");
-            assert!(changes.is_empty(), "{key:?} must not repaint");
+            assert_eq!(changes.len(), 1, "{key:?} pushed more than the veto: {changes:?}");
+            assert!(matches!(changes[0], CallbackChange::PreventDefault), "{key:?}");
             assert_eq!(read(&data).get_text(), "frozen", "{key:?} must not edit");
             assert_eq!(edits_seen(&log).len(), 1);
         }
     }
 
     #[test]
-    fn an_accepting_hook_lets_the_edit_through_and_still_sets_the_update() {
+    fn an_accepting_hook_leaves_the_default_action_alone_and_still_sets_the_update() {
         let log = edit_log(ACCEPT);
         let mut state = wrapper("ab");
         state.on_virtual_key_down = Some(TextAreaOnVirtualKeyDown {
@@ -2693,15 +2711,15 @@ mod autotest_generated {
         .into();
         let data = RefAny::new(state);
 
-        let (out, changes, nodes) = run(
+        let (out, changes, _) = run(
             Env::key(VirtualKeyCode::Back),
             &data,
             default_on_virtual_key_down_inner,
         );
 
         assert_eq!(out, Some(Update::RefreshDom));
-        assert_eq!(read(&data).get_text(), "a");
-        assert_eq!(text_writes(&changes), vec![(nodes.label, "a".to_string())]);
+        assert!(changes.is_empty(), "an accepted key must push nothing: {changes:?}");
+        assert_eq!(read(&data).get_text(), "ab", "the engine owns the deletion");
     }
 
     #[test]
@@ -2714,38 +2732,25 @@ mod autotest_generated {
     }
 
     #[test]
-    fn typing_then_editing_keeps_buffer_and_label_in_agreement() {
-        // One end-to-end pass over the three edit paths: paste, newline,
-        // backspace. The rendered label must equal `get_text()` at every step.
+    fn successive_insertions_accumulate_in_the_mirror_without_touching_the_dom() {
+        // The engine repaints the value; the widget only tracks what was
+        // inserted so its callbacks can hand the host a current state.
         let data = RefAny::new(wrapper(""));
 
-        let (_, changes, nodes) = run(Env::typed("hello"), &data, default_on_text_input_inner);
-        assert_eq!(text_writes(&changes), vec![(nodes.label, "hello".to_string())]);
+        for (chunk, expected) in [
+            ("hello", "hello"),
+            ("\n", "hello\n"),
+            ("world", "hello\nworld"),
+        ] {
+            let (_, changes, _) = run(Env::typed(chunk), &data, default_on_text_input_inner);
+            assert!(
+                text_writes(&changes).is_empty(),
+                "the widget repainted the value for {chunk:?}"
+            );
+            assert_eq!(read(&data).get_text(), expected);
+        }
 
-        let (_, changes, nodes) = run(
-            Env::key(VirtualKeyCode::Return),
-            &data,
-            default_on_virtual_key_down_inner,
-        );
-        assert_eq!(text_writes(&changes), vec![(nodes.label, "hello\n".to_string())]);
-
-        let (_, changes, nodes) = run(Env::typed("world"), &data, default_on_text_input_inner);
-        assert_eq!(
-            text_writes(&changes),
-            vec![(nodes.label, "hello\nworld".to_string())]
-        );
-
-        let (_, changes, nodes) = run(
-            Env::key(VirtualKeyCode::Back),
-            &data,
-            default_on_virtual_key_down_inner,
-        );
-        assert_eq!(
-            text_writes(&changes),
-            vec![(nodes.label, "hello\nworl".to_string())]
-        );
-
-        assert_eq!(read(&data).get_text(), "hello\nworl");
+        assert_eq!(read(&data).cursor_pos, "hello\nworld".len());
     }
 
     // ==================================================================

--- a/layout/src/widgets/text_area.rs
+++ b/layout/src/widgets/text_area.rs
@@ -586,13 +586,13 @@ impl TextArea {
                         // appended, never `with_attributes`: that one replaces the
                         // whole vector, classes included
                         .with_attribute(AttributeType::ContentEditable(false))
-                        .with_children(DomVec::from_vec(vec![Dom::create_text(placeholder)])),
+                        .with_children(DomVec::from_vec(vec![Dom::create_text_do_not_use_without_block_level_wrapper(placeholder)])),
                     Dom::create_p()
                         .with_ids_and_classes(
                             vec![Class("__azul-native-text-area-label".into())].into(),
                         )
                         .with_css_props(self.label_style)
-                        .with_children(DomVec::from_vec(vec![Dom::create_text(label_text)])),
+                        .with_children(DomVec::from_vec(vec![Dom::create_text_do_not_use_without_block_level_wrapper(label_text)])),
                 ]
                 .into(),
             )

--- a/layout/src/widgets/text_input.rs
+++ b/layout/src/widgets/text_input.rs
@@ -976,13 +976,13 @@ impl TextInput {
                         // appended, never `with_attributes`: that one replaces the
                         // whole vector, classes included
                         .with_attribute(AttributeType::ContentEditable(false))
-                        .with_children(DomVec::from_vec(vec![Dom::create_text(placeholder)])),
+                        .with_children(DomVec::from_vec(vec![Dom::create_text_do_not_use_without_block_level_wrapper(placeholder)])),
                     Dom::create_p()
                         .with_ids_and_classes(
                             vec![Class("__azul-native-text-input-label".into())].into(),
                         )
                         .with_css_props(self.label_style)
-                        .with_children(DomVec::from_vec(vec![Dom::create_text(label_text)])),
+                        .with_children(DomVec::from_vec(vec![Dom::create_text_do_not_use_without_block_level_wrapper(label_text)])),
                 ]
                 .into(),
             )

--- a/layout/src/widgets/text_input.rs
+++ b/layout/src/widgets/text_input.rs
@@ -1,8 +1,21 @@
-//! Single-line text input widget with cursor, placeholder, and two-way data binding.
+//! Single-line text input widget with placeholder and two-way data binding.
 //!
 //! The main entry point is [`TextInput`], which holds the editable state
 //! ([`TextInputState`]) together with per-platform default styles.  Call
 //! [`TextInput::dom()`] to obtain a renderable [`Dom`] node.
+//!
+//! The widget is a `contenteditable` host: the container carries the flag and
+//! the tab index, so the engine's `TextEditManager` owns the caret, the
+//! selection and the buffer. Caret and selection are display-list items driven
+//! by that manager — the widget contributes no cursor node — and edits run
+//! through `record_text_input` / `apply_text_changeset`. [`TextInputState`] is a
+//! *mirror* of that state, refreshed from the engine's changesets so the public
+//! callbacks keep the shape existing hosts bind against.
+//!
+//! Both the value and the placeholder are `<p>` blocks wrapping a bare text
+//! node: a [`NodeType::Text`](azul_core::dom::NodeType::Text) node is always
+//! inline-level and owns no rect, so box-model properties on one are inert and
+//! nothing bounds or clips the line.
 //!
 //! For higher-level text-input management (IME, clipboard, undo) see
 //! `layout/src/managers/text_input.rs`.
@@ -11,10 +24,9 @@ use alloc::{string::String, vec::Vec};
 
 use azul_core::{
     callbacks::{CoreCallback, CoreCallbackData, Update},
-    dom::Dom,
+    dom::{Dom, DomNodeId},
     refany::RefAny,
     task::OptionTimerId,
-    window::VirtualKeyCode,
 };
 #[allow(clippy::wildcard_imports)] // widget/render module pulls in the css property/value types it builds with
 use azul_css::{
@@ -63,10 +75,6 @@ const COLOR_4C4C4C: ColorU = ColorU {
     a: 255,
 }; // #4C4C4C
 
-const CURSOR_COLOR_BLACK: &[StyleBackgroundContent] = &[StyleBackgroundContent::Color(BLACK)];
-const CURSOR_COLOR: StyleBackgroundContentVec =
-    StyleBackgroundContentVec::from_const_slice(CURSOR_COLOR_BLACK);
-
 const BACKGROUND_THEME_LIGHT: &[StyleBackgroundContent] =
     &[StyleBackgroundContent::Color(BACKGROUND_COLOR)];
 const BACKGROUND_COLOR_LIGHT: StyleBackgroundContentVec =
@@ -77,25 +85,6 @@ const SANS_SERIF: AzString = AzString::from_const_str(SANS_SERIF_STR);
 const SANS_SERIF_FAMILIES: &[StyleFontFamily] = &[StyleFontFamily::System(SANS_SERIF)];
 const SANS_SERIF_FAMILY: StyleFontFamilyVec =
     StyleFontFamilyVec::from_const_slice(SANS_SERIF_FAMILIES);
-
-// -- cursor style
-
-const TEXT_CURSOR_TRANSFORM: &[StyleTransform] =
-    &[StyleTransform::Translate(StyleTransformTranslate2D {
-        x: PixelValue::const_px(0),
-        y: PixelValue::const_px(2),
-    })];
-
-static TEXT_CURSOR_PROPS: &[CssPropertyWithConditions] = &[
-    CssPropertyWithConditions::simple(CssProperty::const_position(LayoutPosition::Absolute)),
-    CssPropertyWithConditions::simple(CssProperty::const_width(LayoutWidth::const_px(1))),
-    CssPropertyWithConditions::simple(CssProperty::const_height(LayoutHeight::const_px(11))),
-    CssPropertyWithConditions::simple(CssProperty::const_background_content(CURSOR_COLOR)),
-    CssPropertyWithConditions::simple(CssProperty::const_opacity(StyleOpacity::const_new(0))),
-    CssPropertyWithConditions::simple(CssProperty::const_transform(
-        StyleTransformVec::from_const_slice(TEXT_CURSOR_TRANSFORM),
-    )),
-];
 
 // -- container style
 
@@ -448,12 +437,22 @@ static TEXT_INPUT_CONTAINER_PROPS: &[CssPropertyWithConditions] = &[
 ];
 
 // -- label style
+//
+// The label is the `<p>` block wrapping the value text, so it is the box that
+// bounds the line and clips against the container's `overflow: hidden`.
+// `white-space: pre` keeps a single-line field on one line and preserves the
+// spaces the user typed.
 
 #[cfg(target_os = "windows")]
 static TEXT_INPUT_LABEL_PROPS: &[CssPropertyWithConditions] = &[
-    CssPropertyWithConditions::simple(CssProperty::const_display(LayoutDisplay::InlineBlock)),
+    CssPropertyWithConditions::simple(CssProperty::const_display(LayoutDisplay::Block)),
     CssPropertyWithConditions::simple(CssProperty::const_flex_grow(LayoutFlexGrow::const_new(0))),
     CssPropertyWithConditions::simple(CssProperty::const_position(LayoutPosition::Relative)),
+    CssPropertyWithConditions::simple(CssProperty::const_overflow_x(LayoutOverflow::Hidden)),
+    CssPropertyWithConditions::simple(CssProperty::const_overflow_y(LayoutOverflow::Hidden)),
+    CssPropertyWithConditions::simple(CssProperty::WhiteSpace(StyleWhiteSpaceValue::Exact(
+        StyleWhiteSpace::Pre,
+    ))),
     CssPropertyWithConditions::simple(CssProperty::const_font_size(StyleFontSize::const_px(11))),
     CssPropertyWithConditions::simple(CssProperty::const_text_color(StyleTextColor {
         inner: COLOR_4C4C4C,
@@ -463,9 +462,14 @@ static TEXT_INPUT_LABEL_PROPS: &[CssPropertyWithConditions] = &[
 
 #[cfg(target_os = "linux")]
 static TEXT_INPUT_LABEL_PROPS: &[CssPropertyWithConditions] = &[
-    CssPropertyWithConditions::simple(CssProperty::const_display(LayoutDisplay::InlineBlock)),
+    CssPropertyWithConditions::simple(CssProperty::const_display(LayoutDisplay::Block)),
     CssPropertyWithConditions::simple(CssProperty::const_flex_grow(LayoutFlexGrow::const_new(0))),
     CssPropertyWithConditions::simple(CssProperty::const_position(LayoutPosition::Relative)),
+    CssPropertyWithConditions::simple(CssProperty::const_overflow_x(LayoutOverflow::Hidden)),
+    CssPropertyWithConditions::simple(CssProperty::const_overflow_y(LayoutOverflow::Hidden)),
+    CssPropertyWithConditions::simple(CssProperty::WhiteSpace(StyleWhiteSpaceValue::Exact(
+        StyleWhiteSpace::Pre,
+    ))),
     CssPropertyWithConditions::simple(CssProperty::const_font_size(StyleFontSize::const_px(11))),
     CssPropertyWithConditions::simple(CssProperty::const_text_color(StyleTextColor {
         inner: COLOR_4C4C4C,
@@ -475,9 +479,14 @@ static TEXT_INPUT_LABEL_PROPS: &[CssPropertyWithConditions] = &[
 
 #[cfg(not(any(target_os = "windows", target_os = "linux")))]
 static TEXT_INPUT_LABEL_PROPS: &[CssPropertyWithConditions] = &[
-    CssPropertyWithConditions::simple(CssProperty::const_display(LayoutDisplay::InlineBlock)),
+    CssPropertyWithConditions::simple(CssProperty::const_display(LayoutDisplay::Block)),
     CssPropertyWithConditions::simple(CssProperty::const_flex_grow(LayoutFlexGrow::const_new(0))),
     CssPropertyWithConditions::simple(CssProperty::const_position(LayoutPosition::Relative)),
+    CssPropertyWithConditions::simple(CssProperty::const_overflow_x(LayoutOverflow::Hidden)),
+    CssPropertyWithConditions::simple(CssProperty::const_overflow_y(LayoutOverflow::Hidden)),
+    CssPropertyWithConditions::simple(CssProperty::WhiteSpace(StyleWhiteSpaceValue::Exact(
+        StyleWhiteSpace::Pre,
+    ))),
     CssPropertyWithConditions::simple(CssProperty::const_font_size(StyleFontSize::const_px(11))),
     CssPropertyWithConditions::simple(CssProperty::const_text_color(StyleTextColor {
         inner: COLOR_4C4C4C,
@@ -486,6 +495,14 @@ static TEXT_INPUT_LABEL_PROPS: &[CssPropertyWithConditions] = &[
 ];
 
 // --- placeholder
+//
+// An absolutely-positioned `<p>` overlay inside the editable container. It is
+// marked `contenteditable="false"` so the engine's inheritance walk stops at it
+// and the prompt never becomes part of the buffer, and it is toggled with
+// `display` as well as `opacity`: a hidden-but-laid-out overlay would still own
+// the container's first inline layout, which is what
+// `LayoutWindow::reshape_text_node` picks up when it looks for the IFC to write
+// an edit into.
 
 #[cfg(target_os = "windows")]
 static TEXT_INPUT_PLACEHOLDER_PROPS: &[CssPropertyWithConditions] = &[
@@ -856,10 +873,21 @@ impl TextInput {
         s
     }
 
+    /// Renders the widget.
+    ///
+    /// The container is the `contenteditable` host — the flag, the tab index and
+    /// the focus callbacks all sit on it, because focus events do not bubble and
+    /// the engine records an edit against the *focused* node. Its two children
+    /// are `<p>` blocks wrapping a bare text node each; nothing else is emitted,
+    /// in particular no caret node (the engine paints the caret and the
+    /// selection from its display list).
     #[must_use] pub fn dom(mut self) -> Dom {
         use azul_core::{
             callbacks::CoreCallbackData,
-            dom::{EventFilter, FocusEventFilter, HoverEventFilter, IdOrClass::Class, TabIndex},
+            dom::{
+                AttributeType, DomVec, EventFilter, FocusEventFilter, HoverEventFilter,
+                IdOrClass::Class, TabIndex,
+            },
         };
 
         self.text_input_state.inner.cursor_pos = self.text_input_state.inner.text.len();
@@ -880,12 +908,18 @@ impl TextInput {
             .map(|s| s.as_str().to_string())
             .unwrap_or_default();
 
+        let mut placeholder_style = self.placeholder_style;
+        if !self.text_input_state.inner.text.is_empty() {
+            placeholder_style = hidden_placeholder_style(&placeholder_style);
+        }
+
         let state_ref = RefAny::new(self.text_input_state);
 
         Dom::create_div()
             .with_ids_and_classes(vec![Class("__azul-native-text-input-container".into())].into())
             .with_css_props(self.container_style)
             .with_tab_index(TabIndex::Auto)
+            .with_contenteditable(true)
             .with_dataset(Some(state_ref.clone()).into())
             .with_callbacks(
                 vec![
@@ -934,30 +968,128 @@ impl TextInput {
             )
             .with_children(
                 vec![
-                    Dom::create_text(placeholder)
+                    Dom::create_p()
                         .with_ids_and_classes(
                             vec![Class("__azul-native-text-input-placeholder".into())].into(),
                         )
-                        .with_css_props(self.placeholder_style),
-                    Dom::create_text(label_text)
+                        .with_css_props(placeholder_style)
+                        // appended, never `with_attributes`: that one replaces the
+                        // whole vector, classes included
+                        .with_attribute(AttributeType::ContentEditable(false))
+                        .with_children(DomVec::from_vec(vec![Dom::create_text(placeholder)])),
+                    Dom::create_p()
                         .with_ids_and_classes(
                             vec![Class("__azul-native-text-input-label".into())].into(),
                         )
                         .with_css_props(self.label_style)
-                        .with_children(
-                            vec![Dom::create_div()
-                                .with_ids_and_classes(
-                                    vec![Class("__azul-native-text-input-cursor".into())].into(),
-                                )
-                                .with_css_props(CssPropertyWithConditionsVec::from_const_slice(
-                                    TEXT_CURSOR_PROPS,
-                                ))]
-                            .into(),
-                        ),
+                        .with_children(DomVec::from_vec(vec![Dom::create_text(label_text)])),
                 ]
                 .into(),
             )
     }
+}
+
+/// `style` with the placeholder taken out of the flow: `display: none` on top
+/// of `opacity: 0`, so a hidden prompt owns neither pixels nor an inline layout.
+fn hidden_placeholder_style(
+    style: &CssPropertyWithConditionsVec,
+) -> CssPropertyWithConditionsVec {
+    let mut props = style.as_ref().to_vec();
+    props.push(CssPropertyWithConditions::simple(CssProperty::const_display(
+        LayoutDisplay::None,
+    )));
+    props.push(CssPropertyWithConditions::simple(CssProperty::const_opacity(
+        StyleOpacity::const_new(0),
+    )));
+    CssPropertyWithConditionsVec::from_vec(props)
+}
+
+/// The placeholder `<p>` and the value `<p>`, in that order.
+///
+/// Both handlers and tests resolve them through the same hierarchy hops the
+/// container's own layout guarantees; a subtree of any other shape yields
+/// `None` and every handler bails out.
+fn label_nodes(info: &CallbackInfo) -> Option<(DomNodeId, DomNodeId)> {
+    let placeholder = info.get_first_child(info.get_hit_node())?;
+    let label = info.get_next_sibling(placeholder)?;
+    Some((placeholder, label))
+}
+
+/// Shows or hides the placeholder prompt.
+fn set_placeholder_visible(info: &mut CallbackInfo, placeholder: DomNodeId, visible: bool) {
+    let (display, opacity) = if visible {
+        (LayoutDisplay::Block, StyleOpacity::const_new(100))
+    } else {
+        (LayoutDisplay::None, StyleOpacity::const_new(0))
+    };
+    info.set_css_property(placeholder, CssProperty::const_opacity(opacity));
+    info.set_css_property(placeholder, CssProperty::const_display(display));
+}
+
+/// Adopts the engine's text for `node` into the widget's mirror.
+///
+/// The engine owns the buffer, so its answer wins — except that an empty answer
+/// is ambiguous: `get_text_before_textinput` also yields nothing for a node
+/// whose text sits under a block wrapper it does not descend into. An empty
+/// read therefore never clears a non-empty mirror.
+fn adopt_engine_text(state: &mut TextInputState, info: &CallbackInfo, node: DomNodeId) {
+    let Some(text) = info.get_node_text_content(node) else {
+        return;
+    };
+    if text.is_empty() && !state.text.is_empty() {
+        return;
+    }
+    state.text = text.chars().map(|c| c as u32).collect::<Vec<_>>().into();
+}
+
+/// The engine's selection, in the widget's public shape.
+///
+/// Offsets are byte offsets into the value, matching the cursor positions the
+/// engine reports; a range that spans the whole buffer collapses to
+/// [`TextInputSelection::All`].
+fn engine_selection(
+    info: &CallbackInfo,
+    node: DomNodeId,
+    len: usize,
+) -> Option<TextInputSelection> {
+    let ranges = info.get_node_selection_ranges(node);
+    let range = *ranges.as_ref().first()?;
+    let dir_from = range.start.cluster_id.start_byte_in_run as usize;
+    let dir_to = range.end.cluster_id.start_byte_in_run as usize;
+    if len != 0 && dir_from == 0 && dir_to >= len {
+        return Some(TextInputSelection::All);
+    }
+    Some(TextInputSelection::FromTo(TextInputSelectionRange {
+        dir_from,
+        dir_to,
+    }))
+}
+
+/// Mirrors the insertion the engine is about to apply.
+///
+/// The engine inserts at the caret, so the mirror does too whenever the caret
+/// is readable and lands on a character boundary; otherwise it appends, which
+/// is where the caret sits for every append-only path. `cursor_pos` stays a
+/// byte offset, as it has always been.
+fn mirror_insertion(state: &mut TextInputState, inserted: &str, caret: Option<usize>) {
+    let text = state.get_text();
+    let at = caret
+        .filter(|at| *at <= text.len() && text.is_char_boundary(*at))
+        .unwrap_or(text.len());
+
+    let mut next = String::with_capacity(text.len() + inserted.len());
+    next.push_str(&text[..at]);
+    next.push_str(inserted);
+    next.push_str(&text[at..]);
+
+    state.text = next.chars().map(|c| c as u32).collect::<Vec<_>>().into();
+    state.cursor_pos = at.saturating_add(inserted.len());
+}
+
+/// The caret's byte offset inside the edited node, if the engine has one.
+fn engine_caret(info: &CallbackInfo, node: DomNodeId) -> Option<usize> {
+    info.get_node_cursor_position(node)
+        .map(|c| c.cluster_id.start_byte_in_run as usize)
 }
 
 extern "C" fn default_on_focus_received(mut text_input: RefAny, mut info: CallbackInfo) -> Update {
@@ -971,15 +1103,18 @@ extern "C" fn default_on_focus_received(mut text_input: RefAny, mut info: Callba
         return Update::DoNothing;
     };
 
+    let container = info.get_hit_node();
+    adopt_engine_text(&mut text_input.inner, &info, container);
+
     // hide the placeholder text
     if text_input.inner.text.is_empty() {
-        info.set_css_property(
-            placeholder_text_node_id,
-            CssProperty::const_opacity(StyleOpacity::const_new(0)),
-        );
+        set_placeholder_visible(&mut info, placeholder_text_node_id, false);
     }
 
-    text_input.inner.cursor_pos = text_input.inner.text.len();
+    // The engine seeds the caret at the end of the value when focus lands on a
+    // contenteditable host; the mirror follows it.
+    let end_of_text = text_input.inner.text.len();
+    text_input.inner.cursor_pos = engine_caret(&info, container).unwrap_or(end_of_text);
 
     Update::DoNothing
 }
@@ -995,12 +1130,12 @@ extern "C" fn default_on_focus_lost(mut text_input: RefAny, mut info: CallbackIn
         return Update::DoNothing;
     };
 
+    let container = info.get_hit_node();
+    adopt_engine_text(&mut text_input.inner, &info, container);
+
     // show the placeholder text
     if text_input.inner.text.is_empty() {
-        info.set_css_property(
-            placeholder_text_node_id,
-            CssProperty::const_opacity(StyleOpacity::const_new(100)),
-        );
+        set_placeholder_visible(&mut info, placeholder_text_node_id, true);
     }
 
     // rustc doesn't understand the borrowing lifetime here
@@ -1023,18 +1158,59 @@ extern "C" fn default_on_text_input(text_input: RefAny, info: CallbackInfo) -> U
 fn default_on_text_input_inner(mut text_input: RefAny, mut info: CallbackInfo) -> Option<Update> {
     let mut text_input = text_input.downcast_mut::<TextInputStateWrapper>()?;
 
-    // Get the text changeset (replaces old keyboard_state.current_char API)
-    let changeset = info.get_text_changeset()?;
-    let inserted_text = changeset.inserted_text.as_str().to_string();
+    // The engine records the edit before the callbacks run and applies it after
+    // them; this handler only observes it and mirrors it into the widget state.
+    // An `Input` WITHOUT a pending record is a post-edit NOTIFICATION: an edit
+    // committed outside the record pipeline (deletion, programmatic edit) that
+    // is already applied — adopt it and inform the user hook; `valid` cannot
+    // veto what already happened.
+    let inserted_text = info
+        .get_text_changeset()
+        .map(|c| c.inserted_text.as_str().to_string())
+        .unwrap_or_default();
 
-    // Early return if no text to insert
+    let (placeholder_node_id, _label_node_id) = label_nodes(&info)?;
+    let container = info.get_hit_node();
+
     if inserted_text.is_empty() {
-        return None;
+        // Idempotent: a notification that changed nothing observable (a
+        // spurious Input, an edit already mirrored) stays a strict no-op, so
+        // the no-changeset pins keep holding.
+        let before = text_input.inner.get_text();
+        adopt_engine_text(&mut text_input.inner, &info, container);
+        if text_input.inner.get_text() == before {
+            return None;
+        }
+        let len = text_input.inner.get_text().len();
+        text_input.inner.selection = engine_selection(&info, container, len).into();
+        // A field deleted to empty shows its placeholder again.
+        set_placeholder_visible(&mut info, placeholder_node_id, len == 0);
+        let result = {
+            let text_input = &mut *text_input;
+            let inner_clone = text_input.inner.clone();
+            match text_input.on_text_input.as_mut() {
+                Some(TextInputOnTextInput { callback, refany }) => {
+                    (callback.cb)(refany.clone(), info, inner_clone)
+                }
+                None => OnTextInputReturn {
+                    update: Update::DoNothing,
+                    valid: TextInputValid::Yes,
+                },
+            }
+        };
+        return Some(result.update);
     }
 
-    let placeholder_node_id = info.get_first_child(info.get_hit_node())?;
-    let label_node_id = info.get_next_sibling(placeholder_node_id)?;
-    let _cursor_node_id = info.get_first_child(label_node_id)?;
+    // A single-line field never accepts a line separator: veto insertions
+    // carrying one (paste with newlines; the engine's Enter line break is
+    // already vetoed in the key handler).
+    if inserted_text.contains('\n') {
+        info.prevent_default();
+        return Some(Update::DoNothing);
+    }
+
+    let caret = engine_caret(&info, container);
+    adopt_engine_text(&mut text_input.inner, &info, container);
 
     let result = {
         // rustc doesn't understand the borrowing lifetime here
@@ -1043,12 +1219,9 @@ fn default_on_text_input_inner(mut text_input: RefAny, mut info: CallbackInfo) -
 
         // inner_clone has the new text
         let mut inner_clone = text_input.inner.clone();
-        inner_clone.cursor_pos = inner_clone.cursor_pos.saturating_add(inserted_text.len());
-        inner_clone.text = {
-            let mut internal = inner_clone.text.clone().into_library_owned_vec();
-            internal.extend(inserted_text.chars().map(|c| c as u32));
-            internal.into()
-        };
+        mirror_insertion(&mut inner_clone, &inserted_text, caret);
+        let len = inner_clone.get_text().len();
+        inner_clone.selection = engine_selection(&info, container, len).into();
 
         match ontextinput.as_mut() {
             Some(TextInputOnTextInput { callback, refany }) => {
@@ -1063,23 +1236,15 @@ fn default_on_text_input_inner(mut text_input: RefAny, mut info: CallbackInfo) -
 
     if result.valid == TextInputValid::Yes {
         // hide the placeholder text
-        info.set_css_property(
-            placeholder_node_id,
-            CssProperty::const_opacity(StyleOpacity::const_new(0)),
-        );
+        set_placeholder_visible(&mut info, placeholder_node_id, false);
 
-        // append to the text
-        text_input.inner.text = {
-            let mut internal = text_input.inner.text.clone().into_library_owned_vec();
-            internal.extend(inserted_text.chars().map(|c| c as u32));
-            internal.into()
-        };
-        text_input.inner.cursor_pos = text_input
-            .inner
-            .cursor_pos
-            .saturating_add(inserted_text.len());
-
-        info.change_node_text(label_node_id, text_input.inner.get_text().into());
+        mirror_insertion(&mut text_input.inner, &inserted_text, caret);
+        let len = text_input.inner.get_text().len();
+        text_input.inner.selection = engine_selection(&info, container, len).into();
+    } else {
+        // The engine applies the recorded changeset once the callbacks return,
+        // unless one of them vetoes it.
+        info.prevent_default();
     }
 
     Some(result.update)
@@ -1096,17 +1261,21 @@ fn default_on_virtual_key_down_inner(
     let mut text_input = text_input.downcast_mut::<TextInputStateWrapper>()?;
     let keyboard_state = info.get_current_keyboard_state();
 
-    let c = keyboard_state.current_virtual_keycode.into_option()?;
-    let placeholder_node_id = info.get_first_child(info.get_hit_node())?;
-    let label_node_id = info.get_next_sibling(placeholder_node_id)?;
-    let _cursor_node_id = info.get_first_child(label_node_id)?;
+    let keycode = keyboard_state.current_virtual_keycode.into_option()?;
+    let (_placeholder_node_id, _label_node_id) = label_nodes(&info)?;
 
-    // Dispatch to the user's on_virtual_key_down callback first; a
-    // TextInputValid::No return suppresses the built-in editing behavior.
+    let container = info.get_hit_node();
+    adopt_engine_text(&mut text_input.inner, &info, container);
+
+    // Editing keys (Backspace, Delete, the arrows, Enter) are the engine's
+    // default actions; this handler only forwards the key to the user's hook
+    // and lets a rejection stop the default from running.
     let result = {
         // rustc doesn't understand the borrowing lifetime here
         let text_input = &mut *text_input;
-        let inner_clone = text_input.inner.clone();
+        let mut inner_clone = text_input.inner.clone();
+        let len = inner_clone.get_text().len();
+        inner_clone.selection = engine_selection(&info, container, len).into();
         match text_input.on_virtual_key_down.as_mut() {
             Some(TextInputOnVirtualKeyDown { callback, refany }) => {
                 (callback.cb)(refany.clone(), info, inner_clone)
@@ -1118,15 +1287,21 @@ fn default_on_virtual_key_down_inner(
         }
     };
 
-    if result.valid == TextInputValid::Yes && c == VirtualKeyCode::Back {
-        text_input.inner.text = {
-            let mut internal = text_input.inner.text.clone().into_library_owned_vec();
-            internal.pop();
-            internal.into()
-        };
-        text_input.inner.cursor_pos = text_input.inner.cursor_pos.saturating_sub(1);
+    let len = text_input.inner.get_text().len();
+    text_input.inner.selection = engine_selection(&info, container, len).into();
 
-        info.change_node_text(label_node_id, text_input.inner.get_text().into());
+    if result.valid == TextInputValid::No {
+        info.prevent_default();
+    }
+
+    // Single-line field: Enter must never edit the value. The engine-side
+    // default in this host (white-space:pre) is a literal "\n" insert, so it
+    // is vetoed here; activation semantics stay with the user's hook above.
+    if matches!(
+        keycode,
+        azul_core::window::VirtualKeyCode::Return | azul_core::window::VirtualKeyCode::NumpadEnter
+    ) {
+        info.prevent_default();
     }
 
     Some(result.update)
@@ -1150,8 +1325,8 @@ mod autotest_generated {
 
     use azul_core::{
         dom::{
-            DomId, DomNodeId, EventFilter, FocusEventFilter, HoverEventFilter, IdOrClass, NodeId,
-            TabIndex,
+            AttributeType, DomId, DomNodeId, EventFilter, FocusEventFilter, HoverEventFilter,
+            IdOrClass, NodeId, NodeType, TabIndex,
         },
         geom::{LogicalRect, OptionLogicalPosition},
         gl::OptionGlContextPtr,
@@ -1159,7 +1334,7 @@ mod autotest_generated {
         refany::OptionRefAny,
         resources::RendererResources,
         styled_dom::{NodeHierarchyItemId, StyledDom},
-        window::{MonitorVec, RawWindowHandle},
+        window::{MonitorVec, RawWindowHandle, VirtualKeyCode},
     };
     use rust_fontconfig::FcFontCache;
 
@@ -1440,13 +1615,14 @@ mod autotest_generated {
         }
     }
 
-    /// The three child nodes of the container, resolved through the *same* API the
-    /// handlers use — so no test has to hard-code a flattened index.
+    /// The container's two `<p>` children plus the value's bare text leaf,
+    /// resolved through the *same* API the handlers use — so no test has to
+    /// hard-code a flattened index.
     #[derive(Copy, Clone, Debug, PartialEq, Eq)]
     struct Nodes {
         placeholder: Option<DomNodeId>,
         label: Option<DomNodeId>,
-        cursor: Option<DomNodeId>,
+        label_text: Option<DomNodeId>,
     }
 
     /// Runs `f` with a real `CallbackInfo` over a window holding `env.styled_dom` as
@@ -1498,11 +1674,11 @@ mod autotest_generated {
         );
         let placeholder = probe.get_first_child(dom_node(CONTAINER));
         let label = placeholder.and_then(|p| probe.get_next_sibling(p));
-        let cursor = label.and_then(|l| probe.get_first_child(l));
+        let label_text = label.and_then(|l| probe.get_first_child(l));
         let nodes = Nodes {
             placeholder,
             label,
-            cursor,
+            label_text,
         };
 
         let info = CallbackInfo::new(
@@ -1570,11 +1746,42 @@ mod autotest_generated {
             .collect()
     }
 
+    /// The text a `<p>` label wraps, looking through the block wrapper the
+    /// widget convention mandates (`p > text`).
     fn text_of(node: &Dom) -> String {
-        node.root
-            .get_node_type()
-            .format()
-            .expect("expected a text node")
+        assert!(
+            matches!(node.root.get_node_type(), NodeType::P),
+            "widget text must be wrapped in a <p> block"
+        );
+        match node.children.as_ref() {
+            [only] => only
+                .root
+                .get_node_type()
+                .format()
+                .expect("expected a bare text leaf"),
+            other => panic!("a label <p> wraps exactly one text node, found {}", other.len()),
+        }
+    }
+
+    /// Every `NodeType::Text` node in `node`'s subtree that is not a bare leaf
+    /// under a `<p>`: css props, callbacks, a tab index, a dataset or children
+    /// on a text node are all inert, because a text node owns no rect.
+    fn text_nodes_carrying_state(node: &Dom, parent_is_p: bool, bad: &mut Vec<String>) {
+        if let NodeType::Text(t) = node.root.get_node_type() {
+            let carries = !node.root.get_style().is_empty()
+                || !node.root.get_callbacks().as_ref().is_empty()
+                || node.root.get_tab_index().is_some()
+                || node.root.get_dataset().is_some()
+                || !node.children.as_ref().is_empty()
+                || !parent_is_p;
+            if carries {
+                bad.push(t.as_ref().as_str().to_string());
+            }
+        }
+        let is_p = matches!(node.root.get_node_type(), NodeType::P);
+        for c in node.children.as_ref() {
+            text_nodes_carrying_state(c, is_p, bad);
+        }
     }
 
     fn dataset_state(dom: &Dom) -> TextInputState {
@@ -2172,7 +2379,7 @@ mod autotest_generated {
     // ==================================================================
 
     #[test]
-    fn dom_builds_a_container_with_a_placeholder_and_a_label_carrying_a_cursor() {
+    fn dom_builds_a_container_with_a_placeholder_block_and_a_value_block() {
         let dom = TextInput::create().dom();
 
         assert_eq!(classes(&dom), vec!["__azul-native-text-input-container"]);
@@ -2183,22 +2390,105 @@ mod autotest_generated {
         assert_eq!(classes(placeholder), vec!["__azul-native-text-input-placeholder"]);
         assert_eq!(classes(label), vec!["__azul-native-text-input-label"]);
 
+        for block in [placeholder, label] {
+            assert!(matches!(block.root.get_node_type(), NodeType::P));
+            assert_eq!(block.children.as_ref().len(), 1);
+            assert!(matches!(
+                block.children.as_ref()[0].root.get_node_type(),
+                NodeType::Text(_),
+            ));
+        }
+    }
+
+    #[test]
+    fn dom_emits_no_cursor_node() {
+        // The caret and the selection are display-list items driven by the
+        // engine's TextEditManager; a widget-owned cursor div resolved against
+        // the container and never tracked the caret.
+        fn walk(node: &Dom, out: &mut Vec<String>) {
+            out.extend(classes(node));
+            for c in node.children.as_ref() {
+                walk(c, out);
+            }
+        }
+        let mut all = Vec::new();
+        walk(&TextInput::create().with_text("typed".into()).dom(), &mut all);
         assert!(
-            placeholder.children.as_ref().is_empty(),
-            "the placeholder must be a leaf: the handlers reach the label through its sibling",
-        );
-        assert_eq!(label.children.as_ref().len(), 1);
-        assert_eq!(
-            classes(&label.children.as_ref()[0]),
-            vec!["__azul-native-text-input-cursor"],
+            !all.iter().any(|c| c.contains("cursor")),
+            "the widget still emits a cursor node: {all:?}",
         );
     }
 
     #[test]
-    fn dom_marks_the_container_as_keyboard_focusable() {
-        // Without a tab index the widget can never receive the focus events that all
-        // four of its editing handlers are filtered on.
-        assert_eq!(TextInput::create().dom().root.get_tab_index(), Some(TabIndex::Auto));
+    fn dom_carries_no_state_on_any_text_node() {
+        // A NodeType::Text node is unconditionally inline-level and owns no
+        // rect, so css props / callbacks / a tab index / a dataset / children on
+        // one are all inert. Every text node must be a bare leaf under a <p>.
+        for input in [
+            TextInput::create(),
+            TextInput::create().with_text("typed".into()).with_placeholder("hint".into()),
+        ] {
+            let mut bad = Vec::new();
+            text_nodes_carrying_state(&input.dom(), false, &mut bad);
+            assert!(bad.is_empty(), "text nodes carrying inert state: {bad:?}");
+        }
+    }
+
+    #[test]
+    fn dom_marks_the_container_as_keyboard_focusable_and_editable() {
+        // Focus events do not bubble and the engine records an edit against the
+        // FOCUSED node, so the tab index and the contenteditable flag have to
+        // sit on the same node the handlers are attached to.
+        let dom = TextInput::create().dom();
+        assert_eq!(dom.root.get_tab_index(), Some(TabIndex::Auto));
+        assert!(dom.root.is_contenteditable());
+    }
+
+    #[test]
+    fn dom_keeps_the_placeholder_out_of_the_editable_content() {
+        // Everything inside a contenteditable host is editable content unless a
+        // node blocks the inheritance walk; the prompt must never be typed into.
+        let dom = TextInput::create().with_placeholder("hint".into()).dom();
+        let placeholder = &dom.children.as_ref()[PLACEHOLDER_CHILD];
+        assert!(
+            placeholder
+                .root
+                .attributes()
+                .as_ref()
+                .iter()
+                .any(|a| matches!(a, AttributeType::ContentEditable(false))),
+            "the placeholder is inside the editable host and does not opt out",
+        );
+        assert!(!dom.children.as_ref()[LABEL_CHILD]
+            .root
+            .attributes()
+            .as_ref()
+            .iter()
+            .any(|a| matches!(a, AttributeType::ContentEditable(_))));
+    }
+
+    #[test]
+    fn dom_hides_the_placeholder_when_the_buffer_is_not_empty() {
+        let hidden = TextInput::create().with_text("typed".into()).dom();
+        let shown = TextInput::create().dom();
+
+        let display = |node: &Dom| -> Option<CssProperty> {
+            node.root
+                .style
+                .iter_inline_properties()
+                .map(|(p, _)| p.clone())
+                .filter(|p| matches!(p, CssProperty::Display(_)))
+                .last()
+        };
+
+        assert_eq!(
+            display(&hidden.children.as_ref()[PLACEHOLDER_CHILD]),
+            Some(CssProperty::const_display(LayoutDisplay::None)),
+        );
+        assert_ne!(
+            display(&shown.children.as_ref()[PLACEHOLDER_CHILD]),
+            Some(CssProperty::const_display(LayoutDisplay::None)),
+        );
     }
 
     #[test]
@@ -2336,17 +2626,17 @@ mod autotest_generated {
     }
 
     #[test]
-    fn the_rendered_tree_flattens_to_three_distinct_reachable_children() {
+    fn the_rendered_tree_flattens_to_the_shape_the_handlers_navigate() {
         let (styled_dom, _) = rendered(TextInput::create());
         let ((), _, nodes) = run(Env::new(styled_dom), |_| ());
 
         let placeholder = nodes.placeholder.expect("the container has no first child");
         let label = nodes.label.expect("the placeholder has no next sibling");
-        let cursor = nodes.cursor.expect("the label has no first child");
+        let label_text = nodes.label_text.expect("the value block has no text leaf");
 
         assert_ne!(placeholder, label);
-        assert_ne!(label, cursor);
-        assert_ne!(placeholder, cursor);
+        assert_ne!(label, label_text);
+        assert_ne!(placeholder, label_text);
         assert_ne!(placeholder, dom_node(CONTAINER));
     }
 
@@ -2380,14 +2670,14 @@ mod autotest_generated {
     }
 
     #[test]
-    fn focus_received_on_the_cursor_leaf_is_a_no_op() {
-        // The cursor is the one node in the tree with no children of its own.
+    fn focus_received_on_the_value_text_leaf_is_a_no_op() {
+        // The bare text leaf is the one node in the tree with no children.
         let (probe_dom, _) = rendered(TextInput::create());
         let (_, _, nodes) = run(Env::new(probe_dom), |_| ());
-        let cursor = nodes.cursor.expect("no cursor node");
+        let leaf = nodes.label_text.expect("no value text leaf");
 
         let (styled_dom, state) = rendered(TextInput::create());
-        let (update, changes, _) = run(Env::new(styled_dom).hit(cursor), |info| {
+        let (update, changes, _) = run(Env::new(styled_dom).hit(leaf), |info| {
             default_on_focus_received(state.clone(), info)
         });
         assert_eq!(update, Update::DoNothing);
@@ -2540,7 +2830,7 @@ mod autotest_generated {
     }
 
     #[test]
-    fn text_input_appends_the_insertion_hides_the_placeholder_and_repaints_the_label() {
+    fn text_input_mirrors_the_insertion_and_hides_the_placeholder() {
         let (styled_dom, state) = rendered(TextInput::create().with_placeholder("hint".into()));
         let (update, changes, nodes) = run(Env::new(styled_dom).insert("hi"), |info| {
             default_on_text_input(state.clone(), info)
@@ -2554,24 +2844,20 @@ mod autotest_generated {
             pushed_opacities(&changes),
             vec![(inner_id(nodes.placeholder.expect("no placeholder")), 0.0)],
         );
-        assert_eq!(
-            pushed_texts(&changes),
-            vec![(nodes.label.expect("no label"), "hi".to_string())],
-            "the label was not repainted with the new buffer",
+        assert!(
+            pushed_texts(&changes).is_empty(),
+            "the widget repainted the value itself; the engine owns the buffer: {changes:?}",
         );
     }
 
     #[test]
     fn text_input_appends_to_an_existing_buffer_rather_than_replacing_it() {
         let (styled_dom, state) = rendered(TextInput::create().with_text("ab".into()));
-        let (_, changes, nodes) = run(Env::new(styled_dom).insert("cd"), |info| {
+        let (_, changes, _) = run(Env::new(styled_dom).insert("cd"), |info| {
             default_on_text_input(state.clone(), info)
         });
         assert_eq!(state_of(&state).get_text(), "abcd");
-        assert_eq!(
-            pushed_texts(&changes),
-            vec![(nodes.label.expect("no label"), "abcd".to_string())],
-        );
+        assert!(pushed_texts(&changes).is_empty());
     }
 
     #[test]
@@ -2614,8 +2900,16 @@ mod autotest_generated {
         assert_eq!(state_of(&state).get_text(), "ab", "a rejected edit was applied anyway");
         assert_eq!(state_of(&state).cursor_pos, 2, "a rejected edit still moved the cursor");
         assert!(
-            changes.is_empty(),
+            changes
+                .iter()
+                .all(|c| matches!(c, CallbackChange::PreventDefault)),
             "a rejected edit still repainted the widget: {changes:?}",
+        );
+        assert!(
+            changes
+                .iter()
+                .any(|c| matches!(c, CallbackChange::PreventDefault)),
+            "a rejected edit did not stop the engine from applying the changeset",
         );
     }
 
@@ -2641,7 +2935,9 @@ mod autotest_generated {
     }
 
     #[test]
-    fn text_input_saturates_the_cursor_instead_of_overflowing_it() {
+    fn text_input_recomputes_the_cursor_rather_than_accumulating_a_stale_one() {
+        // The cursor is derived from the insertion point every time, so a stale
+        // value planted by a host cannot survive — nor overflow.
         let (styled_dom, state) = rendered(TextInput::create());
         poke(&state, |w| w.inner.cursor_pos = usize::MAX);
 
@@ -2650,11 +2946,7 @@ mod autotest_generated {
         });
 
         assert_eq!(update, Update::DoNothing);
-        assert_eq!(
-            state_of(&state).cursor_pos,
-            usize::MAX,
-            "the cursor wrapped around instead of saturating",
-        );
+        assert_eq!(state_of(&state).cursor_pos, 3);
         assert_eq!(state_of(&state).get_text(), "abc");
     }
 
@@ -2662,15 +2954,12 @@ mod autotest_generated {
     fn text_input_accepts_astral_combining_and_multi_scalar_insertions() {
         for s in ["\u{10ffff}", "e\u{301}", "👨‍👩‍👧‍👦", "日本語", "\0"] {
             let (styled_dom, state) = rendered(TextInput::create());
-            let (_, changes, nodes) = run(Env::new(styled_dom).insert(s), |info| {
+            let (_, changes, _) = run(Env::new(styled_dom).insert(s), |info| {
                 default_on_text_input(state.clone(), info)
             });
             assert_eq!(state_of(&state).get_text(), s, "the buffer mangled {s:?}");
             assert_eq!(state_of(&state).text.len(), s.chars().count());
-            assert_eq!(
-                pushed_texts(&changes),
-                vec![(nodes.label.expect("no label"), s.to_string())],
-            );
+            assert!(pushed_texts(&changes).is_empty());
         }
     }
 
@@ -2754,87 +3043,54 @@ mod autotest_generated {
     }
 
     #[test]
-    fn backspace_pops_one_code_unit_and_walks_the_cursor_back() {
+    fn backspace_is_the_engines_default_action_not_the_widgets() {
+        // Deletion is `SystemChange::ApplySelectionOp` on the engine side; a
+        // widget that also popped its own buffer would double-delete.
         let (styled_dom, state) = rendered(TextInput::create().with_text("abc".into()));
-        let (update, changes, nodes) =
+        let (update, changes, _) =
             run(Env::new(styled_dom).key(VirtualKeyCode::Back), |info| {
                 default_on_virtual_key_down(state.clone(), info)
             });
 
         assert_eq!(update, Update::DoNothing);
-        assert_eq!(state_of(&state).get_text(), "ab");
-        assert_eq!(state_of(&state).cursor_pos, 2);
-        assert_eq!(
-            pushed_texts(&changes),
-            vec![(nodes.label.expect("no label"), "ab".to_string())],
-        );
-        assert!(pushed_opacities(&changes).is_empty(), "backspace must not touch the placeholder");
+        assert!(changes.is_empty(), "backspace still mutated the DOM: {changes:?}");
+        assert_eq!(state_of(&state).get_text(), "abc", "the widget deleted behind the engine");
     }
 
     #[test]
-    fn backspace_on_an_empty_buffer_saturates_at_zero_instead_of_underflowing() {
-        let (styled_dom, state) = rendered(TextInput::create());
-        let (update, changes, nodes) =
-            run(Env::new(styled_dom).key(VirtualKeyCode::Back), |info| {
+    fn every_key_reaches_the_hook_and_leaves_the_buffer_alone() {
+        for key in [VirtualKeyCode::A, VirtualKeyCode::Back, VirtualKeyCode::Return] {
+            let probe = recorder(Update::RefreshDom, TextInputValid::Yes);
+            let (styled_dom, state) = rendered(
+                TextInput::create().with_text("ab".into()).with_on_virtual_key_down(
+                    probe.clone(),
+                    record_virtual_key as TextInputOnVirtualKeyDownCallbackType,
+                ),
+            );
+
+            let (update, changes, _) = run(Env::new(styled_dom).key(key), |info| {
                 default_on_virtual_key_down(state.clone(), info)
             });
 
-        assert_eq!(update, Update::DoNothing);
-        assert_eq!(state_of(&state).cursor_pos, 0, "the cursor underflowed past zero");
-        assert!(state_of(&state).text.is_empty());
-        // The repaint is still pushed — with the (unchanged) empty text.
-        assert_eq!(
-            pushed_texts(&changes),
-            vec![(nodes.label.expect("no label"), String::new())],
-        );
+            assert_eq!(update, Update::RefreshDom, "{key:?} swallowed the hook's Update");
+            if matches!(key, VirtualKeyCode::Return) {
+                // Single-line field: Enter must never edit the value, so the
+                // handler vetoes the engine's "\n" default — and nothing else.
+                assert_eq!(changes.len(), 1, "Return must veto exactly once: {changes:?}");
+                assert!(
+                    matches!(changes[0], CallbackChange::PreventDefault),
+                    "Return must veto the engine line break, and only that: {changes:?}"
+                );
+            } else {
+                assert!(changes.is_empty(), "{key:?} repainted the value: {changes:?}");
+            }
+            assert_eq!(state_of(&state).get_text(), "ab");
+            assert_eq!(recorded(&probe).len(), 1, "the hook must see {key:?} too");
+        }
     }
 
     #[test]
-    fn backspace_deletes_one_scalar_not_one_grapheme() {
-        // "e" + COMBINING ACUTE renders as a single glyph but is two scalars, so one
-        // backspace leaves a bare "e" behind rather than clearing the cell.
-        let (styled_dom, state) = rendered(TextInput::create().with_text("e\u{301}".into()));
-        let (_, _, _) = run(Env::new(styled_dom).key(VirtualKeyCode::Back), |info| {
-            default_on_virtual_key_down(state.clone(), info)
-        });
-        assert_eq!(state_of(&state).get_text(), "e");
-        assert_eq!(state_of(&state).cursor_pos, 1);
-    }
-
-    #[test]
-    fn backspace_deletes_a_whole_astral_scalar_at_once() {
-        // The buffer is UTF-32, so a 4-byte scalar is one unit: no half-a-character
-        // can survive the pop.
-        let (styled_dom, state) = rendered(TextInput::create().with_text("a\u{10ffff}".into()));
-        let (_, _, _) = run(Env::new(styled_dom).key(VirtualKeyCode::Back), |info| {
-            default_on_virtual_key_down(state.clone(), info)
-        });
-        assert_eq!(state_of(&state).get_text(), "a");
-        assert_eq!(state_of(&state).text.as_slice(), &[0x61]);
-    }
-
-    #[test]
-    fn a_non_backspace_key_still_reaches_the_hook_but_leaves_the_buffer_alone() {
-        let probe = recorder(Update::RefreshDom, TextInputValid::Yes);
-        let (styled_dom, state) = rendered(
-            TextInput::create().with_text("ab".into()).with_on_virtual_key_down(
-                probe.clone(),
-                record_virtual_key as TextInputOnVirtualKeyDownCallbackType,
-            ),
-        );
-
-        let (update, changes, _) = run(Env::new(styled_dom).key(VirtualKeyCode::A), |info| {
-            default_on_virtual_key_down(state.clone(), info)
-        });
-
-        assert_eq!(update, Update::RefreshDom);
-        assert!(changes.is_empty(), "a plain key press repainted the label: {changes:?}");
-        assert_eq!(state_of(&state).get_text(), "ab");
-        assert_eq!(recorded(&probe).len(), 1, "the hook must see every key, not just backspace");
-    }
-
-    #[test]
-    fn a_rejecting_hook_suppresses_the_deletion_but_keeps_its_update() {
+    fn a_rejecting_hook_vetoes_the_engines_default_and_keeps_its_update() {
         let probe = recorder(Update::RefreshDomAllWindows, TextInputValid::No);
         let (styled_dom, state) = rendered(
             TextInput::create().with_text("abc".into()).with_on_virtual_key_down(
@@ -2848,16 +3104,21 @@ mod autotest_generated {
         });
 
         assert_eq!(update, Update::RefreshDomAllWindows);
-        assert!(changes.is_empty(), "a vetoed backspace still repainted: {changes:?}");
-        assert_eq!(state_of(&state).get_text(), "abc", "a vetoed backspace deleted anyway");
+        assert_eq!(
+            changes.len(),
+            1,
+            "a veto must push nothing but the preventDefault: {changes:?}",
+        );
+        assert!(matches!(changes[0], CallbackChange::PreventDefault));
+        assert_eq!(state_of(&state).get_text(), "abc");
         assert_eq!(state_of(&state).cursor_pos, 3);
     }
 
     #[test]
-    fn the_virtual_key_hook_is_shown_the_state_from_before_the_deletion() {
-        // The hook runs first so that it can veto; that means it necessarily sees the
-        // pre-delete buffer. Pinned because "which side of the edit does the hook
-        // see" is exactly the thing a refactor gets wrong.
+    fn the_virtual_key_hook_is_shown_the_state_from_before_the_key_is_handled() {
+        // The hook runs first so that it can veto; that means it necessarily sees
+        // the pre-edit buffer. Pinned because "which side of the edit does the
+        // hook see" is exactly the thing a refactor gets wrong.
         let probe = recorder(Update::DoNothing, TextInputValid::Yes);
         let (styled_dom, state) = rendered(
             TextInput::create().with_text("abc".into()).with_on_virtual_key_down(
@@ -2874,7 +3135,6 @@ mod autotest_generated {
         assert_eq!(seen.len(), 1);
         assert_eq!(seen[0].get_text(), "abc");
         assert_eq!(seen[0].cursor_pos, 3);
-        assert_eq!(state_of(&state).get_text(), "ab", "... and the deletion still happened");
     }
 
     #[test]
@@ -2910,8 +3170,9 @@ mod autotest_generated {
     }
 
     #[test]
-    fn repeated_backspaces_drain_the_buffer_and_then_stop() {
-        // Six backspaces over a three-scalar buffer: the last three must be harmless.
+    fn repeated_key_presses_are_idempotent_on_the_widget_state() {
+        // Six backspaces over a three-scalar buffer: the widget must not move a
+        // single unit — every one of them belongs to the engine.
         let (_, state) = rendered(TextInput::create().with_text("abc".into()));
         for i in 0..6 {
             // The tree shape does not depend on what the buffer holds, so a fresh
@@ -2923,8 +3184,8 @@ mod autotest_generated {
             assert_eq!(update, Update::DoNothing, "backspace #{i} reported work to do");
         }
         let after = state_of(&state);
-        assert!(after.text.is_empty());
-        assert_eq!(after.cursor_pos, 0);
+        assert_eq!(after.get_text(), "abc");
+        assert_eq!(after.cursor_pos, 3);
     }
 
     // ==================================================================

--- a/layout/src/widgets/time_picker.rs
+++ b/layout/src/widgets/time_picker.rs
@@ -399,7 +399,7 @@ impl TimePicker {
                 on_hour_up as usize,
                 on_hour_down as usize,
             ),
-            Dom::create_text(SEPARATOR_TEXT)
+            Dom::create_p_with_text(SEPARATOR_TEXT)
                 .with_ids_and_classes(IdOrClassVec::from_const_slice(SEPARATOR_CLASS))
                 .with_css_props(CssPropertyWithConditionsVec::from_const_slice(SEPARATOR_STYLE)),
             build_spinner(
@@ -417,7 +417,7 @@ impl TimePicker {
                 AzString::from_const_str("AM")
             };
             children.push(
-                Dom::create_text(ampm_text)
+                Dom::create_p_with_text(ampm_text)
                     .with_ids_and_classes(IdOrClassVec::from_const_slice(AMPM_CLASS))
                     .with_css_props(CssPropertyWithConditionsVec::from_const_slice(AMPM_STYLE))
                     .with_callbacks(
@@ -457,7 +457,7 @@ fn build_spinner(value: AzString, state: RefAny, up_cb: usize, down_cb: usize) -
     use azul_core::dom::{EventFilter, HoverEventFilter};
 
     let arrow_cell = |arrow: AzString, cb: usize, refany: RefAny| -> Dom {
-        Dom::create_text(arrow)
+        Dom::create_p_with_text(arrow)
             .with_ids_and_classes(IdOrClassVec::from_const_slice(ARROW_CLASS))
             .with_css_props(CssPropertyWithConditionsVec::from_const_slice(ARROW_STYLE))
             .with_callbacks(
@@ -480,7 +480,7 @@ fn build_spinner(value: AzString, state: RefAny, up_cb: usize, down_cb: usize) -
         .with_children(
             alloc::vec![
                 arrow_cell(UP_ARROW, up_cb, state.clone()),
-                Dom::create_text(value)
+                Dom::create_p_with_text(value)
                     .with_ids_and_classes(IdOrClassVec::from_const_slice(DISPLAY_CLASS))
                     .with_css_props(CssPropertyWithConditionsVec::from_const_slice(DISPLAY_STYLE)),
                 arrow_cell(DOWN_ARROW, down_cb, state),
@@ -494,8 +494,9 @@ fn build_spinner(value: AzString, state: RefAny, up_cb: usize, down_cb: usize) -
 /// optional `on_change`.
 #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)] // bounded layout/render numeric cast
 fn adjust_spinner(mut data: RefAny, mut info: CallbackInfo, is_hour: bool, delta: i64) -> Update {
-    // The clicked node is an arrow; its parent is the spinner; the spinner's
-    // first child is the up arrow and the next sibling is the value display.
+    // The clicked node is an arrow `<p>`; its parent is the spinner; the
+    // spinner's first child is the up arrow and the next sibling is the value
+    // display `<p>`, whose only child is the re-textable bare text node.
     let hit = info.get_hit_node();
     let Some(parent) = info.get_parent(hit) else {
         return Update::DoNothing;
@@ -503,7 +504,10 @@ fn adjust_spinner(mut data: RefAny, mut info: CallbackInfo, is_hour: bool, delta
     let Some(up) = info.get_first_child(parent) else {
         return Update::DoNothing;
     };
-    let Some(display) = info.get_next_sibling(up) else {
+    let Some(display_box) = info.get_next_sibling(up) else {
+        return Update::DoNothing;
+    };
+    let Some(display) = info.get_first_child(display_box) else {
         return Update::DoNothing;
     };
 
@@ -553,9 +557,13 @@ extern "C" fn on_minute_down(data: RefAny, info: CallbackInfo) -> Update {
     adjust_spinner(data, info, false, -1)
 }
 
-/// Toggles the AM/PM flag and re-texts the clicked toggle node.
+/// Toggles the AM/PM flag and re-texts the clicked toggle node. The hit node is
+/// the toggle's `<p>` box; the text it wraps is what gets re-texted.
 extern "C" fn on_ampm_toggle(mut data: RefAny, mut info: CallbackInfo) -> Update {
     let hit = info.get_hit_node();
+    let Some(text_node) = info.get_first_child(hit) else {
+        return Update::DoNothing;
+    };
 
     let (update, text) = {
         let Some(mut w) = data.downcast_mut::<TimePickerStateWrapper>() else {
@@ -578,7 +586,7 @@ extern "C" fn on_ampm_toggle(mut data: RefAny, mut info: CallbackInfo) -> Update
         (update, text)
     };
 
-    info.change_node_text(hit, text);
+    info.change_node_text(text_node, text);
     update
 }
 
@@ -647,30 +655,46 @@ mod autotest_generated {
     // Flattened node layout
     //
     // `convert_dom_into_compact_dom` walks the tree in pre-order, and a time
-    // picker is a fixed-shape widget:
+    // picker is a fixed-shape widget. Every label is a `<p>` box wrapping one
+    // bare text node (the widget label convention), so each cell costs two
+    // flattened nodes:
     //
     //     container
-    //       hour spinner   → [▲, display, ▼]
-    //       ":"
-    //       minute spinner → [▲, display, ▼]
-    //       AM/PM          (12-hour mode only)
+    //       hour spinner   → [▲ <p> → text, display <p> → text, ▼ <p> → text]
+    //       ":" <p> → text
+    //       minute spinner → [▲ <p> → text, display <p> → text, ▼ <p> → text]
+    //       AM/PM <p> → text   (12-hour mode only)
     //
     // so the flattened indices are constant. `flattened_layout_is_the_fixed
-    // _ten_or_eleven_nodes` pins them against the real hierarchy, so the click
-    // tests below cannot silently drift onto the wrong node.
+    // _seventeen_or_nineteen_nodes` pins them against the real hierarchy, so the
+    // click tests below cannot silently drift onto the wrong node.
     // ==================================================================
 
     const N_CONTAINER: usize = 0;
     const N_HOUR_SPINNER: usize = 1;
     const N_HOUR_UP: usize = 2;
-    const N_HOUR_DISPLAY: usize = 3;
-    const N_HOUR_DOWN: usize = 4;
-    const N_SEPARATOR: usize = 5;
-    const N_MINUTE_SPINNER: usize = 6;
-    const N_MINUTE_UP: usize = 7;
-    const N_MINUTE_DISPLAY: usize = 8;
-    const N_MINUTE_DOWN: usize = 9;
-    const N_AMPM: usize = 10;
+    const N_HOUR_DISPLAY: usize = 4;
+    const N_HOUR_DOWN: usize = 6;
+    const N_SEPARATOR: usize = 8;
+    const N_MINUTE_SPINNER: usize = 10;
+    const N_MINUTE_UP: usize = 11;
+    const N_MINUTE_DISPLAY: usize = 13;
+    /// The bare text leaf inside the minute display's `<p>` — the node
+    /// `adjust_spinner` retexts (the label convention moved the text one
+    /// level under the styled wrapper).
+    const N_MINUTE_TEXT: usize = 14;
+    const N_MINUTE_DOWN: usize = 15;
+    const N_AMPM: usize = 17;
+
+    /// The bare text node a label `<p>` wraps — pre-order puts it right after its
+    /// box. This is what `change_node_text` has to target.
+    const fn text_leaf(label_box: usize) -> usize {
+        label_box + 1
+    }
+
+    /// Total flattened node count, 24-hour and 12-hour.
+    const N_NODES_24H: usize = 17;
+    const N_NODES_12H: usize = 19;
 
     // The class names are part of the widget's public surface: user stylesheets
     // select on them, so a rename is a breaking change and is spelled out here
@@ -791,7 +815,16 @@ mod autotest_generated {
 
     /// The text a node renders, or `None` for a non-text node.
     fn text_of(dom: &Dom) -> Option<String> {
-        dom.root.get_node_type().format()
+        // P-wrap transparent (the label convention): a styled `<p>` wraps the
+        // bare text leaf, so read through one wrapper level when present.
+        dom.root.get_node_type().format().or_else(|| {
+            let c = dom.children.as_ref();
+            if c.len() == 1 {
+                c[0].root.get_node_type().format()
+            } else {
+                None
+            }
+        })
     }
 
     fn classes(dom: &Dom) -> Vec<String> {
@@ -820,8 +853,14 @@ mod autotest_generated {
     }
 
     /// The text of a *flattened* node.
+    /// The text a flattened node renders, looking through the `<p>` block
+    /// wrapper the label convention mandates (`p > text`).
     fn flat_text(sd: &StyledDom, idx: usize) -> Option<String> {
-        sd.node_data.as_ref()[idx].get_node_type().format()
+        let data = sd.node_data.as_ref();
+        match data[idx].get_node_type() {
+            NodeType::P => data.get(text_leaf(idx))?.get_node_type().format(),
+            other => other.format(),
+        }
     }
 
     /// The recursive `1-per-descendant` total of a `Dom`'s children — what
@@ -2012,7 +2051,7 @@ mod autotest_generated {
         for is_24h in [false, true] {
             for (h, m) in [(0u32, 0u32), (23, 59), (u32::MAX, u32::MAX)] {
                 let dom = TimePicker::create(h, m).with_24h(is_24h).dom();
-                let expected_nodes = if is_24h { 10 } else { 11 };
+                let expected_nodes = if is_24h { N_NODES_24H } else { N_NODES_12H };
                 assert_eq!(
                     dom.estimated_total_children,
                     descendants(&dom),
@@ -2029,7 +2068,7 @@ mod autotest_generated {
     }
 
     #[test]
-    fn flattened_layout_is_the_fixed_ten_or_eleven_nodes() {
+    fn flattened_layout_is_the_fixed_seventeen_or_nineteen_nodes() {
         // Pins the pre-order indices the click tests below index by name.
         let styled = StyledDom::create_from_dom(TimePicker::create(7, 8).with_24h(false).dom());
         for (idx, class, text) in [
@@ -2199,7 +2238,9 @@ mod autotest_generated {
         for value in ["", "0", "999999"] {
             let dom = build_spinner(AzString::from(value.to_string()), RefAny::new(0u8), 1, 2);
             assert_eq!(dom.estimated_total_children, descendants(&dom));
-            assert_eq!(dom.estimated_total_children, 3);
+            // Three cells (▲ / value / ▼), each a styled `<p>` wrapping its
+            // bare text leaf per the label convention: 6 descendants.
+            assert_eq!(dom.estimated_total_children, 6);
         }
     }
 
@@ -2219,7 +2260,7 @@ mod autotest_generated {
         assert_eq!(update, Update::DoNothing, "no callback is installed, so nothing to report");
         assert_eq!(
             only_retext(&changes),
-            (node(N_HOUR_DISPLAY), "10".to_string()),
+            (node(text_leaf(N_HOUR_DISPLAY)), "10".to_string()),
             "the up arrow retexted the wrong node (or with the wrong text)",
         );
     }
@@ -2233,7 +2274,10 @@ mod autotest_generated {
 
         assert_eq!(read_state(&shared).minute, 29, "the down arrow did not decrement the minute");
         assert_eq!(read_state(&shared).hour, 9, "the minute arrow moved the hour");
-        assert_eq!(only_retext(&changes), (node(N_MINUTE_DISPLAY), "29".to_string()));
+        assert_eq!(
+            only_retext(&changes),
+            (node(text_leaf(N_MINUTE_DISPLAY)), "29".to_string())
+        );
 
         // ... and single digits keep the two-digit form the initial render used.
         let (styled, _) = laid_out(TimePicker::create(9, 10));
@@ -2305,7 +2349,7 @@ mod autotest_generated {
             assert_eq!(read_state(&shared).hour, 12, "the minute carried into the hour");
             assert_eq!(
                 only_retext(&changes),
-                (node(N_MINUTE_DISPLAY), format!("{want:02}")),
+                (node(N_MINUTE_TEXT), format!("{want:02}")),
                 "the clamped minute was retexted wrongly",
             );
         }
@@ -2367,7 +2411,7 @@ mod autotest_generated {
     fn a_press_on_a_detached_or_out_of_range_node_changes_nothing_at_all() {
         for (name, hit) in [
             ("no node at all", node_none()),
-            ("one past the end", node(11)),
+            ("one past the end", node(N_NODES_24H)),
             ("far out of range", node(usize::MAX / 2)),
         ] {
             let (styled, shared) = laid_out(TimePicker::create(9, 30));
@@ -2403,7 +2447,7 @@ mod autotest_generated {
         assert_eq!(read_state(&shared).minute, 30, "an hour press moved the minute");
         assert_eq!(
             only_retext(&changes),
-            (node(N_SEPARATOR), "10".to_string()),
+            (node(text_leaf(N_SEPARATOR)), "10".to_string()),
             "the positional lookup landed somewhere other than the separator",
         );
     }
@@ -2540,7 +2584,7 @@ mod autotest_generated {
 
             assert_eq!(
                 only_retext(&changes).0,
-                node(want_node),
+                node(text_leaf(want_node)),
                 "a press on node {hit:?} retexted the wrong display",
             );
         }
@@ -2620,7 +2664,7 @@ mod autotest_generated {
         assert_eq!(read_state(&shared).minute, 31);
         assert_eq!(
             only_retext(&changes),
-            (node(N_MINUTE_DISPLAY), "31".to_string()),
+            (node(text_leaf(N_MINUTE_DISPLAY)), "31".to_string()),
             "a DoNothing user callback suppressed the widget's own repaint",
         );
     }
@@ -2739,8 +2783,8 @@ mod autotest_generated {
         assert_eq!(update, Update::DoNothing);
         assert_eq!(
             only_retext(&changes),
-            (node(N_AMPM), "PM".to_string()),
-            "the toggle did not relabel itself",
+            (node(text_leaf(N_AMPM)), "PM".to_string()),
+            "the toggle did not relabel the text inside its <p>",
         );
     }
 
@@ -2851,22 +2895,23 @@ mod autotest_generated {
     }
 
     #[test]
-    fn the_ampm_toggle_retexts_whatever_node_it_was_told_was_hit() {
-        // Unlike the spinner arrows, the toggle does not validate the hit node —
-        // it relabels it directly. Pinned so the loose behaviour is visible: a
-        // detached hit still produces a (harmless, unappliable) retext.
+    fn the_ampm_toggle_declines_a_hit_that_wraps_no_text_node() {
+        // The toggle relabels the bare text leaf inside its own `<p>`, so a hit
+        // it cannot resolve to one (a detached id, or any childless node) is
+        // declined *before* the flag flips — no half-applied toggle.
         let (styled, shared) = laid_out(TimePicker::create(9, 30).with_24h(false));
         let (_, payload) = wired_to(&styled, on_ampm_toggle as usize);
 
-        let (update, changes) = press(styled, &payload, node_none(), on_ampm_toggle);
+        for hit in [node_none(), node(text_leaf(N_AMPM))] {
+            let (update, changes) = press(styled.clone(), &payload, hit, on_ampm_toggle);
 
-        assert_eq!(update, Update::DoNothing);
-        assert!(read_state(&shared).is_pm, "the flag did not flip for a detached hit");
-        assert_eq!(
-            only_retext(&changes),
-            (node_none(), "PM".to_string()),
-            "the toggle did not retext the (detached) node it was handed",
-        );
+            assert_eq!(update, Update::DoNothing, "{hit:?}: unexpected verdict");
+            assert!(changes.is_empty(), "{hit:?}: an unresolvable hit still retexted");
+            assert!(
+                !read_state(&shared).is_pm,
+                "{hit:?}: an unresolvable hit flipped the flag anyway",
+            );
+        }
     }
 
     #[test]

--- a/layout/src/widgets/titlebar.rs
+++ b/layout/src/widgets/titlebar.rs
@@ -371,7 +371,7 @@ impl Titlebar {
         let title_node = Dom::create_div()
             .with_ids_and_classes(title_classes)
             .with_css_props(title_style)
-            .with_child(Dom::create_text(self.title)) // moves self.title
+            .with_child(Dom::create_text_do_not_use_without_block_level_wrapper(self.title)) // moves self.title
             .with_callbacks(vec![
                 CoreCallbackData {
                     event: EventFilter::Hover(HoverEventFilter::DragStart),

--- a/layout/src/widgets/titlebar.rs
+++ b/layout/src/widgets/titlebar.rs
@@ -921,10 +921,18 @@ mod autotest_generated {
             .collect()
     }
 
-    /// The text of a `NodeType::Text` node (`None` for any other node type).
+    /// The text of a text node, looking through the `<p>` block wrapper the
+    /// label convention mandates (`p > text`).
     fn text_of(node: &Dom) -> Option<&str> {
         match node.root.get_node_type() {
             NodeType::Text(s) => Some(s.as_ref().as_str()),
+            NodeType::P => match node.children.as_ref() {
+                [only] => match only.root.get_node_type() {
+                    NodeType::Text(s) => Some(s.as_ref().as_str()),
+                    _ => None,
+                },
+                _ => None,
+            },
             _ => None,
         }
     }

--- a/layout/src/widgets/toast.rs
+++ b/layout/src/widgets/toast.rs
@@ -394,14 +394,14 @@ impl Toast {
             refany::OptionRefAny,
         };
 
-        let message = Dom::create_text(self.message)
+        let message = Dom::create_p_with_text(self.message)
             .with_ids_and_classes(IdOrClassVec::from_const_slice(TOAST_MESSAGE_CLASS))
             .with_css_props(CssPropertyWithConditionsVec::from_const_slice(TOAST_MESSAGE_STYLE));
 
         let mut children = alloc::vec![message];
 
         if self.dismissible {
-            let close = Dom::create_text(AzString::from_const_str("\u{00D7}"))
+            let close = Dom::create_p_with_text(AzString::from_const_str("\u{00D7}"))
                 .with_ids_and_classes(IdOrClassVec::from_const_slice(TOAST_CLOSE_CLASS))
                 .with_css_props(CssPropertyWithConditionsVec::from_const_slice(TOAST_CLOSE_STYLE))
                 .with_tab_index(TabIndex::Auto)
@@ -520,10 +520,18 @@ mod autotest_generated {
         ToastKind::Danger,
     ];
 
-    /// The text of a `NodeType::Text` node (`None` for any other node type).
+    /// The text of a text node, looking through the `<p>` block wrapper the
+    /// label convention mandates (`p > text`).
     fn text_of(node: &Dom) -> Option<&str> {
         match node.root.get_node_type() {
             NodeType::Text(s) => Some(s.as_ref().as_str()),
+            NodeType::P => match node.children.as_ref() {
+                [only] => match only.root.get_node_type() {
+                    NodeType::Text(s) => Some(s.as_ref().as_str()),
+                    _ => None,
+                },
+                _ => None,
+            },
             _ => None,
         }
     }
@@ -685,8 +693,8 @@ mod autotest_generated {
         let styled = StyledDom::create_from_dom(toast.dom());
         assert_eq!(
             styled.node_hierarchy.as_ref().len(),
-            3,
-            "fixture must flatten to exactly container/message/close"
+            5,
+            "fixture must flatten to container / message <p> + text / close <p> + text"
         );
         styled
     }
@@ -694,6 +702,12 @@ mod autotest_generated {
     /// Invokes `default_on_toast_dismiss` against a `LayoutWindow` holding
     /// `styled` (or nothing at all, when `styled` is `None`), with `hit` as the
     /// hit node. Returns the `Update` plus every recorded `CallbackChange`.
+    /// Flat indices in `dismissible_styled_dom`, depth-first pre-order:
+    /// `0 container / 1 message <p> / 2 message text / 3 close <p> / 4 close text`.
+    /// Both callbacks and styles sit on the `<p>`s, never on the text nodes.
+    const MESSAGE_NODE: usize = 1;
+    const CLOSE_NODE: usize = 3;
+
     fn run_dismiss(
         styled: Option<StyledDom>,
         hit: usize,
@@ -1704,7 +1718,7 @@ mod autotest_generated {
         let mut data = RefAny::new(ToastStateWrapper::default());
 
         // node 2 == the close button, its parent (node 0) is the container
-        let (update, changes) = run_dismiss(Some(dismissible_styled_dom()), 2, data.clone());
+        let (update, changes) = run_dismiss(Some(dismissible_styled_dom()), CLOSE_NODE, data.clone());
 
         assert_eq!(update, Update::DoNothing, "no user callback -> DoNothing");
         assert_eq!(
@@ -1727,7 +1741,7 @@ mod autotest_generated {
             .into(),
         });
 
-        let (update, changes) = run_dismiss(Some(dismissible_styled_dom()), 2, data.clone());
+        let (update, changes) = run_dismiss(Some(dismissible_styled_dom()), CLOSE_NODE, data.clone());
 
         assert_eq!(
             update,
@@ -1760,7 +1774,7 @@ mod autotest_generated {
         });
 
         for _ in 0..2 {
-            let (update, changes) = run_dismiss(Some(dismissible_styled_dom()), 2, data.clone());
+            let (update, changes) = run_dismiss(Some(dismissible_styled_dom()), CLOSE_NODE, data.clone());
             assert_eq!(update, Update::RefreshDom);
             assert_eq!(
                 display_writes(&changes),
@@ -1779,12 +1793,12 @@ mod autotest_generated {
     #[test]
     fn dismiss_from_the_message_node_also_hides_the_container() {
         // Pinned: the handler hides `parent(hit)`, whatever the hit node is.
-        // For the 3-node toast the message's parent is the container too, so a
+        // For the toast the message <p>'s parent is the container too, so a
         // mis-wired handler would still "work" - which is why the close button
         // must stay the only node carrying it (see the wiring test above).
         let mut data = RefAny::new(ToastStateWrapper::default());
 
-        let (update, changes) = run_dismiss(Some(dismissible_styled_dom()), 1, data.clone());
+        let (update, changes) = run_dismiss(Some(dismissible_styled_dom()), MESSAGE_NODE, data.clone());
 
         assert_eq!(update, Update::DoNothing);
         assert_eq!(
@@ -1835,7 +1849,7 @@ mod autotest_generated {
     fn dismiss_without_any_layout_result_is_a_noop() {
         let mut data = RefAny::new(ToastStateWrapper::default());
 
-        let (update, changes) = run_dismiss(None, 2, data.clone());
+        let (update, changes) = run_dismiss(None, CLOSE_NODE, data.clone());
 
         assert_eq!(update, Update::DoNothing);
         assert!(changes.is_empty());
@@ -1847,7 +1861,7 @@ mod autotest_generated {
         // the callback-bearing node carries a RefAny of the *wrong* type
         let data = RefAny::new(0xdead_beef_u64);
 
-        let (update, changes) = run_dismiss(Some(dismissible_styled_dom()), 2, data.clone());
+        let (update, changes) = run_dismiss(Some(dismissible_styled_dom()), CLOSE_NODE, data.clone());
 
         assert_eq!(update, Update::DoNothing);
         assert!(
@@ -1868,7 +1882,7 @@ mod autotest_generated {
         let mut payload = entry.refany.clone();
 
         let styled = StyledDom::create_from_dom(dom);
-        let (update, changes) = run_dismiss(Some(styled), 2, payload.clone());
+        let (update, changes) = run_dismiss(Some(styled), CLOSE_NODE, payload.clone());
 
         assert_eq!(update, Update::DoNothing);
         assert_eq!(
@@ -1895,7 +1909,7 @@ mod autotest_generated {
             .clone();
 
         let styled = StyledDom::create_from_dom(dom);
-        let (update, changes) = run_dismiss(Some(styled), 2, payload);
+        let (update, changes) = run_dismiss(Some(styled), CLOSE_NODE, payload);
 
         assert_eq!(update, Update::RefreshDom);
         assert_eq!(

--- a/layout/src/widgets/tooltip.rs
+++ b/layout/src/widgets/tooltip.rs
@@ -187,7 +187,7 @@ impl Tooltip {
         // the hovered wrapper), so no per-tooltip state is needed.
         let marker = RefAny::new(());
 
-        let tip = Dom::create_text(self.text)
+        let tip = Dom::create_p_with_text(self.text)
             .with_ids_and_classes(IdOrClassVec::from_const_slice(TOOLTIP_TIP_CLASS))
             .with_css_props(self.tip_style);
 
@@ -299,10 +299,18 @@ mod autotest_generated {
             .any(|c| matches!(c, Class(s) if s.as_str() == name))
     }
 
-    /// The text of a `NodeType::Text` node (`None` for any other node type).
+    /// The text of a text node, looking through the `<p>` block wrapper the
+    /// label convention mandates (`p > text`).
     fn text_of(node: &Dom) -> Option<&str> {
         match node.root.get_node_type() {
             NodeType::Text(s) => Some(s.as_ref().as_str()),
+            NodeType::P => match node.children.as_ref() {
+                [only] => match only.root.get_node_type() {
+                    NodeType::Text(s) => Some(s.as_ref().as_str()),
+                    _ => None,
+                },
+                _ => None,
+            },
             _ => None,
         }
     }
@@ -1075,8 +1083,8 @@ mod autotest_generated {
         let styled = StyledDom::create_from_dom(dom);
         assert_eq!(
             styled.node_hierarchy.as_ref().len(),
-            1 + 1 + 2000 + 1,
-            "wrapper + anchor + 2000 grandchildren + tip"
+            1 + 1 + 2000 + 2,
+            "wrapper + anchor + 2000 grandchildren + tip <p> + tip text"
         );
     }
 

--- a/layout/src/widgets/tooltip.rs
+++ b/layout/src/widgets/tooltip.rs
@@ -386,7 +386,7 @@ mod autotest_generated {
     /// A `Dom` nested `depth` levels deep — a stress input for the recursive
     /// child bookkeeping `dom()` relies on.
     fn nested_anchor(depth: usize) -> Dom {
-        let mut d = Dom::create_div().with_child(Dom::create_text("leaf"));
+        let mut d = Dom::create_div().with_child(Dom::create_text_do_not_use_without_block_level_wrapper("leaf"));
         for _ in 0..depth {
             d = Dom::create_div().with_child(d);
         }
@@ -567,7 +567,7 @@ mod autotest_generated {
 
     #[test]
     fn new_stores_anchor_and_text_verbatim() {
-        let anchor = Dom::create_div().with_child(Dom::create_text("anchor"));
+        let anchor = Dom::create_div().with_child(Dom::create_text_do_not_use_without_block_level_wrapper("anchor"));
         let text = AzString::from("tip".to_string());
         let t = Tooltip::new(anchor.clone(), text.clone());
 
@@ -665,7 +665,7 @@ mod autotest_generated {
     fn set_text_and_with_text_agree_and_touch_nothing_else() {
         for s in adversarial_texts() {
             let base = Tooltip::new(
-                Dom::create_div().with_child(Dom::create_text("a")),
+                Dom::create_div().with_child(Dom::create_text_do_not_use_without_block_level_wrapper("a")),
                 AzString::from_const_str("initial"),
             );
 
@@ -784,7 +784,7 @@ mod autotest_generated {
     #[test]
     fn swap_with_default_returns_the_old_value_and_leaves_a_default() {
         let original = Tooltip::new(
-            Dom::create_div().with_child(Dom::create_text("anchor")),
+            Dom::create_div().with_child(Dom::create_text_do_not_use_without_block_level_wrapper("anchor")),
             AzString::from("tip".to_string()),
         )
         .with_tip_style(style_of(vec![CssProperty::const_opacity(
@@ -922,7 +922,7 @@ mod autotest_generated {
 
     #[test]
     fn dom_builds_a_wrapper_with_the_anchor_then_the_tip() {
-        let anchor = Dom::create_div().with_child(Dom::create_text("anchor"));
+        let anchor = Dom::create_div().with_child(Dom::create_text_do_not_use_without_block_level_wrapper("anchor"));
         let dom = Tooltip::new(anchor.clone(), AzString::from_const_str("tip")).dom();
 
         assert!(has_class(&dom, WRAPPER_CLASS_NAME));
@@ -1009,7 +1009,7 @@ mod autotest_generated {
     #[test]
     fn dom_binds_no_callbacks_on_the_anchor_or_the_tip() {
         let dom = Tooltip::new(
-            Dom::create_div().with_child(Dom::create_text("a")),
+            Dom::create_div().with_child(Dom::create_text_do_not_use_without_block_level_wrapper("a")),
             AzString::from_const_str("t"),
         )
         .dom();
@@ -1028,7 +1028,7 @@ mod autotest_generated {
         // deliberately compared field-by-field rather than with `==`.
         let make = || {
             Tooltip::new(
-                Dom::create_div().with_child(Dom::create_text("a")),
+                Dom::create_div().with_child(Dom::create_text_do_not_use_without_block_level_wrapper("a")),
                 AzString::from_const_str("tip"),
             )
         };

--- a/layout/src/widgets/tree_view.rs
+++ b/layout/src/widgets/tree_view.rs
@@ -1183,7 +1183,7 @@ mod autotest_generated {
         let on_click = some_click(record_click, &log);
 
         // Pre-existing content in `out` must be preserved, not clobbered.
-        let mut out = vec![Dom::create_div(), Dom::create_text("sentinel")];
+        let mut out = vec![Dom::create_div(), Dom::create_text_do_not_use_without_block_level_wrapper("sentinel")];
         let mut index = start;
         render_node(&shape, &on_click, &mut index, &mut out);
 

--- a/layout/src/widgets/tree_view.rs
+++ b/layout/src/widgets/tree_view.rs
@@ -312,7 +312,7 @@ fn render_node(
     };
 
     // Build the label
-    let label = Dom::create_text(node.label.clone())
+    let label = Dom::create_p_with_text(node.label.clone())
         .with_css_props(CssPropertyWithConditionsVec::from_const_slice(LABEL_STYLE));
 
     // Build the row with click callback
@@ -568,9 +568,18 @@ mod autotest_generated {
     // Fixtures: DOM inspection
     // ------------------------------------------------------------------
 
+    /// The text of a text node, looking through the `<p>` block wrapper the
+    /// label convention mandates (`p > text`).
     fn text_of(dom: &Dom) -> Option<&str> {
         match dom.root.get_node_type() {
             NodeType::Text(s) => Some(s.as_ref().as_str()),
+            NodeType::P => match dom.children.as_ref() {
+                [only] => match only.root.get_node_type() {
+                    NodeType::Text(s) => Some(s.as_ref().as_str()),
+                    _ => None,
+                },
+                _ => None,
+            },
             _ => None,
         }
     }

--- a/layout/src/window.rs
+++ b/layout/src/window.rs
@@ -18,6 +18,7 @@
 //! - **Scrolling**: scroll state, scrollbar opacity, and
 //!   scroll-into-view for cursors and selections
 
+use crate::solver3::layout_tree::LayoutNodeId;
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap},
     sync::{
@@ -683,7 +684,7 @@ pub struct DomLayoutResult {
     pub display_list: Arc<DisplayList>,
     /// Stable scroll IDs computed from `node_data_hash`
     /// Maps layout node index -> external scroll ID
-    pub scroll_ids: HashMap<usize, u64>,
+    pub scroll_ids: HashMap<LayoutNodeId, u64>,
     /// Mapping from scroll IDs to DOM `NodeIds` for hit testing
     /// This allows us to map `WebRender` scroll IDs back to DOM nodes
     pub scroll_id_to_node_id: HashMap<u64, NodeId>,
@@ -1947,7 +1948,7 @@ impl LayoutWindow {
                 .get(&node_id)
                 .and_then(|v| v.first())
             {
-                if let Some(pos) = solver3::pos_get(&lr.calculated_positions, layout_idx) {
+                if let Some(pos) = solver3::pos_get(&lr.calculated_positions, layout_idx.index()) {
                     self.pagination_dirty_from =
                         Some(self.pagination_dirty_from.map_or(pos.y, |p| p.min(pos.y)));
                 }
@@ -5221,7 +5222,7 @@ impl LayoutWindow {
         // Use dom_to_layout mapping since layout tree indices differ from DOM indices
         let layout_indices = layout_result.layout_tree.dom_to_layout.get(&nid)?;
         let layout_index = *layout_indices.first()?;
-        let position = layout_result.calculated_positions.get(layout_index)?;
+        let position = layout_result.calculated_positions.get(layout_index.index())?;
         Some(*position)
     }
 
@@ -5285,7 +5286,7 @@ impl LayoutWindow {
             rect = crate::headless::node_rect_to_screen(
                 layout_result,
                 node_id.dom,
-                idx,
+                idx.index(),
                 rect,
                 &|d, n| self.scroll_manager.get_current_offset(d, n),
                 &|d, n| {
@@ -6693,7 +6694,7 @@ impl LayoutWindow {
         let layout_result = self.layout_results.get(&dom_id)?;
         let layout_indices = layout_result.layout_tree.dom_to_layout.get(&node_id)?;
         let layout_index = *layout_indices.first()?;
-        layout_result.layout_tree.get_dense_for_node(layout_index)
+        layout_result.layout_tree.get_dense_for_node(layout_index.index())
     }
 
     pub fn get_inline_layout_for_node(
@@ -6707,7 +6708,7 @@ impl LayoutWindow {
         let layout_index = *layout_indices.first()?;
 
         // Use the centralized LayoutTree method that handles IFC membership
-        layout_result.layout_tree.get_inline_layout_for_node(layout_index)
+        layout_result.layout_tree.get_inline_layout_for_node(layout_index.index())
     }
 
     /// (d6f) Dense-first step resolution: the dense dispatcher when the
@@ -8115,7 +8116,7 @@ impl LayoutWindow {
         // Iterate over all nodes with scrollbar info
         for (node_idx, node) in layout_tree.nodes.iter().enumerate() {
             // Check if node needs scrollbars
-            let warm = layout_tree.warm(node_idx);
+            let warm = layout_tree.warm(LayoutNodeId::new(node_idx));
             let Some(scrollbar_info) = warm.and_then(|w| w.scrollbar_info.as_ref()) else {
                 continue;
             };
@@ -8283,7 +8284,7 @@ impl LayoutWindow {
     #[must_use] pub fn compute_scroll_ids(
         layout_tree: &LayoutTree,
         styled_dom: &StyledDom,
-    ) -> (HashMap<usize, u64>, HashMap<u64, NodeId>) {
+    ) -> (HashMap<LayoutNodeId, u64>, HashMap<u64, NodeId>) {
         use azul_css::props::layout::LayoutOverflow;
 
         use crate::solver3::getters::{get_overflow_x, get_overflow_y};
@@ -8326,13 +8327,13 @@ impl LayoutWindow {
             let scroll_id = {
                 use std::hash::{Hash, Hasher, DefaultHasher};
                 let mut h = DefaultHasher::new();
-                if let Some(cold) = layout_tree.cold(layout_idx) {
+                if let Some(cold) = layout_tree.cold(LayoutNodeId::new(layout_idx)) {
                     cold.node_data_fingerprint.hash(&mut h);
                 }
                 h.finish()
             };
 
-            scroll_ids.insert(layout_idx, scroll_id);
+            scroll_ids.insert(LayoutNodeId::new(layout_idx), scroll_id);
             scroll_id_to_node_id.insert(scroll_id, dom_node_id);
         }
 
@@ -8641,10 +8642,10 @@ impl LayoutWindow {
         // sentinel; geometry runs on the transient expansion. (An
         // instrumentation pass once clobbered this line — the caret
         // reveal died sentinel-blind until caret_scroll_glide caught it.)
-        let inline_layout = tree.materialized_inline_layout_for_node(layout_idx)?;
+        let inline_layout = tree.materialized_inline_layout_for_node(layout_idx.index())?;
         // `pos_get` (not a raw index) so the POSITION_UNSET sentinel reads as
         // "not laid out yet" instead of placing the caret at f32::MIN.
-        let origin = solver3::pos_get(&layout_result.calculated_positions, layout_idx)?;
+        let origin = solver3::pos_get(&layout_result.calculated_positions, layout_idx.index())?;
         Some((inline_layout, origin))
     }
 
@@ -8994,7 +8995,7 @@ impl LayoutWindow {
                 .position(|node| node.dom_node_id == current_node_id)?;
 
             // Check if this node has scrollbar info (meaning it's scrollable)
-            if layout_tree.warm(layout_idx).and_then(|w| w.scrollbar_info.as_ref()).is_some() {
+            if layout_tree.warm(LayoutNodeId::new(layout_idx)).and_then(|w| w.scrollbar_info.as_ref()).is_some() {
                 // Check if it actually has a scroll state registered
                 let check_node_id = current_node_id?;
                 if self
@@ -9013,8 +9014,8 @@ impl LayoutWindow {
             }
 
             // Move to parent
-            let parent_idx = layout_tree.get(layout_idx)?.parent?;
-            let parent_node = layout_tree.get(parent_idx)?;
+            let parent_idx = layout_tree.get(LayoutNodeId::new(layout_idx))?.parent?;
+            let parent_node = layout_tree.get(LayoutNodeId::new(parent_idx))?;
             current_node_id = parent_node.dom_node_id;
         }
     }
@@ -11821,7 +11822,7 @@ impl LayoutWindow {
                 for &idx in layout_indices {
                     if let Some(w) = layout_result.layout_tree.warm(idx) {
                         if let Some(ref cached) = w.inline_layout_result {
-                            found = Some((idx, cached));
+                            found = Some((idx.index(), cached));
                             break;
                         }
                     }
@@ -11836,7 +11837,7 @@ impl LayoutWindow {
                         for &idx in child_indices {
                             if let Some(w) = layout_result.layout_tree.warm(idx) {
                                 if let Some(ref cached) = w.inline_layout_result {
-                                    found = Some((idx, cached));
+                                    found = Some((idx.index(), cached));
                                     break;
                                 }
                             }
@@ -11891,10 +11892,10 @@ impl LayoutWindow {
 
             // Fallback: walk up the IFC's ancestors in the layout tree
             if !found_width {
-                if let Some(parent_idx) = layout_result.layout_tree.get(ifc_layout_index)
+                if let Some(parent_idx) = layout_result.layout_tree.get(LayoutNodeId::new(ifc_layout_index))
                     .and_then(|n| n.parent)
                 {
-                    if let Some(parent_node) = layout_result.layout_tree.get(parent_idx) {
+                    if let Some(parent_node) = layout_result.layout_tree.get(LayoutNodeId::new(parent_idx)) {
                         if let Some(parent_size) = parent_node.used_size {
                             let bp = parent_node.box_props.unpack();
                             let content_width = parent_size.width
@@ -11921,7 +11922,7 @@ impl LayoutWindow {
         let cached_snapshot = self
             .layout_results
             .get(&dom_id)
-            .and_then(|lr| lr.layout_tree.warm(ifc_layout_index))
+            .and_then(|lr| lr.layout_tree.warm(LayoutNodeId::new(ifc_layout_index)))
             .and_then(|w| w.inline_layout_result.as_ref())
             .cloned();
 
@@ -11940,7 +11941,7 @@ impl LayoutWindow {
         // 4. Update the layout cache with the new layout
         // Use the ifc_layout_index we found earlier (correct layout tree index)
         if let Some(layout_result) = self.layout_results.get_mut(&dom_id) {
-            let old_size = layout_result.layout_tree.get(ifc_layout_index).and_then(|n| n.used_size);
+            let old_size = layout_result.layout_tree.get(LayoutNodeId::new(ifc_layout_index)).and_then(|n| n.used_size);
             let new_bounds = new_layout.bounds();
             let new_size = Some(LogicalSize {
                 width: new_bounds.width,
@@ -11958,7 +11959,7 @@ impl LayoutWindow {
             }
 
             // Update the inline layout result with the new layout but preserve constraints (warm data)
-            if let Some(warm_node) = layout_result.layout_tree.warm_mut(ifc_layout_index) {
+            if let Some(warm_node) = layout_result.layout_tree.warm_mut(LayoutNodeId::new(ifc_layout_index)) {
                 warm_node.inline_layout_result = Some(Box::new(CachedInlineLayout::new_with_constraints(
                     Arc::new(new_layout),
                     constraints.available_width,
@@ -12213,7 +12214,7 @@ impl LayoutWindow {
                     if let Some(cached) = self.layout_cache.cached_display_list.as_mut() {
                         let root_hash = layout_result
                             .layout_tree
-                            .cold(layout_result.layout_tree.root)
+                            .cold(LayoutNodeId::new(layout_result.layout_tree.root))
                             .map(|c| c.subtree_hash);
                         if let Some(h) = root_hash {
                             *cached = (
@@ -12556,7 +12557,7 @@ impl LayoutWindow {
         let size = node.used_size?;
 
         // Get position from calculated_positions — uses layout tree index, not DOM node index
-        let position = layout_result.calculated_positions.get(idx)?;
+        let position = layout_result.calculated_positions.get(idx.index())?;
 
         Some(LayoutRect {
             origin: azul_css::props::basic::LayoutPoint {
@@ -12875,7 +12876,7 @@ impl LayoutWindow {
         // (d6h) Materialized: sentinel-safe for every geometry/search
         // caller of this accessor (caret scroll, selection paint,
         // occurrence search).
-        tree.materialized_inline_layout_for_node(layout_idx)
+        tree.materialized_inline_layout_for_node(layout_idx.index())
     }
 
     /// Edit the text content of a node (used for text input actions)
@@ -13041,7 +13042,7 @@ impl LayoutWindow {
                     let Some(layout_node_idx) = layout_node_idx else {
                         continue;
                     };
-                    let Some(warm_node) = tree.warm(layout_node_idx) else {
+                    let Some(warm_node) = tree.warm(LayoutNodeId::new(layout_node_idx)) else {
                         continue;
                     };
 
@@ -13052,8 +13053,8 @@ impl LayoutWindow {
                         (cached, *node_id)
                     } else if let Some(ref membership) = warm_node.ifc_membership {
                         // This node participates in an IFC - get layout and NodeId from IFC root
-                        match tree.warm(membership.ifc_root_layout_index) {
-                            Some(ifc_root_warm) => match (ifc_root_warm.inline_layout_result.as_ref(), tree.get(membership.ifc_root_layout_index).and_then(|n| n.dom_node_id)) {
+                        match tree.warm(LayoutNodeId::new(membership.ifc_root_layout_index)) {
+                            Some(ifc_root_warm) => match (ifc_root_warm.inline_layout_result.as_ref(), tree.get(LayoutNodeId::new(membership.ifc_root_layout_index)).and_then(|n| n.dom_node_id)) {
                                 (Some(cached), Some(root_dom_id)) => (cached, root_dom_id),
                                 _ => continue,
                             },
@@ -13098,7 +13099,7 @@ impl LayoutWindow {
 
                 // Only iterate IFC roots (nodes with inline_layout_result)
                 for (node_idx, layout_node) in tree.nodes.iter().enumerate() {
-                    let Some(warm) = tree.warm(node_idx) else {
+                    let Some(warm) = tree.warm(LayoutNodeId::new(node_idx)) else {
                         continue;
                     };
                     let Some(cached_layout) = warm.inline_layout_result.as_ref() else {
@@ -13178,7 +13179,7 @@ impl LayoutWindow {
 
             // Find layout node - ifc_root_node_id is always the IFC root, so it has inline_layout_result
             let layout_idx = tree.nodes.iter().position(|n| n.dom_node_id == Some(ifc_root_node_id))?;
-            let cached_layout = tree.warm(layout_idx)?.inline_layout_result.as_ref()?;
+            let cached_layout = tree.warm(LayoutNodeId::new(layout_idx))?.inline_layout_result.as_ref()?;
             let layout = &cached_layout.layout;
 
             match click_count {
@@ -13329,7 +13330,7 @@ impl LayoutWindow {
             .unwrap_or_default();
         // (the anchor node's cached inline layout is re-borrowed below,
         // after the cross-block branch may have taken &mut self)
-        tree.warm(layout_idx)?.inline_layout_result.as_ref()?;
+        tree.warm(LayoutNodeId::new(layout_idx))?.inline_layout_result.as_ref()?;
 
         let local_pos = LogicalPosition {
             x: current_position.x - node_pos.x,
@@ -13343,7 +13344,7 @@ impl LayoutWindow {
         // regular single-node range below.
         let anchor_rect_contains = {
             let size = tree
-                .get(layout_idx)
+                .get(LayoutNodeId::new(layout_idx))
                 .and_then(|n| n.used_size)
                 .unwrap_or_default();
             local_pos.x >= 0.0
@@ -13369,7 +13370,7 @@ impl LayoutWindow {
         // Re-borrow after the possible &mut use above.
         let layout_result = self.layout_results.get(&dom_id)?;
         let tree = &layout_result.layout_tree;
-        let cached = tree.warm(layout_idx)?.inline_layout_result.as_ref()?;
+        let cached = tree.warm(LayoutNodeId::new(layout_idx))?.inline_layout_result.as_ref()?;
         // (d6h) Materialized: sentinel-safe click hittest.
         let focus = Self::materialized_inline_layout(cached).hittest_cursor(local_pos)?;
 
@@ -13411,7 +13412,7 @@ impl LayoutWindow {
         let mut best: Option<(f32, NodeId, LogicalPosition)> = None; // (y-distance, node, local)
         for (idx, node) in tree.nodes.iter().enumerate() {
             let Some(node_dom_id) = node.dom_node_id else { continue };
-            let Some(warm) = tree.warm(idx) else { continue };
+            let Some(warm) = tree.warm(LayoutNodeId::new(idx)) else { continue };
             if warm.inline_layout_result.is_none() {
                 continue;
             }
@@ -13442,10 +13443,10 @@ impl LayoutWindow {
             .nodes
             .iter()
             .position(|n| n.dom_node_id == Some(node_dom_id))?;
-        let cached = tree.warm(layout_idx)?.inline_layout_result.as_ref()?;
+        let cached = tree.warm(LayoutNodeId::new(layout_idx))?.inline_layout_result.as_ref()?;
         // Clamp the local point into the block so line hit-testing lands on
         // the nearest line instead of failing outside the box.
-        let size = tree.get(layout_idx).and_then(|n| n.used_size).unwrap_or_default();
+        let size = tree.get(LayoutNodeId::new(layout_idx)).and_then(|n| n.used_size).unwrap_or_default();
         let clamped = LogicalPosition {
             x: local.x.clamp(0.0, size.width.max(0.0)),
             y: local.y.clamp(0.0, size.height.max(0.0)),
@@ -13928,7 +13929,7 @@ impl LayoutWindow {
         let layout_index = layout_indices[0];
 
         // Get position
-        let position = *layout_result.calculated_positions.get(layout_index)?;
+        let position = *layout_result.calculated_positions.get(layout_index.index())?;
 
         // Get size
         let layout_node = layout_result.layout_tree.get(layout_index)?;

--- a/layout/src/window.rs
+++ b/layout/src/window.rs
@@ -1837,6 +1837,16 @@ impl LayoutWindow {
             self.scroll_focused_cursor_into_view();
         }
 
+        // Developer warning pass: raw text nodes used without a containing
+        // block (azul does not auto-wrap them in anonymous blocks the way
+        // browsers do — state on a text node is inert). One warning per
+        // unique finding per process; a correct app emits nothing.
+        if result.is_ok() {
+            for lr in self.layout_results.values() {
+                crate::dom_lint::warn_text_without_block_container(&lr.styled_dom);
+            }
+        }
+
         result
     }
 
@@ -2551,7 +2561,7 @@ impl LayoutWindow {
             let _ = &mut root;
             let replacement = Dom {
                 root,
-                children: alloc::vec![Dom::create_text(merged_text)]
+                children: alloc::vec![Dom::create_text_do_not_use_without_block_level_wrapper(merged_text)]
                     .into(),
                 css: Vec::new().into(),
                 estimated_total_children: 1,
@@ -15496,7 +15506,7 @@ mod autotest_generated {
 
         // body > text("hello") => 2 nodes.
         let with_text =
-            StyledDom::create_from_dom(Dom::create_body().with_child(Dom::create_text("hello")));
+            StyledDom::create_from_dom(Dom::create_body().with_child(Dom::create_text_do_not_use_without_block_level_wrapper("hello")));
         assert_eq!(with_text.node_hierarchy.len(), 2);
         assert!(
             LayoutWindow::node_has_text_content(&with_text, NodeId::new(0)),
@@ -15509,7 +15519,7 @@ mod autotest_generated {
 
         // Empty and astral-plane text still count as text nodes.
         for s in ["", "🇺🇳👩‍👩‍👧‍👦", "\u{202e}\u{0}"] {
-            let d = StyledDom::create_from_dom(Dom::create_body().with_child(Dom::create_text(s)));
+            let d = StyledDom::create_from_dom(Dom::create_body().with_child(Dom::create_text_do_not_use_without_block_level_wrapper(s)));
             assert!(LayoutWindow::node_has_text_content(&d, NodeId::new(1)), "{s:?}");
             assert!(LayoutWindow::node_has_text_content(&d, NodeId::new(0)), "{s:?}");
         }
@@ -15591,7 +15601,7 @@ mod autotest_generated {
         let w = window_for(StyledDom::create_from_dom(
             Dom::create_div()
                 .with_contenteditable(true)
-                .with_child(Dom::create_p().with_child(Dom::create_text("hello"))),
+                .with_child(Dom::create_p().with_child(Dom::create_text_do_not_use_without_block_level_wrapper("hello"))),
         ));
         assert_eq!(text_of(&w, 0), "hello", "a <p> wrapper must not hide the value");
         assert_eq!(text_of(&w, 1), "hello", "and the <p> itself reads the same");
@@ -15601,9 +15611,9 @@ mod autotest_generated {
         let w = window_for(StyledDom::create_from_dom(
             Dom::create_div().with_child(
                 Dom::create_p()
-                    .with_child(Dom::create_text("a"))
-                    .with_child(Dom::create_em().with_child(Dom::create_text("b")))
-                    .with_child(Dom::create_span().with_child(Dom::create_text("c"))),
+                    .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("a"))
+                    .with_child(Dom::create_em().with_child(Dom::create_text_do_not_use_without_block_level_wrapper("b")))
+                    .with_child(Dom::create_span().with_child(Dom::create_text_do_not_use_without_block_level_wrapper("c"))),
             ),
         ));
         assert_eq!(text_of(&w, 0), "abc");
@@ -15615,8 +15625,8 @@ mod autotest_generated {
         // must not leak into an editable value.
         let w = window_for(StyledDom::create_from_dom(
             Dom::create_div()
-                .with_child(Dom::create_head().with_child(Dom::create_text("metadata")))
-                .with_child(Dom::create_p().with_child(Dom::create_text("body"))),
+                .with_child(Dom::create_head().with_child(Dom::create_text_do_not_use_without_block_level_wrapper("metadata")))
+                .with_child(Dom::create_p().with_child(Dom::create_text_do_not_use_without_block_level_wrapper("body"))),
         ));
         assert_eq!(text_of(&w, 0), "body");
         assert_eq!(text_of(&w, 1), "", "a metadata container collects nothing");
@@ -15634,9 +15644,9 @@ mod autotest_generated {
                 .with_child(
                     Dom::create_p()
                         .with_attribute(AttributeType::ContentEditable(false))
-                        .with_child(Dom::create_text("Type here...")),
+                        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Type here...")),
                 )
-                .with_child(Dom::create_p().with_child(Dom::create_text("real value"))),
+                .with_child(Dom::create_p().with_child(Dom::create_text_do_not_use_without_block_level_wrapper("real value"))),
         ));
         assert_eq!(text_of(&w, 0), "real value");
         // The wall is about the parent's collection, not a global mute: asked
@@ -15652,8 +15662,8 @@ mod autotest_generated {
         // the placeholder, so `reshape_text_node` has to ask the caret first.
         let mut w = window_for(StyledDom::create_from_dom(
             Dom::create_div()
-                .with_child(Dom::create_p().with_child(Dom::create_text("prompt")))
-                .with_child(Dom::create_p().with_child(Dom::create_text("value"))),
+                .with_child(Dom::create_p().with_child(Dom::create_text_do_not_use_without_block_level_wrapper("prompt")))
+                .with_child(Dom::create_p().with_child(Dom::create_text_do_not_use_without_block_level_wrapper("value"))),
         ));
 
         assert_eq!(
@@ -16426,8 +16436,8 @@ mod autotest_generated {
         // inline layout) and programmatic focus never painted a caret.
         let dom = StyledDom::create_from_dom(Dom::create_body().with_child(
             Dom::create_div()
-                .with_child(Dom::create_div().with_child(Dom::create_text("first para")))
-                .with_child(Dom::create_div().with_child(Dom::create_text("last para"))),
+                .with_child(Dom::create_div().with_child(Dom::create_text_do_not_use_without_block_level_wrapper("first para")))
+                .with_child(Dom::create_div().with_child(Dom::create_text_do_not_use_without_block_level_wrapper("last para"))),
         ));
         let win = laid_out(dom, 400.0, 300.0);
         let container = NodeId::new(1); // body(0) > div(1)
@@ -16452,7 +16462,7 @@ mod autotest_generated {
     #[test]
     fn text_node_navigation_walks_a_real_dom_without_running_off_the_end() {
         let dom = StyledDom::create_from_dom(
-            Dom::create_body().with_child(Dom::create_text("hello world")),
+            Dom::create_body().with_child(Dom::create_text_do_not_use_without_block_level_wrapper("hello world")),
         );
         let win = laid_out(dom, 200.0, 150.0);
         let node_count = win

--- a/layout/src/window.rs
+++ b/layout/src/window.rs
@@ -8628,14 +8628,33 @@ impl LayoutWindow {
 
         // A DOM node can map to several layout nodes; the caret lives on the
         // one that actually carries an inline layout.
-        let layout_idx = tree
-            .dom_to_layout
-            .get(&node_id)?
+        let candidates = tree.dom_to_layout.get(&node_id)?;
+        let layout_idx = candidates
             .iter()
             .copied()
             .find(|&idx| {
                 tree.warm(idx)
                     .is_some_and(|w| w.inline_layout_result.is_some())
+            })
+            .or_else(|| {
+                // ...or on the IFC ROOT above it. A session is anchored either
+                // on the block that establishes the inline context (the click
+                // path passes `ifc_root_node_id`) or on the raw text node
+                // inside it (the focus path passes `pending.text_node_id`),
+                // and a text node carries no inline layout of its own. Looking
+                // only at the anchored node left every focus-opened session
+                // with no caret rect at all -- and with it, no caret reveal.
+                let mut cur = tree.nodes.get(candidates.first()?.index())?.parent;
+                while let Some(idx) = cur {
+                    if tree
+                        .warm(LayoutNodeId::new(idx))
+                        .is_some_and(|w| w.inline_layout_result.is_some())
+                    {
+                        return Some(LayoutNodeId::new(idx));
+                    }
+                    cur = tree.nodes.get(idx)?.parent;
+                }
+                None
             })?;
 
         // (d6h) Materialized: the stored layout may be the retirement
@@ -9071,13 +9090,26 @@ impl LayoutWindow {
             }
         };
 
-        // Get the focused node (or bail if no focus)
-        let Some(focused_node) = self.focus_manager.focused_node else {
+        // Anchor the ancestor search on the SAME node the caret geometry came
+        // from. `get_focused_cursor_rect` was re-keyed onto the editing
+        // SESSION's node (focus sits on the contenteditable container while
+        // the caret is anchored on the IFC root inside it); leaving this on
+        // `focus_manager` meant the two disagreed — the rect resolved, then
+        // the reveal bailed looking for a scrollable ancestor of a different
+        // node, or of no node at all when the session had never taken window
+        // focus. The caret then never scrolled into view.
+        let anchor_node = self
+            .text_edit_manager
+            .multi_cursor
+            .as_ref()
+            .map(|mc| mc.node_id)
+            .or(self.focus_manager.focused_node);
+        let Some(anchor_node) = anchor_node else {
             return false;
         };
 
         // Find scrollable ancestor
-        let Some(scroll_container) = self.find_scrollable_ancestor(focused_node) else {
+        let Some(scroll_container) = self.find_scrollable_ancestor(anchor_node) else {
             return false; // No scrollable ancestor
         };
 
@@ -12862,14 +12894,33 @@ impl LayoutWindow {
         let tree = &self.layout_results.get(&dom_id)?.layout_tree;
 
         // Find the layout node index carrying the inline layout for this DOM node
-        let layout_idx = tree
-            .dom_to_layout
-            .get(&node_id)?
+        let candidates = tree.dom_to_layout.get(&node_id)?;
+        let layout_idx = candidates
             .iter()
             .copied()
             .find(|&idx| {
                 tree.warm(idx)
                     .is_some_and(|w| w.inline_layout_result.is_some())
+            })
+            .or_else(|| {
+                // ...or on the IFC ROOT above it. A session is anchored either
+                // on the block that establishes the inline context (the click
+                // path passes `ifc_root_node_id`) or on the raw text node
+                // inside it (the focus path passes `pending.text_node_id`),
+                // and a text node carries no inline layout of its own. Looking
+                // only at the anchored node left every focus-opened session
+                // with no caret rect at all -- and with it, no caret reveal.
+                let mut cur = tree.nodes.get(candidates.first()?.index())?.parent;
+                while let Some(idx) = cur {
+                    if tree
+                        .warm(LayoutNodeId::new(idx))
+                        .is_some_and(|w| w.inline_layout_result.is_some())
+                    {
+                        return Some(LayoutNodeId::new(idx));
+                    }
+                    cur = tree.nodes.get(idx)?.parent;
+                }
+                None
             })?;
 
         // Return the inline layout result (warm data).

--- a/layout/src/window.rs
+++ b/layout/src/window.rs
@@ -806,7 +806,7 @@ const fn memory_walk_coverage_is_exhaustive(w: &LayoutWindow) {
         structural_history_suppression: _,
         pagination_dirty_from: _,
         font_stacks_hash: _,
-        pre_preedit_content: _,
+        preedit_shaped_node: _,
         timers: _,
         threads: _,
         renderer_resources: _,
@@ -939,6 +939,23 @@ impl E2eMountOverride {
 /// - Manage multiple DOMs (for `VirtualViews`)
 // Independent lifecycle FLAGS (frame/tick/present bookkeeping), not an
 // encodable state machine — each is owned by a different subsystem.
+/// Whether a committed text edit still owes the user an `Input` event.
+/// `AlreadyDispatched` = the edit came through the text-input record pipeline,
+/// whose provider dispatched `Input` at determination time. `QueueInput` = the
+/// edit bypassed that pipeline (deletion, multi-cursor paste, Enter line
+/// break) and the host pass must dispatch the event from
+/// [`LayoutWindow::take_text_edit_notifications`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TextEditNotify {
+    AlreadyDispatched,
+    QueueInput,
+}
+
+/// One monotonic id for every recorded text edit (typing, deletion,
+/// multi-cursor paste). Replaces the three formerly hand-picked per-site id
+/// bands, which existed only so the sites could not collide.
+static CHANGESET_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Debug)]
 pub struct LayoutWindow {
@@ -1252,10 +1269,14 @@ pub struct LayoutWindow {
     /// Used to skip font chain resolution on frames where the font requirements
     /// haven't changed (e.g. scroll-only frames).
     font_stacks_hash: u64,
-    /// Snapshot of inline content before IME preedit injection.
-    /// Saved on first setMarkedText so each subsequent call injects into
-    /// clean original text instead of accumulating old preedits.
-    pre_preedit_content: Option<Vec<InlineContent>>,
+    /// The node whose INLINE LAYOUT currently carries an IME composition.
+    ///
+    /// The composed text is deliberately absent from the content overlay and
+    /// the `StyledDom` — it is glyphs, not document text (see
+    /// [`Self::apply_preedit_to_text_cache`]). This marker is what lets the
+    /// engine know shaped state has to be rebuilt when the composition ends,
+    /// and re-composed when a relayout re-shapes the clean base underneath it.
+    preedit_shaped_node: Option<(DomId, NodeId)>,
     /// Configurable input interpreter: maps raw events → `SystemChange` actions.
     /// Default: `default_input_interpreter` (standard desktop keybindings).
     /// Replace to implement vim, game controls, accessibility remaps, etc.
@@ -1609,7 +1630,7 @@ impl LayoutWindow {
             system_style: None,
             monitors: Arc::new(std::sync::Mutex::new(MonitorVec::from_const_slice(&[]))),
             font_stacks_hash: 0,
-            pre_preedit_content: None,
+            preedit_shaped_node: None,
             input_interpreter: azul_core::events::InputInterpreterCallback::default(),
             post_filter: azul_core::events::PostFilterCallback::default(),
             custom_e2e_op: azul_core::events::CustomE2eOpCallback::default(),
@@ -1957,7 +1978,26 @@ impl LayoutWindow {
     ) -> Option<crate::default_actions::EditingQueryState> {
         let focus = focused_node?;
         let node_id = focus.node.into_crate_internal()?;
-        self.find_contenteditable_host(focus.dom, node_id)?;
+        let host = self.find_contenteditable_host(focus.dom, node_id)?;
+
+        // Plain-text editing contexts are recognized by the HOST's computed
+        // `white-space`: when newlines are preserved, `"\n"` is the native
+        // line separator and Enter inserts one instead of splitting blocks.
+        let host_preserves_newlines = self.layout_results.get(&focus.dom).is_some_and(|lr| {
+            use azul_css::props::style::StyleWhiteSpace;
+            use crate::solver3::getters::{get_white_space_property, MultiValue};
+            lr.styled_dom.styled_nodes.as_container().get(host).is_some_and(|n| {
+                matches!(
+                    get_white_space_property(&lr.styled_dom, host, &n.styled_node_state),
+                    MultiValue::Exact(
+                        StyleWhiteSpace::Pre
+                            | StyleWhiteSpace::PreWrap
+                            | StyleWhiteSpace::BreakSpaces
+                            | StyleWhiteSpace::PreLine
+                    )
+                )
+            })
+        });
 
         // Caret at block start / end, judged against the CURRENT effective
         // content (overlay-first via get_text_before_textinput). Conservative
@@ -1993,6 +2033,7 @@ impl LayoutWindow {
             is_contenteditable: true,
             cursor_at_block_start: at_start,
             cursor_at_block_end: at_end,
+            host_preserves_newlines,
         })
     }
 
@@ -2011,6 +2052,61 @@ impl LayoutWindow {
             current = hierarchy.get(nid).and_then(azul_core::styled_dom::NodeHierarchyItem::parent_id);
         }
         None
+    }
+
+    /// The ONE commit point for a text-mutating edit: stores the styled
+    /// pre/post content snapshots, records the operation in the undo history
+    /// under a single monotonic id (shared by typing, deletion and
+    /// multi-cursor paste — the three formerly hand-picked id bands), and,
+    /// unless the edit already produced its user-facing `Input` event through
+    /// the text-input record pipeline, queues an edit notification the host
+    /// pass turns into an `EventType::Input` dispatch.
+    pub fn record_text_edit_undo(
+        &mut self,
+        target: DomNodeId,
+        pre_state: crate::managers::undo_redo::NodeStateSnapshot,
+        pre_content: Vec<crate::text3::cache::InlineContent>,
+        post_content: Vec<crate::text3::cache::InlineContent>,
+        operation: crate::managers::changeset::TextOperation,
+        notify: TextEditNotify,
+    ) -> usize {
+        use crate::managers::changeset::TextChangeset;
+        let changeset_id = CHANGESET_COUNTER.fetch_add(1, Ordering::SeqCst);
+        let timestamp = {
+            #[cfg(feature = "std")]
+            {
+                Instant::now()
+            }
+            #[cfg(not(feature = "std"))]
+            {
+                azul_core::task::Instant::Tick(azul_core::task::SystemTick { tick_counter: 0 })
+            }
+        };
+        let changeset = TextChangeset {
+            id: changeset_id,
+            target,
+            operation,
+            timestamp,
+        };
+        self.undo_redo_manager
+            .store_content_snapshot(changeset_id, pre_content, post_content);
+        self.undo_redo_manager.record_operation(changeset, pre_state);
+        if matches!(notify, TextEditNotify::QueueInput) {
+            self.text_edit_manager.pending_edit_notifications.push(target);
+        }
+        changeset_id
+    }
+
+    /// Drain the edit notifications queued by [`Self::record_text_edit_undo`]
+    /// (deduplicated, order-preserving). The host pass dispatches one
+    /// `EventType::Input` per returned host.
+    pub fn take_text_edit_notifications(&mut self) -> Vec<DomNodeId> {
+        let mut seen = std::collections::BTreeSet::new();
+        self.text_edit_manager
+            .pending_edit_notifications
+            .drain(..)
+            .filter(|id| seen.insert(*id))
+            .collect()
     }
 
     /// EXECUTE a structural default action — which, for structural edits,
@@ -5388,26 +5484,10 @@ impl LayoutWindow {
         )
     }
 
-    /// Scroll a text cursor into view
-    ///
-    /// Used when the cursor moves within a contenteditable element.
-    /// The cursor rect should be in node-local coordinates.
-    pub fn scroll_cursor_into_view(
-        &mut self,
-        cursor_rect: LogicalRect,
-        node_id: DomNodeId,
-        options: crate::managers::scroll_into_view::ScrollIntoViewOptions,
-        now: Instant,
-    ) -> Vec<crate::managers::scroll_into_view::ScrollAdjustment> {
-        crate::managers::scroll_into_view::scroll_cursor_into_view(
-            cursor_rect,
-            node_id,
-            &self.layout_results,
-            &mut self.scroll_manager,
-            options,
-            now,
-        )
-    }
+    // NOTE: no `LayoutWindow::scroll_cursor_into_view` wrapper. Caret reveal
+    // goes through `scroll_selection_into_view`, which knows the session's
+    // geometry; the wrapper took a pre-computed rect nobody had, and every
+    // call site had already migrated away from it.
 
     // Timer Management
 
@@ -5622,6 +5702,18 @@ impl LayoutWindow {
         let sel_ms = cfg.selection_tween_duration_ms;
         let ring_ms = cfg.focus_ring_duration_ms;
 
+        // The tween durations as CLOCK durations, not bare numbers. Progress is
+        // then `elapsed.div(&duration)` — a ratio of two `Duration`s, which
+        // stays exact within one unit and converts on the canonical nanosecond
+        // scale across units. Dividing an `as_millis_u64()` by a raw `_ms`
+        // integer instead only happens to agree while the clock is wall-clock:
+        // under the tick clock the E2E harness drives, whole-millisecond
+        // truncation is the entire resolution of a 60 ms tween, which is why
+        // tweens could not be turned on in headless tests.
+        let caret_duration = Duration::from_millis(u64::from(caret_ms));
+        let sel_duration = Duration::from_millis(u64::from(sel_ms));
+        let ring_duration = Duration::from_millis(u64::from(ring_ms));
+
         // Ledger #29 (opt-in): the focus-ring glide target — the focused
         // node's border-box (inflated 2px), only when NO text-editing
         // session owns focus (there the caret is the indicator) and the
@@ -5763,9 +5855,7 @@ impl LayoutWindow {
                 }
                 let rendered = match &tween.caret {
                     Some(trk) => {
-                        let elapsed =
-                            now.duration_since(&trk.start).as_millis_u64() as f32;
-                        let t = elapsed / caret_ms as f32;
+                        let t = now.duration_since(&trk.start).div(&caret_duration);
                         if t >= 1.0 {
                             tween.caret = None;
                             current
@@ -5828,8 +5918,7 @@ impl LayoutWindow {
                 }
                 let rendered: Vec<LogicalRect> = match &tween.selection {
                     Some(trk) => {
-                        let elapsed = now.duration_since(&trk.start).as_millis_u64() as f32;
-                        let t = elapsed / sel_ms as f32;
+                        let t = now.duration_since(&trk.start).div(&sel_duration);
                         if t >= 1.0 {
                             tween.selection = None;
                             current.clone()
@@ -5897,8 +5986,7 @@ impl LayoutWindow {
                 }
                 let rendered = match &tween.focus_ring {
                     Some(trk) => {
-                        let elapsed = now.duration_since(&trk.start).as_millis_u64() as f32;
-                        let t = elapsed / ring_ms as f32;
+                        let t = now.duration_since(&trk.start).div(&ring_duration);
                         if t >= 1.0 {
                             tween.focus_ring = None;
                             current
@@ -6123,34 +6211,101 @@ impl LayoutWindow {
         is_node_contenteditable_inherited(&layout_result.styled_dom, node_id)
     }
 
+    /// Whether `node_id` is `ancestor` itself or lives anywhere below it.
+    ///
+    /// Walks parents rather than descending, so the cost is the node's depth
+    /// and not the subtree size.
+    fn node_is_self_or_descendant(&self, dom_id: DomId, node_id: NodeId, ancestor: NodeId) -> bool {
+        if node_id == ancestor {
+            return true;
+        }
+        let Some(layout_result) = self.layout_results.get(&dom_id) else {
+            return false;
+        };
+        let node_hierarchy = layout_result.styled_dom.node_hierarchy.as_container();
+        let mut current = node_hierarchy
+            .get(node_id)
+            .and_then(azul_core::styled_dom::NodeHierarchyItem::parent_id);
+        while let Some(parent) = current {
+            if parent == ancestor {
+                return true;
+            }
+            current = node_hierarchy
+                .get(parent)
+                .and_then(azul_core::styled_dom::NodeHierarchyItem::parent_id);
+        }
+        false
+    }
+
     /// The caret blink interval for a node, from its `caret-animation-duration`.
     ///
     /// Returns a [`Duration`] rather than milliseconds so the stylesheet's UNIT
     /// survives: `caret-animation-duration: 5t` yields `Duration::Tick(5)` (five
     /// frames, no clock involved) and `500ms` yields `Duration::System(500ms)`.
     ///
-    /// Falls back to [`crate::managers::text_edit::CURSOR_BLINK_INTERVAL`] when
-    /// the node's layout is not available, and when the resolved interval is
-    /// ZERO. Zero is documented in `CaretStyle` as "no blink", which is not the
-    /// same thing as "blink every frame" — until suppression is actually
-    /// implemented, honouring it literally would turn `0` into a strobing caret,
-    /// so the default is the conservative reading.
+    /// Precedence: an explicit `caret-animation-duration` wins; with the property
+    /// unset the OS setting is the next authority
+    /// (`SystemStyle::input::caret_blink_rate_ms`, captured from
+    /// `GetCaretBlinkTime()` on Windows and from GNOME's `cursor-blink*` on
+    /// Linux); only then [`crate::managers::text_edit::CURSOR_BLINK_INTERVAL`],
+    /// which is also what an unavailable layout returns.
+    ///
+    /// The property is read from the cache directly rather than through
+    /// `get_caret_style`, which substitutes its own 500 ms default and so makes
+    /// "the author said nothing" indistinguishable from "the author said 500ms"
+    /// — with that helper the OS branch below is unreachable.
+    ///
+    /// A CSS interval of ZERO is documented in `CaretStyle` as "no blink", which
+    /// is not the same thing as "blink every frame" — until suppression is
+    /// actually implemented, honouring it literally would turn `0` into a
+    /// strobing caret, so the default is the conservative reading.
     #[must_use]
     pub fn caret_blink_interval_for(&self, dom_id: DomId, node_id: NodeId) -> Duration {
-        use crate::{managers::text_edit::CURSOR_BLINK_INTERVAL, solver3::getters::get_caret_style};
+        use azul_core::styled_dom::StyledNodeState;
+
+        use crate::managers::text_edit::CURSOR_BLINK_INTERVAL;
 
         let Some(layout_result) = self.layout_results.get(&dom_id) else {
             return CURSOR_BLINK_INTERVAL;
         };
 
-        let interval: Duration = get_caret_style(&layout_result.styled_dom, Some(node_id))
-            .animation_duration
-            .into();
+        let css_interval: Option<Duration> = layout_result
+            .styled_dom
+            .node_data
+            .as_container()
+            .get(node_id)
+            .and_then(|node_data| {
+                layout_result
+                    .styled_dom
+                    .css_property_cache
+                    .ptr
+                    .get_caret_animation_duration(
+                        node_data,
+                        &node_id,
+                        &StyledNodeState::default(),
+                    )
+                    .and_then(|d| d.get_property().copied())
+            })
+            .map(|d| Duration::from(d.inner));
 
-        if interval.as_nanos() == 0 {
-            CURSOR_BLINK_INTERVAL
-        } else {
-            interval
+        if let Some(interval) = css_interval {
+            return if interval.as_nanos() == 0 {
+                CURSOR_BLINK_INTERVAL
+            } else {
+                interval
+            };
+        }
+
+        // Windows returns INFINITE (u32::MAX) for the accessibility "caret does
+        // not blink" setting; the Linux capture writes 0 for GNOME's
+        // `cursor-blink = false`. Both mean "never toggle", spelled as a ~49-day
+        // interval for the same reason the CSS zero is not taken literally — a
+        // real suppression path (blink timer off, caret forced visible) would be
+        // better than a very long period.
+        match self.system_style.as_ref().map(|s| s.input.caret_blink_rate_ms) {
+            None => CURSOR_BLINK_INTERVAL,
+            Some(0 | u32::MAX) => Duration::from_millis(u64::from(u32::MAX)),
+            Some(ms) => Duration::from_millis(u64::from(ms)),
         }
     }
 
@@ -6236,8 +6391,46 @@ impl LayoutWindow {
         } else {
             // Focus is moving away from contenteditable or being cleared
 
-            // Clear the cursor AND the pending focus flag
-            self.text_edit_manager.clear_editing();
+            // A highlighted RANGE over non-editable text is a selection, not an
+            // editing session, and it must outlive this call: the very click
+            // that drags it commonly also focuses a plain focusable (a button,
+            // the body), and `clear_editing` then erased the highlight the user
+            // was still looking at. Tear the caret machinery down, keep the
+            // range.
+            let non_editable_range = self
+                .text_edit_manager
+                .multi_cursor
+                .as_ref()
+                .filter(|mc| {
+                    mc.selections
+                        .iter()
+                        .any(|sel| matches!(sel.selection, Selection::Range(_)))
+                })
+                .and_then(|mc| {
+                    mc.node_id
+                        .node
+                        .into_crate_internal()
+                        .map(|node| (mc.node_id.dom, node))
+                })
+                .is_some_and(|(dom, node)| {
+                    !self.is_node_contenteditable_inherited_internal(dom, node)
+                });
+
+            if non_editable_range {
+                let had_blink = self.text_edit_manager.blink.is_visible
+                    || self.text_edit_manager.blink.blink_timer_active;
+                self.text_edit_manager.blink.clear();
+                if had_blink {
+                    self.text_edit_manager.mark_dirty();
+                }
+            } else {
+                // Clear the cursor
+                self.text_edit_manager.clear_editing();
+                // `clear_editing` drops `preedit_text`, but the composed glyphs
+                // live in the SHAPING, which only this call knows how to undo.
+                self.end_preedit_shaping();
+            }
+            // Clear the pending focus flag
             self.focus_manager.clear_pending_contenteditable_focus();
 
             if timer_was_active {
@@ -6307,6 +6500,43 @@ impl LayoutWindow {
         None
     }
 
+    /// Re-resolve a focus request that arrived before there was any layout to
+    /// resolve it against, and apply it.
+    ///
+    /// `resolve_focus_target_or_defer` parks such a request on the
+    /// [`FocusManager`] instead of answering `Ok(None)` — which every caller
+    /// applies as "clear focus", so a `set_focus` from a `create` callback
+    /// (which runs before the first layout) used to disappear, and apps worked
+    /// around it with a short timer.
+    ///
+    /// Returns the blink [`Timer`] the shell must arm an OS timer for, when
+    /// the recovered focus landed on a contenteditable. The timer is already
+    /// registered in [`Self::timers`], so a host that pumps that map (headless,
+    /// E2E) needs nothing further.
+    pub fn drain_deferred_focus_target(&mut self) -> Option<Timer> {
+        use crate::managers::focus_cursor::resolve_focus_target;
+
+        if !self.focus_manager.has_deferred_focus_target() || self.layout_results.is_empty() {
+            return None;
+        }
+        let target = self.focus_manager.take_deferred_focus_target()?;
+        let current_focus = self.focus_manager.get_focused_node().copied();
+        let Ok(resolved) = resolve_focus_target(&target, &self.layout_results, current_focus) else {
+            return None;
+        };
+        // A target that STILL matches nothing is a genuine "no such focusable"
+        // answer now that layout exists — do not re-queue it, or it would
+        // re-run on every frame for the window's lifetime.
+        let new_focus = resolved?;
+
+        self.focus_manager.set_focused_node(Some(new_focus));
+        let window_state = self.current_window_state.clone();
+        match self.handle_focus_change_for_cursor_blink(Some(new_focus), &window_state) {
+            CursorBlinkTimerAction::Start(timer) => Some(timer),
+            CursorBlinkTimerAction::Stop | CursorBlinkTimerAction::NoChange => None,
+        }
+    }
+
     /// Finalize pending focus changes after layout pass (W3C "flag and defer" pattern)
     ///
     /// This method should be called AFTER the layout pass completes. It checks if
@@ -6329,6 +6559,14 @@ impl LayoutWindow {
     ///
     /// `true` if cursor was initialized, `false` if no pending focus or initialization failed.
     pub fn finalize_pending_focus_changes(&mut self) -> bool {
+        // A focus request that arrived before the first layout waited here for
+        // one. Applying it BEFORE taking the pending contenteditable focus lets
+        // the caret it flags be seeded in this very call.
+        if let Some(blink_timer) = self.drain_deferred_focus_target() {
+            self.timers
+                .insert(azul_core::task::CURSOR_BLINK_TIMER_ID, blink_timer);
+        }
+
         // Take the pending focus info (this clears the flag)
         let Some(pending) = self.focus_manager.take_pending_contenteditable_focus() else {
             return false;
@@ -6336,11 +6574,32 @@ impl LayoutWindow {
 
         // Bug B+H fix: If process_mouse_click_for_selection already positioned
         // the cursor in this node during the same event cycle, don't override it
-        // with initialize_cursor_at_end. The click handler sets cursor on the IFC
-        // root node (may differ from text_node_id), so check both.
-        if self.text_edit_manager.multi_cursor.as_ref().is_some_and(|mc| mc.node_id.dom == pending.dom_id && mc.node_id.node.into_crate_internal() == Some(pending.text_node_id))
-            || self.text_edit_manager.multi_cursor.as_ref().is_some_and(|mc| mc.node_id.dom == pending.dom_id && mc.node_id.node.into_crate_internal() == Some(pending.container_node_id))
-        {
+        // with initialize_cursor_at_end.
+        //
+        // The test is CONTAINMENT, not equality against the two remembered ids:
+        // the click handler keys the session on the IFC ROOT, which in a
+        // P-wrapped editable (container div > p > text) is neither the
+        // container nor `find_last_text_child`'s text node. An equality guard
+        // missed it and the end-of-text seed below overrode the caret the user
+        // had just clicked.
+        let session_inside_pending = self
+            .text_edit_manager
+            .multi_cursor
+            .as_ref()
+            .and_then(|mc| {
+                (mc.node_id.dom == pending.dom_id)
+                    .then(|| mc.node_id.node.into_crate_internal())
+                    .flatten()
+            })
+            .is_some_and(|session_node| {
+                session_node == pending.text_node_id
+                    || self.node_is_self_or_descendant(
+                        pending.dom_id,
+                        session_node,
+                        pending.container_node_id,
+                    )
+            });
+        if session_inside_pending {
             return true;
         }
 
@@ -6370,6 +6629,27 @@ impl LayoutWindow {
                 assert_eq!(d, s, "d4 verify: last-cluster cursor diverged");
             }
         }
+        // No layout for this node YET (the node is not in the layout tree at
+        // all) is not the same as "the node has no clusters": seeding cluster
+        // (0,0) there produces a caret at the start of a text nobody has
+        // measured, and the end-of-text seed this function exists for never
+        // happens. Put the request back and let the next post-layout call do
+        // it properly. Bounded by `MAX_PENDING_FOCUS_RETRIES` so a node that
+        // never gains an inline layout still gets its (0,0) fallback.
+        let node_has_layout = self
+            .layout_results
+            .get(&pending.dom_id)
+            .is_some_and(|lr| lr.layout_tree.dom_to_layout.contains_key(&pending.text_node_id));
+        if dense_cursor.is_none()
+            && sparse_cursor.is_none()
+            && !node_has_layout
+            && self
+                .focus_manager
+                .rearm_pending_contenteditable_focus(pending)
+        {
+            return false;
+        }
+
         let cursor = dense_cursor.or(sparse_cursor)
             .unwrap_or(TextCursor {
                 cluster_id: GraphemeClusterId { source_run: 0, start_byte_in_run: 0 },
@@ -6498,9 +6778,13 @@ impl LayoutWindow {
         match op.mode {
             SelectionMode::Move | SelectionMode::Extend => {
                 let extend = matches!(op.mode, SelectionMode::Extend);
+                // Only a CHARACTER step collapses an active range to its edge
+                // (the Left/Right rule). Word, visual-line, Home/End and
+                // document jumps are movements and must actually be performed.
+                let collapse = matches!(op.step, SelectionStep::Character);
                 if let Some(ref mut mc) = self.text_edit_manager.multi_cursor {
                     for _ in 0..op.repeat.max(1) {
-                        mc.move_all_cursors(extend, |c| {
+                        mc.move_all_cursors_with(extend, collapse, |c| {
                             Self::resolve_step_with(dense.as_deref(), &layout, c, op.direction, op.step)
                         });
                     }
@@ -6551,8 +6835,13 @@ impl LayoutWindow {
 
     /// Helper: Handle cursor movement with optional selection extension.
     ///
-    /// Updates the primary cursor in `TextEditManager.multi_cursor` to the given
-    /// position and triggers a display list regeneration.
+    /// Updates the primary selection in `TextEditManager.multi_cursor` to the
+    /// given position and triggers a display list regeneration.
+    ///
+    /// `node_id` is accepted for call-site symmetry and deliberately NOT used
+    /// to re-target the session: callers pass the FOCUSED node, while the
+    /// editing session is keyed on the IFC root inside it, so gating on
+    /// equality would drop every movement in a nested editable.
     pub fn handle_cursor_movement(
         &mut self,
         dom_id: DomId,
@@ -6560,9 +6849,34 @@ impl LayoutWindow {
         new_cursor: TextCursor,
         extend_selection: bool,
     ) {
+        let _ = node_id;
+
         // Update multi_cursor with the new cursor position
         if let Some(ref mut mc) = self.text_edit_manager.multi_cursor {
-            mc.set_single_cursor(new_cursor);
+            // Shift+move keeps the ANCHOR and travels only the focus, so a bare
+            // caret becomes a range and an existing range grows. This used to
+            // call `set_single_cursor` unconditionally — the parameter was
+            // accepted and dropped, so no shortcut routed through here (arrow
+            // keys, Home/End, Ctrl+Home/End) could ever select anything.
+            let anchor = if extend_selection {
+                mc.get_primary().map(|p| match p.selection {
+                    Selection::Range(r) => r.start,
+                    Selection::Cursor(c) => c,
+                })
+            } else {
+                None
+            };
+            match anchor {
+                Some(anchor) if anchor != new_cursor => {
+                    mc.set_single_range(SelectionRange {
+                        start: anchor,
+                        end: new_cursor,
+                    });
+                }
+                // No anchor, or the focus walked back onto it: a range of zero
+                // width is a caret.
+                _ => mc.set_single_cursor(new_cursor),
+            }
         }
 
         self.regenerate_display_list_for_dom(dom_id);
@@ -7123,7 +7437,7 @@ impl LayoutWindow {
                 // the manager is remapped to the new tree right after this.
                 let frozen_scroll = self
                     .scroll_manager
-                    .build_scroll_offset_map(dom_id, &retained.scroll_ids);
+                    .build_scroll_offset_map(dom_id, &retained.scroll_id_to_node_id);
                 let mut rects = BTreeMap::new();
                 let mut retained_keys = BTreeMap::new();
                 for node in exit_tracks.keys() {
@@ -7949,6 +8263,13 @@ impl LayoutWindow {
     /// Returns:
     /// - `scroll_ids`: Map from layout node index -> external scroll ID
     /// - `scroll_id_to_node_id`: Map from scroll ID -> DOM `NodeId` (for hit testing)
+    ///
+    /// NOTE: ids are registered for every scroll CONTAINER (`scroll | auto |
+    /// hidden`), while the display-list builder emits `PushScrollFrame` only
+    /// for `overflow.is_scroll()` — so these tables can carry ids no
+    /// display-list item references. Harmless for the offset map (an
+    /// unreferenced id never matches a frame), but "an id exists" does NOT
+    /// imply "a scroll frame exists".
     #[must_use] pub fn compute_scroll_ids(
         layout_tree: &LayoutTree,
         styled_dom: &StyledDom,
@@ -8279,41 +8600,62 @@ impl LayoutWindow {
         });
     }
 
-    pub fn get_focused_cursor_rect(&self) -> Option<LogicalRect> {
-        // Get the focused node
-        let focused_node = self.focus_manager.focused_node?;
+    /// Inline layout + absolute origin of the node an editing session is
+    /// anchored on, resolved in THAT session's own DOM.
+    ///
+    /// The geometry helpers used to walk `layout_cache.tree`, which only ever
+    /// holds the ROOT dom, and matched a bare `dom_node_id` with no `DomId`
+    /// alongside it — so in a virtualized view the caret answered for whatever
+    /// unrelated node happened to occupy the same index, or for nothing at all.
+    fn session_inline_geometry(
+        &self,
+        node: DomNodeId,
+    ) -> Option<(Arc<UnifiedLayout>, LogicalPosition)> {
+        let node_id = node.node.into_crate_internal()?;
+        let layout_result = self.layout_results.get(&node.dom)?;
+        let tree = &layout_result.layout_tree;
 
-        // Get the text cursor
-        let cursor = self.text_edit_manager.get_primary_cursor()?;
-
-        // Get the layout tree from cache
-        let layout_tree = self.layout_cache.tree.as_ref()?;
-
-        // Find the layout node index corresponding to the focused DOM node
-        let target_node_id = focused_node.node.into_crate_internal();
-        let layout_idx = layout_tree
-            .nodes
+        // A DOM node can map to several layout nodes; the caret lives on the
+        // one that actually carries an inline layout.
+        let layout_idx = tree
+            .dom_to_layout
+            .get(&node_id)?
             .iter()
-            .position(|node| node.dom_node_id == target_node_id)?;
+            .copied()
+            .find(|&idx| {
+                tree.warm(idx)
+                    .is_some_and(|w| w.inline_layout_result.is_some())
+            })?;
 
-        // Get the text layout result for this node (warm data)
-        let warm_node = layout_tree.warm(layout_idx)?;
-        let cached_layout = warm_node.inline_layout_result.as_ref()?;
         // (d6h) Materialized: the stored layout may be the retirement
         // sentinel; geometry runs on the transient expansion. (An
         // instrumentation pass once clobbered this line — the caret
         // reveal died sentinel-blind until caret_scroll_glide caught it.)
-        let inline_layout = cached_layout.materialized();
+        let inline_layout = tree.materialized_inline_layout_for_node(layout_idx)?;
+        // `pos_get` (not a raw index) so the POSITION_UNSET sentinel reads as
+        // "not laid out yet" instead of placing the caret at f32::MIN.
+        let origin = solver3::pos_get(&layout_result.calculated_positions, layout_idx)?;
+        Some((inline_layout, origin))
+    }
+
+    pub fn get_focused_cursor_rect(&self) -> Option<LogicalRect> {
+        // Keyed on the SESSION's node, not the focused node: focus lands on the
+        // contenteditable container while the caret is anchored on the IFC root
+        // inside it, so matching the focused node returned None for every
+        // nested editable — and with it, no caret reveal.
+        let session_node = self.text_edit_manager.multi_cursor.as_ref()?.node_id;
+
+        // Get the text cursor
+        let cursor = self.text_edit_manager.get_primary_cursor()?;
+
+        let (inline_layout, origin) = self.session_inline_geometry(session_node)?;
 
         // Get the cursor rect in node-relative coordinates
         let mut cursor_rect = inline_layout.get_cursor_rect(&cursor)?;
 
-        // Get the calculated layout position from cache (already in logical units)
-        let calc_pos = self.layout_cache.calculated_positions.get(layout_idx)?;
-
         // Add layout position to cursor rect (both already in logical units)
-        cursor_rect.origin.x += calc_pos.x;
-        cursor_rect.origin.y += calc_pos.y;
+        cursor_rect.origin.x += origin.x;
+        cursor_rect.origin.y += origin.y;
 
         // Return ABSOLUTE position (no scroll correction)
         Some(cursor_rect)
@@ -8322,7 +8664,6 @@ impl LayoutWindow {
     /// Compute the bounding rect of all selection ranges in the focused node.
     /// Returns the union of all selection rects in absolute coordinates.
     pub fn calculate_selection_bounding_rect(&self) -> Option<LogicalRect> {
-        let focused_node = self.focus_manager.focused_node?;
         let mc = self.text_edit_manager.multi_cursor.as_ref()?;
 
         // Collect Range selections
@@ -8338,15 +8679,9 @@ impl LayoutWindow {
             return None;
         }
 
-        // Get the inline layout for the focused node
-        let target_node_id = focused_node.node.into_crate_internal();
-        let layout_tree = self.layout_cache.tree.as_ref()?;
-        let layout_idx = layout_tree.nodes.iter()
-            .position(|n| n.dom_node_id == target_node_id)?;
-        let warm = layout_tree.warm(layout_idx)?;
-        // (d6h) Materialized: sentinel-safe geometry (see the helper).
-        let inline_layout = Self::materialized_inline_layout(warm.inline_layout_result.as_ref()?);
-        let calc_pos = self.layout_cache.calculated_positions.get(layout_idx)?;
+        // Get the inline layout for the node the SESSION is anchored on, in
+        // its own dom (see `session_inline_geometry`).
+        let (inline_layout, calc_pos) = self.session_inline_geometry(mc.node_id)?;
 
         let mut min_x = f32::MAX;
         let mut min_y = f32::MAX;
@@ -8723,10 +9058,6 @@ impl LayoutWindow {
                     None => return false,
                 }
             }
-            SelectionScrollType::DragSelection { mouse_position } => {
-                // For drag: use mouse position to determine scroll direction/speed
-                LogicalRect::new(mouse_position, LogicalSize::zero())
-            }
         };
 
         // Get the focused node (or bail if no focus)
@@ -8791,18 +9122,13 @@ impl LayoutWindow {
             container_rect.size,
         );
 
-        // Calculate scroll delta based on mode
-        let scroll_delta = match scroll_mode {
-            ScrollMode::Instant => {
-                // For typing/clicking: instant scroll with fixed padding
-                calculate_instant_scroll_delta(bounds, visible_area)
-            }
-            ScrollMode::Accelerated => {
-                // For drag: accelerated scroll based on distance from edge
-                let distance = calculate_edge_distance(bounds, visible_area);
-                calculate_accelerated_scroll_delta(distance)
-            }
-        };
+        // For typing/clicking: instant scroll with fixed padding. (The
+        // "accelerated drag" mode that used to live here had ZERO call
+        // sites — drag-autoscroll ships through `auto_scroll_timer_callback`
+        // in the shared shell layer, which also extends the selection as the
+        // view scrolls. An unused "intended mechanism" is what let the
+        // original drag-autoscroll bug survive an audit; deleted, not kept.)
+        let scroll_delta = calculate_instant_scroll_delta(bounds, visible_area);
 
         // Apply scroll if needed
         if scroll_delta.x != 0.0 || scroll_delta.y != 0.0 {
@@ -8840,13 +9166,7 @@ impl LayoutWindow {
                 return true;
             }
 
-            let duration = match scroll_mode {
-                ScrollMode::Instant => Duration::System(SystemTimeDiff { secs: 0, nanos: 0 }),
-                ScrollMode::Accelerated => Duration::System(SystemTimeDiff {
-                    secs: 0,
-                    nanos: 16_666_667,
-                }), // 60fps
-            };
+            let duration = Duration::System(SystemTimeDiff { secs: 0, nanos: 0 });
 
             self.scroll_manager.scroll_to(
                 scroll_container.dom,
@@ -8880,8 +9200,6 @@ pub enum SelectionScrollType {
     Cursor,
     /// Scroll current selection bounds into view
     Selection,
-    /// Scroll for drag selection (use mouse position for direction/speed)
-    DragSelection { mouse_position: LogicalPosition },
 }
 
 /// Scroll animation mode
@@ -8889,33 +9207,6 @@ pub enum SelectionScrollType {
 pub enum ScrollMode {
     /// Instant scroll with fixed padding (for typing, arrow keys)
     Instant,
-    /// Accelerated scroll based on distance from edge (for drag-to-scroll)
-    Accelerated,
-}
-
-/// Distance from rect edges to container edges (for acceleration calculation)
-#[derive(Debug, Clone, Copy)]
-struct EdgeDistance {
-    left: f32,
-    right: f32,
-    top: f32,
-    bottom: f32,
-}
-
-/// Calculate distance from rect to container edges
-fn calculate_edge_distance(rect: LogicalRect, container: LogicalRect) -> EdgeDistance {
-    EdgeDistance {
-        // Distance from rect's left edge to container's left edge
-        left: (rect.origin.x - container.origin.x).max(0.0),
-        // Distance from container's right edge to rect's right edge
-        right: ((container.origin.x + container.size.width) - (rect.origin.x + rect.size.width))
-            .max(0.0),
-        // Distance from rect's top edge to container's top edge
-        top: (rect.origin.y - container.origin.y).max(0.0),
-        // Distance from container's bottom edge to rect's bottom edge
-        bottom: ((container.origin.y + container.size.height) - (rect.origin.y + rect.size.height))
-            .max(0.0),
-    }
 }
 
 /// Calculate scroll delta with fixed padding (instant scroll mode)
@@ -8949,56 +9240,6 @@ fn calculate_instant_scroll_delta(
     }
 
     delta
-}
-
-/// Calculate scroll delta with distance-based acceleration (drag-to-scroll mode)
-fn calculate_accelerated_scroll_delta(distance: EdgeDistance) -> LogicalPosition {
-    // Acceleration zones (in pixels from edge)
-    const DEAD_ZONE: f32 = 20.0;
-    const SLOW_ZONE: f32 = 50.0;
-    const MEDIUM_ZONE: f32 = 100.0;
-    const FAST_ZONE: f32 = 200.0;
-
-    // Scroll speeds (pixels per frame at 60fps)
-    const SLOW_SPEED: f32 = 2.0;
-    const MEDIUM_SPEED: f32 = 4.0;
-    const FAST_SPEED: f32 = 8.0;
-    const VERY_FAST_SPEED: f32 = 16.0;
-
-    // Helper to calculate speed for one direction
-    let speed_for_distance = |dist: f32| -> f32 {
-        if dist < DEAD_ZONE {
-            0.0
-        } else if dist < SLOW_ZONE {
-            SLOW_SPEED
-        } else if dist < MEDIUM_ZONE {
-            MEDIUM_SPEED
-        } else if dist < FAST_ZONE {
-            FAST_SPEED
-        } else {
-            VERY_FAST_SPEED
-        }
-    };
-
-    // Calculate horizontal scroll (left vs right)
-    let scroll_x = if distance.left < distance.right {
-        // Closer to left edge - scroll left
-        -speed_for_distance(distance.left)
-    } else {
-        // Closer to right edge - scroll right
-        speed_for_distance(distance.right)
-    };
-
-    // Calculate vertical scroll (top vs bottom)
-    let scroll_y = if distance.top < distance.bottom {
-        // Closer to top edge - scroll up
-        -speed_for_distance(distance.top)
-    } else {
-        // Closer to bottom edge - scroll down
-        speed_for_distance(distance.bottom)
-    };
-
-    LogicalPosition::new(scroll_x, scroll_y)
 }
 
 /// Result of a layout operation
@@ -10984,9 +11225,8 @@ impl LayoutWindow {
     /// and whether a full re-layout is needed (text size changed).
     #[allow(clippy::too_many_lines)] // large but cohesive: single-purpose layout/render/parse routine (one branch per case)
     pub fn apply_text_changeset(&mut self) -> TextChangesetResult {
-        use crate::managers::changeset::{TextChangeset, TextOpInsertText, TextOperation};
+        use crate::managers::changeset::{TextOpInsertText, TextOperation};
         use crate::text3::edit::{edit_text, TextEdit};
-        static CHANGESET_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
         // Get the changeset from TextInputManager
         let empty = TextChangesetResult { dirty_nodes: Vec::new(), needs_relayout: false };
@@ -11007,30 +11247,14 @@ impl LayoutWindow {
 
         let dom_id = changeset.node.dom;
 
-        // Check if node is contenteditable
-        let Some(layout_result) = self.layout_results.get(&dom_id) else {
-            self.text_input_manager.clear_changeset();
-            return empty;
-        };
-
-        let Some(styled_node) = layout_result
-            .styled_dom
-            .node_data
-            .as_ref()
-            .get(node_id.index()) else {
-            self.text_input_manager.clear_changeset();
-            return empty;
-        };
-
-        // Check BOTH: the contenteditable boolean field AND the attribute
-        // NodeData has a direct `contenteditable: bool` field that should be
-        // checked in addition to the attribute for robustness
-        let is_contenteditable = styled_node.is_contenteditable()
-            || styled_node.attributes().as_ref().iter().any(|attr| {
-                matches!(attr, AttributeType::ContentEditable(_))
-            });
-
-        if !is_contenteditable {
+        // Check if node is contenteditable.
+        //
+        // INHERITED, exactly like the focus path
+        // (`handle_focus_change_for_cursor_blink`) and the click path: the
+        // attribute sits on the editable container, so a node focused INSIDE
+        // one is editable too. An own-node-only test here accepted the input
+        // in `record_text_input` and then silently dropped the changeset.
+        if !self.is_node_contenteditable_inherited_internal(dom_id, node_id) {
             self.text_input_manager.clear_changeset();
             return empty;
         }
@@ -11100,6 +11324,12 @@ impl LayoutWindow {
         let pre_content_snapshot = content;
         let post_content_snapshot = new_content.clone();
 
+        // A committed edit supersedes any composition on the same node: the
+        // shaping below is rebuilt from the store, so nothing is left to undo.
+        if self.preedit_shaped_node == Some((dom_id, node_id)) {
+            self.preedit_shaped_node = None;
+        }
+
         // Update the text cache with the new inline content
         self.update_text_cache_after_edit(dom_id, node_id, new_content);
 
@@ -11121,26 +11351,20 @@ impl LayoutWindow {
                     .map_or(CursorPosition::Uninitialized, |r| CursorPosition::InWindow(r.origin))
             });
 
-        // Generate a unique changeset ID
-        let changeset_id = CHANGESET_COUNTER.fetch_add(1, Ordering::SeqCst);
-
-        let undo_changeset = TextChangeset {
-            id: changeset_id,
-            target: changeset.node,
-            operation: TextOperation::InsertText(TextOpInsertText {
+        // The record pipeline's provider already dispatched this edit's Input
+        // event at determination time — commit without a second notification.
+        self.record_text_edit_undo(
+            changeset.node,
+            pre_state,
+            pre_content_snapshot,
+            post_content_snapshot,
+            TextOperation::InsertText(TextOpInsertText {
                 text: changeset.inserted_text,
                 position: old_cursor_pos,
                 new_cursor,
             }),
-            #[cfg(feature = "std")]
-            timestamp: Instant::now(),
-            #[cfg(not(feature = "std"))]
-            timestamp: azul_core::task::Instant::Tick(azul_core::task::SystemTick { tick_counter: 0 }),
-        };
-        self.undo_redo_manager
-            .store_content_snapshot(changeset_id, pre_content_snapshot, post_content_snapshot);
-        self.undo_redo_manager
-            .record_operation(undo_changeset, pre_state);
+            TextEditNotify::AlreadyDispatched,
+        );
 
         // Clear the changeset now that it's been applied
         self.text_input_manager.clear_changeset();
@@ -11260,10 +11484,115 @@ impl LayoutWindow {
                     source_node_id: Some(node_id),
                 })]
             }
-            NodeType::Div | NodeType::Body | NodeType::VirtualView => {
-                // Container nodes - recursively collect text from children
-                self.collect_text_from_children(dom_id, node_id)
-            }
+            // Container nodes - recursively collect text from children.
+            //
+            // The buffer of a contenteditable host is the flattened inline
+            // content of its subtree, so EVERY element that can carry flow
+            // content participates: the block containers (`P`, `Li`, `H1`, the
+            // table and form containers) exactly as much as the inline ones
+            // (`Span`, `Em`, `A`, ...). Listing only `Div`/`Body` made a
+            // `div[contenteditable] > p > text` value — the shape the text
+            // widgets, `azul-writer` and the contenteditable e2e fixtures all
+            // use — read back as EMPTY, so the first keystroke computed its
+            // changeset against "" and could wipe the field.
+            //
+            // Deliberately NOT collected: replaced elements (`Image`, `Canvas`,
+            // `Input`, `TextArea`, `Select`, `Video`, ...), whose contents are
+            // not part of the host's inline formatting context; `Html`/`Head`
+            // and the metadata elements (`Title`, `Meta`, `Script`, `Style`,
+            // ...), which are never rendered; the non-rendered option model of
+            // a form control (`DataList`, `OptGroup`, `SelectOption`); the
+            // `Svg*` family, which carries its text in `SvgText`; the
+            // pseudo-element nodes (`Before`, `After`, `Marker`, `Placeholder`),
+            // which are generated content and not document text; and the void
+            // elements (`Br`, `Hr`, `Wbr`, `Col`), which have no children.
+            // `VirtualView` stays because its children ARE the virtualized
+            // document.
+            NodeType::Body
+            | NodeType::Div
+            | NodeType::VirtualView
+            // block containers
+            | NodeType::P
+            | NodeType::Article
+            | NodeType::Section
+            | NodeType::Nav
+            | NodeType::Aside
+            | NodeType::Header
+            | NodeType::Footer
+            | NodeType::Main
+            | NodeType::Figure
+            | NodeType::FigCaption
+            | NodeType::H1
+            | NodeType::H2
+            | NodeType::H3
+            | NodeType::H4
+            | NodeType::H5
+            | NodeType::H6
+            | NodeType::Pre
+            | NodeType::BlockQuote
+            | NodeType::Address
+            | NodeType::Details
+            | NodeType::Summary
+            | NodeType::Dialog
+            // lists
+            | NodeType::Ul
+            | NodeType::Ol
+            | NodeType::Li
+            | NodeType::Dl
+            | NodeType::Dt
+            | NodeType::Dd
+            | NodeType::Menu
+            | NodeType::MenuItem
+            | NodeType::Dir
+            // tables
+            | NodeType::Table
+            | NodeType::Caption
+            | NodeType::THead
+            | NodeType::TBody
+            | NodeType::TFoot
+            | NodeType::Tr
+            | NodeType::Th
+            | NodeType::Td
+            // form containers that render their own text
+            | NodeType::Form
+            | NodeType::FieldSet
+            | NodeType::Legend
+            | NodeType::Label
+            | NodeType::Button
+            | NodeType::Output
+            // inline containers
+            | NodeType::Span
+            | NodeType::A
+            | NodeType::Em
+            | NodeType::Strong
+            | NodeType::B
+            | NodeType::I
+            | NodeType::U
+            | NodeType::S
+            | NodeType::Mark
+            | NodeType::Del
+            | NodeType::Ins
+            | NodeType::Code
+            | NodeType::Samp
+            | NodeType::Kbd
+            | NodeType::Var
+            | NodeType::Cite
+            | NodeType::Dfn
+            | NodeType::Abbr
+            | NodeType::Acronym
+            | NodeType::Q
+            | NodeType::Time
+            | NodeType::Sub
+            | NodeType::Sup
+            | NodeType::Small
+            | NodeType::Big
+            | NodeType::Bdo
+            | NodeType::Bdi
+            | NodeType::Ruby
+            | NodeType::Rt
+            | NodeType::Rtc
+            | NodeType::Rp
+            | NodeType::Data => self.collect_text_from_children(dom_id, node_id),
             _ => {
                 // Other node types (Image, etc.) don't contribute text
                 Vec::new()
@@ -11296,6 +11625,12 @@ impl LayoutWindow {
     }
 
     /// Recursively collect text content from child nodes
+    ///
+    /// A subtree carrying an explicit `contenteditable="false"` is skipped: that
+    /// is what stops the inheritance walk in
+    /// [`solver3::getters::is_node_contenteditable_inherited`], and the text
+    /// widgets rely on it to keep their placeholder prompt — which lives *inside*
+    /// the editable container — out of the value the engine edits.
     fn collect_text_from_children(
         &self,
         dom_id: DomId,
@@ -11309,15 +11644,28 @@ impl LayoutWindow {
         let Some(parent_item) = node_hierarchy.get(parent_node_id.index()) else {
             return Vec::new();
         };
+        let node_data = layout_result.styled_dom.node_data.as_ref();
 
         let mut result = Vec::new();
 
         // Traverse all children
         let mut current_child = parent_item.first_child_id(parent_node_id);
         while let Some(child_id) = current_child {
-            // Get content from this child (recursive)
-            let child_content = self.get_text_before_textinput(dom_id, child_id);
-            result.extend(child_content);
+            // Same precedence as `is_node_contenteditable_inherited`: the
+            // `set_contenteditable()` flag wins, otherwise an explicit
+            // `contenteditable="false"` attribute walls the subtree off.
+            let is_walled_off = node_data.get(child_id.index()).is_some_and(|nd| {
+                !nd.is_contenteditable()
+                    && nd.attributes().as_ref().iter().any(|attr| {
+                        matches!(attr, AttributeType::ContentEditable(false))
+                    })
+            });
+
+            if !is_walled_off {
+                // Get content from this child (recursive)
+                let child_content = self.get_text_before_textinput(dom_id, child_id);
+                result.extend(child_content);
+            }
 
             // Move to next sibling
             let Some(child_item) = node_hierarchy.get(child_id.index()) else {
@@ -11354,19 +11702,12 @@ impl LayoutWindow {
     // it is both cloned into the dirty-node cache and re-read for relayout, so it is taken
     // owned at this boundary rather than rippling a &[InlineContent] across the backends.
     #[allow(clippy::needless_pass_by_value)]
-    #[allow(clippy::too_many_lines, clippy::cognitive_complexity)] // large but cohesive: single-purpose layout/render/parse routine (one branch per case)
     pub fn update_text_cache_after_edit(
         &mut self,
         dom_id: DomId,
         node_id: NodeId,
         new_inline_content: Vec<InlineContent>,
     ) {
-        use crate::solver3::layout_tree::CachedInlineLayout;
-
-        // B4: record the topmost changed document Y for the embedder's paged
-        // view (drained by take_pagination_dirty_from → incremental re-break).
-        self.mark_pagination_dirty_at_node(dom_id, node_id);
-
         // 1. Store the new content in dirty_text_nodes for tracking
         let cursor = self.text_edit_manager.get_primary_cursor();
         self.content_overlay.set_text(
@@ -11378,6 +11719,79 @@ impl LayoutWindow {
                 needs_ancestor_relayout: false, // Will be set if size changes
             },
         );
+
+        self.reshape_text_node(dom_id, node_id, new_inline_content);
+    }
+
+    /// The direct children of `node_id` in the order [`Self::reshape_text_node`]
+    /// searches them for an inline formatting context: the block that owns the
+    /// caret first, then document order.
+    ///
+    /// Plain document order hands `container > [placeholder p, value p]` to the
+    /// *placeholder* whenever it is displayed, so the edit lands in the prompt
+    /// instead of the value.
+    fn ifc_candidate_children(&self, dom_id: DomId, node_id: NodeId) -> Vec<NodeId> {
+        let Some(layout_result) = self.layout_results.get(&dom_id) else {
+            return Vec::new();
+        };
+        let node_hierarchy = layout_result.styled_dom.node_hierarchy.as_ref();
+        let Some(parent_item) = node_hierarchy.get(node_id.index()) else {
+            return Vec::new();
+        };
+
+        let mut children = Vec::new();
+        let mut child = parent_item.first_child_id(node_id);
+        while let Some(child_id) = child {
+            children.push(child_id);
+            let Some(child_item) = node_hierarchy.get(child_id.index()) else {
+                break;
+            };
+            child = child_item.next_sibling_id();
+        }
+
+        let caret = self
+            .text_edit_manager
+            .multi_cursor
+            .as_ref()
+            .filter(|mc| mc.node_id.dom == dom_id)
+            .and_then(|mc| mc.node_id.node.into_crate_internal());
+
+        if let Some(caret) = caret {
+            if let Some(pos) = children
+                .iter()
+                .position(|&c| self.node_is_self_or_descendant(dom_id, caret, c))
+            {
+                let owner = children.remove(pos);
+                children.insert(0, owner);
+            }
+        }
+
+        children
+    }
+
+    /// Re-shape `new_inline_content` into the node's inline layout WITHOUT
+    /// writing it to the content overlay.
+    ///
+    /// This is the half of [`Self::update_text_cache_after_edit`] that touches
+    /// only shaped/derived state. IME composition needs exactly that: the
+    /// preedit is glyphs on screen, never text in the document. Writing it to
+    /// the overlay (as the preedit path used to) made every subsequent read
+    /// through `get_text_before_textinput` — which prefers the overlay — see
+    /// clean+preedit, so committing a composition inserted the composed text a
+    /// second time and cancelling one left the fragment behind.
+    #[allow(clippy::needless_pass_by_value)]
+    #[allow(clippy::too_many_lines, clippy::cognitive_complexity)] // large but cohesive: single-purpose layout/render/parse routine (one branch per case)
+    pub fn reshape_text_node(
+        &mut self,
+        dom_id: DomId,
+        node_id: NodeId,
+        new_inline_content: Vec<InlineContent>,
+    ) {
+        use crate::solver3::layout_tree::CachedInlineLayout;
+
+        // B4: record the topmost changed document Y for the embedder's paged
+        // view (drained by take_pagination_dirty_from → incremental re-break).
+        self.mark_pagination_dirty_at_node(dom_id, node_id);
 
         // 2. Get the cached constraints from the existing inline layout result.
         // We need to find the IFC root node. The layout tree uses its own indices
@@ -11404,25 +11818,21 @@ impl LayoutWindow {
                 }
             }
 
-            // If not found on this node, check child DOM nodes (text children of contenteditable)
+            // If not found on this node, check child DOM nodes (text children of
+            // contenteditable) — caret-owning block first, then document order.
             if found.is_none() {
-                let node_hierarchy = layout_result.styled_dom.node_hierarchy.as_ref();
-                if let Some(parent_item) = node_hierarchy.get(node_id.index()) {
-                    let mut child = parent_item.first_child_id(node_id);
-                    while let Some(child_id) = child {
-                        if let Some(child_indices) = layout_result.layout_tree.dom_to_layout.get(&child_id) {
-                            for &idx in child_indices {
-                                if let Some(w) = layout_result.layout_tree.warm(idx) {
-                                    if let Some(ref cached) = w.inline_layout_result {
-                                        found = Some((idx, cached));
-                                        break;
-                                    }
+                for child_id in self.ifc_candidate_children(dom_id, node_id) {
+                    if let Some(child_indices) = layout_result.layout_tree.dom_to_layout.get(&child_id) {
+                        for &idx in child_indices {
+                            if let Some(w) = layout_result.layout_tree.warm(idx) {
+                                if let Some(ref cached) = w.inline_layout_result {
+                                    found = Some((idx, cached));
+                                    break;
                                 }
                             }
                         }
-                        if found.is_some() { break; }
-                        child = node_hierarchy.get(child_id.index()).and_then(azul_core::styled_dom::NodeHierarchyItem::next_sibling_id);
                     }
+                    if found.is_some() { break; }
                 }
             }
 
@@ -11554,27 +11964,31 @@ impl LayoutWindow {
         self.regenerate_display_list_for_dom(dom_id);
     }
 
-    /// Re-apply a dirty text node's content to the layout cache after a full DOM rebuild.
+    /// Shape the live IME composition into the node's inline layout and
+    /// regenerate the display list.
     ///
-    /// Called by `regenerate_layout()` after `layout_and_generate_display_list()`.
-    /// The layout just ran on the stale DOM text, so we re-shape the edited text
-    /// from `dirty_text_nodes` and update the inline layout result + display list.
-    /// Inject preedit text into the text cache and regenerate the display list.
+    /// Called from the platform IME handler (setMarkedText / preedit_string).
+    /// Composes `base text + preedit` at the caret and re-shapes THAT — the
+    /// composed string is never written to the content overlay, so it exists
+    /// only as glyphs.
     ///
-    /// Called from the platform IME handler (setMarkedText). Gets the current
-    /// text content, splices the preedit string at the cursor position, then
-    /// re-shapes and regenerates the display list so the preedit glyphs appear
-    /// inline with an underline.
-    /// # Panics
-    ///
-    /// Panics if there is no saved pre-preedit content to restore.
+    /// That separation is the whole point. The preedit used to be spliced into
+    /// the overlay, which `get_text_before_textinput` prefers over the
+    /// `StyledDom`, so every later read saw base+preedit: committing a
+    /// composition produced base+preedit+committed (typing "か" and committing
+    /// gave "かか"), and cancelling one "restored" from the contaminated
+    /// overlay, leaving the fragment behind for good. With the composition kept
+    /// out of the store, ending it is just re-shaping the base, and committing
+    /// is a plain insert.
     pub fn apply_preedit_to_text_cache(&mut self, dom_id: DomId, node_id: NodeId) {
         let preedit = match &self.text_edit_manager.preedit_text {
             Some(p) if !p.is_empty() => p.clone(),
             _ => {
-                // No preedit — restore original text and clear snapshot
-                self.pre_preedit_content = None;
-                self.reapply_dirty_text_node(dom_id, node_id);
+                // Composition ended (committed or cancelled). Nothing to undo in
+                // the text — only the shaping still carries the composed glyphs.
+                if self.preedit_shaped_node == Some((dom_id, node_id)) {
+                    self.end_preedit_shaping();
+                }
                 return;
             }
         };
@@ -11583,15 +11997,9 @@ impl LayoutWindow {
             return;
         };
 
-        // Save the original content on the FIRST preedit call so we always
-        // inject into clean text (prevents accumulation of old preedits).
-        if self.pre_preedit_content.is_none() {
-            let original = self.get_text_before_textinput(dom_id, node_id);
-            self.pre_preedit_content = Some(original);
-        }
-
-        // Clone the saved original — never modify it in place
-        let mut content = self.pre_preedit_content.clone().unwrap();
+        // Always compose from the CLEAN base: no snapshot to keep, because the
+        // base is never overwritten in the first place.
+        let mut content = self.get_text_before_textinput(dom_id, node_id);
 
         // Insert preedit at cursor position
         let run_idx = cursor.cluster_id.source_run as usize;
@@ -11604,10 +12012,29 @@ impl LayoutWindow {
         }
 
         // Re-shape text with preedit injected — font fallback handles CJK
-        self.update_text_cache_after_edit(dom_id, node_id, content);
+        self.preedit_shaped_node = Some((dom_id, node_id));
+        self.reshape_text_node(dom_id, node_id, content);
         self.regenerate_display_list_for_dom(dom_id);
     }
 
+    /// Drop a composition that exists only in the shaping (see
+    /// [`Self::preedit_shaped_node`]) and put the clean base back on screen.
+    ///
+    /// No text is undone — the composed string was never in the store.
+    pub fn end_preedit_shaping(&mut self) {
+        let Some((dom_id, node_id)) = self.preedit_shaped_node.take() else {
+            return;
+        };
+        let base = self.get_text_before_textinput(dom_id, node_id);
+        self.reshape_text_node(dom_id, node_id, base);
+        self.regenerate_display_list_for_dom(dom_id);
+    }
+
+    /// Re-apply a dirty text node's content to the layout cache after a full DOM rebuild.
+    ///
+    /// Called by `regenerate_layout()` after `layout_and_generate_display_list()`.
+    /// The layout just ran on the stale DOM text, so we re-shape the edited text
+    /// from `dirty_text_nodes` and update the inline layout result + display list.
     pub fn reapply_dirty_text_node(&mut self, dom_id: DomId, node_id: NodeId) {
         let content = match self.content_overlay.text_for_node(dom_id, node_id) {
             Some(dirty) => dirty.content.clone(),
@@ -11617,6 +12044,13 @@ impl LayoutWindow {
         self.update_text_cache_after_edit(dom_id, node_id, content);
         // Regenerate display list with updated text
         self.regenerate_display_list_for_dom(dom_id);
+
+        // The re-shape above ran on the CLEAN base, which is all the store
+        // holds; a composition in flight lives only in the shaping, so put it
+        // back or a rebuild mid-composition would blank the composed glyphs.
+        if self.preedit_shaped_node == Some((dom_id, node_id)) {
+            self.apply_preedit_to_text_cache(dom_id, node_id);
+        }
     }
 
     /// Regenerate the display list for a specific DOM from the current layout tree.
@@ -12410,23 +12844,28 @@ impl LayoutWindow {
         dom_id: DomId,
         node_id: NodeId,
     ) -> Option<Arc<UnifiedLayout>> {
-        // Get the layout tree from cache
-        let layout_tree = self.layout_cache.tree.as_ref()?;
+        // The tree of the REQUESTED dom. `layout_cache.tree` is the root dom's
+        // only, so a bare `dom_node_id` match against it answered for an
+        // unrelated node of the root DOM whenever `dom_id` named a virtualized
+        // view — the `dom_id` parameter was accepted and then ignored.
+        let tree = &self.layout_results.get(&dom_id)?.layout_tree;
 
-        // Find the layout node index corresponding to the DOM node
-        let layout_idx = layout_tree
-            .nodes
+        // Find the layout node index carrying the inline layout for this DOM node
+        let layout_idx = tree
+            .dom_to_layout
+            .get(&node_id)?
             .iter()
-            .position(|node| node.dom_node_id == Some(node_id))?;
+            .copied()
+            .find(|&idx| {
+                tree.warm(idx)
+                    .is_some_and(|w| w.inline_layout_result.is_some())
+            })?;
 
         // Return the inline layout result (warm data).
         // (d6h) Materialized: sentinel-safe for every geometry/search
         // caller of this accessor (caret scroll, selection paint,
         // occurrence search).
-        layout_tree.warm(layout_idx)?
-            .inline_layout_result
-            .as_ref()
-            .map(|b| Self::materialized_inline_layout(b))
+        tree.materialized_inline_layout_for_node(layout_idx)
     }
 
     /// Edit the text content of a node (used for text input actions)
@@ -12806,9 +13245,23 @@ impl LayoutWindow {
                 mc.set_single_range(final_range);
             }
         }
-        let now = Instant::now();
-        self.text_edit_manager.blink.reset_blink_on_input(now);
-        self.text_edit_manager.blink.set_blink_timer_active(true);
+        // Only an EDITABLE click owns a caret, and the blink flag means "an OS
+        // timer is running", not "a caret exists". Asserting it on every
+        // selectable-text click claimed a timer nobody had armed: the next
+        // focus into a real editable then read `timer_was_active == true` in
+        // `handle_focus_change_for_cursor_blink`, returned `NoChange` instead
+        // of `Start`, and the caret stayed solid for the window's lifetime.
+        //
+        // Arming stays the focus path's job; the flag is only raised here when
+        // the blink timer is genuinely in the timer map already (a click INSIDE
+        // an editable that is already focused and already blinking).
+        if is_contenteditable {
+            let now = Instant::now();
+            self.text_edit_manager.blink.reset_blink_on_input(now);
+            if self.timers.contains_key(&azul_core::task::CURSOR_BLINK_TIMER_ID) {
+                self.text_edit_manager.blink.set_blink_timer_active(true);
+            }
+        }
         // No legacy cursor manager sync needed -- multi_cursor is the source of truth
 
         // Regenerate display list so cursor appears at the clicked position
@@ -13037,12 +13490,9 @@ impl LayoutWindow {
         // a DeleteText operation with styled pre/post snapshots; the actual
         // undo/redo restore uses the snapshots (keyed by changeset id),
         // deleted_text/range are informational for the C-API inspect fns.
-        // Ids count DOWN from usize::MAX so they cannot collide with the
-        // insertion counter in apply_text_changeset (counts up from 0).
         {
-            use crate::managers::changeset::{TextChangeset, TextOpDeleteText, TextOperation};
+            use crate::managers::changeset::{TextOpDeleteText, TextOperation};
             use crate::managers::undo_redo::NodeStateSnapshot;
-            static DELETE_CHANGESET_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
             let pre_text = self.extract_text_from_inline_content(&content);
             let old_cursor = current_selections.first().and_then(|sel| match sel {
@@ -13066,8 +13516,6 @@ impl LayoutWindow {
                     end: anchor,
                 }
             });
-            let changeset_id =
-                usize::MAX - DELETE_CHANGESET_COUNTER.fetch_add(1, Ordering::SeqCst);
             let timestamp = {
                 #[cfg(feature = "std")]
                 {
@@ -13085,24 +13533,22 @@ impl LayoutWindow {
                 text_content: pre_text.into(),
                 cursor_position: old_cursor.into(),
                 selection_range: old_range.into(),
-                timestamp: timestamp.clone(),
+                timestamp,
             };
-            let changeset = TextChangeset {
-                id: changeset_id,
+            // Deletions never pass through the text-input record pipeline, so
+            // the commit queues the host's Input notification here.
+            self.record_text_edit_undo(
                 target,
-                operation: TextOperation::DeleteText(TextOpDeleteText {
+                pre_state,
+                content,
+                new_content.clone(),
+                TextOperation::DeleteText(TextOpDeleteText {
                     range: record_range,
                     deleted_text: "".into(),
                     new_cursor: CursorPosition::Uninitialized,
                 }),
-                timestamp,
-            };
-            self.undo_redo_manager.store_content_snapshot(
-                changeset_id,
-                content,
-                new_content.clone(),
+                TextEditNotify::QueueInput,
             );
-            self.undo_redo_manager.record_operation(changeset, pre_state);
         }
 
         // Update multi-cursor state
@@ -13629,7 +14075,7 @@ impl LayoutWindow {
             system_style: _,
             monitors: _,
             font_stacks_hash: _,
-            pre_preedit_content: _,
+            preedit_shaped_node: _,
             input_interpreter: _,
             post_filter: _,
             custom_e2e_op: _,
@@ -14662,232 +15108,6 @@ mod autotest_generated {
     }
 
     // ==================================================================
-    // calculate_edge_distance
-    // ==================================================================
-
-    #[test]
-    fn edge_distance_for_a_rect_fully_inside_its_container() {
-        let d = calculate_edge_distance(rect(10.0, 10.0, 20.0, 20.0), rect(0.0, 0.0, 100.0, 100.0));
-        assert_eq!(d.left, 10.0);
-        assert_eq!(d.right, 70.0);
-        assert_eq!(d.top, 10.0);
-        assert_eq!(d.bottom, 70.0);
-    }
-
-    #[test]
-    fn edge_distance_clamps_negative_overhang_to_zero() {
-        // Rect hangs off the top-left.
-        let d = calculate_edge_distance(rect(-50.0, -50.0, 10.0, 10.0), rect(0.0, 0.0, 100.0, 100.0));
-        assert_eq!(d.left, 0.0);
-        assert_eq!(d.top, 0.0);
-        assert_eq!(d.right, 140.0);
-        assert_eq!(d.bottom, 140.0);
-        // Rect dwarfs the container.
-        let d = calculate_edge_distance(rect(0.0, 0.0, 1000.0, 1000.0), rect(0.0, 0.0, 100.0, 100.0));
-        assert_eq!(d.left, 0.0);
-        assert_eq!(d.top, 0.0);
-        assert_eq!(d.right, 0.0);
-        assert_eq!(d.bottom, 0.0);
-    }
-
-    #[test]
-    fn edge_distance_never_returns_nan_or_a_negative_number() {
-        let hostile = [
-            (rect(f32::NAN, f32::NAN, f32::NAN, f32::NAN), rect(0.0, 0.0, 100.0, 100.0)),
-            (rect(0.0, 0.0, 10.0, 10.0), rect(f32::NAN, f32::NAN, f32::NAN, f32::NAN)),
-            (
-                rect(f32::INFINITY, f32::INFINITY, 1.0, 1.0),
-                rect(0.0, 0.0, 100.0, 100.0),
-            ),
-            (
-                rect(0.0, 0.0, f32::INFINITY, f32::INFINITY),
-                rect(0.0, 0.0, f32::INFINITY, f32::INFINITY),
-            ),
-            (LogicalRect::zero(), LogicalRect::zero()),
-            (
-                rect(f32::MIN, f32::MIN, f32::MAX, f32::MAX),
-                rect(f32::MAX, f32::MAX, f32::MIN, f32::MIN),
-            ),
-        ];
-        for (r, c) in hostile {
-            let d = calculate_edge_distance(r, c);
-            for (name, v) in [
-                ("left", d.left),
-                ("right", d.right),
-                ("top", d.top),
-                ("bottom", d.bottom),
-            ] {
-                assert!(!v.is_nan(), "{name} is NaN for rect={r:?} container={c:?}");
-                assert!(v >= 0.0, "{name} is negative ({v}) for rect={r:?}");
-            }
-        }
-        // Specifically: NaN in => 0.0 out (f32::max ignores NaN).
-        let d = calculate_edge_distance(
-            rect(f32::NAN, f32::NAN, 1.0, 1.0),
-            rect(0.0, 0.0, 100.0, 100.0),
-        );
-        assert_eq!(d.left, 0.0);
-        assert_eq!(d.top, 0.0);
-    }
-
-    // ==================================================================
-    // calculate_instant_scroll_delta
-    // ==================================================================
-
-    #[test]
-    fn instant_scroll_delta_is_zero_when_bounds_sit_comfortably_inside() {
-        let d = calculate_instant_scroll_delta(rect(20.0, 20.0, 10.0, 10.0), rect(0.0, 0.0, 100.0, 100.0));
-        assert_eq!(d, pos(0.0, 0.0));
-    }
-
-    #[test]
-    fn instant_scroll_delta_pushes_by_the_five_px_padding() {
-        // Flush against the near edge -> scroll back by PADDING.
-        let d = calculate_instant_scroll_delta(rect(0.0, 0.0, 10.0, 10.0), rect(0.0, 0.0, 100.0, 100.0));
-        assert_eq!(d, pos(-5.0, -5.0));
-        // Partially inside the near padding band.
-        let d = calculate_instant_scroll_delta(rect(3.0, 3.0, 1.0, 1.0), rect(0.0, 0.0, 100.0, 100.0));
-        assert_eq!(d, pos(-2.0, -2.0));
-        // Past the far edge -> scroll forward past it, plus PADDING.
-        let d = calculate_instant_scroll_delta(rect(95.0, 95.0, 10.0, 10.0), rect(0.0, 0.0, 100.0, 100.0));
-        assert_eq!(d, pos(10.0, 10.0));
-    }
-
-    #[test]
-    fn instant_scroll_delta_near_edge_branch_wins_for_an_oversized_rect() {
-        // The rect overflows BOTH edges; only the near-edge branch may fire
-        // (they are `if / else if`), so the delta is the near-edge one.
-        let d = calculate_instant_scroll_delta(rect(0.0, 0.0, 500.0, 500.0), rect(0.0, 0.0, 100.0, 100.0));
-        assert_eq!(d, pos(-5.0, -5.0));
-    }
-
-    #[test]
-    fn instant_scroll_delta_with_nan_bounds_is_zero_not_nan() {
-        let d = calculate_instant_scroll_delta(
-            rect(f32::NAN, f32::NAN, f32::NAN, f32::NAN),
-            rect(0.0, 0.0, 100.0, 100.0),
-        );
-        assert!(!d.x.is_nan() && !d.y.is_nan(), "NaN must not leak into the scroll delta");
-        assert_eq!(d, pos(0.0, 0.0));
-    }
-
-    #[test]
-    fn instant_scroll_delta_saturates_instead_of_panicking_on_huge_bounds() {
-        let d = calculate_instant_scroll_delta(
-            rect(f32::MAX, f32::MAX, f32::MAX, f32::MAX),
-            rect(0.0, 0.0, 100.0, 100.0),
-        );
-        assert!(d.x.is_infinite() && d.x > 0.0);
-        assert!(d.y.is_infinite() && d.y > 0.0);
-        // A zero-size viewport still yields a finite, deterministic nudge.
-        let d = calculate_instant_scroll_delta(LogicalRect::zero(), LogicalRect::zero());
-        assert_eq!(d, pos(-5.0, -5.0));
-    }
-
-    // ==================================================================
-    // calculate_accelerated_scroll_delta
-    // ==================================================================
-
-    fn edges(left: f32, right: f32, top: f32, bottom: f32) -> EdgeDistance {
-        EdgeDistance {
-            left,
-            right,
-            top,
-            bottom,
-        }
-    }
-
-    #[test]
-    fn accelerated_scroll_delta_dead_zone_produces_no_movement() {
-        assert_eq!(
-            calculate_accelerated_scroll_delta(edges(0.0, 0.0, 0.0, 0.0)),
-            pos(0.0, 0.0)
-        );
-        // Anything strictly inside the 20px dead zone.
-        assert_eq!(
-            calculate_accelerated_scroll_delta(edges(19.999, 1000.0, 19.999, 1000.0)),
-            pos(0.0, 0.0)
-        );
-    }
-
-    #[test]
-    fn accelerated_scroll_delta_zone_boundaries_are_exact() {
-        // The comparisons are `<`, so each boundary value belongs to the NEXT
-        // (faster) zone.
-        let cases = [
-            (19.999_f32, 0.0_f32),
-            (20.0, -2.0),
-            (49.999, -2.0),
-            (50.0, -4.0),
-            (99.999, -4.0),
-            (100.0, -8.0),
-            (199.999, -8.0),
-            (200.0, -16.0),
-            (1e9, -16.0),
-        ];
-        for (dist, expected_x) in cases {
-            let d = calculate_accelerated_scroll_delta(edges(dist, f32::MAX, dist, f32::MAX));
-            assert_eq!(d.x, expected_x, "left={dist}");
-            assert_eq!(d.y, expected_x, "top={dist}");
-        }
-    }
-
-    #[test]
-    fn accelerated_scroll_delta_picks_the_nearer_edge_and_signs_it() {
-        // Nearer to the left/top -> negative (scroll back).
-        let d = calculate_accelerated_scroll_delta(edges(30.0, 1000.0, 30.0, 1000.0));
-        assert_eq!(d, pos(-2.0, -2.0));
-        // Nearer to the right/bottom -> positive (scroll forward).
-        let d = calculate_accelerated_scroll_delta(edges(1000.0, 60.0, 1000.0, 60.0));
-        assert_eq!(d, pos(4.0, 4.0));
-        // Ties go to the far edge (`<` is false), i.e. positive.
-        let d = calculate_accelerated_scroll_delta(edges(60.0, 60.0, 60.0, 60.0));
-        assert_eq!(d, pos(4.0, 4.0));
-    }
-
-    #[test]
-    fn accelerated_scroll_delta_treats_negative_distances_as_dead_zone() {
-        let d = calculate_accelerated_scroll_delta(edges(-100.0, 1000.0, -100.0, 1000.0));
-        assert_eq!(d.x, 0.0);
-        assert_eq!(d.y, 0.0);
-    }
-
-    #[test]
-    fn accelerated_scroll_delta_with_nan_distances_falls_into_the_fastest_zone() {
-        // Every `dist < ZONE` comparison is false for NaN, so the chain falls
-        // through to VERY_FAST_SPEED. Pinned: NaN edge distances scroll at the
-        // maximum rate instead of not scrolling.
-        let d = calculate_accelerated_scroll_delta(edges(f32::NAN, f32::NAN, f32::NAN, f32::NAN));
-        assert_eq!(d, pos(16.0, 16.0));
-        assert!(!d.x.is_nan() && !d.y.is_nan());
-    }
-
-    #[test]
-    fn accelerated_scroll_delta_speed_is_always_bounded() {
-        let vals = [
-            0.0_f32,
-            -1.0,
-            19.9,
-            20.0,
-            50.0,
-            100.0,
-            200.0,
-            f32::MAX,
-            f32::INFINITY,
-            f32::NEG_INFINITY,
-            f32::NAN,
-        ];
-        for l in vals {
-            for r in vals {
-                let d = calculate_accelerated_scroll_delta(edges(l, r, l, r));
-                assert!(d.x.abs() <= 16.0, "|x| out of range for ({l}, {r}): {}", d.x);
-                assert!(d.y.abs() <= 16.0, "|y| out of range for ({l}, {r}): {}", d.y);
-                assert!(!d.x.is_nan() && !d.y.is_nan());
-            }
-        }
-    }
-
-    // ==================================================================
     // LayoutWindow::calculate_scrollbar_opacity
     // ==================================================================
 
@@ -15344,6 +15564,169 @@ mod autotest_generated {
         assert!(!w.is_node_contenteditable_internal(DomId::ROOT_ID, NodeId::new(2)));
         // ...but it inherits editability from its ancestor.
         assert!(w.is_node_contenteditable_inherited_internal(DomId::ROOT_ID, NodeId::new(2)));
+    }
+
+    // ==================================================================
+    // Editable-buffer text collection
+    // ==================================================================
+
+    fn window_for(dom: StyledDom) -> LayoutWindow {
+        let mut w = fresh_window();
+        w.layout_results
+            .insert(DomId::ROOT_ID, bare_layout_result(dom));
+        w
+    }
+
+    fn text_of(w: &LayoutWindow, node: usize) -> String {
+        let content = w.get_text_before_textinput(DomId::ROOT_ID, NodeId::new(node));
+        w.extract_text_from_inline_content(&content)
+    }
+
+    #[test]
+    fn get_text_before_textinput_descends_through_block_and_inline_wrappers() {
+        // `div[contenteditable] > p > text` is the shape the converted text
+        // widgets, azul-writer and the contenteditable e2e fixtures all use.
+        // Reading it as EMPTY made the first keystroke diff against "" and wipe
+        // the value.
+        let w = window_for(StyledDom::create_from_dom(
+            Dom::create_div()
+                .with_contenteditable(true)
+                .with_child(Dom::create_p().with_child(Dom::create_text("hello"))),
+        ));
+        assert_eq!(text_of(&w, 0), "hello", "a <p> wrapper must not hide the value");
+        assert_eq!(text_of(&w, 1), "hello", "and the <p> itself reads the same");
+
+        // Inline wrappers count too — the buffer is the flattened inline content
+        // of the subtree, not just its direct text children.
+        let w = window_for(StyledDom::create_from_dom(
+            Dom::create_div().with_child(
+                Dom::create_p()
+                    .with_child(Dom::create_text("a"))
+                    .with_child(Dom::create_em().with_child(Dom::create_text("b")))
+                    .with_child(Dom::create_span().with_child(Dom::create_text("c"))),
+            ),
+        ));
+        assert_eq!(text_of(&w, 0), "abc");
+    }
+
+    #[test]
+    fn get_text_before_textinput_leaves_metadata_subtrees_out() {
+        // `<head>` and the metadata elements are never rendered, so their text
+        // must not leak into an editable value.
+        let w = window_for(StyledDom::create_from_dom(
+            Dom::create_div()
+                .with_child(Dom::create_head().with_child(Dom::create_text("metadata")))
+                .with_child(Dom::create_p().with_child(Dom::create_text("body"))),
+        ));
+        assert_eq!(text_of(&w, 0), "body");
+        assert_eq!(text_of(&w, 1), "", "a metadata container collects nothing");
+    }
+
+    #[test]
+    fn collect_text_from_children_skips_a_contenteditable_false_island() {
+        // The text widgets keep their placeholder prompt INSIDE the editable
+        // container and wall it off with `contenteditable="false"` — the same
+        // attribute that stops the inheritance walk. Collecting it would type the
+        // prompt into the user's value.
+        let w = window_for(StyledDom::create_from_dom(
+            Dom::create_div()
+                .with_contenteditable(true)
+                .with_child(
+                    Dom::create_p()
+                        .with_attribute(AttributeType::ContentEditable(false))
+                        .with_child(Dom::create_text("Type here...")),
+                )
+                .with_child(Dom::create_p().with_child(Dom::create_text("real value"))),
+        ));
+        assert_eq!(text_of(&w, 0), "real value");
+        // The wall is about the parent's collection, not a global mute: asked
+        // directly, the island still reports its own text.
+        assert_eq!(text_of(&w, 1), "Type here...");
+    }
+
+    #[test]
+    fn ifc_candidate_children_puts_the_carets_block_ahead_of_document_order() {
+        use azul_core::selection::MultiCursorState;
+
+        // `container > [placeholder p, value p]`: document order hands the IFC to
+        // the placeholder, so `reshape_text_node` has to ask the caret first.
+        let mut w = window_for(StyledDom::create_from_dom(
+            Dom::create_div()
+                .with_child(Dom::create_p().with_child(Dom::create_text("prompt")))
+                .with_child(Dom::create_p().with_child(Dom::create_text("value"))),
+        ));
+
+        assert_eq!(
+            w.ifc_candidate_children(DomId::ROOT_ID, NodeId::new(0)),
+            vec![NodeId::new(1), NodeId::new(3)],
+            "with no caret the order is the document's"
+        );
+
+        // Caret on the TEXT LEAF of the second <p>: the block that owns it wins.
+        w.text_edit_manager.multi_cursor = Some(MultiCursorState::new_with_cursor(
+            TextCursor {
+                cluster_id: GraphemeClusterId {
+                    source_run: 0,
+                    start_byte_in_run: 0,
+                },
+                affinity: CursorAffinity::Leading,
+            },
+            dnid(4),
+            0,
+        ));
+        assert_eq!(
+            w.ifc_candidate_children(DomId::ROOT_ID, NodeId::new(0)),
+            vec![NodeId::new(3), NodeId::new(1)],
+            "the caret's block must be searched first"
+        );
+    }
+
+    #[test]
+    fn caret_blink_interval_falls_back_to_the_os_rate_and_honours_never_blink() {
+        use crate::managers::text_edit::CURSOR_BLINK_INTERVAL;
+
+        fn os_style(rate_ms: u32) -> Arc<azul_css::system::SystemStyle> {
+            let mut style = azul_css::system::SystemStyle::default();
+            style.input.caret_blink_rate_ms = rate_ms;
+            Arc::new(style)
+        }
+
+        let mut w = window_with_fixture();
+        let node = NodeId::new(1);
+
+        // Nothing captured from the OS yet -> the 530 ms default.
+        assert_eq!(
+            w.caret_blink_interval_for(DomId::ROOT_ID, node),
+            CURSOR_BLINK_INTERVAL
+        );
+
+        // With CSS silent, the OS rate is used verbatim.
+        w.set_system_style(os_style(1200));
+        assert_eq!(
+            w.caret_blink_interval_for(DomId::ROOT_ID, node),
+            Duration::from_millis(1200)
+        );
+
+        // Windows' INFINITE and GNOME's `cursor-blink = false` both mean
+        // "never toggle".
+        for never in [0, u32::MAX] {
+            w.set_system_style(os_style(never));
+            assert_eq!(
+                w.caret_blink_interval_for(DomId::ROOT_ID, node),
+                Duration::from_millis(u64::from(u32::MAX)),
+                "caret_blink_rate_ms = {never} must not blink"
+            );
+        }
+
+        // An explicit stylesheet value still wins over the OS.
+        let mut styled = window_for(StyledDom::create_from_dom(
+            Dom::create_div().with_css("caret-animation-duration: 250ms;"),
+        ));
+        styled.set_system_style(os_style(1200));
+        assert_eq!(
+            styled.caret_blink_interval_for(DomId::ROOT_ID, NodeId::new(0)),
+            Duration::from_millis(250)
+        );
     }
 
     // ==================================================================

--- a/layout/src/window.rs
+++ b/layout/src/window.rs
@@ -2076,8 +2076,8 @@ impl LayoutWindow {
         &mut self,
         target: DomNodeId,
         pre_state: crate::managers::undo_redo::NodeStateSnapshot,
-        pre_content: Vec<crate::text3::cache::InlineContent>,
-        post_content: Vec<crate::text3::cache::InlineContent>,
+        pre_content: Vec<InlineContent>,
+        post_content: Vec<InlineContent>,
         operation: crate::managers::changeset::TextOperation,
         notify: TextEditNotify,
     ) -> usize {
@@ -2112,7 +2112,7 @@ impl LayoutWindow {
     /// (deduplicated, order-preserving). The host pass dispatches one
     /// `EventType::Input` per returned host.
     pub fn take_text_edit_notifications(&mut self) -> Vec<DomNodeId> {
-        let mut seen = std::collections::BTreeSet::new();
+        let mut seen = BTreeSet::new();
         self.text_edit_manager
             .pending_edit_notifications
             .drain(..)
@@ -12010,7 +12010,7 @@ impl LayoutWindow {
     /// Shape the live IME composition into the node's inline layout and
     /// regenerate the display list.
     ///
-    /// Called from the platform IME handler (setMarkedText / preedit_string).
+    /// Called from the platform IME handler (`setMarkedText` / `preedit_string`).
     /// Composes `base text + preedit` at the caret and re-shapes THAT — the
     /// composed string is never written to the content overlay, so it exists
     /// only as glyphs.

--- a/layout/src/window_state.rs
+++ b/layout/src/window_state.rs
@@ -209,11 +209,11 @@ mod autotest_generated {
     }
 
     extern "C" fn cb_beta(_: RefAny, _: LayoutCallbackInfo) -> Dom {
-        Dom::create_text("beta")
+        Dom::create_text_do_not_use_without_block_level_wrapper("beta")
     }
 
     extern "C" fn cb_gamma(_: RefAny, _: LayoutCallbackInfo) -> Dom {
-        Dom::create_text("gamma-gamma-gamma")
+        Dom::create_text_do_not_use_without_block_level_wrapper("gamma-gamma-gamma")
     }
 
     /// Stored by `create` but never invoked by it — invoking it fails the test.

--- a/layout/src/xml/mod.rs
+++ b/layout/src/xml/mod.rs
@@ -131,7 +131,7 @@ use xmlparser::Tokenizer;
             return DomXml {
                 parsed_dom: {
                     let mut dom = Dom::create_body()
-                        .with_children(vec![Dom::create_text(format!("{e}"))].into());
+                        .with_children(vec![Dom::create_text_do_not_use_without_block_level_wrapper(format!("{e}"))].into());
                     StyledDom::create(&mut dom, error_css)
                 },
             };
@@ -144,7 +144,7 @@ use xmlparser::Tokenizer;
             return DomXml {
                 parsed_dom: {
                     let mut dom = Dom::create_body()
-                        .with_children(vec![Dom::create_text(format!("{e}"))].into());
+                        .with_children(vec![Dom::create_text_do_not_use_without_block_level_wrapper(format!("{e}"))].into());
                     StyledDom::create(&mut dom, error_css)
                 },
             };
@@ -165,7 +165,7 @@ use xmlparser::Tokenizer;
     let component_map = ComponentMap::with_builtin();
     match str_to_dom_unstyled(xml.root.as_ref(), &component_map) {
         Ok(dom) => dom,
-        Err(e) => Dom::create_body().with_children(vec![Dom::create_text(format!("{e}"))].into()),
+        Err(e) => Dom::create_body().with_children(vec![Dom::create_text_do_not_use_without_block_level_wrapper(format!("{e}"))].into()),
     }
 }
 
@@ -592,7 +592,7 @@ fn parse_xml_to_fast_dom_with_css(xml: &str) -> Result<(azul_core::dom::FastDom,
                         let inside_body = tag_stack.iter().any(|t| t == "body");
                         if inside_body || !text_str.trim().is_empty() {
                             let decoded = decode_xml_entities(text_str);
-                            builder.add_leaf(NodeData::create_text(str_arena.intern(&decoded)));
+                            builder.add_leaf(NodeData::create_text_do_not_use_without_block_level_wrapper(str_arena.intern(&decoded)));
                         }
                     }
                 }
@@ -637,7 +637,7 @@ pub fn domxml_from_file<I: AsRef<Path>>(
                 parsed_dom: {
                     let mut dom = Dom::create_body()
                         .with_children(
-                            vec![Dom::create_text(format!(
+                            vec![Dom::create_text_do_not_use_without_block_level_wrapper(format!(
                                 "Error reading: \"{}\": {}",
                                 file_path.as_ref().to_string_lossy(),
                                 e

--- a/layout/tests/block_merge_filter.rs
+++ b/layout/tests/block_merge_filter.rs
@@ -31,7 +31,7 @@ fn cls(name: &str) -> azul_core::dom::IdOrClassVec {
 fn para(text: &str) -> Dom {
     Dom::create_div()
         .with_ids_and_classes(cls("p"))
-        .with_child(Dom::create_text(text))
+        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper(text))
 }
 
 fn layout(mut dom: Dom) -> LayoutWindow {
@@ -98,7 +98,7 @@ fn whitespace_text_between_blocks_is_skipped() {
     let mut lw = layout(
         Dom::create_body()
             .with_child(para("first"))
-            .with_child(Dom::create_text("\n    "))
+            .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("\n    "))
             .with_child(para("second")),
     );
     assert_eq!(
@@ -115,16 +115,16 @@ fn first_list_item_has_no_merge_partner_inside_the_list() {
     // whitespace (or anything outside the list).
     let list = Dom::create_div()
         .with_ids_and_classes(cls("p"))
-        .with_child(Dom::create_text("\n  "))
+        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("\n  "))
         .with_child(
             Dom::create_div()
                 .with_ids_and_classes(cls("li"))
-                .with_child(Dom::create_text("one")),
+                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("one")),
         )
         .with_child(
             Dom::create_div()
                 .with_ids_and_classes(cls("li"))
-                .with_child(Dom::create_text("two")),
+                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("two")),
         );
     let mut lw = layout(Dom::create_body().with_child(list));
     assert_eq!(
@@ -144,7 +144,7 @@ fn a_real_inline_text_run_is_not_a_merge_partner() {
     // run (it has no child list) — engine default is a safe no-op.
     let mut lw = layout(
         Dom::create_body()
-            .with_child(Dom::create_text("intro text"))
+            .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("intro text"))
             .with_child(para("para")),
     );
     assert_eq!(merge_partner(&mut lw, 2), None);
@@ -160,7 +160,7 @@ fn an_inline_element_between_blocks_stops_the_merge() {
             .with_child(
                 Dom::create_div()
                     .with_ids_and_classes(cls("inline"))
-                    .with_child(Dom::create_text("inline island")),
+                    .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("inline island")),
             )
             .with_child(para("second")),
     );

--- a/layout/tests/cache_and_dirty_propagation.rs
+++ b/layout/tests/cache_and_dirty_propagation.rs
@@ -14,6 +14,7 @@
 //! - CSS 2.1 §8.3.1 (margin collapsing), §9.2.2.1 (anonymous boxes),
 //!   §10.3 (containing block), §14.2 (canvas background)
 
+use azul_layout::solver3::LayoutNodeId;
 use azul_core::dom::{Dom, DomId};
 use azul_core::geom::{LogicalPosition, LogicalRect, LogicalSize};
 use azul_core::resources::RendererResources;
@@ -482,7 +483,7 @@ fn test_whitespace_between_blocks_no_spurious_ifc() {
     let mut anonymous_ifc_count = 0;
     for (idx, node) in tree.nodes.iter().enumerate() {
         if node.dom_node_id.is_none() {
-            if let Some(cold) = tree.cold(idx) {
+            if let Some(cold) = tree.cold(LayoutNodeId::new(idx)) {
                 if let Some(azul_layout::solver3::layout_tree::AnonymousBoxType::InlineWrapper) = cold.anonymous_type {
                     anonymous_ifc_count += 1;
                 }

--- a/layout/tests/caret_scroll_glide.rs
+++ b/layout/tests/caret_scroll_glide.rs
@@ -30,7 +30,7 @@ fn build(animations: SystemAnimations) -> LayoutWindow {
     let mut dom = Dom::create_body().with_child(
         Dom::create_div()
             .with_ids_and_classes(vec![azul_core::dom::IdOrClass::Class("clip".into())].into())
-            .with_child(editor.with_child(Dom::create_text(long.as_str()))),
+            .with_child(editor.with_child(Dom::create_text_do_not_use_without_block_level_wrapper(long.as_str()))),
     );
     let (css, _) = azul_css::parser2::new_from_str(CSS);
     let styled_dom = StyledDom::create(&mut dom, css);

--- a/layout/tests/caret_tween.rs
+++ b/layout/tests/caret_tween.rs
@@ -55,7 +55,7 @@ fn build_editor_window(animations: SystemAnimations) -> LayoutWindow {
     editor.set_contenteditable(true);
     editor.set_tab_index(TabIndex::Auto);
     let mut dom =
-        Dom::create_body().with_child(editor.with_child(Dom::create_text("hello world tween target")));
+        Dom::create_body().with_child(editor.with_child(Dom::create_text_do_not_use_without_block_level_wrapper("hello world tween target")));
 
     let (css, _) = azul_css::parser2::new_from_str(CSS);
     let styled_dom = StyledDom::create(&mut dom, css);
@@ -360,17 +360,17 @@ fn build_three_paragraphs(animations: SystemAnimations) -> LayoutWindow {
         .with_child(
             Dom::create_div()
                 .with_ids_and_classes(class("p"))
-                .with_child(Dom::create_text("first paragraph")),
+                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("first paragraph")),
         )
         .with_child(
             Dom::create_div()
                 .with_ids_and_classes(class("p"))
-                .with_child(Dom::create_text("second paragraph")),
+                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("second paragraph")),
         )
         .with_child(
             Dom::create_div()
                 .with_ids_and_classes(class("p"))
-                .with_child(Dom::create_text("third paragraph")),
+                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("third paragraph")),
         );
     let (css, _) = azul_css::parser2::new_from_str(P_CSS);
     let styled_dom = StyledDom::create(&mut dom, css);

--- a/layout/tests/contenteditable_e2e.rs
+++ b/layout/tests/contenteditable_e2e.rs
@@ -1890,3 +1890,54 @@ fn probe_incremental_keystroke_median() {
         "damage-present median regressed: {med_d:?} (was ~113 us)"
     );
 }
+
+/// PIN — audit F4 (focus before the first layout). A `set_focus` issued from
+/// a create callback used to VANISH: `resolve_focus_target` answers `Ok(None)`
+/// with empty `layout_results` and every caller applied that as "clear focus".
+/// It now parks on the `FocusManager` (`FocusResolution::Deferred`) and is
+/// applied by the layout tail / `finalize_pending_focus_changes` once a
+/// layout exists. This test is RED before that batch.
+#[test]
+fn focus_set_before_the_first_layout_survives_until_layout_exists() {
+    use azul_core::callbacks::FocusTarget;
+    use azul_layout::managers::focus_cursor::{resolve_focus_target_or_defer, FocusResolution};
+
+    let mut h = ContentEditableHarness::new(400.0, 300.0);
+    let dom_id = DomId { inner: 0 };
+    // body(0) > div(1): the deterministic assignment every test here uses.
+    let editor_node = NodeId::new(1);
+    let target_id =
+        DomNodeId { dom: dom_id, node: NodeHierarchyItemId::from(Some(editor_node)) };
+
+    {
+        let lw = h.layout_window.as_mut().unwrap();
+        assert!(lw.layout_results.is_empty(), "premise: nothing is laid out yet");
+        let r = resolve_focus_target_or_defer(
+            &mut lw.focus_manager,
+            &FocusTarget::Id(target_id),
+            &lw.layout_results,
+        );
+        assert!(matches!(r, Ok(FocusResolution::Deferred)));
+        // The whole bug in one line: focus is neither set NOR cleared.
+        assert!(lw.focus_manager.get_focused_node().is_none());
+        assert!(lw.focus_manager.has_deferred_focus_target());
+    }
+
+    let mut editor = Dom::create_div();
+    editor = editor.with_ids_and_classes(cls("editor").into());
+    editor.set_contenteditable(true);
+    editor.set_tab_index(TabIndex::Auto);
+    editor = editor.with_child(Dom::create_text("hello"));
+    let dom = Dom::create_body().with_child(editor);
+    h.layout_dom(dom, CE_CSS);
+
+    let lw = h.layout_window.as_mut().unwrap();
+    // The host's layout-tail / end-of-pass call.
+    lw.finalize_pending_focus_changes();
+    assert_eq!(lw.focus_manager.get_focused_node().copied(), Some(target_id));
+    assert!(lw.text_edit_manager.multi_cursor.is_some(), "the caret was seeded");
+    assert!(
+        !lw.focus_manager.has_deferred_focus_target(),
+        "queue drained, not re-queued"
+    );
+}

--- a/layout/tests/contenteditable_e2e.rs
+++ b/layout/tests/contenteditable_e2e.rs
@@ -7,6 +7,7 @@
 // 4. Verify damage rects cover only the text region
 // 5. Test cursor movement, selection, backspace
 
+use azul_layout::solver3::LayoutNodeId;
 use std::path::PathBuf;
 use azul_core::{
     dom::{Dom, DomId, DomNodeId, IdOrClass, NodeId, NodeType, TabIndex},
@@ -305,10 +306,10 @@ impl ContentEditableHarness {
         let result = lw.layout_results.get(&dom_id).unwrap();
         let tree = &result.layout_tree;
         for idx in 0..tree.nodes.len() {
-            let node = tree.get(idx).unwrap();
+            let node = tree.get(LayoutNodeId::new(idx)).unwrap();
             let children = tree.children(idx);
-            let has_ifc = tree.warm(idx).and_then(|w| w.ifc_membership.as_ref()).is_some();
-            let has_inline = tree.warm(idx).and_then(|w| w.inline_layout_result.as_ref()).is_some();
+            let has_ifc = tree.warm(LayoutNodeId::new(idx)).and_then(|w| w.ifc_membership.as_ref()).is_some();
+            let has_inline = tree.warm(LayoutNodeId::new(idx)).and_then(|w| w.inline_layout_result.as_ref()).is_some();
             eprintln!("  [layout_tree] idx={} dom_node_id={:?} children={:?} ifc_member={} has_inline={}",
                 idx, node.dom_node_id, children, has_ifc, has_inline);
         }
@@ -993,7 +994,7 @@ fn contenteditable_overflow_wraps_at_end_not_start() {
     // Find the inline layout result (on the text child or the contenteditable div)
     let mut inline_layout = None;
     for idx in 0..layout_result.layout_tree.nodes.len() {
-        if let Some(w) = layout_result.layout_tree.warm(idx) {
+        if let Some(w) = layout_result.layout_tree.warm(LayoutNodeId::new(idx)) {
             if let Some(ref cached) = w.inline_layout_result {
                 // (d7) materialized(): the stored layout is the
                 // retirement sentinel under the dense default; the
@@ -1415,12 +1416,12 @@ mod structural_roundtrip {
                 Some(azul_layout::solver3::layout_tree::AnonymousBoxType::SplitPreviewPart),
             );
             assert_eq!(
-                lr.layout_tree.children(part1).len(),
+                lr.layout_tree.children(part1.index()).len(),
                 2,
                 "alpha + beta stay in part 1"
             );
             assert_eq!(
-                lr.layout_tree.children(part2).len(),
+                lr.layout_tree.children(part2.index()).len(),
                 1,
                 "gamma moves to the preview part"
             );
@@ -1518,7 +1519,7 @@ mod structural_roundtrip {
             let lr = lw.layout_results.get(&dom_id).unwrap();
             let idx = lr.layout_tree.dom_to_layout.get(&ul_node).unwrap()[0];
             assert_eq!(
-                lr.layout_tree.children(idx).len(),
+                lr.layout_tree.children(idx.index()).len(),
                 2,
                 "the removed child's layout node detached from the preview tree"
             );
@@ -1587,7 +1588,7 @@ mod structural_roundtrip {
             let lr = lw.layout_results.get(&dom_id).unwrap();
             let p1_idx = lr.layout_tree.dom_to_layout.get(&p1_node).unwrap()[0];
             assert_eq!(
-                lr.layout_tree.children(p1_idx).len(),
+                lr.layout_tree.children(p1_idx.index()).len(),
                 2,
                 "p2's text child moved onto p1 in the preview tree"
             );
@@ -1595,7 +1596,7 @@ mod structural_roundtrip {
             let editor_idx = lr.layout_tree.dom_to_layout.get(&NodeId::new(1)).unwrap()[0];
             let p2_idx = lr.layout_tree.dom_to_layout.get(&p2_node).unwrap()[0];
             assert!(
-                !lr.layout_tree.children(editor_idx).contains(&p2_idx),
+                !lr.layout_tree.children(editor_idx.index()).contains(&p2_idx.index()),
                 "the merged-away block detached from its parent"
             );
         }
@@ -1674,8 +1675,8 @@ mod structural_roundtrip {
             let (p1, p2) = (indices[0], indices[1]);
             // Ordinal conservation: everything renders exactly once.
             let (n1, n2) = (
-                lr.layout_tree.children(p1).len(),
-                lr.layout_tree.children(p2).len(),
+                lr.layout_tree.children(p1.index()).len(),
+                lr.layout_tree.children(p2.index()).len(),
             );
             assert_eq!(
                 n1, 1,
@@ -1753,12 +1754,12 @@ mod structural_roundtrip {
             assert_eq!(indices.len(), 2, "two layout slots (part 1 + preview part)");
             let (p1, p2) = (indices[0], indices[1]);
             assert_eq!(
-                lr.layout_tree.children(p1).len(),
+                lr.layout_tree.children(p1.index()).len(),
                 1,
                 "part 1: the first half of the split wrapper"
             );
             assert_eq!(
-                lr.layout_tree.children(p2).len(),
+                lr.layout_tree.children(p2.index()).len(),
                 2,
                 "part 2: the wrapper's second half + the p"
             );

--- a/layout/tests/contenteditable_e2e.rs
+++ b/layout/tests/contenteditable_e2e.rs
@@ -396,7 +396,7 @@ fn keystroke_cost_on_the_incremental_path() {
     editor = editor.with_ids_and_classes(cls("editor").into());
     editor.set_contenteditable(true);
     editor.set_tab_index(TabIndex::Auto);
-    editor = editor.with_child(Dom::create_text(
+    editor = editor.with_child(Dom::create_text_do_not_use_without_block_level_wrapper(
         "the quick brown fox jumps over the lazy dog and keeps on running",
     ));
     let dom = Dom::create_body().with_child(editor);
@@ -536,7 +536,7 @@ fn contenteditable_initial_render() {
     editor = editor.with_ids_and_classes(cls("editor").into());
     editor.set_contenteditable(true);
     editor.set_tab_index(TabIndex::Auto);
-    let text_child = Dom::create_text("Hello World");
+    let text_child = Dom::create_text_do_not_use_without_block_level_wrapper("Hello World");
     editor = editor.with_child(text_child);
 
     let dom = Dom::create_body().with_child(editor);
@@ -604,7 +604,7 @@ fn contenteditable_text_input_changes_output() {
     editor = editor.with_ids_and_classes(cls("editor").into());
     editor.set_contenteditable(true);
     editor.set_tab_index(TabIndex::Auto);
-    editor = editor.with_child(Dom::create_text("Hello"));
+    editor = editor.with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Hello"));
 
     let dom = Dom::create_body().with_child(editor);
 
@@ -708,7 +708,7 @@ fn contenteditable_multiple_keystrokes() {
     editor = editor.with_ids_and_classes(cls("editor").into());
     editor.set_contenteditable(true);
     editor.set_tab_index(TabIndex::Auto);
-    editor = editor.with_child(Dom::create_text("AB"));
+    editor = editor.with_child(Dom::create_text_do_not_use_without_block_level_wrapper("AB"));
 
     let dom = Dom::create_body().with_child(editor);
 
@@ -761,12 +761,12 @@ fn contenteditable_damage_detection() {
     let mut h = ContentEditableHarness::new(400.0, 300.0);
 
     // Layout with two divs: a static header and a contenteditable editor
-    let label = Dom::create_text("Static Header").with_ids_and_classes(cls("label").into());
+    let label = Dom::create_text_do_not_use_without_block_level_wrapper("Static Header").with_ids_and_classes(cls("label").into());
     let mut editor = Dom::create_div();
     editor = editor.with_ids_and_classes(cls("editor").into());
     editor.set_contenteditable(true);
     editor.set_tab_index(TabIndex::Auto);
-    editor = editor.with_child(Dom::create_text("AAAA"));
+    editor = editor.with_child(Dom::create_text_do_not_use_without_block_level_wrapper("AAAA"));
 
     let dom = Dom::create_body()
         .with_child(label)
@@ -827,13 +827,13 @@ fn contenteditable_two_editors_isolated() {
     editor1 = editor1.with_ids_and_classes(cls("editor").into());
     editor1.set_contenteditable(true);
     editor1.set_tab_index(TabIndex::Auto);
-    editor1 = editor1.with_child(Dom::create_text("Editor 1"));
+    editor1 = editor1.with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Editor 1"));
 
     let mut editor2 = Dom::create_div();
     editor2 = editor2.with_ids_and_classes(cls("editor").into());
     editor2.set_contenteditable(true);
     editor2.set_tab_index(TabIndex::Auto);
-    editor2 = editor2.with_child(Dom::create_text("Editor 2"));
+    editor2 = editor2.with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Editor 2"));
 
     let dom = Dom::create_body()
         .with_child(editor1)
@@ -879,7 +879,7 @@ fn contenteditable_incremental_render_matches_full() {
     editor = editor.with_ids_and_classes(cls("editor").into());
     editor.set_contenteditable(true);
     editor.set_tab_index(TabIndex::Auto);
-    editor = editor.with_child(Dom::create_text("Test"));
+    editor = editor.with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Test"));
 
     let dom = Dom::create_body().with_child(editor);
     h.layout_dom(dom, CE_CSS);
@@ -959,7 +959,7 @@ fn contenteditable_overflow_wraps_at_end_not_start() {
     editor = editor.with_ids_and_classes(cls("editor").into());
     editor.set_contenteditable(true);
     editor.set_tab_index(TabIndex::Auto);
-    editor = editor.with_child(Dom::create_text(initial_text));
+    editor = editor.with_child(Dom::create_text_do_not_use_without_block_level_wrapper(initial_text));
 
     let dom = Dom::create_body().with_child(editor);
     h.layout_dom(dom, NARROW_CSS);
@@ -1068,7 +1068,7 @@ mod structural_roundtrip {
             .with_contenteditable(true)
             .with_tab_index(TabIndex::Auto);
         let mut p = Dom::create_p();
-        p.add_child(Dom::create_text("hello world"));
+        p.add_child(Dom::create_text_do_not_use_without_block_level_wrapper("hello world"));
         editor.add_child(p);
         editor
     }
@@ -1544,9 +1544,9 @@ mod structural_roundtrip {
             .with_contenteditable(true)
             .with_tab_index(TabIndex::Auto);
         let mut p1 = Dom::create_p();
-        p1.add_child(Dom::create_text("hello"));
+        p1.add_child(Dom::create_text_do_not_use_without_block_level_wrapper("hello"));
         let mut p2 = Dom::create_p();
-        p2.add_child(Dom::create_text("world"));
+        p2.add_child(Dom::create_text_do_not_use_without_block_level_wrapper("world"));
         model.add_child(p1);
         model.add_child(p2);
 
@@ -1626,11 +1626,11 @@ mod structural_roundtrip {
         // stacked unstyled divs is pixel-identical — the tree asserts below
         // would still hold, but the render check would be vacuous).
         let mut host = Dom::create_div().with_ids_and_classes(cls("host").into());
-        host.add_child(Dom::create_text("aaaa aaaa"));
+        host.add_child(Dom::create_text_do_not_use_without_block_level_wrapper("aaaa aaaa"));
         let mut para = Dom::create_p();
-        para.add_child(Dom::create_text("bbbb bbbb"));
+        para.add_child(Dom::create_text_do_not_use_without_block_level_wrapper("bbbb bbbb"));
         host.add_child(para);
-        host.add_child(Dom::create_text("cccc cccc"));
+        host.add_child(Dom::create_text_do_not_use_without_block_level_wrapper("cccc cccc"));
         model.add_child(host);
 
         let mut h = ContentEditableHarness::new(400.0, 300.0);
@@ -1708,10 +1708,10 @@ mod structural_roundtrip {
             .with_contenteditable(true)
             .with_tab_index(TabIndex::Auto);
         let mut host = Dom::create_div();
-        host.add_child(Dom::create_text("aaaa aaaa"));
-        host.add_child(Dom::create_text("bbbb bbbb"));
+        host.add_child(Dom::create_text_do_not_use_without_block_level_wrapper("aaaa aaaa"));
+        host.add_child(Dom::create_text_do_not_use_without_block_level_wrapper("bbbb bbbb"));
         let mut para = Dom::create_p();
-        para.add_child(Dom::create_text("cccc cccc"));
+        para.add_child(Dom::create_text_do_not_use_without_block_level_wrapper("cccc cccc"));
         host.add_child(para);
         model.add_child(host);
 
@@ -1786,11 +1786,11 @@ fn probe_incremental_keystroke_median() {
     editor = editor.with_ids_and_classes(cls("editor").into());
     editor.set_contenteditable(true);
     editor.set_tab_index(TabIndex::Auto);
-    editor = editor.with_child(Dom::create_text("Start: "));
+    editor = editor.with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Start: "));
     body = body.with_child(editor);
     for i in 0..200 {
         body = body.with_child(
-            Dom::create_div().with_child(Dom::create_text(azul_css::AzString::from(
+            Dom::create_div().with_child(Dom::create_text_do_not_use_without_block_level_wrapper(azul_css::AzString::from(
                 format!("Paragraph {i} with a reasonable amount of running text in it"),
             ))),
         );
@@ -1927,7 +1927,7 @@ fn focus_set_before_the_first_layout_survives_until_layout_exists() {
     editor = editor.with_ids_and_classes(cls("editor").into());
     editor.set_contenteditable(true);
     editor.set_tab_index(TabIndex::Auto);
-    editor = editor.with_child(Dom::create_text("hello"));
+    editor = editor.with_child(Dom::create_text_do_not_use_without_block_level_wrapper("hello"));
     let dom = Dom::create_body().with_child(editor);
     h.layout_dom(dom, CE_CSS);
 

--- a/layout/tests/cross_block_selection.rs
+++ b/layout/tests/cross_block_selection.rs
@@ -48,17 +48,17 @@ fn layout_three_paragraphs() -> LayoutWindow {
         .with_child(
             Dom::create_div()
                 .with_ids_and_classes(class("p"))
-                .with_child(Dom::create_text("first paragraph")),
+                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("first paragraph")),
         )
         .with_child(
             Dom::create_div()
                 .with_ids_and_classes(class("p"))
-                .with_child(Dom::create_text("second paragraph")),
+                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("second paragraph")),
         )
         .with_child(
             Dom::create_div()
                 .with_ids_and_classes(class("p"))
-                .with_child(Dom::create_text("third paragraph")),
+                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("third paragraph")),
         );
     let (css, _) = azul_css::parser2::new_from_str(CSS);
     let styled_dom = StyledDom::create(&mut dom, css);

--- a/layout/tests/demo_layout_regressions.rs
+++ b/layout/tests/demo_layout_regressions.rs
@@ -146,13 +146,13 @@ fn maps_demo_dom() -> Dom {
         button_row = button_row.with_child(
             Dom::create_div()
                 .with_ids_and_classes(class("btn"))
-                .with_child(Dom::create_text(label)),
+                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper(label)),
         );
     }
 
     let header = Dom::create_div()
         .with_ids_and_classes(class("header"))
-        .with_child(Dom::create_text("AzulMaps — centre 37.0000°, -122.0000° · zoom 2.0"))
+        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("AzulMaps — centre 37.0000°, -122.0000° · zoom 2.0"))
         .with_child(button_row);
 
     // The REAL widget, like examples/azul-maps does it (an empty-div
@@ -524,11 +524,11 @@ fn maps_demo_dom_with_css() -> Dom {
     let mut button_row = Dom::create_div().with_css("display: flex; flex-direction: row;");
     for label in ["←", "→", "↑", "↓", "+", "−", "Recentre", "Locate", "Clear pins"] {
         button_row = button_row
-            .with_child(Dom::create_div().with_css(BTN).with_child(Dom::create_text(label)));
+            .with_child(Dom::create_div().with_css(BTN).with_child(Dom::create_text_do_not_use_without_block_level_wrapper(label)));
     }
     let header = Dom::create_div()
         .with_css(HEADER)
-        .with_child(Dom::create_text("AzulMaps — centre 37.0000°, -122.0000° · zoom 2.0"))
+        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("AzulMaps — centre 37.0000°, -122.0000° · zoom 2.0"))
         .with_child(button_row);
     let map = MapWidget::create(MapTileLayer::default())
         .with_viewport(MapViewport::default())
@@ -586,7 +586,7 @@ fn maps_header_survives_incremental_relayout() {
 fn paint_canvas_with_menubar_wrapper_must_stretch_full_width() {
     let header = Dom::create_div()
         .with_ids_and_classes(class("header"))
-        .with_child(Dom::create_text("AzulPaint  ·  0 strokes  ·  Effect: Metaballs"));
+        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("AzulPaint  ·  0 strokes  ·  Effect: Metaballs"));
 
     let canvas = Dom::create_image(sizeless_image()).with_ids_and_classes(class("canvas"));
 
@@ -663,17 +663,17 @@ fn menubar_flex_row_items_lay_out_horizontally_without_clipping() {
         .with_child(
             Dom::create_div()
                 .with_ids_and_classes(class("mitem"))
-                .with_child(Dom::create_text("File")),
+                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("File")),
         )
         .with_child(
             Dom::create_div()
                 .with_ids_and_classes(class("mitem"))
-                .with_child(Dom::create_text("Edit")),
+                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Edit")),
         )
         .with_child(
             Dom::create_div()
                 .with_ids_and_classes(class("mitem"))
-                .with_child(Dom::create_text("View")),
+                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("View")),
         );
     let dom = Dom::create_body().with_child(bar);
     let css = r#"

--- a/layout/tests/display_list_ids.rs
+++ b/layout/tests/display_list_ids.rs
@@ -23,7 +23,7 @@ fn build_dom() -> StyledDom {
     let mut children = Vec::new();
     for i in 0..8 {
         children.push(
-            Dom::create_div().with_child(Dom::create_text(format!("paragraph number {i}"))),
+            Dom::create_div().with_child(Dom::create_text_do_not_use_without_block_level_wrapper(format!("paragraph number {i}"))),
         );
     }
     let mut dom = Dom::create_div().with_children(children.into());

--- a/layout/tests/dl_patch_golden.rs
+++ b/layout/tests/dl_patch_golden.rs
@@ -26,13 +26,13 @@ fn test_dom() -> StyledDom {
         .with_child(
             Dom::create_node(NodeType::Div)
                 .with_ids_and_classes(vec![IdOrClass::Class("page".into())].into())
-                .with_child(Dom::create_text("the first paragraph of golden text"))
-                .with_child(Dom::create_text("a second, slightly longer paragraph")),
+                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("the first paragraph of golden text"))
+                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("a second, slightly longer paragraph")),
         )
         .with_child(
             Dom::create_node(NodeType::Div)
                 .with_ids_and_classes(vec![IdOrClass::Class("bar".into())].into())
-                .with_child(Dom::create_text("chrome that tracks the window"))
+                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("chrome that tracks the window"))
         );
     let css_str = r#"
         * { margin: 0px; padding: 0px; }

--- a/layout/tests/document_edit_notify.rs
+++ b/layout/tests/document_edit_notify.rs
@@ -45,17 +45,17 @@ fn three_paragraph_dom() -> StyledDom {
         .with_child(
             Dom::create_div()
                 .with_ids_and_classes(class("p"))
-                .with_child(Dom::create_text("first paragraph")),
+                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("first paragraph")),
         )
         .with_child(
             Dom::create_div()
                 .with_ids_and_classes(class("p"))
-                .with_child(Dom::create_text("second paragraph")),
+                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("second paragraph")),
         )
         .with_child(
             Dom::create_div()
                 .with_ids_and_classes(class("p"))
-                .with_child(Dom::create_text("third paragraph")),
+                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("third paragraph")),
         );
     let (css, _) = azul_css::parser2::new_from_str(CSS);
     StyledDom::create(&mut dom, css)

--- a/layout/tests/embedded_font_renders.rs
+++ b/layout/tests/embedded_font_renders.rs
@@ -48,7 +48,7 @@ fn text_in_an_embedded_fontref_family_rasterizes() {
 
     // Exactly what `layout/src/icon.rs::create_font_icon_from_original` builds for
     // every widget icon: a text node whose font-family is `StyleFontFamily::Ref`.
-    let mut text = Dom::create_text("HELLO");
+    let mut text = Dom::create_text_do_not_use_without_block_level_wrapper("HELLO");
     text.root
         .set_css_props(CssPropertyWithConditionsVec::from_vec(vec![
             CssPropertyWithConditions::simple(CssProperty::font_family(

--- a/layout/tests/flex_intrinsic_text.rs
+++ b/layout/tests/flex_intrinsic_text.rs
@@ -73,7 +73,7 @@ fn btn_row(label: &str) -> Dom {
         .with_ids_and_classes(class("btn"))
         .with_child(Dom::create_div().with_ids_and_classes(class("ico")))
         .with_child(
-            Dom::create_text(label).with_ids_and_classes(class("lbl")),
+            Dom::create_text_do_not_use_without_block_level_wrapper(label).with_ids_and_classes(class("lbl")),
         )
 }
 
@@ -174,8 +174,8 @@ fn ribbon_widget_rows_size_to_one_line_text() {
     let styles = RibbonGroup::new("Styles".into())
         .with_item(RibbonItem::Gallery(RibbonGallery::new(
             vec![
-                RibbonGalleryCell::new(Dom::create_text("AaBbCcDc"), "Normal".into()),
-                RibbonGalleryCell::new(Dom::create_text("AaBbCcDc"), "No Spacing".into()),
+                RibbonGalleryCell::new(Dom::create_text_do_not_use_without_block_level_wrapper("AaBbCcDc"), "Normal".into()),
+                RibbonGalleryCell::new(Dom::create_text_do_not_use_without_block_level_wrapper("AaBbCcDc"), "No Spacing".into()),
             ]
             .into(),
         )))
@@ -296,7 +296,7 @@ fn ribbon_overflow_shrinks_only_the_gallery() {
     let g2 = RibbonGroup::new("Font".into())
         .with_item(wide_col(["Grow Font", "Shrink Font", "Clear Formatting"]));
     let cells: Vec<RibbonGalleryCell> = (0..8)
-        .map(|i| RibbonGalleryCell::new(Dom::create_text("AaBbCcDc"), format!("Style {i}").into()))
+        .map(|i| RibbonGalleryCell::new(Dom::create_text_do_not_use_without_block_level_wrapper("AaBbCcDc"), format!("Style {i}").into()))
         .collect();
     let g3 = RibbonGroup::new("Styles".into())
         .with_item(RibbonItem::Gallery(RibbonGallery::new(cells.into())))
@@ -518,8 +518,8 @@ fn two_text_children_in_a_flex_row_stay_on_one_line() {
 
     let btn = Dom::create_div()
         .with_ids_and_classes(class("btn"))
-        .with_child(Dom::create_text("X").with_ids_and_classes(class("glyph")))
-        .with_child(Dom::create_text("Format Painter").with_ids_and_classes(class("lbl")));
+        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("X").with_ids_and_classes(class("glyph")))
+        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Format Painter").with_ids_and_classes(class("lbl")));
     let dom = Dom::create_body().with_child(btn);
 
     let lw = layout_dom(dom, PROBE_CSS, 800.0, 100.0);
@@ -573,7 +573,7 @@ fn label_beside_a_resolved_fontref_icon_stays_on_one_line() {
     let btn = Dom::create_div()
         .with_ids_and_classes(class("btn"))
         .with_child(Dom::create_icon("content_cut").with_ids_and_classes(class("glyph")))
-        .with_child(Dom::create_text("Format Painter").with_ids_and_classes(class("lbl")));
+        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Format Painter").with_ids_and_classes(class("lbl")));
     let mut dom = Dom::create_body().with_child(btn);
 
     let (css, _) = azul_css::parser2::new_from_str(PROBE_CSS);
@@ -749,7 +749,7 @@ fn hit_testing_a_nodes_own_centre_returns_that_node() {
     };
 
     let cells: Vec<RibbonGalleryCell> = (0..8)
-        .map(|i| RibbonGalleryCell::new(Dom::create_text("AaBbCcDc"), format!("Style {i}").into()))
+        .map(|i| RibbonGalleryCell::new(Dom::create_text_do_not_use_without_block_level_wrapper("AaBbCcDc"), format!("Style {i}").into()))
         .collect();
     let tab = RibbonTab::new("HOME".into()).with_group(
         RibbonGroup::new("Styles".into())
@@ -960,7 +960,7 @@ fn hit_test_bounds_match_the_layout_rect_in_a_full_ribbon() {
         }))
     };
     let cells: Vec<RibbonGalleryCell> = (0..8)
-        .map(|i| RibbonGalleryCell::new(Dom::create_text("AaBbCcDc"), format!("Style {i}").into()))
+        .map(|i| RibbonGalleryCell::new(Dom::create_text_do_not_use_without_block_level_wrapper("AaBbCcDc"), format!("Style {i}").into()))
         .collect();
 
     let tab = RibbonTab::new("HOME".into())
@@ -989,7 +989,7 @@ fn hit_test_bounds_match_the_layout_rect_in_a_full_ribbon() {
         .with_css("display: flex; flex-direction: row; align-items: center; height: 30px;")
         .with_child(Dom::create_icon("save"))
         .with_child(Dom::create_icon("undo"))
-        .with_child(Dom::create_text("Document1 - AzWriter"))
+        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Document1 - AzWriter"))
         .with_child(Dom::create_icon("close"));
     let dom = Dom::create_body()
         .with_child(title_bar)
@@ -1188,7 +1188,7 @@ fn inline_viewport_conditions_are_applied() {
         ),
     ]);
 
-    let mut panel = Dom::create_div().with_child(Dom::create_text("touch"));
+    let mut panel = Dom::create_div().with_child(Dom::create_text_do_not_use_without_block_level_wrapper("touch"));
     panel.root.set_css_props(mobile_only);
     let dom = Dom::create_body().with_child(panel);
 
@@ -1307,7 +1307,7 @@ fn logical_overflow_properties_map_onto_physical_axes() {
     let dom = Dom::create_body().with_child(
         Dom::create_div()
             .with_ids_and_classes(class("h"))
-            .with_child(Dom::create_text("wide wide wide wide wide")),
+            .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("wide wide wide wide wide")),
     );
     let lw = layout_dom(dom, CSS, 800.0, 600.0);
     let lr = lw.layout_results.get(&DomId { inner: 0 }).expect("layout");
@@ -1345,7 +1345,7 @@ fn text_box_edge_cap_alphabetic_trims_to_the_metrics() {
         Dom::create_body().with_child(
             Dom::create_div()
                 .with_ids_and_classes(class("t"))
-                .with_child(Dom::create_text("Hello")),
+                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Hello")),
         )
     };
     let h_text = layout_dom(build(), CSS_TEXT, 400.0, 300.0)
@@ -1424,7 +1424,7 @@ fn absolute_line_heights_above_32px_survive_the_compact_cache() {
     let dom = Dom::create_body().with_child(
         Dom::create_div()
             .with_ids_and_classes(class("t"))
-            .with_child(Dom::create_text("one line")),
+            .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("one line")),
     );
     let lw = layout_dom(dom, CSS, 800.0, 600.0);
     let h = lw
@@ -1456,17 +1456,17 @@ fn shrink_to_fit_labels_do_not_wrap_with_the_system_sans_font() {
         .with_child(
             Dom::create_div()
                 .with_ids_and_classes(class("btn"))
-                .with_child(Dom::create_text("Format Painter")),
+                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Format Painter")),
         )
         .with_child(
             Dom::create_div()
                 .with_ids_and_classes(class("btn"))
-                .with_child(Dom::create_text("Decrease Indent")),
+                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Decrease Indent")),
         )
         .with_child(
             Dom::create_div()
                 .with_ids_and_classes(class("btn"))
-                .with_child(Dom::create_text("No Spacing")),
+                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("No Spacing")),
         );
     let lw = layout_dom(dom, CSS, 800.0, 400.0);
     // 0 body, 1 btn, 2 text, 3 btn, 4 text, 5 btn, 6 text
@@ -1533,7 +1533,7 @@ fn table_cell_padding_offsets_text_from_the_cell_top() {
             Dom::create_div().with_ids_and_classes(class("row")).with_child(
                 Dom::create_div()
                     .with_ids_and_classes(class("c"))
-                    .with_child(Dom::create_text("Red 1")),
+                    .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Red 1")),
             ),
         ),
     );
@@ -1657,8 +1657,8 @@ fn real_table_cells_center_their_text_vertically() {
         Dom::create_table_no_a11y().with_child(
             Dom::create_thead().with_child(
                 Dom::create_tr()
-                    .with_child(Dom::create_th().with_child(Dom::create_text("Header A")))
-                    .with_child(Dom::create_th().with_child(Dom::create_text("Header B"))),
+                    .with_child(Dom::create_th().with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Header A")))
+                    .with_child(Dom::create_th().with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Header B"))),
             ),
         ),
     );
@@ -1750,7 +1750,7 @@ fn glyph_advances_stay_linear_and_unquantized() {
     let w10 = {
         let dom = Dom::create_body().with_child(
             Dom::create_div().with_ids_and_classes(class("m"))
-                .with_child(Dom::create_text("llllllllll")),
+                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("llllllllll")),
         );
         layout_dom(dom, CSS, 800.0, 600.0)
             .get_node_layout_rect(node_id(1)).expect("10-run").size.width
@@ -1758,7 +1758,7 @@ fn glyph_advances_stay_linear_and_unquantized() {
     let (w40, expected) = {
         let dom = Dom::create_body().with_child(
             Dom::create_div().with_ids_and_classes(class("m"))
-                .with_child(Dom::create_text("llllllllllllllllllllllllllllllllllllllll")),
+                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("llllllllllllllllllllllllllllllllllllllll")),
         );
         let lw = layout_dom(dom, CSS, 800.0, 600.0);
         let w = lw.get_node_layout_rect(node_id(1)).expect("40-run").size.width;

--- a/layout/tests/flex_text_width_bug.rs
+++ b/layout/tests/flex_text_width_bug.rs
@@ -6,6 +6,7 @@
 ///
 /// Expected: Text should measure its intrinsic min-content width (widest word)
 /// and the flex item should have non-zero width.
+use azul_layout::solver3::LayoutNodeId;
 use azul_core::dom::{Dom, DomId};
 use azul_core::geom::{LogicalPosition, LogicalRect, LogicalSize};
 use azul_core::resources::RendererResources;
@@ -133,7 +134,7 @@ fn test_flex_column_child_text_has_nonzero_width() {
     // ...
 
     // Check titlebar (node 1) has non-zero width
-    let titlebar = tree.get(1).expect("Titlebar node should exist");
+    let titlebar = tree.get(LayoutNodeId::new(1)).expect("Titlebar node should exist");
     let titlebar_size = titlebar.used_size.expect("Titlebar should have used_size");
     
     println!("Titlebar size: {titlebar_size:?}");
@@ -147,7 +148,7 @@ fn test_flex_column_child_text_has_nonzero_width() {
     );
 
     // Check title-container (node 2) has non-zero width
-    let title_container = tree.get(2).expect("Title container node should exist");
+    let title_container = tree.get(LayoutNodeId::new(2)).expect("Title container node should exist");
     let container_size = title_container.used_size.expect("Container should have used_size");
     
     println!("Title container size: {container_size:?}");
@@ -249,9 +250,9 @@ fn test_flex_row_text_child_has_intrinsic_width() {
 
     // Debug: print all nodes
     for i in 0..10 {
-        if let Some(node) = tree.get(i) {
+        if let Some(node) = tree.get(LayoutNodeId::new(i)) {
             let size = node.used_size.unwrap_or_default();
-            let intrinsic = tree.warm(i).and_then(|w| w.intrinsic_sizes).unwrap_or_default();
+            let intrinsic = tree.warm(LayoutNodeId::new(i)).and_then(|w| w.intrinsic_sizes).unwrap_or_default();
             println!("Node {}: size={:?}, intrinsic_min_w={}, intrinsic_max_w={}, fc={:?}",
                 i, size, intrinsic.min_content_width, intrinsic.max_content_width, node.formatting_context);
         }
@@ -261,11 +262,11 @@ fn test_flex_row_text_child_has_intrinsic_width() {
     // Find a node that has non-zero intrinsic width (the text content node)
     let text_div_idx = (0..10)
         .find(|&i| {
-            let has_intrinsic = tree.warm(i)
+            let has_intrinsic = tree.warm(LayoutNodeId::new(i))
                 .and_then(|w| w.intrinsic_sizes)
                 .map(|s| s.min_content_width > 20.0)
                 .unwrap_or(false);
-            tree.get(i)
+            tree.get(LayoutNodeId::new(i))
                 .map(|n| {
                     has_intrinsic
                     && n.used_size.map(|s| s.width > 0.0).unwrap_or(false)
@@ -274,7 +275,7 @@ fn test_flex_row_text_child_has_intrinsic_width() {
         })
         .expect("Should find text div with non-zero width");
 
-    let text_div = tree.get(text_div_idx).expect("Text div should exist");
+    let text_div = tree.get(LayoutNodeId::new(text_div_idx)).expect("Text div should exist");
     let text_div_size = text_div.used_size.expect("Text div should have used_size");
     
     println!("Text div size: {text_div_size:?}");

--- a/layout/tests/flexbox_integration.rs
+++ b/layout/tests/flexbox_integration.rs
@@ -635,7 +635,7 @@ fn test_flexbox_flex_basis_auto() {
         .with_child(
             Dom::create_div()
                 .with_ids_and_classes(vec![IdOrClass::Class("item".into())].into())
-                .with_child(Dom::create_text("Content")),
+                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Content")),
         );
 
     let css = r#"

--- a/layout/tests/focus_ring_tween.rs
+++ b/layout/tests/focus_ring_tween.rs
@@ -27,7 +27,7 @@ fn build(animations: SystemAnimations) -> LayoutWindow {
         let mut b = Dom::create_div()
             .with_ids_and_classes(vec![azul_core::dom::IdOrClass::Class("btn".into())].into());
         b.set_tab_index(TabIndex::Auto);
-        b.with_child(Dom::create_text(label))
+        b.with_child(Dom::create_text_do_not_use_without_block_level_wrapper(label))
     };
     let mut dom = Dom::create_body()
         .with_child(btn("one"))

--- a/layout/tests/ifc_caching.rs
+++ b/layout/tests/ifc_caching.rs
@@ -7,6 +7,7 @@
 //! 4. `RestyleResult.max_relayout_scope` is tracked during restyle
 //! 5. IFC layouts with text produce correct item_metrics
 
+use azul_layout::solver3::LayoutNodeId;
 use azul_core::dom::{Dom, DomId};
 use azul_core::geom::{LogicalPosition, LogicalRect, LogicalSize};
 use azul_core::resources::RendererResources;
@@ -415,7 +416,7 @@ fn test_ifc_layout_produces_item_metrics() {
     // Find nodes with inline_layout_result (IFC roots)
     let ifc_nodes: Vec<(usize, &CachedInlineLayout)> = tree.nodes.iter().enumerate()
         .filter_map(|(idx, _)| {
-            tree.warm(idx)
+            tree.warm(LayoutNodeId::new(idx))
                 .and_then(|w| w.inline_layout_result.as_ref())
                 .map(|ilr| (idx, &**ilr))
         })
@@ -470,7 +471,7 @@ fn test_ifc_layout_metrics_have_correct_line_indices() {
 
     let ifc_nodes: Vec<(usize, &CachedInlineLayout)> = tree.nodes.iter().enumerate()
         .filter_map(|(idx, _)| {
-            tree.warm(idx)
+            tree.warm(LayoutNodeId::new(idx))
                 .and_then(|w| w.inline_layout_result.as_ref())
                 .map(|ilr| (idx, &**ilr))
         })
@@ -513,7 +514,7 @@ fn test_ifc_layout_metrics_x_offsets_increase_on_same_line() {
 
     let ifc_nodes: Vec<(usize, &CachedInlineLayout)> = tree.nodes.iter().enumerate()
         .filter_map(|(idx, _)| {
-            tree.warm(idx)
+            tree.warm(LayoutNodeId::new(idx))
                 .and_then(|w| w.inline_layout_result.as_ref())
                 .map(|ilr| (idx, &**ilr))
         })
@@ -556,7 +557,7 @@ fn test_ifc_layout_metrics_source_node_ids_for_text() {
 
     let ifc_nodes: Vec<(usize, &CachedInlineLayout)> = tree.nodes.iter().enumerate()
         .filter_map(|(idx, _)| {
-            tree.warm(idx)
+            tree.warm(LayoutNodeId::new(idx))
                 .and_then(|w| w.inline_layout_result.as_ref())
                 .map(|ilr| (idx, &**ilr))
         })

--- a/layout/tests/incremental_rendering.rs
+++ b/layout/tests/incremental_rendering.rs
@@ -144,12 +144,12 @@ fn text_change_only_affects_text_region() {
     let dom1 = Dom::create_body().with_child(
         Dom::create_div()
             .with_ids_and_classes(cls("box").into())
-            .with_child(Dom::create_text("Hello")),
+            .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Hello")),
     );
     let dom2 = Dom::create_body().with_child(
         Dom::create_div()
             .with_ids_and_classes(cls("box").into())
-            .with_child(Dom::create_text("World")),
+            .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("World")),
     );
 
     let frame1 = h.render_frame(dom1, css, 200.0, 200.0);
@@ -184,8 +184,8 @@ fn different_text_content_produces_different_output() {
         body { width: 200px; height: 100px; font-family: sans-serif; font-size: 16px; }
     "#;
 
-    let dom1 = Dom::create_body().with_child(Dom::create_text("AAAA"));
-    let dom2 = Dom::create_body().with_child(Dom::create_text("ZZZZ"));
+    let dom1 = Dom::create_body().with_child(Dom::create_text_do_not_use_without_block_level_wrapper("AAAA"));
+    let dom2 = Dom::create_body().with_child(Dom::create_text_do_not_use_without_block_level_wrapper("ZZZZ"));
 
     let frame1 = h.render_frame(dom1, css, 200.0, 100.0);
     let frame2 = h.render_frame(dom2, css, 200.0, 100.0);

--- a/layout/tests/inline_block_text.rs
+++ b/layout/tests/inline_block_text.rs
@@ -653,9 +653,9 @@ fn test_body_as_root_inline_block_positioning() {
     use azul_core::styled_dom::StyledDom;
 
     // Create the DOM structure programmatically (like the Live-App does)
-    let label = Dom::create_text("5")
+    let label = Dom::create_text_do_not_use_without_block_level_wrapper("5")
         .with_ids_and_classes(vec![IdOrClass::Class("label".into())].into());
-    let button = Dom::create_text("Increase counter")
+    let button = Dom::create_text_do_not_use_without_block_level_wrapper("Increase counter")
         .with_ids_and_classes(vec![IdOrClass::Class("button".into())].into());
 
     let mut body_dom = Dom::create_body()

--- a/layout/tests/inline_block_text.rs
+++ b/layout/tests/inline_block_text.rs
@@ -1,5 +1,6 @@
 /// Test inline-block text rendering
 /// Verifies that text inside inline-block elements generates TextLayout / Text items
+use azul_layout::solver3::LayoutNodeId;
 use azul_core::dom::{Dom, DomId};
 use azul_core::geom::{LogicalPosition, LogicalRect, LogicalSize};
 use azul_core::resources::RendererResources;
@@ -523,7 +524,7 @@ fn test_inline_text_and_inline_block_on_same_line() {
         println!("\n=== Layout Tree ===");
         for (idx, node) in tree.nodes.iter().enumerate() {
             let dom_idx = node.dom_node_id.map(|id| id.index() as i64).unwrap_or(-1);
-            let rel_pos = tree.warm(idx).and_then(|w| w.relative_position).map(|p| format!("({:.2}, {:.2})", p.x, p.y)).unwrap_or("None".to_string());
+            let rel_pos = tree.warm(LayoutNodeId::new(idx)).and_then(|w| w.relative_position).map(|p| format!("({:.2}, {:.2})", p.x, p.y)).unwrap_or("None".to_string());
             let abs_pos = layout_cache.calculated_positions.get(idx).map(|p| format!("({:.2}, {:.2})", p.x, p.y)).unwrap_or("None".to_string());
             let fc = format!("{:?}", node.formatting_context);
             
@@ -749,7 +750,7 @@ fn test_body_as_root_inline_block_positioning() {
         println!("\n=== Layout Tree (Body as Root) ===");
         for (idx, node) in tree.nodes.iter().enumerate() {
             let dom_idx = node.dom_node_id.map(|id| id.index() as i64).unwrap_or(-1);
-            let rel_pos = tree.warm(idx).and_then(|w| w.relative_position).map(|p| format!("({:.2}, {:.2})", p.x, p.y)).unwrap_or("None".to_string());
+            let rel_pos = tree.warm(LayoutNodeId::new(idx)).and_then(|w| w.relative_position).map(|p| format!("({:.2}, {:.2})", p.x, p.y)).unwrap_or("None".to_string());
             let abs_pos = layout_cache.calculated_positions.get(idx).map(|p| format!("({:.2}, {:.2})", p.x, p.y)).unwrap_or("None".to_string());
             let fc = format!("{:?}", node.formatting_context);
             

--- a/layout/tests/map_widget_fill.rs
+++ b/layout/tests/map_widget_fill.rs
@@ -2,6 +2,7 @@
 /// no size, so it collapsed to zero height → the VirtualView got zero bounds →
 /// no tiles rendered (the azul-maps demo showed only the container background).
 /// build_dom now gives the outer div + VirtualView `width/height:100%`.
+use azul_layout::solver3::LayoutNodeId;
 use azul_core::dom::{Dom, DomId};
 use azul_core::geom::{LogicalPosition, LogicalRect, LogicalSize};
 use azul_core::resources::RendererResources;
@@ -80,7 +81,7 @@ fn test_map_widget_fills_flex_container() {
     let tree = layout_cache.tree.as_ref().expect("tree");
     println!("\n=== FULL CHAIN (640x480, body→header→map_area→mapdiv→vview) ===");
     for i in 0..8 {
-        if let Some(n) = tree.get(i) {
+        if let Some(n) = tree.get(LayoutNodeId::new(i)) {
             let s = n.used_size.unwrap_or_default();
             let nt = n.dom_node_id;
             println!("Node {}: fc={:?} size=({:.1},{:.1}) dom={:?}", i, n.formatting_context, s.width, s.height, nt);
@@ -90,8 +91,8 @@ fn test_map_widget_fills_flex_container() {
     // (height:100%) — must fill the ~441px box. The VirtualView (deepest, node 5) is
     // the one that previously collapsed to 0: a %-height child of an absolute-inset
     // parent whose height was resolved AFTER its subtree was (never) laid out.
-    let widget_div_h = tree.get(4).and_then(|n| n.used_size).map(|s| s.height).unwrap_or(0.0);
-    let vview_h = tree.get(5).and_then(|n| n.used_size).map(|s| s.height).unwrap_or(0.0);
+    let widget_div_h = tree.get(LayoutNodeId::new(4)).and_then(|n| n.used_size).map(|s| s.height).unwrap_or(0.0);
+    let vview_h = tree.get(LayoutNodeId::new(5)).and_then(|n| n.used_size).map(|s| s.height).unwrap_or(0.0);
     println!("=> map widget div height={widget_div_h:.1}, VirtualView height={vview_h:.1}");
     assert!(widget_div_h > 400.0, "abs map widget div collapsed: {widget_div_h:.1}");
     assert!(
@@ -158,7 +159,7 @@ fn test_map_widget_fills_container() {
     println!("\n=== MAP WIDGET TREE ===");
     let mut max_inner_h = 0.0f32;
     for i in 0..10 {
-        if let Some(node) = tree.get(i) {
+        if let Some(node) = tree.get(LayoutNodeId::new(i)) {
             let s = node.used_size.unwrap_or_default();
             println!("Node {}: fc={:?} size=({:.1},{:.1})", i, node.formatting_context, s.width, s.height);
             // nodes 2+ are the map widget div + virtual view (inside the 400px area)

--- a/layout/tests/map_widget_fill.rs
+++ b/layout/tests/map_widget_fill.rs
@@ -48,7 +48,7 @@ fn test_map_widget_fills_flex_container() {
         .with_css("flex-grow: 1; position: relative; background: #cbd2d8; overflow: hidden;")
         .with_child(map);
     let header = Dom::create_div().with_css("background: #2b2b2b; padding: 10px 16px; flex-shrink: 0;")
-        .with_child(Dom::create_text("AzulMaps"));
+        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("AzulMaps"));
     let body = Dom::create_body()
         .with_css("display: flex; flex-direction: column; height: 100%;")
         .with_child(header)

--- a/layout/tests/margin_collapsing_bug.rs
+++ b/layout/tests/margin_collapsing_bug.rs
@@ -19,7 +19,7 @@ fn test_margin_collapsing() {
         )
         .with_child(
             Dom::create_p()
-                .with_child(Dom::create_text("Paragraph"))
+                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Paragraph"))
                 .with_ids_and_classes(vec![IdOrClass::Class("my-p".into())].into()),
         );
 

--- a/layout/tests/media_restyle_cost.rs
+++ b/layout/tests/media_restyle_cost.rs
@@ -31,7 +31,7 @@ fn document_scale_dom() -> (Dom, &'static str) {
                 .with_ids_and_classes(
                     vec![azul_core::dom::IdOrClass::Class("para".into())].into(),
                 )
-                .with_child(Dom::create_text(azul_css::AzString::from(
+                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper(azul_css::AzString::from(
                     format!("Section {s} paragraph {p} with some running text"),
                 )));
             section = section.with_child(para);

--- a/layout/tests/menubar_item_clip.rs
+++ b/layout/tests/menubar_item_clip.rs
@@ -7,6 +7,7 @@
 ///
 /// Bug (task #11): a flex item whose single child is text gets its main-axis
 /// (width) constrained to the cross-axis (height = 26px), clipping the text.
+use azul_layout::solver3::LayoutNodeId;
 use azul_core::dom::{Dom, DomId};
 use azul_core::geom::{LogicalPosition, LogicalRect, LogicalSize};
 use azul_core::resources::RendererResources;
@@ -90,9 +91,9 @@ fn test_real_menubar_widget_not_clipped() {
     let tree = layout_cache.tree.as_ref().expect("Layout tree should exist");
     println!("\n=== REAL WIDGET TREE ===");
     for i in 0..20 {
-        if let Some(node) = tree.get(i) {
+        if let Some(node) = tree.get(LayoutNodeId::new(i)) {
             let size = node.used_size.unwrap_or_default();
-            let intrinsic = tree.warm(i).and_then(|w| w.intrinsic_sizes).unwrap_or_default();
+            let intrinsic = tree.warm(LayoutNodeId::new(i)).and_then(|w| w.intrinsic_sizes).unwrap_or_default();
             println!(
                 "Node {}: fc={:?} size=({:.1},{:.1}) intrinsic_min_w={:.1} max_w={:.1}",
                 i, node.formatting_context, size.width, size.height,
@@ -113,7 +114,7 @@ fn test_real_menubar_widget_not_clipped() {
     // The 3 item flex nodes should be wider than the 26px cross-axis height.
     let mut item_widths = Vec::new();
     for i in 0..20 {
-        if let Some(node) = tree.get(i) {
+        if let Some(node) = tree.get(LayoutNodeId::new(i)) {
             if matches!(node.formatting_context, azul_core::dom::FormattingContext::Flex) {
                 let w = node.used_size.unwrap_or_default().width;
                 if w > 0.0 && w < 400.0 { item_widths.push((i, w)); }
@@ -224,9 +225,9 @@ fn test_app_path_menubar_not_clipped() {
     let tree = layout_cache.tree.as_ref().expect("tree");
     println!("\n=== APP-PATH TREE (system_style=Some, Linux) ===");
     for i in 0..12 {
-        if let Some(node) = tree.get(i) {
+        if let Some(node) = tree.get(LayoutNodeId::new(i)) {
             let size = node.used_size.unwrap_or_default();
-            let intr = tree.warm(i).and_then(|w| w.intrinsic_sizes).unwrap_or_default();
+            let intr = tree.warm(LayoutNodeId::new(i)).and_then(|w| w.intrinsic_sizes).unwrap_or_default();
             println!("Node {}: fc={:?} size=({:.1},{:.1}) intr_min_w={:.1} max_w={:.1}",
                 i, node.formatting_context, size.width, size.height,
                 intr.min_content_width, intr.max_content_width);
@@ -234,7 +235,7 @@ fn test_app_path_menubar_not_clipped() {
     }
     let mut item_widths = Vec::new();
     for i in 0..12 {
-        if let Some(node) = tree.get(i) {
+        if let Some(node) = tree.get(LayoutNodeId::new(i)) {
             if matches!(node.formatting_context, azul_core::dom::FormattingContext::Flex) {
                 let w = node.used_size.unwrap_or_default().width;
                 if w > 0.0 && w < 400.0 { item_widths.push((i, w)); }
@@ -412,9 +413,9 @@ fn test_menubar_item_text_not_clipped() {
     // Dump the whole tree for orientation.
     println!("\n=== TREE ===");
     for i in 0..16 {
-        if let Some(node) = tree.get(i) {
+        if let Some(node) = tree.get(LayoutNodeId::new(i)) {
             let size = node.used_size.unwrap_or_default();
-            let intrinsic = tree.warm(i).and_then(|w| w.intrinsic_sizes).unwrap_or_default();
+            let intrinsic = tree.warm(LayoutNodeId::new(i)).and_then(|w| w.intrinsic_sizes).unwrap_or_default();
             println!(
                 "Node {}: fc={:?} size=({:.1},{:.1}) intrinsic_min_w={:.1} max_w={:.1}",
                 i, node.formatting_context, size.width, size.height,
@@ -438,7 +439,7 @@ fn test_menubar_item_text_not_clipped() {
     // The 3 items are siblings; locate them by being Flex with a text descendant.
     let mut item_widths = Vec::new();
     for i in 0..16 {
-        if let Some(node) = tree.get(i) {
+        if let Some(node) = tree.get(LayoutNodeId::new(i)) {
             if matches!(node.formatting_context, azul_core::dom::FormattingContext::Flex) {
                 let w = node.used_size.unwrap_or_default().width;
                 // bar is full width (~800); items are the narrow ones

--- a/layout/tests/mock_font_metrics.rs
+++ b/layout/tests/mock_font_metrics.rs
@@ -13,6 +13,7 @@
 //!     (which previously only looked at fonts that exist as files on disk);
 //!  2. N distinct families must produce N distinct `FontId`s.
 
+use azul_layout::solver3::LayoutNodeId;
 use std::collections::{BTreeMap, HashMap};
 
 use azul_core::{
@@ -109,11 +110,11 @@ fn layout_and_measure(
 
     let tree = layout_cache.tree.as_ref().expect("layout tree");
     let mut i = 0;
-    while let Some(n) = tree.get(i) {
+    while let Some(n) = tree.get(LayoutNodeId::new(i)) {
         println!("  node {i}: used_size={:?}", n.used_size);
         i += 1;
     }
-    tree.get(node_index)
+    tree.get(LayoutNodeId::new(node_index))
         .expect("node exists")
         .used_size
         .expect("used_size")

--- a/layout/tests/pagination_dom_breaks.rs
+++ b/layout/tests/pagination_dom_breaks.rs
@@ -281,7 +281,7 @@ fn materialized_breaks_reproduce_the_estimated_boundaries() {
                 d.root.set_ids_and_classes(vec![
                     azul_core::dom::IdOrClass::Class("p".into()),
                 ].into());
-                d.with_child(Dom::create_text(format!("block {i}")))
+                d.with_child(Dom::create_text_do_not_use_without_block_level_wrapper(format!("block {i}")))
             })
             .collect()
     }
@@ -377,7 +377,7 @@ fn midblock_breaks_materialize_at_the_spine_block_top() {
                 d.root.set_ids_and_classes(vec![
                     azul_core::dom::IdOrClass::Class("p".into()),
                 ].into());
-                d.with_child(Dom::create_text(format!("block {i}")))
+                d.with_child(Dom::create_text_do_not_use_without_block_level_wrapper(format!("block {i}")))
             })
             .collect()
     }
@@ -998,9 +998,9 @@ fn applied_edit_inverse_resume_makes_undo_a_verbatim_replay() {
     }
 
     let mut model = Dom::create_div()
-        .with_child(Dom::create_p().with_child(Dom::create_text("First paragraph here.")))
-        .with_child(Dom::create_p().with_child(Dom::create_text("Second.")))
-        .with_child(Dom::create_p().with_child(Dom::create_text("Third.")));
+        .with_child(Dom::create_p().with_child(Dom::create_text_do_not_use_without_block_level_wrapper("First paragraph here.")))
+        .with_child(Dom::create_p().with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Second.")))
+        .with_child(Dom::create_p().with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Third.")));
     model.fixup_children_estimated();
     let before = block_texts(&model);
 
@@ -1040,9 +1040,9 @@ fn applied_edit_inverse_resume_makes_undo_a_verbatim_replay() {
     // naively reach for) must NOT restore it — otherwise this test would
     // pass even with inverse_resume removed.
     let mut model2 = Dom::create_div()
-        .with_child(Dom::create_p().with_child(Dom::create_text("First paragraph here.")))
-        .with_child(Dom::create_p().with_child(Dom::create_text("Second.")))
-        .with_child(Dom::create_p().with_child(Dom::create_text("Third.")));
+        .with_child(Dom::create_p().with_child(Dom::create_text_do_not_use_without_block_level_wrapper("First paragraph here.")))
+        .with_child(Dom::create_p().with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Second.")))
+        .with_child(Dom::create_p().with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Third.")));
     model2.fixup_children_estimated();
     let applied2 =
         azul_layout::document_edit::apply_document_operation(&mut model2, &[], &forward)

--- a/layout/tests/pagination_dom_breaks.rs
+++ b/layout/tests/pagination_dom_breaks.rs
@@ -9,6 +9,7 @@
 //! - Forced breaks carry `causing_node` end to end (display-list recording
 //!   through `PageBreakPosition`).
 
+use azul_layout::solver3::LayoutNodeId;
 use azul_core::dom::{Dom, DomId};
 use azul_core::geom::{LogicalPosition, LogicalRect, LogicalSize};
 use azul_core::resources::RendererResources;
@@ -344,7 +345,7 @@ fn materialized_breaks_reproduce_the_estimated_boundaries() {
         .get(&block2_dom)
         .and_then(|v| v.first())
         .expect("block 2 laid out");
-    let block2_y = cache_b.calculated_positions.get(li).map(|p| p.y).unwrap();
+    let block2_y = cache_b.calculated_positions.get(li.index()).map(|p| p.y).unwrap();
     assert!(
         (block2_y - 300.0).abs() < 1.0,
         "inserting the empty break element must not move block 2 (margin \
@@ -741,7 +742,7 @@ fn estimator_node_heights(xml: &str, label: &str) {
     if let Some(t) = layout_cache.tree.as_ref() {
         for (i, n) in t.nodes.iter().enumerate() {
             let lines = t
-                .warm(i)
+                .warm(LayoutNodeId::new(i))
                 .and_then(|w| w.inline_layout_result.as_ref())
                 .map(|r| format!("{:?}", r.layout.bounds()))
                 .unwrap_or_else(|| "-".into());

--- a/layout/tests/resize_relayout_bug.rs
+++ b/layout/tests/resize_relayout_bug.rs
@@ -14,6 +14,7 @@
 //! asserts the absolutely-positioned grandchild grows to fill the new viewport.
 //! Without the fix the second layout leaves it at 480 tall (the bug).
 
+use azul_layout::solver3::LayoutNodeId;
 use azul_core::{
     dom::{Dom, DomId, DomNodeId, IdOrClass, NodeId},
     geom::LogicalSize,
@@ -442,7 +443,7 @@ fn resize_only_hint_skips_reconcile_but_still_resizes() {
             .get(&DomId::ROOT_ID)
             .expect("layout result");
         let tree = &lr.layout_tree;
-        tree.get(tree.root)
+        tree.get(LayoutNodeId::new(tree.root))
             .and_then(|n| n.used_size)
             .map(|s| s.width)
             .expect("root used_size")

--- a/layout/tests/resize_relayout_bug.rs
+++ b/layout/tests/resize_relayout_bug.rs
@@ -150,11 +150,11 @@ fn absolute_inset_child_grows_on_viewport_resize() {
 fn viewport_resize_reuses_every_reconciled_node() {
     let dom = Dom::create_div()
         .with_ids_and_classes(vec![IdOrClass::Class("root".into())].into())
-        .with_child(Dom::create_text("some shaped text that must not be re-shaped"))
+        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("some shaped text that must not be re-shaped"))
         .with_child(
             Dom::create_div()
                 .with_ids_and_classes(vec![IdOrClass::Class("child".into())].into())
-                .with_child(Dom::create_text("a second paragraph of shaped text")),
+                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("a second paragraph of shaped text")),
         );
 
     let css_str = r#"
@@ -259,7 +259,7 @@ fn viewport_resize_reuses_every_reconciled_node() {
 fn vw_font_size_sets_the_viewport_units_flag() {
     let dom = Dom::create_div()
         .with_ids_and_classes(vec![IdOrClass::Class("root".into())].into())
-        .with_child(Dom::create_text("vw sized text"));
+        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("vw sized text"));
 
     let css_str = r#"
         * { margin: 0px; padding: 0px; }
@@ -281,7 +281,7 @@ fn vw_font_size_sets_the_viewport_units_flag() {
 
 #[test]
 fn px_only_document_does_not_set_uses_viewport_units() {
-    let mut dom = Dom::create_div().with_child(Dom::create_text("plain"));
+    let mut dom = Dom::create_div().with_child(Dom::create_text_do_not_use_without_block_level_wrapper("plain"));
     let (css, _) = azul_css::parser2::new_from_str(
         "* { margin: 0px; } div { width: 100%; font-size: 20px; }",
     );
@@ -310,7 +310,7 @@ fn scrollbar_toggle_does_not_remeasure_all_intrinsics() {
     // but not 800px (scrollbar OFF) — the resize crosses the toggle.
     let mut children = Vec::new();
     for i in 0..24 {
-        children.push(Dom::create_text(format!("line of overflow text number {i}")));
+        children.push(Dom::create_text_do_not_use_without_block_level_wrapper(format!("line of overflow text number {i}")));
     }
     let dom = Dom::create_div()
         .with_ids_and_classes(vec![IdOrClass::Class("scroller".into())].into())
@@ -384,8 +384,8 @@ fn scrollbar_toggle_does_not_remeasure_all_intrinsics() {
 fn resize_only_hint_skips_reconcile_but_still_resizes() {
     let dom = Dom::create_div()
         .with_ids_and_classes(vec![IdOrClass::Class("root".into())].into())
-        .with_child(Dom::create_text("skip-path paragraph one"))
-        .with_child(Dom::create_text("skip-path paragraph two"));
+        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("skip-path paragraph one"))
+        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("skip-path paragraph two"));
 
     let css_str = r#"
         * { margin: 0px; padding: 0px; }
@@ -483,8 +483,8 @@ fn dom_diff_clean_hint_skips_fingerprint_recompute() {
     let dom = || {
         Dom::create_div()
             .with_ids_and_classes(vec![IdOrClass::Class("root".into())].into())
-            .with_child(Dom::create_text("granular diff paragraph one"))
-            .with_child(Dom::create_text("granular diff paragraph two"))
+            .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("granular diff paragraph one"))
+            .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("granular diff paragraph two"))
     };
     let css_str = r#"* { margin: 0px; } .root { width: 100%; }"#;
 

--- a/layout/tests/ribbon_group_overlap.rs
+++ b/layout/tests/ribbon_group_overlap.rs
@@ -62,7 +62,7 @@ fn word_like_ribbon() -> Dom {
     // the real gallery, not plain buttons.
     let cell = |sample: &str, name: &str| {
         RibbonGalleryCell::new(
-            Dom::create_text(AzString::from(sample)).with_css("font-size: 14px;"),
+            Dom::create_text_do_not_use_without_block_level_wrapper(AzString::from(sample)).with_css("font-size: 14px;"),
             name.into(),
         )
     };

--- a/layout/tests/ribbon_tab_whitespace.rs
+++ b/layout/tests/ribbon_tab_whitespace.rs
@@ -83,7 +83,7 @@ fn azwriter_like_ribbon() -> Dom {
         }))
     };
     let cells: Vec<RibbonGalleryCell> = (0..4)
-        .map(|i| RibbonGalleryCell::new(Dom::create_text("AaBbCcDc"), format!("Style {i}").into()))
+        .map(|i| RibbonGalleryCell::new(Dom::create_text_do_not_use_without_block_level_wrapper("AaBbCcDc"), format!("Style {i}").into()))
         .collect();
 
     let tab = RibbonTab::new("HOME".into())
@@ -323,7 +323,7 @@ fn nc_squeezed_label_is_detected_as_wrapped() {
         Dom::create_div().with_ids_and_classes(class("row")).with_child(
             Dom::create_p()
                 .with_ids_and_classes(class("sq"))
-                .with_child(Dom::create_text("PAGE LAYOUT")),
+                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("PAGE LAYOUT")),
         ),
     );
     let lw = layout_dom_css(dom, NC_CSS, 800.0, 200.0);
@@ -355,7 +355,7 @@ fn nc_non_growing_caption_is_detected_off_center() {
             .with_child(
                 Dom::create_p()
                     .with_ids_and_classes(class("cap"))
-                    .with_child(Dom::create_text("Clipboard")),
+                    .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Clipboard")),
             )
             .with_child(Dom::create_div().with_ids_and_classes(class("fill"))),
     );

--- a/layout/tests/session_regression.rs
+++ b/layout/tests/session_regression.rs
@@ -105,7 +105,7 @@ fn test_whitespace_nowrap_single_line() {
     let dom = Dom::create_body().with_child(
         Dom::create_div()
             .with_ids_and_classes(cls("box").into())
-            .with_child(Dom::create_text(
+            .with_child(Dom::create_text_do_not_use_without_block_level_wrapper(
                 "This is a very long text that would normally wrap to multiple lines in a narrow box",
             )),
     );
@@ -138,7 +138,7 @@ fn test_inline_block_auto_width_not_inflated() {
             .with_child(
                 Dom::create_node(NodeType::Span)
                     .with_ids_and_classes(cls("ib").into())
-                    .with_child(Dom::create_text("AB")),
+                    .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("AB")),
             ),
     );
 
@@ -169,8 +169,8 @@ fn test_table_auto_width_nonzero() {
     let dom = Dom::create_body().with_child(
         Dom::create_node(NodeType::Table).with_child(
             Dom::create_node(NodeType::Tr)
-                .with_child(Dom::create_node(NodeType::Td).with_child(Dom::create_text("Hi")))
-                .with_child(Dom::create_node(NodeType::Td).with_child(Dom::create_text("There"))),
+                .with_child(Dom::create_node(NodeType::Td).with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Hi")))
+                .with_child(Dom::create_node(NodeType::Td).with_child(Dom::create_text_do_not_use_without_block_level_wrapper("There"))),
         ),
     );
 
@@ -193,7 +193,7 @@ fn test_table_auto_width_nonzero() {
 #[test]
 fn test_star_selector_skips_text_nodes() {
     let dom = Dom::create_body().with_child(
-        Dom::create_node(NodeType::P).with_child(Dom::create_text("Hello")),
+        Dom::create_node(NodeType::P).with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Hello")),
     );
 
     let css = "* { color: #666666; } p { color: #ff0000; }";
@@ -224,7 +224,7 @@ fn test_font_size_em_resolves_against_parent() {
         .with_child(
             Dom::create_div()
                 .with_ids_and_classes(cls("p20").into())
-                .with_child(Dom::create_text("X")),
+                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("X")),
         )
         .with_child(
             Dom::create_div()
@@ -232,7 +232,7 @@ fn test_font_size_em_resolves_against_parent() {
                 .with_child(
                     Dom::create_div()
                         .with_ids_and_classes(cls("em15").into())
-                        .with_child(Dom::create_text("X")),
+                        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("X")),
                 ),
         );
 
@@ -333,7 +333,7 @@ fn test_descendant_selector_matches_deeply_nested() {
             .with_ids_and_classes(cls("outer").into())
             .with_child(
                 Dom::create_div().with_child(
-                    Dom::create_node(NodeType::P).with_child(Dom::create_text("deep")),
+                    Dom::create_node(NodeType::P).with_child(Dom::create_text_do_not_use_without_block_level_wrapper("deep")),
                 ),
             ),
     );
@@ -361,7 +361,7 @@ fn test_table_cell_has_content() {
     let dom = Dom::create_body().with_child(
         Dom::create_node(NodeType::Table).with_child(
             Dom::create_node(NodeType::Tr).with_child(
-                Dom::create_node(NodeType::Td).with_child(Dom::create_text("Cell")),
+                Dom::create_node(NodeType::Td).with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Cell")),
             ),
         ),
     );
@@ -388,11 +388,11 @@ fn test_table_not_oversized_from_double_offset() {
         Dom::create_node(NodeType::Table)
             .with_child(
                 Dom::create_node(NodeType::Tr)
-                    .with_child(Dom::create_node(NodeType::Td).with_child(Dom::create_text("R1"))),
+                    .with_child(Dom::create_node(NodeType::Td).with_child(Dom::create_text_do_not_use_without_block_level_wrapper("R1"))),
             )
             .with_child(
                 Dom::create_node(NodeType::Tr)
-                    .with_child(Dom::create_node(NodeType::Td).with_child(Dom::create_text("R2"))),
+                    .with_child(Dom::create_node(NodeType::Td).with_child(Dom::create_text_do_not_use_without_block_level_wrapper("R2"))),
             ),
     );
 
@@ -423,7 +423,7 @@ fn test_inline_block_text_only_has_size() {
             .with_child(
                 Dom::create_node(NodeType::Span)
                     .with_ids_and_classes(cls("ib").into())
-                    .with_child(Dom::create_text("Hello World")),
+                    .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Hello World")),
             ),
     );
 
@@ -447,7 +447,7 @@ fn test_inline_block_text_only_has_size() {
 #[test]
 fn test_global_star_font_weight_applied() {
     let dom = Dom::create_body().with_child(
-        Dom::create_div().with_child(Dom::create_text("test")),
+        Dom::create_div().with_child(Dom::create_text_do_not_use_without_block_level_wrapper("test")),
     );
 
     let css = "* { font-weight: bold; }";
@@ -471,8 +471,8 @@ fn test_table_layout_with_whitespace_nodes() {
     let dom = Dom::create_body().with_child(
         Dom::create_node(NodeType::Table).with_child(
             Dom::create_node(NodeType::Tr)
-                .with_child(Dom::create_node(NodeType::Td).with_child(Dom::create_text("A")))
-                .with_child(Dom::create_node(NodeType::Td).with_child(Dom::create_text("B"))),
+                .with_child(Dom::create_node(NodeType::Td).with_child(Dom::create_text_do_not_use_without_block_level_wrapper("A")))
+                .with_child(Dom::create_node(NodeType::Td).with_child(Dom::create_text_do_not_use_without_block_level_wrapper("B"))),
         ),
     );
 

--- a/layout/tests/solver3/test_inline_intrinsic_width.rs
+++ b/layout/tests/solver3/test_inline_intrinsic_width.rs
@@ -47,7 +47,7 @@ mod inline_intrinsic_width_tests {
         // Create a simple DOM with text content
         // Using Dom::label creates a proper inline element with text
         let mut dom = Dom::create_body();
-        dom.add_child(Dom::create_text("Hello world"));
+        dom.add_child(Dom::create_text_do_not_use_without_block_level_wrapper("Hello world"));
 
         let mut styled_dom = StyledDom::create_node(&mut dom, Css::empty());
         styled_dom.dom_id = DomId::ROOT_ID;
@@ -161,7 +161,7 @@ mod inline_intrinsic_width_tests {
     fn test_inline_child_gets_correct_available_width_in_bfc() {
         // Create DOM: <body><p>Test text that should wrap properly</p></body>
         let mut dom = Dom::create_body();
-        dom.add_child(Dom::create_text("Test text that should wrap properly"));
+        dom.add_child(Dom::create_text_do_not_use_without_block_level_wrapper("Test text that should wrap properly"));
 
         let mut styled_dom = StyledDom::create_node(&mut dom, Css::empty());
         styled_dom.dom_id = DomId::ROOT_ID;

--- a/layout/tests/table_cell_width.rs
+++ b/layout/tests/table_cell_width.rs
@@ -64,15 +64,15 @@ fn test_table_percentage_width_cells_expand() {
             Dom::create_node(NodeType::Tr)
                 .with_child(
                     Dom::create_node(NodeType::Td)
-                        .with_child(Dom::create_text("Left"))
+                        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Left"))
                 )
                 .with_child(
                     Dom::create_node(NodeType::Td)
-                        .with_child(Dom::create_text("Middle content here"))
+                        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Middle content here"))
                 )
                 .with_child(
                     Dom::create_node(NodeType::Td)
-                        .with_child(Dom::create_text("Right"))
+                        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Right"))
                 )
         );
 
@@ -123,11 +123,11 @@ fn test_table_auto_width_fills_parent() {
             Dom::create_node(NodeType::Tr)
                 .with_child(
                     Dom::create_node(NodeType::Td)
-                        .with_child(Dom::create_text("Left"))
+                        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Left"))
                 )
                 .with_child(
                     Dom::create_node(NodeType::Td)
-                        .with_child(Dom::create_text("Right"))
+                        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Right"))
                 )
         );
 
@@ -156,11 +156,11 @@ fn test_table_two_cells_have_nonzero_width() {
             Dom::create_node(NodeType::Tr)
                 .with_child(
                     Dom::create_node(NodeType::Td)
-                        .with_child(Dom::create_text("CellA"))
+                        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("CellA"))
                 )
                 .with_child(
                     Dom::create_node(NodeType::Td)
-                        .with_child(Dom::create_text("CellB"))
+                        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("CellB"))
                 )
         );
 
@@ -215,7 +215,7 @@ fn test_single_table_cell_nonzero_width() {
             Dom::create_node(NodeType::Tr)
                 .with_child(
                     Dom::create_node(NodeType::Td)
-                        .with_child(Dom::create_text("Hello"))
+                        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Hello"))
                 )
         );
 
@@ -322,7 +322,7 @@ fn test_hn_header_three_cells_all_nonzero() {
                             Dom::create_node(NodeType::Span)
                                 .with_child(
                                     Dom::create_node(NodeType::A)
-                                        .with_child(Dom::create_text("Hacker News"))
+                                        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Hacker News"))
                                 )
                         )
                 )
@@ -330,7 +330,7 @@ fn test_hn_header_three_cells_all_nonzero() {
                     Dom::create_node(NodeType::Td)
                         .with_child(
                             Dom::create_node(NodeType::Span)
-                                .with_child(Dom::create_text("new | past | comments | ask | show"))
+                                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("new | past | comments | ask | show"))
                         )
                 )
                 .with_child(
@@ -339,7 +339,7 @@ fn test_hn_header_three_cells_all_nonzero() {
                             Dom::create_node(NodeType::Span)
                                 .with_child(
                                     Dom::create_node(NodeType::A)
-                                        .with_child(Dom::create_text("login"))
+                                        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("login"))
                                 )
                         )
                 )
@@ -382,20 +382,20 @@ fn test_hn_header_three_cells_all_nonzero() {
             Dom::create_node(NodeType::Tr)
                 .with_child(
                     Dom::create_node(NodeType::Td)
-                        .with_child(Dom::create_text("direct text"))
+                        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("direct text"))
                 )
                 .with_child(
                     Dom::create_node(NodeType::Td)
                         .with_child(
                             Dom::create_node(NodeType::A)
-                                .with_child(Dom::create_text("in anchor"))
+                                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("in anchor"))
                         )
                 )
                 .with_child(
                     Dom::create_node(NodeType::Td)
                         .with_child(
                             Dom::create_node(NodeType::Span)
-                                .with_child(Dom::create_text("in span"))
+                                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("in span"))
                         )
                 )
         );
@@ -414,7 +414,7 @@ fn test_hn_header_three_cells_all_nonzero() {
             Dom::create_node(NodeType::Tr)
                 .with_child(
                     Dom::create_node(NodeType::Td)
-                        .with_child(Dom::create_text("plain"))
+                        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("plain"))
                 )
                 .with_child(
                     Dom::create_node(NodeType::Td)
@@ -422,7 +422,7 @@ fn test_hn_header_three_cells_all_nonzero() {
                             Dom::create_node(NodeType::Span)
                                 .with_child(
                                     Dom::create_node(NodeType::A)
-                                        .with_child(Dom::create_text("nested"))
+                                        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("nested"))
                                 )
                         )
                 )

--- a/layout/tests/table_cell_width_diag.rs
+++ b/layout/tests/table_cell_width_diag.rs
@@ -150,7 +150,7 @@ fn diag_dump_3cell_layout_tree() {
                             Dom::create_node(NodeType::Span)
                                 .with_child(
                                     Dom::create_node(NodeType::A)
-                                        .with_child(Dom::create_text("Hacker News"))
+                                        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Hacker News"))
                                 )
                         )
                 )
@@ -158,7 +158,7 @@ fn diag_dump_3cell_layout_tree() {
                     Dom::create_node(NodeType::Td)
                         .with_child(
                             Dom::create_node(NodeType::Span)
-                                .with_child(Dom::create_text("new | past | comments | ask | show"))
+                                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("new | past | comments | ask | show"))
                         )
                 )
                 .with_child(
@@ -167,7 +167,7 @@ fn diag_dump_3cell_layout_tree() {
                             Dom::create_node(NodeType::Span)
                                 .with_child(
                                     Dom::create_node(NodeType::A)
-                                        .with_child(Dom::create_text("login"))
+                                        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("login"))
                                 )
                         )
                 )
@@ -222,7 +222,7 @@ fn diag_compare_2cell_vs_3cell() {
                             Dom::create_node(NodeType::Span)
                                 .with_child(
                                     Dom::create_node(NodeType::A)
-                                        .with_child(Dom::create_text("Hacker News"))
+                                        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Hacker News"))
                                 )
                         )
                 )
@@ -232,7 +232,7 @@ fn diag_compare_2cell_vs_3cell() {
                             Dom::create_node(NodeType::Span)
                                 .with_child(
                                     Dom::create_node(NodeType::A)
-                                        .with_child(Dom::create_text("login"))
+                                        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("login"))
                                 )
                         )
                 )
@@ -260,7 +260,7 @@ fn diag_compare_2cell_vs_3cell() {
                             Dom::create_node(NodeType::Span)
                                 .with_child(
                                     Dom::create_node(NodeType::A)
-                                        .with_child(Dom::create_text("Hacker News"))
+                                        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Hacker News"))
                                 )
                         )
                 )
@@ -268,7 +268,7 @@ fn diag_compare_2cell_vs_3cell() {
                     Dom::create_node(NodeType::Td)
                         .with_child(
                             Dom::create_node(NodeType::Span)
-                                .with_child(Dom::create_text("new | past | comments"))
+                                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("new | past | comments"))
                         )
                 )
                 .with_child(
@@ -277,7 +277,7 @@ fn diag_compare_2cell_vs_3cell() {
                             Dom::create_node(NodeType::Span)
                                 .with_child(
                                     Dom::create_node(NodeType::A)
-                                        .with_child(Dom::create_text("login"))
+                                        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("login"))
                                 )
                         )
                 )
@@ -334,7 +334,7 @@ fn diag_3cell_all_nested_inline() {
                             Dom::create_node(NodeType::Span)
                                 .with_child(
                                     Dom::create_node(NodeType::A)
-                                        .with_child(Dom::create_text("Hacker News"))
+                                        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Hacker News"))
                                 )
                         )
                 )
@@ -344,7 +344,7 @@ fn diag_3cell_all_nested_inline() {
                             Dom::create_node(NodeType::Span)
                                 .with_child(
                                     Dom::create_node(NodeType::A)
-                                        .with_child(Dom::create_text("new | past | comments"))
+                                        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("new | past | comments"))
                                 )
                         )
                 )
@@ -354,7 +354,7 @@ fn diag_3cell_all_nested_inline() {
                             Dom::create_node(NodeType::Span)
                                 .with_child(
                                     Dom::create_node(NodeType::A)
-                                        .with_child(Dom::create_text("login"))
+                                        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("login"))
                                 )
                         )
                 )
@@ -399,7 +399,7 @@ fn diag_cell_order_matters() {
                     Dom::create_node(NodeType::Td)
                         .with_child(
                             Dom::create_node(NodeType::Span)
-                                .with_child(Dom::create_text("direct text first"))
+                                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("direct text first"))
                         )
                 )
                 .with_child(
@@ -408,7 +408,7 @@ fn diag_cell_order_matters() {
                             Dom::create_node(NodeType::Span)
                                 .with_child(
                                     Dom::create_node(NodeType::A)
-                                        .with_child(Dom::create_text("nested second"))
+                                        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("nested second"))
                                 )
                         )
                 )
@@ -418,7 +418,7 @@ fn diag_cell_order_matters() {
                             Dom::create_node(NodeType::Span)
                                 .with_child(
                                     Dom::create_node(NodeType::A)
-                                        .with_child(Dom::create_text("nested third"))
+                                        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("nested third"))
                                 )
                         )
                 )
@@ -445,7 +445,7 @@ fn diag_cell_order_matters() {
                             Dom::create_node(NodeType::Span)
                                 .with_child(
                                     Dom::create_node(NodeType::A)
-                                        .with_child(Dom::create_text("nested first"))
+                                        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("nested first"))
                                 )
                         )
                 )
@@ -455,7 +455,7 @@ fn diag_cell_order_matters() {
                             Dom::create_node(NodeType::Span)
                                 .with_child(
                                     Dom::create_node(NodeType::A)
-                                        .with_child(Dom::create_text("nested second"))
+                                        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("nested second"))
                                 )
                         )
                 )
@@ -463,7 +463,7 @@ fn diag_cell_order_matters() {
                     Dom::create_node(NodeType::Td)
                         .with_child(
                             Dom::create_node(NodeType::Span)
-                                .with_child(Dom::create_text("direct text last"))
+                                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("direct text last"))
                         )
                 )
         );
@@ -489,7 +489,7 @@ fn diag_cell_order_matters() {
                             Dom::create_node(NodeType::Span)
                                 .with_child(
                                     Dom::create_node(NodeType::A)
-                                        .with_child(Dom::create_text("nested first"))
+                                        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("nested first"))
                                 )
                         )
                 )
@@ -497,7 +497,7 @@ fn diag_cell_order_matters() {
                     Dom::create_node(NodeType::Td)
                         .with_child(
                             Dom::create_node(NodeType::Span)
-                                .with_child(Dom::create_text("direct text middle"))
+                                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("direct text middle"))
                         )
                 )
                 .with_child(
@@ -506,7 +506,7 @@ fn diag_cell_order_matters() {
                             Dom::create_node(NodeType::Span)
                                 .with_child(
                                     Dom::create_node(NodeType::A)
-                                        .with_child(Dom::create_text("nested last"))
+                                        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("nested last"))
                                 )
                         )
                 )
@@ -541,15 +541,15 @@ fn diag_cache_depth_analysis() {
             Dom::create_node(NodeType::Tr)
                 .with_child(
                     Dom::create_node(NodeType::Td)
-                        .with_child(Dom::create_text("plain text"))
+                        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("plain text"))
                 )
                 .with_child(
                     Dom::create_node(NodeType::Td)
-                        .with_child(Dom::create_text("more plain"))
+                        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("more plain"))
                 )
                 .with_child(
                     Dom::create_node(NodeType::Td)
-                        .with_child(Dom::create_text("yet more"))
+                        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("yet more"))
                 )
         );
     let lw1 = layout_dom(dom1, "", 800.0, 600.0);
@@ -566,21 +566,21 @@ fn diag_cache_depth_analysis() {
                     Dom::create_node(NodeType::Td)
                         .with_child(
                             Dom::create_node(NodeType::A)
-                                .with_child(Dom::create_text("link one"))
+                                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("link one"))
                         )
                 )
                 .with_child(
                     Dom::create_node(NodeType::Td)
                         .with_child(
                             Dom::create_node(NodeType::A)
-                                .with_child(Dom::create_text("link two"))
+                                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("link two"))
                         )
                 )
                 .with_child(
                     Dom::create_node(NodeType::Td)
                         .with_child(
                             Dom::create_node(NodeType::A)
-                                .with_child(Dom::create_text("link three"))
+                                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("link three"))
                         )
                 )
         );
@@ -601,7 +601,7 @@ fn diag_cache_depth_analysis() {
                             Dom::create_node(NodeType::Span)
                                 .with_child(
                                     Dom::create_node(NodeType::A)
-                                        .with_child(Dom::create_text("nested one"))
+                                        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("nested one"))
                                 )
                         )
                 )
@@ -611,7 +611,7 @@ fn diag_cache_depth_analysis() {
                             Dom::create_node(NodeType::Span)
                                 .with_child(
                                     Dom::create_node(NodeType::A)
-                                        .with_child(Dom::create_text("nested two"))
+                                        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("nested two"))
                                 )
                         )
                 )
@@ -621,7 +621,7 @@ fn diag_cache_depth_analysis() {
                             Dom::create_node(NodeType::Span)
                                 .with_child(
                                     Dom::create_node(NodeType::A)
-                                        .with_child(Dom::create_text("nested three"))
+                                        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("nested three"))
                                 )
                         )
                 )
@@ -706,7 +706,7 @@ fn diag_longer_text_nested_inline() {
                             Dom::create_node(NodeType::Span)
                                 .with_child(
                                     Dom::create_node(NodeType::A)
-                                        .with_child(Dom::create_text(
+                                        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper(
                                             "This is a very long text string that should definitely have significant width"
                                         ))
                                 )
@@ -716,7 +716,7 @@ fn diag_longer_text_nested_inline() {
                     Dom::create_node(NodeType::Td)
                         .with_child(
                             Dom::create_node(NodeType::Span)
-                                .with_child(Dom::create_text("short"))
+                                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("short"))
                         )
                 )
                 .with_child(
@@ -725,7 +725,7 @@ fn diag_longer_text_nested_inline() {
                             Dom::create_node(NodeType::Span)
                                 .with_child(
                                     Dom::create_node(NodeType::A)
-                                        .with_child(Dom::create_text(
+                                        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper(
                                             "Another very long text that should be wide"
                                         ))
                                 )
@@ -760,9 +760,9 @@ fn diag_nesting_depth_isolation() {
     let dom_d1 = Dom::create_node(NodeType::Table)
         .with_child(
             Dom::create_node(NodeType::Tr)
-                .with_child(Dom::create_node(NodeType::Td).with_child(Dom::create_text("AAA")))
-                .with_child(Dom::create_node(NodeType::Td).with_child(Dom::create_text("BBB")))
-                .with_child(Dom::create_node(NodeType::Td).with_child(Dom::create_text("CCC")))
+                .with_child(Dom::create_node(NodeType::Td).with_child(Dom::create_text_do_not_use_without_block_level_wrapper("AAA")))
+                .with_child(Dom::create_node(NodeType::Td).with_child(Dom::create_text_do_not_use_without_block_level_wrapper("BBB")))
+                .with_child(Dom::create_node(NodeType::Td).with_child(Dom::create_text_do_not_use_without_block_level_wrapper("CCC")))
         );
     let lw1 = layout_dom(dom_d1, "", 800.0, 600.0);
     let t1 = lw1.layout_cache.tree.as_ref().unwrap();
@@ -779,11 +779,11 @@ fn diag_nesting_depth_isolation() {
         .with_child(
             Dom::create_node(NodeType::Tr)
                 .with_child(Dom::create_node(NodeType::Td).with_child(
-                    Dom::create_node(NodeType::A).with_child(Dom::create_text("AAA"))))
+                    Dom::create_node(NodeType::A).with_child(Dom::create_text_do_not_use_without_block_level_wrapper("AAA"))))
                 .with_child(Dom::create_node(NodeType::Td).with_child(
-                    Dom::create_node(NodeType::A).with_child(Dom::create_text("BBB"))))
+                    Dom::create_node(NodeType::A).with_child(Dom::create_text_do_not_use_without_block_level_wrapper("BBB"))))
                 .with_child(Dom::create_node(NodeType::Td).with_child(
-                    Dom::create_node(NodeType::A).with_child(Dom::create_text("CCC"))))
+                    Dom::create_node(NodeType::A).with_child(Dom::create_text_do_not_use_without_block_level_wrapper("CCC"))))
         );
     let lw2 = layout_dom(dom_d2, "", 800.0, 600.0);
     let t2 = lw2.layout_cache.tree.as_ref().unwrap();
@@ -801,13 +801,13 @@ fn diag_nesting_depth_isolation() {
             Dom::create_node(NodeType::Tr)
                 .with_child(Dom::create_node(NodeType::Td).with_child(
                     Dom::create_node(NodeType::Span).with_child(
-                        Dom::create_node(NodeType::A).with_child(Dom::create_text("AAA")))))
+                        Dom::create_node(NodeType::A).with_child(Dom::create_text_do_not_use_without_block_level_wrapper("AAA")))))
                 .with_child(Dom::create_node(NodeType::Td).with_child(
                     Dom::create_node(NodeType::Span).with_child(
-                        Dom::create_node(NodeType::A).with_child(Dom::create_text("BBB")))))
+                        Dom::create_node(NodeType::A).with_child(Dom::create_text_do_not_use_without_block_level_wrapper("BBB")))))
                 .with_child(Dom::create_node(NodeType::Td).with_child(
                     Dom::create_node(NodeType::Span).with_child(
-                        Dom::create_node(NodeType::A).with_child(Dom::create_text("CCC")))))
+                        Dom::create_node(NodeType::A).with_child(Dom::create_text_do_not_use_without_block_level_wrapper("CCC")))))
         );
     let lw3 = layout_dom(dom_d3, "", 800.0, 600.0);
     let t3 = lw3.layout_cache.tree.as_ref().unwrap();
@@ -826,15 +826,15 @@ fn diag_nesting_depth_isolation() {
                 .with_child(Dom::create_node(NodeType::Td).with_child(
                     Dom::create_div().with_child(
                         Dom::create_node(NodeType::Span).with_child(
-                            Dom::create_node(NodeType::A).with_child(Dom::create_text("AAA"))))))
+                            Dom::create_node(NodeType::A).with_child(Dom::create_text_do_not_use_without_block_level_wrapper("AAA"))))))
                 .with_child(Dom::create_node(NodeType::Td).with_child(
                     Dom::create_div().with_child(
                         Dom::create_node(NodeType::Span).with_child(
-                            Dom::create_node(NodeType::A).with_child(Dom::create_text("BBB"))))))
+                            Dom::create_node(NodeType::A).with_child(Dom::create_text_do_not_use_without_block_level_wrapper("BBB"))))))
                 .with_child(Dom::create_node(NodeType::Td).with_child(
                     Dom::create_div().with_child(
                         Dom::create_node(NodeType::Span).with_child(
-                            Dom::create_node(NodeType::A).with_child(Dom::create_text("CCC"))))))
+                            Dom::create_node(NodeType::A).with_child(Dom::create_text_do_not_use_without_block_level_wrapper("CCC"))))))
         );
     let lw4 = layout_dom(dom_d4, "", 800.0, 600.0);
     let t4 = lw4.layout_cache.tree.as_ref().unwrap();
@@ -861,7 +861,7 @@ fn diag_cell_count_matters() {
             Dom::create_node(NodeType::Tr)
                 .with_child(Dom::create_node(NodeType::Td).with_child(
                     Dom::create_node(NodeType::Span).with_child(
-                        Dom::create_node(NodeType::A).with_child(Dom::create_text("cell1")))))
+                        Dom::create_node(NodeType::A).with_child(Dom::create_text_do_not_use_without_block_level_wrapper("cell1")))))
         );
     let lw1 = layout_dom(dom1, "", 800.0, 600.0);
     let t1 = lw1.layout_cache.tree.as_ref().unwrap();
@@ -878,10 +878,10 @@ fn diag_cell_count_matters() {
             Dom::create_node(NodeType::Tr)
                 .with_child(Dom::create_node(NodeType::Td).with_child(
                     Dom::create_node(NodeType::Span).with_child(
-                        Dom::create_node(NodeType::A).with_child(Dom::create_text("cell1")))))
+                        Dom::create_node(NodeType::A).with_child(Dom::create_text_do_not_use_without_block_level_wrapper("cell1")))))
                 .with_child(Dom::create_node(NodeType::Td).with_child(
                     Dom::create_node(NodeType::Span).with_child(
-                        Dom::create_node(NodeType::A).with_child(Dom::create_text("cell2")))))
+                        Dom::create_node(NodeType::A).with_child(Dom::create_text_do_not_use_without_block_level_wrapper("cell2")))))
         );
     let lw2 = layout_dom(dom2, "", 800.0, 600.0);
     let t2 = lw2.layout_cache.tree.as_ref().unwrap();
@@ -898,13 +898,13 @@ fn diag_cell_count_matters() {
             Dom::create_node(NodeType::Tr)
                 .with_child(Dom::create_node(NodeType::Td).with_child(
                     Dom::create_node(NodeType::Span).with_child(
-                        Dom::create_node(NodeType::A).with_child(Dom::create_text("cell1")))))
+                        Dom::create_node(NodeType::A).with_child(Dom::create_text_do_not_use_without_block_level_wrapper("cell1")))))
                 .with_child(Dom::create_node(NodeType::Td).with_child(
                     Dom::create_node(NodeType::Span).with_child(
-                        Dom::create_node(NodeType::A).with_child(Dom::create_text("cell2")))))
+                        Dom::create_node(NodeType::A).with_child(Dom::create_text_do_not_use_without_block_level_wrapper("cell2")))))
                 .with_child(Dom::create_node(NodeType::Td).with_child(
                     Dom::create_node(NodeType::Span).with_child(
-                        Dom::create_node(NodeType::A).with_child(Dom::create_text("cell3")))))
+                        Dom::create_node(NodeType::A).with_child(Dom::create_text_do_not_use_without_block_level_wrapper("cell3")))))
         );
     let lw3 = layout_dom(dom3, "", 800.0, 600.0);
     let t3 = lw3.layout_cache.tree.as_ref().unwrap();
@@ -921,16 +921,16 @@ fn diag_cell_count_matters() {
             Dom::create_node(NodeType::Tr)
                 .with_child(Dom::create_node(NodeType::Td).with_child(
                     Dom::create_node(NodeType::Span).with_child(
-                        Dom::create_node(NodeType::A).with_child(Dom::create_text("cell1")))))
+                        Dom::create_node(NodeType::A).with_child(Dom::create_text_do_not_use_without_block_level_wrapper("cell1")))))
                 .with_child(Dom::create_node(NodeType::Td).with_child(
                     Dom::create_node(NodeType::Span).with_child(
-                        Dom::create_node(NodeType::A).with_child(Dom::create_text("cell2")))))
+                        Dom::create_node(NodeType::A).with_child(Dom::create_text_do_not_use_without_block_level_wrapper("cell2")))))
                 .with_child(Dom::create_node(NodeType::Td).with_child(
                     Dom::create_node(NodeType::Span).with_child(
-                        Dom::create_node(NodeType::A).with_child(Dom::create_text("cell3")))))
+                        Dom::create_node(NodeType::A).with_child(Dom::create_text_do_not_use_without_block_level_wrapper("cell3")))))
                 .with_child(Dom::create_node(NodeType::Td).with_child(
                     Dom::create_node(NodeType::Span).with_child(
-                        Dom::create_node(NodeType::A).with_child(Dom::create_text("cell4")))))
+                        Dom::create_node(NodeType::A).with_child(Dom::create_text_do_not_use_without_block_level_wrapper("cell4")))))
         );
     let lw4 = layout_dom(dom4, "", 800.0, 600.0);
     let t4 = lw4.layout_cache.tree.as_ref().unwrap();
@@ -975,15 +975,15 @@ fn diag_root_cause_overflow_propagation() {
             Dom::create_node(NodeType::Tr)
                 .with_child(
                     Dom::create_node(NodeType::Td)
-                        .with_child(Dom::create_text("direct text"))
+                        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("direct text"))
                 )
                 .with_child(
                     Dom::create_node(NodeType::Td)
-                        .with_child(Dom::create_text("more text"))
+                        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("more text"))
                 )
                 .with_child(
                     Dom::create_node(NodeType::Td)
-                        .with_child(Dom::create_text("third"))
+                        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("third"))
                 )
         );
     let lw_a = layout_dom(dom_a, "", 800.0, 600.0);
@@ -1020,13 +1020,13 @@ fn diag_root_cause_overflow_propagation() {
                             Dom::create_node(NodeType::Span)
                                 .with_child(
                                     Dom::create_node(NodeType::A)
-                                        .with_child(Dom::create_text("nested text"))
+                                        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("nested text"))
                                 )
                         )
                 )
                 .with_child(
                     Dom::create_node(NodeType::Td)
-                        .with_child(Dom::create_text("direct text"))
+                        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("direct text"))
                 )
                 .with_child(
                     Dom::create_node(NodeType::Td)
@@ -1034,7 +1034,7 @@ fn diag_root_cause_overflow_propagation() {
                             Dom::create_node(NodeType::Span)
                                 .with_child(
                                     Dom::create_node(NodeType::A)
-                                        .with_child(Dom::create_text("also nested"))
+                                        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("also nested"))
                                 )
                         )
                 )
@@ -1100,7 +1100,7 @@ fn diag_bfc_overflow_direct_vs_inline() {
     // propagate through inline elements.
     let dom_direct = Dom::create_div()
         .with_ids_and_classes(vec![IdOrClass::Class("box".into())].into())
-        .with_child(Dom::create_text("Hello World"));
+        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Hello World"));
 
     let css = ".box { width: auto; }";
     let lw1 = layout_dom(dom_direct, css, 800.0, 600.0);
@@ -1122,7 +1122,7 @@ fn diag_bfc_overflow_direct_vs_inline() {
             Dom::create_node(NodeType::Span)
                 .with_child(
                     Dom::create_node(NodeType::A)
-                        .with_child(Dom::create_text("Hello World"))
+                        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Hello World"))
                 )
         );
 

--- a/layout/tests/test_text_layout.rs
+++ b/layout/tests/test_text_layout.rs
@@ -12,7 +12,7 @@ fn test_text_node_in_div_creates_ifc() {
     // HTML: <div>Hello World</div>
     // Expected: The DIV creates a BFC, which contains an IFC for the text
 
-    let mut dom = Dom::create_div().with_children(vec![Dom::create_text("Hello World")].into());
+    let mut dom = Dom::create_div().with_children(vec![Dom::create_text_do_not_use_without_block_level_wrapper("Hello World")].into());
     let styled_dom = StyledDom::create(&mut dom, Css::empty());
 
     eprintln!("Test: text_node_in_div_creates_ifc");
@@ -48,7 +48,7 @@ fn test_nested_text_nodes() {
     // Expected: DIV creates BFC with IFC, spans are inline, text is inline content
 
     let mut dom = Dom::create_div()
-        .with_children(vec![Dom::create_text("Hello "), Dom::create_text("World")].into());
+        .with_children(vec![Dom::create_text_do_not_use_without_block_level_wrapper("Hello "), Dom::create_text_do_not_use_without_block_level_wrapper("World")].into());
     let styled_dom = StyledDom::create(&mut dom, Css::empty());
 
     eprintln!("\nTest: nested_text_nodes");
@@ -72,7 +72,7 @@ fn test_div_with_explicit_font_size() {
 
     let mut dom = Dom::create_div()
         .with_ids_and_classes(vec![IdOrClass::Class("t".into())].into())
-        .with_children(vec![Dom::create_text("Test Text")].into());
+        .with_children(vec![Dom::create_text_do_not_use_without_block_level_wrapper("Test Text")].into());
 
     let (css, _) = azul_css::parser2::new_from_str(
         ".t { font-size: 24px; width: 400px; height: 30px; }",

--- a/layout/tests/text3_brutal_solver3.rs
+++ b/layout/tests/text3_brutal_solver3.rs
@@ -150,7 +150,7 @@ fn run_layout(html: &str) -> Solver3LayoutCache {
 fn intrinsics(cache: &Solver3LayoutCache) -> Vec<(f32, f32)> {
     let tree = cache.tree.as_ref().expect("layout tree");
     (0..64)
-        .filter_map(|i| tree.warm(i).and_then(|w| w.intrinsic_sizes))
+        .filter_map(|i| tree.warm(azul_layout::solver3::LayoutNodeId::new(i)).and_then(|w| w.intrinsic_sizes))
         .map(|s| (s.min_content_width, s.max_content_width))
         .collect()
 }
@@ -159,7 +159,7 @@ fn intrinsics(cache: &Solver3LayoutCache) -> Vec<(f32, f32)> {
 fn used_sizes(cache: &Solver3LayoutCache) -> Vec<(f32, f32)> {
     let tree = cache.tree.as_ref().expect("layout tree");
     (0..64)
-        .filter_map(|i| tree.get(i).and_then(|n| n.used_size))
+        .filter_map(|i| tree.get(azul_layout::solver3::LayoutNodeId::new(i)).and_then(|n| n.used_size))
         .map(|s| (s.width, s.height))
         .collect()
 }

--- a/layout/tests/text3_regression_solver3.rs
+++ b/layout/tests/text3_regression_solver3.rs
@@ -147,7 +147,7 @@ fn run_layout(html: &str) -> Solver3LayoutCache {
 fn intrinsics(cache: &Solver3LayoutCache) -> Vec<(f32, f32)> {
     let tree = cache.tree.as_ref().expect("layout tree");
     (0..64)
-        .filter_map(|i| tree.warm(i).and_then(|w| w.intrinsic_sizes))
+        .filter_map(|i| tree.warm(azul_layout::solver3::LayoutNodeId::new(i)).and_then(|w| w.intrinsic_sizes))
         .map(|s| (s.min_content_width, s.max_content_width))
         .collect()
 }
@@ -155,7 +155,7 @@ fn intrinsics(cache: &Solver3LayoutCache) -> Vec<(f32, f32)> {
 fn used_sizes(cache: &Solver3LayoutCache) -> Vec<(f32, f32)> {
     let tree = cache.tree.as_ref().expect("layout tree");
     (0..64)
-        .filter_map(|i| tree.get(i).and_then(|n| n.used_size))
+        .filter_map(|i| tree.get(azul_layout::solver3::LayoutNodeId::new(i)).and_then(|n| n.used_size))
         .map(|s| (s.width, s.height))
         .collect()
 }

--- a/layout/tests/text3_shaping_cache_identity.rs
+++ b/layout/tests/text3_shaping_cache_identity.rs
@@ -61,12 +61,12 @@ fn layout_two_same_text_nodes() -> Vec<RunIdentity> {
         .with_child(
             Dom::create_div()
                 .with_ids_and_classes(vec![IdOrClass::Class("a".into())].into())
-                .with_child(Dom::create_text("Layout")),
+                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Layout")),
         )
         .with_child(
             Dom::create_div()
                 .with_ids_and_classes(vec![IdOrClass::Class("b".into())].into())
-                .with_child(Dom::create_text("Layout")),
+                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Layout")),
         );
     let css_str = r#"
         .a { color: rgb(200, 30, 30); }

--- a/layout/tests/unresolved_family_render.rs
+++ b/layout/tests/unresolved_family_render.rs
@@ -35,7 +35,7 @@ fn dark_pixels(pm: &AzulPixmap) -> usize {
 fn render_text_in(family: &str) -> usize {
     let dom = Dom::create_div()
         .with_ids_and_classes(vec![IdOrClass::Class("t".to_string().into())].into())
-        .with_child(Dom::create_text("HELLO WORLD"));
+        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("HELLO WORLD"));
     let style = css(&format!(
         "font-family: {family}; font-size: 40px; color: #000000;"
     ));

--- a/layout/tests/vview_contenteditable_e2e.rs
+++ b/layout/tests/vview_contenteditable_e2e.rs
@@ -77,7 +77,7 @@ extern "C" fn pages_view(mut data: RefAny, info: VirtualViewCallbackInfo) -> Vir
         for para in &model.pages[page_idx] {
             let mut p = Dom::create_div().with_css("display: block;");
             p.set_contenteditable(true);
-            p = p.with_child(Dom::create_text(para.as_str()));
+            p = p.with_child(Dom::create_text_do_not_use_without_block_level_wrapper(para.as_str()));
             page = page.with_child(p);
         }
         root = root.with_child(page);

--- a/layout/tests/web_events_repro.rs
+++ b/layout/tests/web_events_repro.rs
@@ -32,7 +32,7 @@ fn web_events_dom_layouts_natively() {
     let mut body = Dom::create_body();
     for label in labels {
         let mut div = Dom::create_div();
-        div.add_child(Dom::create_text(label));
+        div.add_child(Dom::create_text_do_not_use_without_block_level_wrapper(label));
         body.add_child(div);
     }
 

--- a/layout/tests/web_lift_nested_text_repro.rs
+++ b/layout/tests/web_lift_nested_text_repro.rs
@@ -52,7 +52,7 @@ fn node_id(n: usize) -> DomNodeId {
 /// web-text-min's WORKING case: body directly contains text (body FC = Inline).
 #[test]
 fn body_with_direct_text_lays_out() {
-    let dom = Dom::create_body().with_child(Dom::create_text("Hello"));
+    let dom = Dom::create_body().with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Hello"));
     let lw = layout_dom(dom, "", 800.0, 600.0);
     let body = lw.get_node_layout_rect(node_id(0)).expect("body rect");
     eprintln!("[direct] body rect = {body:?}");
@@ -69,7 +69,7 @@ fn nested_div_with_text_has_nonzero_height() {
     let dom = Dom::create_body().with_child(
         Dom::create_div()
             .with_ids_and_classes(vec![IdOrClass::Class("counter".into())].into())
-            .with_child(Dom::create_text("5")),
+            .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("5")),
     );
     let lw = layout_dom(dom, ".counter { font-size: 32px; }", 800.0, 600.0);
     // node 0 = body, node 1 = div.counter, node 2 = text "5"

--- a/layout/tests/xml_dom_embed.rs
+++ b/layout/tests/xml_dom_embed.rs
@@ -63,8 +63,8 @@ fn text_items_of(dom: Dom) -> usize {
 fn xml_built_content_renders_inside_an_app_dom() {
     // Control: hand-built equivalent MUST produce text items.
     let control = Dom::create_div()
-        .with_child(Dom::create_div().with_child(Dom::create_text("Title")))
-        .with_child(Dom::create_div().with_child(Dom::create_text("Hello world paragraph")));
+        .with_child(Dom::create_div().with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Title")))
+        .with_child(Dom::create_div().with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Hello world paragraph")));
     let control_texts = text_items_of(control);
     assert!(
         control_texts >= 2,
@@ -91,7 +91,7 @@ fn xml_built_content_renders_inside_the_word_shell_shape() {
 
     let canary = Dom::create_div()
         .with_css("background: #ff0000; height: 30px; width: 300px;")
-        .with_child(Dom::create_text("CANARY"));
+        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("CANARY"));
 
     let sheet = Dom::create_div()
         .with_css(

--- a/scripts/m9_e2e/layout-flexbox.js
+++ b/scripts/m9_e2e/layout-flexbox.js
@@ -1040,7 +1040,7 @@ function fail(msg) { console.error('FAIL:', msg); process.exit(1); }
           const rootDisc = D(0x406E4), childDisc = D(0x406E8);
           console.log('[cb-dom] cb-Dom root(body).disc=' + rootDisc + ' | first-child(text).disc=' + childDisc
             + (childDisc === 177 ? ' → child=177 ✓ createText OK → DROP IS IN THE CASCADE (StyledDom::create copy of data-variant)'
-               : childDisc === 0 ? ' → child=0 ✗ → AzDom_createText DROPPED node_type (X8/sret build-lift)'
+               : childDisc === 0 ? ' → child=0 ✗ → AzDom_createTextDoNotUseWithoutBlockLevelWrapper DROPPED node_type (X8/sret build-lift)'
                : ' → child=' + childDisc + ' (root should be 2=Body)'));
         }
         const ph = mini.AzStartup_peekU32(0x401C0);

--- a/tests/e2e/async.c
+++ b/tests/e2e/async.c
@@ -52,7 +52,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     
     // Title
     AzString title_text = str("Background Thread Progress Demo");
-    AzDom title = AzDom_createText(title_text);
+    AzDom title = AzDom_createTextDoNotUseWithoutBlockLevelWrapper(title_text);
     AzString title_style = str("font-size: 24px; margin-bottom: 30px;");
     AzDom_setInlineStyle(&title, title_style);
     AzDom_addChild(&body, title);
@@ -67,7 +67,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     char progress_buf[32];
     snprintf(progress_buf, sizeof(progress_buf), "Progress: %.0f%%", state.ptr->progress);
     AzString progress_label_text = str(progress_buf);
-    AzDom progress_label = AzDom_createText(progress_label_text);
+    AzDom progress_label = AzDom_createTextDoNotUseWithoutBlockLevelWrapper(progress_label_text);
     AzString progress_label_style = str("margin-bottom: 20px;");
     AzDom_setInlineStyle(&progress_label, progress_label_style);
     AzDom_addChild(&body, progress_label);
@@ -83,7 +83,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
         AzDom_addChild(&body, button);
     } else {
         AzString running_text = str("Processing...");
-        AzDom running = AzDom_createText(running_text);
+        AzDom running = AzDom_createTextDoNotUseWithoutBlockLevelWrapper(running_text);
         AzString running_style = str("color: #666;");
         AzDom_setInlineStyle(&running, running_style);
         AzDom_addChild(&body, running);

--- a/tests/e2e/contenteditable.c
+++ b/tests/e2e/contenteditable.c
@@ -172,7 +172,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     // Label 1: Single Line Input — wrap text in a <p> so the class applies
     AzDom label1 = AzDom_createDiv();
     AzDom_addClass(&label1, AZ_STR("label"));
-    AzDom_addChild(&label1, AzDom_createText(AZ_STR("Single Line Input (48px font):")));
+    AzDom_addChild(&label1, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AZ_STR("Single Line Input (48px font):")));
     AzDom_addChild(&root, label1);
     
     // Single-line contenteditable input
@@ -184,7 +184,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     AzDom_setTabIndex(&single_input, tab_auto);
     
     // Add text as child
-    AzDom single_text = AzDom_createText(AZ_STR(ref.ptr->single_line_text));
+    AzDom single_text = AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AZ_STR(ref.ptr->single_line_text));
     AzDom_addChild(&single_input, single_text);
     
     // Add text input callback - use Focus filter for text input
@@ -196,7 +196,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     // Label 2: Multi Line Text Area
     AzDom label2 = AzDom_createDiv();
     AzDom_addClass(&label2, AZ_STR("label"));
-    AzDom_addChild(&label2, AzDom_createText(AZ_STR("Multi Line Text Area (scroll test):")));
+    AzDom_addChild(&label2, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AZ_STR("Multi Line Text Area (scroll test):")));
     AzDom_addChild(&root, label2);
     
     // Multi-line contenteditable textarea
@@ -207,7 +207,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     AzDom_setTabIndex(&multi_input, tab_auto);
     
     // Add text as child
-    AzDom multi_text = AzDom_createText(AZ_STR(ref.ptr->multi_line_text));
+    AzDom multi_text = AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AZ_STR(ref.ptr->multi_line_text));
     AzDom_addChild(&multi_input, multi_text);
     
     // Add callbacks
@@ -228,7 +228,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     
     AzDom status_bar = AzDom_createDiv();
     AzDom_addClass(&status_bar, AZ_STR("status-bar"));
-    AzDom_addChild(&status_bar, AzDom_createText(AZ_STR(status)));
+    AzDom_addChild(&status_bar, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AZ_STR(status)));
     AzDom_addChild(&root, status_bar);
     
     ContentEditableDataRef_delete(&ref);

--- a/tests/e2e/drag_select_scroll.c
+++ b/tests/e2e/drag_select_scroll.c
@@ -75,7 +75,7 @@ AzDom create_paragraph(int index) {
     
     AzString text = AzString_copyFromBytes((uint8_t*)buffer, 0, len);
     AzDom p = AzDom_createDiv();
-    AzDom_addChild(&p, AzDom_createText(text));
+    AzDom_addChild(&p, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(text));
     
     // Alternate colors
     const char* bg_color = (index % 2 == 0) ? "#e8f4f8" : "#f8f4e8";
@@ -124,7 +124,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     
     // Instructions
     AzDom instructions = AzDom_createDiv();
-    AzDom_addChild(&instructions, AzDom_createText(AZ_STR(
+    AzDom_addChild(&instructions, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AZ_STR(
         "Test drag-to-select with auto-scroll:\n"
         "1. Click and drag to select text\n"
         "2. Drag to bottom edge → should auto-scroll down\n"
@@ -135,14 +135,14 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     
     // Status bar
     AzDom status_bar = AzDom_createDiv();
-    AzDom_addChild(&status_bar, AzDom_createText(AZ_STR(status)));
+    AzDom_addChild(&status_bar, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AZ_STR(status)));
     AzDom_addClass(&status_bar, AZ_STR("status"));
     
     // Build body
     AzDom body = AzDom_createBody();
     
     AzDom label = AzDom_createDiv();
-    AzDom_addChild(&label, AzDom_createText(AZ_STR("Drag-Select-Scroll Test:")));
+    AzDom_addChild(&label, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AZ_STR("Drag-Select-Scroll Test:")));
     AzDom_addClass(&label, AZ_STR("label"));
     AzDom_addChild(&body, label);
     

--- a/tests/e2e/focus_backup_with_text.c
+++ b/tests/e2e/focus_backup_with_text.c
@@ -81,7 +81,7 @@ AzUpdate on_button3_click(AzRefAny data, AzCallbackInfo info) {
 AzDom create_button(const char* label, int button_num, AzCallbackType click_callback, AzRefAny data) {
     AzString text = AzString_copyFromBytes((const uint8_t*)label, 0, strlen(label));
     AzDom button = AzDom_createDiv();
-    AzDom_addChild(&button, AzDom_createText(text));
+    AzDom_addChild(&button, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(text));
     
     // Add click callback - use leftMouseUp for click
     AzEventFilter event = AzEventFilter_hover(AzHoverEventFilter_leftMouseUp());
@@ -122,7 +122,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     // Create header
     AzString header_text = AzString_copyFromBytes((const uint8_t*)"Focus & Tab Navigation Test", 0, 28);
     AzDom header = AzDom_createDiv();
-    AzDom_addChild(&header, AzDom_createText(header_text));
+    AzDom_addChild(&header, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(header_text));
     AzString header_style = AzString_copyFromBytes((const uint8_t*)
         "padding: 20px; background-color: #2c3e50; color: white; "
         "font-size: 28px; font-weight: bold; text-align: center;", 0, 111);
@@ -132,7 +132,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     AzString instructions_text = AzString_copyFromBytes((const uint8_t*)
         "Press Tab to navigate between buttons. Press Enter or Space to activate. Press Escape to clear focus.", 0, 102);
     AzDom instructions = AzDom_createDiv();
-    AzDom_addChild(&instructions, AzDom_createText(instructions_text));
+    AzDom_addChild(&instructions, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(instructions_text));
     AzString instructions_style = AzString_copyFromBytes((const uint8_t*)
         "padding: 15px; background-color: #ecf0f1; color: #2c3e50; "
         "font-size: 16px; text-align: center; border-bottom: 1px solid #bdc3c7;", 0, 126);
@@ -165,7 +165,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     
     AzString status_text = AzString_copyFromBytes((const uint8_t*)status_buf, 0, status_len);
     AzDom status = AzDom_createDiv();
-    AzDom_addChild(&status, AzDom_createText(status_text));
+    AzDom_addChild(&status, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(status_text));
     AzString status_id = AzString_copyFromBytes((const uint8_t*)"status", 0, 6);
     status = AzDom_withId(status, status_id);
     AzString status_style = AzString_copyFromBytes((const uint8_t*)

--- a/tests/e2e/focus_scroll.c
+++ b/tests/e2e/focus_scroll.c
@@ -128,7 +128,7 @@ AzDom create_item(int item_num, AzRefAny data) {
     // Add text label
     char label[64];
     snprintf(label, sizeof(label), "Item %d - Focusable Element", item_num);
-    AzDom text = AzDom_createText(AZ_STR(label));
+    AzDom text = AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AZ_STR(label));
     AzDom_addChild(&item, text);
     
     return item;

--- a/tests/e2e/hello-world.c
+++ b/tests/e2e/hello-world.c
@@ -18,7 +18,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     MyDataModelRef_delete(&d);
 
     AzString label_text = AzString_copyFromBytes(buffer, 0, written);
-    AzDom label = AzDom_createText(label_text);
+    AzDom label = AzDom_createTextDoNotUseWithoutBlockLevelWrapper(label_text);
     
     AzCssProperty font_size = AzCssProperty_fontSize(AzStyleFontSize_px(50.0));
     AzCssPropertyWithConditions font_size_prop = AzCssPropertyWithConditions_simple(font_size);
@@ -29,7 +29,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     AzCssPropertyWithConditions flex_grow_prop = AzCssPropertyWithConditions_simple(flex_grow);
     AzDom_addCssProperty(&button, flex_grow_prop);
     AzString button_text = AzString_copyFromBytes("Increase counter", 0, 16);
-    AzDom_addChild(&button, AzDom_createText(button_text));
+    AzDom_addChild(&button, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(button_text));
     
     AzEventFilter event = AzEventFilter_hover(AzHoverEventFilter_mouseUp());
     AzRefAny data_clone = AzRefAny_clone(&data);

--- a/tests/e2e/scrollbar_drag.c
+++ b/tests/e2e/scrollbar_drag.c
@@ -69,7 +69,7 @@ AzDom create_item(int index) {
     
     AzString text = AzString_copyFromBytes((uint8_t*)buffer, 0, len);
     AzDom item = AzDom_createDiv();
-    AzDom_addChild(&item, AzDom_createText(text));
+    AzDom_addChild(&item, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(text));
     
     // Alternate colors
     const char* bg_color = (index % 2 == 0) ? "#3498db" : "#2980b9";
@@ -111,12 +111,12 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     
     // Status bar
     AzDom status_bar = AzDom_createDiv();
-    AzDom_addChild(&status_bar, AzDom_createText(AZ_STR(status)));
+    AzDom_addChild(&status_bar, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AZ_STR(status)));
     AzDom_addClass(&status_bar, AZ_STR("status"));
     
     // Instructions
     AzDom instructions = AzDom_createDiv();
-    AzDom_addChild(&instructions, AzDom_createText(AZ_STR(
+    AzDom_addChild(&instructions, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AZ_STR(
         "Test scrollbar interaction:\n"
         "1. Wheel scroll on container\n"
         "2. Drag scrollbar thumb\n"
@@ -129,7 +129,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     AzDom body = AzDom_createBody();
     
     AzDom label = AzDom_createDiv();
-    AzDom_addChild(&label, AzDom_createText(AZ_STR("Scrollbar Drag Test:")));
+    AzDom_addChild(&label, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AZ_STR("Scrollbar Drag Test:")));
     AzDom_addClass(&label, AZ_STR("label"));
     AzDom_addChild(&body, label);
     

--- a/tests/e2e/scrolling.c
+++ b/tests/e2e/scrolling.c
@@ -32,7 +32,7 @@ AzDom create_scroll_item(int index) {
     
     AzString text = AzString_copyFromBytes(buffer, 0, len);
     AzDom item = AzDom_createDiv();
-    AzDom_addChild(&item, AzDom_createText(text));
+    AzDom_addChild(&item, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(text));
     
     // Alternate background colors for visibility - use bright colors for debugging
     char style[256];
@@ -60,7 +60,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     // Create header
     AzString header_text = AzString_copyFromBytes("Scrolling Test - Overflowing Content", 0, 37);
     AzDom header = AzDom_createDiv();
-    AzDom_addChild(&header, AzDom_createText(header_text));
+    AzDom_addChild(&header, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(header_text));
     AzString header_style = AzString_copyFromBytes(
         "padding: 15px; background-color: #4a90d9; color: white; "
         "font-size: 24px; font-weight: bold; text-align: center;", 0, 121);
@@ -87,7 +87,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     AzString footer_text = AzString_copyFromBytes(
         "Use mouse wheel or drag scrollbar to scroll. Debug API: POST scroll event.", 0, 75);
     AzDom footer = AzDom_createDiv();
-    AzDom_addChild(&footer, AzDom_createText(footer_text));
+    AzDom_addChild(&footer, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(footer_text));
     AzString footer_style = AzString_copyFromBytes(
         "padding: 10px; background-color: #f0f0f0; color: #666; "
         "font-size: 12px; text-align: center;", 0, 95);

--- a/tests/e2e/selection.c
+++ b/tests/e2e/selection.c
@@ -52,7 +52,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     AzDom p1 = AzDom_createDiv();
     
     // Create text node with click handler
-    AzDom p1_text_node = AzDom_createText(p1_text);
+    AzDom p1_text_node = AzDom_createTextDoNotUseWithoutBlockLevelWrapper(p1_text);
     AzEventFilter p1_text_event = AzEventFilter_hover(AzHoverEventFilter_mouseDown());
     AzDom_addCallback(&p1_text_node, p1_text_event, AzRefAny_clone(&data), on_p1_text_click);
     AzDom_addChild(&p1, p1_text_node);
@@ -71,7 +71,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     AzString p2_text = AzString_copyFromBytes(
         "SECOND PARAGRAPH - user-select: none - This should be SKIPPED!", 0, 63);
     AzDom p2 = AzDom_createDiv();
-    AzDom_addChild(&p2, AzDom_createText(p2_text));
+    AzDom_addChild(&p2, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(p2_text));
     AzString p2_style = AzString_copyFromBytes(
         "font-size: 28px; padding: 15px; background-color: #ffc0c0; margin: 8px; user-select: none;", 0, 92);
     AzDom_setInlineStyle(&p2, p2_style);
@@ -82,7 +82,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     AzString p3_text = AzString_copyFromBytes(
         "THIRD PARAGRAPH - This text is also selectable. End your selection here.", 0, 73);
     AzDom p3 = AzDom_createDiv();
-    AzDom_addChild(&p3, AzDom_createText(p3_text));
+    AzDom_addChild(&p3, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(p3_text));
     AzString p3_style = AzString_copyFromBytes(
         "font-size: 28px; padding: 15px; background-color: #c0c0ff; margin: 8px;", 0, 73);
     AzDom_setInlineStyle(&p3, p3_style);

--- a/tests/e2e/simple_contenteditable.c
+++ b/tests/e2e/simple_contenteditable.c
@@ -54,7 +54,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     AzDom_setContenteditable(&editor, true);
     
     // Initial text
-    AzDom text = AzDom_createText(AZ_STR("Click here and type..."));
+    AzDom text = AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AZ_STR("Click here and type..."));
     AzDom_addChild(&editor, text);
     
     AzDom_addChild(&root, editor);

--- a/tests/e2e/text_area.c
+++ b/tests/e2e/text_area.c
@@ -121,7 +121,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     AzDom textarea = AzDom_createDiv();
     
     // Add text content
-    AzDom text_node = AzDom_createText(AZ_STR(ref.ptr->text));
+    AzDom text_node = AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AZ_STR(ref.ptr->text));
     AzDom_addChild(&textarea, text_node);
     
     // Make it focusable
@@ -146,7 +146,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
              ref.ptr->key_count, ref.ptr->scroll_count);
     
     AzDom status_bar = AzDom_createDiv();
-    AzDom_addChild(&status_bar, AzDom_createText(AZ_STR(status)));
+    AzDom_addChild(&status_bar, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AZ_STR(status)));
     AzDom_addClass(&status_bar, AZ_STR("status"));
     
     TextAreaDataRef_delete(&ref);
@@ -156,7 +156,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     
     // Label
     AzDom label = AzDom_createDiv();
-    AzDom_addChild(&label, AzDom_createText(AZ_STR("Multi-Line Text Area (scroll test):")));
+    AzDom_addChild(&label, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AZ_STR("Multi-Line Text Area (scroll test):")));
     AzDom_addClass(&label, AZ_STR("label"));
     AzDom_addChild(&body, label);
     

--- a/tests/e2e/text_input.c
+++ b/tests/e2e/text_input.c
@@ -98,7 +98,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     AzDom input = AzDom_createDiv();
     
     // Add text content
-    AzDom text_node = AzDom_createText(AZ_STR(ref.ptr->text));
+    AzDom text_node = AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AZ_STR(ref.ptr->text));
     AzDom_addChild(&input, text_node);
     
     // Make it focusable and contenteditable
@@ -119,7 +119,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
              ref.ptr->selection_start, ref.ptr->selection_end);
     
     AzDom status_label = AzDom_createDiv();
-    AzDom_addChild(&status_label, AzDom_createText(AZ_STR(status)));
+    AzDom_addChild(&status_label, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AZ_STR(status)));
     AzDom_addClass(&status_label, AZ_STR("status"));
     
     TextInputDataRef_delete(&ref);
@@ -129,7 +129,7 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     
     // Label
     AzDom label = AzDom_createDiv();
-    AzDom_addChild(&label, AzDom_createText(AZ_STR("Single-Line Input (Tab to focus, then type):")));
+    AzDom_addChild(&label, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AZ_STR("Single-Line Input (Tab to focus, then type):")));
     AzDom_addClass(&label, AZ_STR("label"));
     AzDom_addChild(&body, label);
     

--- a/tests/e2e/whitespace_test.c
+++ b/tests/e2e/whitespace_test.c
@@ -33,34 +33,34 @@ AzDom layout(AzRefAny data, AzLayoutCallbackInfo info) {
     
     // ========== Test 1: white-space: nowrap ==========
     AzDom label1 = AzDom_createDiv();
-    AzDom_addChild(&label1, AzDom_createText(AZ_STR("1. white-space: nowrap (single line, clipped):")));
+    AzDom_addChild(&label1, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AZ_STR("1. white-space: nowrap (single line, clipped):")));
     AzDom_addClass(&label1, AZ_STR("label"));
     AzDom_addChild(&body, label1);
     
     AzDom nowrap_div = AzDom_createDiv();
-    AzDom_addChild(&nowrap_div, AzDom_createText(AZ_STR("This is a very long line that should never wrap at word boundaries because white-space is set to nowrap")));
+    AzDom_addChild(&nowrap_div, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AZ_STR("This is a very long line that should never wrap at word boundaries because white-space is set to nowrap")));
     AzDom_addClass(&nowrap_div, AZ_STR("nowrap-box"));
     AzDom_addChild(&body, nowrap_div);
     
     // ========== Test 2: white-space: pre ==========
     AzDom label2 = AzDom_createDiv();
-    AzDom_addChild(&label2, AzDom_createText(AZ_STR("2. white-space: pre (5 lines from \\n):")));
+    AzDom_addChild(&label2, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AZ_STR("2. white-space: pre (5 lines from \\n):")));
     AzDom_addClass(&label2, AZ_STR("label"));
     AzDom_addChild(&body, label2);
     
     AzDom pre_div = AzDom_createDiv();
-    AzDom_addChild(&pre_div, AzDom_createText(AZ_STR("Line 1\nLine 2\nLine 3\nLine 4\nLine 5")));
+    AzDom_addChild(&pre_div, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AZ_STR("Line 1\nLine 2\nLine 3\nLine 4\nLine 5")));
     AzDom_addClass(&pre_div, AZ_STR("pre-box"));
     AzDom_addChild(&body, pre_div);
     
     // ========== Test 3: white-space: normal ==========
     AzDom label3 = AzDom_createDiv();
-    AzDom_addChild(&label3, AzDom_createText(AZ_STR("3. white-space: normal (wraps at words):")));
+    AzDom_addChild(&label3, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AZ_STR("3. white-space: normal (wraps at words):")));
     AzDom_addClass(&label3, AZ_STR("label"));
     AzDom_addChild(&body, label3);
     
     AzDom normal_div = AzDom_createDiv();
-    AzDom_addChild(&normal_div, AzDom_createText(AZ_STR("This is a very long line that should wrap at word boundaries because white-space is normal")));
+    AzDom_addChild(&normal_div, AzDom_createTextDoNotUseWithoutBlockLevelWrapper(AZ_STR("This is a very long line that should wrap at word boundaries because white-space is normal")));
     AzDom_addClass(&normal_div, AZ_STR("normal-box"));
     AzDom_addChild(&body, normal_div);
     

--- a/tests/src/css.rs
+++ b/tests/src/css.rs
@@ -157,12 +157,12 @@ fn test_case_issue_93() {
         Dom::create_div()
             .with_ids_and_classes(vec![IdOrClass::Class("tabwidget-tab".into())].into())
             .with_child(
-                Dom::create_text("").with_ids_and_classes(
+                Dom::create_text_do_not_use_without_block_level_wrapper("").with_ids_and_classes(
                     vec![IdOrClass::Class("tabwidget-tab-label".into())].into(),
                 ),
             )
             .with_child(
-                Dom::create_text("").with_ids_and_classes(
+                Dom::create_text_do_not_use_without_block_level_wrapper("").with_ids_and_classes(
                     vec![IdOrClass::Class("tabwidget-tab-close".into())].into(),
                 ),
             )

--- a/tests/src/dom.rs
+++ b/tests/src/dom.rs
@@ -216,7 +216,7 @@ fn test_dom_from_iter_1() {
 
     let dom = Dom::create_body().with_children(
         (0..5)
-            .map(|e| Dom::create_text(format!("{}", e + 1)))
+            .map(|e| Dom::create_text_do_not_use_without_block_level_wrapper(format!("{}", e + 1)))
             .collect::<Vec<_>>()
             .into(),
     );

--- a/tests/test_xml_inline_parsing.rs
+++ b/tests/test_xml_inline_parsing.rs
@@ -23,11 +23,11 @@ fn test_manual_dom_structure() {
     // First, verify that manually creating the DOM structure works correctly
     
     let dom = Dom::p().with_children(vec![
-        Dom::create_text("Before "),
+        Dom::create_text_do_not_use_without_block_level_wrapper("Before "),
         Dom::create_node(NodeType::Span).with_children(vec![
-            Dom::create_text("inline")
+            Dom::create_text_do_not_use_without_block_level_wrapper("inline")
         ].into()),
-        Dom::create_text(" after")
+        Dom::create_text_do_not_use_without_block_level_wrapper(" after")
     ].into());
     
     // Verify structure


### PR DESCRIPTION
Implements the 2026-08-18 seam audit end to end, plus three follow-up batches from PR review. **Stacked on #430 (`feat/observability`)** — merge after it lands. Three commits, ~300 files:

- `0c675a42` — the audit batch (15 parallel implementation lanes + a final review sweep)
- `c4df13b4` — bare-text developer lint + ABI rename of the raw text constructor
- `63e25a92` — `LayoutNodeId` newtype + VirtualView scrolls by default

## ⚠️ ABI change (know before merging)

`Dom::create_text` / `NodeData::create_text` are **renamed** to `create_text_do_not_use_without_block_level_wrapper` (C: `AzDom_createTextDoNotUseWithoutBlockLevelWrapper`), through `api.json` + full codegen (all 35 bindings). Rationale: azul deliberately does NOT auto-wrap raw text in anonymous blocks the way browsers do — a bare text node has no box, so box-model CSS, callbacks, `tab_index`, `dataset` on it are silently inert; that shipped real bugs. The name is the warning; the `create_*_with_text` family (`create_div_with_text` newly added) is the sanctioned path. 840 Rust + 138 guide/example references renamed. Generated sources aren't committed — run codegen after checkout (`cargo run --release -p azul-doc -- codegen all` + touch `dll/src/lib.rs`).

## Type-level fix: `LayoutNodeId`

The frozen-scroll root cause (DOM `NodeId` index used as a layout-tree index) is now **unrepresentable**: `LayoutNodeId` is the only currency at every DOM→layout crossing — `dom_to_layout` values, both scroll-id tables, and the whole `LayoutTree` accessor surface (`get`/`warm`/`cold`/`get_content_size`/…). Interior SoA arithmetic stays `usize`; every interior wrap is an explicit, greppable `LayoutNodeId::new(..)`. ~470 sites converted compiler-driven. The old bug's premise test now needs a deliberate cross-space cast just to ask the question.

## VirtualView scrolls by default

UA stylesheet gives `VirtualView` `overflow: auto` on both axes (on BOTH cascade paths — `prop_cache.rs`'s UA list was missing OverflowX/Y and would have silently disagreed with the compact path). Combined with the virtual-size-aware necessity rule: bars + wheel scrolling appear exactly when the published `virtual_scroll_size` overflows the viewport; smaller content = no bars. azul-writer's VV needs **no overflow CSS anymore**; map/video keep their deliberate `overflow: hidden` opt-outs (wheel-for-zoom); invisible-but-scrollable = default + `scrollbar-width: none` (already supported).

## Bare-text warning pass

`layout/src/dom_lint.rs`, in the shared layout funnel: warns once per unique finding on state-on-text (inert), text competing as one of several flex/grid items, text beside block siblings, parentless/text-parented text. Sole-text-leaf-in-a-flex-wrapper is sanctioned and silent. Suppress: `AZ_SUPPRESS=bare_text` (typo `AZ_SUPRESS` accepted); every warning names the knob. First run caught a live bug (backstage nav labels as raw flex items — fixed); an all-45-widgets sweep test keeps the set warning-free.

## What the audit batch fixes, by symptom

**AzWriter scrolling**: `build_scroll_offset_map` index conflation (content frozen while thumb moved) → keyed via `scroll_id_to_node_id` + red-first divergence test. VV wheel/paging + virtual-size-aware scrollbar necessity in ONE rule (`apply_virtual_scroll_necessity`) shared by paint, GPU thumb, hit test, e2e runner. `ScrollPosition` origin convention fixed (thumb no longer starts partway down for scrollers below the window origin); masking `.abs()` removed.

**AzWidgets text editing**: 44 raw-text sites across 25 widgets → `<p>`-wrap + enforcement test; text_input/text_area revamped onto contenteditable; `get_text_before_textinput` collects through every flow container (P/Span/… read as EMPTY before — first keystroke could wipe the value) with `contenteditable="false"` islands excluded; Enter inserts `"\n"` in plain-text hosts / Shift+Enter soft break everywhere / structural split for document hosts (new tail-appended `DefaultAction::InsertLineBreakAtCursor`); IME preedit is a read-time overlay (no more commit duplication); one text-edit commit point (`record_text_edit_undo`: single undo counter + `Input` dispatched for deletions/paste/line breaks; vetoed edits clear the pending record); focus-before-first-layout survives via deferred queue drained at the layout tail on both hosts.

**The seam (all shells + headless)**: `os_synced_state` split from `previous_window_state` on all 7 backends (Resized/Moved/DpiChanged/flag events now fire everywhere); `AZ_VALIDATE=1` unconsumed-delta assertion + sanctioned `discard_input_delta`; Wayland KeyUp/double-tap fix, per-button state, close veto, per-pass IME sync; X11 touch dispatch, XI2 valuator scroll, IME truncation + activation, keysym table, XI2 events routed by real target window; Win32 Alt+F4, renderer leak + pump UAF, IME surrogates/candidate tracking; macOS printable-key dispatch, keycode table, mouse selectors, deferred context menu, fullscreen flap; Android theme queue + resize/DPI events; e2e runner unified (reconcile, scroll registration, veto, Input notifications, focus drain); shared `WHEEL_SCROLL_PIXELS_PER_LINE`; one caret-blink default (530 ms, OS setting honored); dead `present()` chain + never-wired accelerated-scroll path deleted.

## Deliberate behavior changes (ruled)

TextArea Enter = real newline; TextInput vetoes Enter · widget `on_text_input` also fires as post-edit notification (deletions visible; idempotent when nothing changed) · `contenteditable="false"` honored in editability + collection · Home/End/Word/VisualLine move with active selection (Left/Right collapse) · blink 530 ms unified · overlay scrollbars skip the per-relayout reflow · macOS wheel 20 px/line (tune if slow) · VirtualView is a scroll container by default (opt out with `overflow: hidden`).

## Verification

layout lib **7295**, core **2695**, contenteditable_e2e 16, all 12 newtype-touched integration binaries green (115 tests); dll `--lib` + azul-writer compile against regenerated bindings. Windows/macOS reviewed against vendored ABI sources (can't compile here); hands-on checklists in the worktree review docs.

## For the merger

- `AZ_VALIDATE=1` should stay silent — a panic is a real finding.
- Watch stderr for `[azul][text-without-block]` warnings in app code; suppress with `AZ_SUPPRESS=bare_text` once read.
- Live checks on KWin: AzWriter wheel-scroll both modes; AzWidgets type/delete/Enter; double-tap Backspace; right-click while drag-selecting.
- This PR changes `api.json` — regenerate after checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jht5zm6ii676tH4MiNtjxQ