### PR TITLE
docs(internals): point three renamed paths at where the code went

### DIFF
--- a/doc/guide/en/internals/events/hit-testing.md
+++ b/doc/guide/en/internals/events/hit-testing.md
@@ -11,7 +11,7 @@ short_desc: Hit-test tag generation and cursor-to-node routing
 prerequisites: [events]
 tracked_files:
   - core/src/hit_test.rs
-  - core/src/hit_test_tag.rs
+  - core/src/hit_test.rs
   - core/src/drag.rs
   - core/src/selection.rs
   - layout/src/hit_test.rs
@@ -85,7 +85,7 @@ WebRender returns small, sequential `tag_value`s for normal DOM nodes
 scrollbar component. For a tag value of 673 that expression is `0`, the
 same encoding the decoder uses for `VerticalTrack`. Every normal click
 was misclassified as a scrollbar hit and the button callback never
-ran. The namespace constants in `core/src/hit_test_tag.rs` are the
+ran. The namespace constants in `core/src/hit_test.rs` are the
 fix.
 
 ## HitTestTag

--- a/doc/guide/en/internals/layout/fragmentation.md
+++ b/doc/guide/en/internals/layout/fragmentation.md
@@ -13,7 +13,7 @@ tracked_files:
   - layout/src/lib.rs
   - layout/src/window.rs
   - layout/src/fragmentation.rs
-  - layout/src/paged.rs
+  - core/src/paged.rs
   - layout/src/solver3/pagination.rs
   - layout/src/solver3/paged_layout.rs
 last_generated_rev: 7ecd570e4c0c3584e5107e770058c16cb59fa6e7
@@ -49,7 +49,7 @@ trade-off is that CSS break properties are parsed but largely advisory.
 - **`layout/src/fragmentation.rs`.** Partially superseded. CSS-spec-style
   "decide breaks during layout". Defines `FragmentationLayoutContext`,
   `BoxBreakBehavior`, and `BreakPoint`.
-- **`layout/src/paged.rs`.** Active container model. The
+- **`core/src/paged.rs`.** Active container model. The
   `FragmentationContext` enum has `Continuous`, `Paged`, `MultiColumn`, and
   `Regions` variants. Defines `Fragmentainer` and `FragmentationState`.
 - **`layout/src/solver3/pagination.rs`.** Active. `PageGeometer` is the

--- a/doc/guide/en/internals/rendering/text-pipeline.md
+++ b/doc/guide/en/internals/rendering/text-pipeline.md
@@ -80,7 +80,7 @@ without holding any locks during shaping.
 
 ## Per-node font_family_hash and the font_dirty_nodes set
 
-`build_compact_cache` (in `core/src/compact_cache_builder.rs`) computes a
+`build_compact_cache` (in `core/src/compact.rs`) computes a
 per-node `font_family_hash`:
 
 ```rust,ignore

--- a/doc/guide/en/internals/styling/compact-cache.md
+++ b/doc/guide/en/internals/styling/compact-cache.md
@@ -11,7 +11,7 @@ short_desc: How layout results are stored across frames
 prerequisites: []
 tracked_files:
   - css/src/compact_cache.rs
-  - core/src/compact_cache_builder.rs
+  - core/src/compact.rs
 last_generated_rev: 7ecd570e4c0c3584e5107e770058c16cb59fa6e7
 generated_at: 2026-05-02T00:00:00Z
 default-search-keys:
@@ -277,7 +277,7 @@ if let Some(val) = self.get_width(nd, &node_id, &default_state) {
 
 Each `get_*` call cascades through `CssPropertyCache` (UA → global → cascaded → inline → user override). The result is an `Option<CssPropertyValue<T>>`; `None` leaves the slot at `Default::default()`.
 
-`encode_layout_width` and friends live in `core/src/compact_cache_builder.rs` because they need access to the cascade's `CssPropertyValue` resolution; pure encode helpers (`encode_pixel_value_u32`, `encode_resolved_px_i16`, `encode_flex_u16`, `encode_color_u32`) are in `css/src/compact_cache.rs` and have no `core` dependency.
+`encode_layout_width` and friends live in `core/src/compact.rs` because they need access to the cascade's `CssPropertyValue` resolution; pure encode helpers (`encode_pixel_value_u32`, `encode_resolved_px_i16`, `encode_flex_u16`, `encode_color_u32`) are in `css/src/compact_cache.rs` and have no `core` dependency.
 
 ## Defaults
 
@@ -320,7 +320,7 @@ For uncommon properties (transform, box-shadow, filter, content, transitions), t
 2. Add the field to the appropriate struct in `css/src/compact_cache.rs`. Update `Default`.
 3. If new tier-1 bits, add `*_SHIFT` and `*_MASK` constants and update `encode_tier1` + the matching `decode_*`.
 4. Add `encode_*` and `decode_*` helpers near the existing ones.
-5. Add encoder calls in `core/src/compact_cache_builder.rs` Step 3 and (if it's a global `*` rule target) Step 2.5.
+5. Add encoder calls in `core/src/compact.rs` Step 3 and (if it's a global `*` rule target) Step 2.5.
 6. Add inheritance handling in Step 1 if the property inherits.
 7. Add a getter on `CompactLayoutCache` (`get_<prop>_raw`, `get_<prop>`, `is_<prop>_auto`).
 8. Update the slow-path fallback in `CssPropertyCache::get_property_slow` so callers who don't use the compact cache still work.

--- a/doc/guide/en/internals/styling/css-parser.md
+++ b/doc/guide/en/internals/styling/css-parser.md
@@ -103,7 +103,7 @@ The signature is `pub fn new_from_str<'a>(css_string: &'a str) -> (Css, Vec<CssP
 
 ## Selectors: CssPath and parse_css_path
 
-`parse_css_path(input) -> Result<CssPath, CssPathParseError>` handles the selector half of a rule independently. It's used by `parser2.rs` itself (called per rule), by `core/src/style.rs` for runtime `StyledDom::with_css(...)` overrides, and by `dll/src/web/cb_gen.rs` for the codegen pipeline that compiles HTML+CSS to const Rust.
+`parse_css_path(input) -> Result<CssPath, CssPathParseError>` handles the selector half of a rule independently. It's used by `parser2.rs` itself (called per rule), by `core/src/style.rs` for runtime `StyledDom::with_css(...)` overrides, and by `dll/src/web/mod.rs` for the codegen pipeline that compiles HTML+CSS to const Rust.
 
 ```rust,ignore
 use azul_css::parser2::parse_css_path;
@@ -295,7 +295,7 @@ Putting it all together, here's what it takes to add `text-stroke: 1px red`:
 4. Add an arm to `parse_css_property` routing to your parser.
 5. Add the new variant to `css_property_from_type!` so `auto` / `none` / `initial` / `inherit` work generically.
 6. Implement `CssProperty::get_type()`, `relayout_scope()`, and the formatter (`props/formatter.rs`).
-7. If the property should be inheritable, add it to the inheritance lists in `core/src/prop_cache.rs` and `core/src/compact_cache_builder.rs`.
+7. If the property should be inheritable, add it to the inheritance lists in `core/src/prop_cache.rs` and `core/src/compact.rs`.
 8. If it has a UA default, add it to `core/src/ua_css.rs`.
 9. If it's frequently set, encode into the [Compact Property Cache](compact-cache.md) instead of leaving it on the slow cascade path.
 


### PR DESCRIPTION
The internals guide points at four source files that have moved or merged. Each target verified present on `master`, each source verified absent.

| document | says | actually |
|---|---|---|
| `rendering/text-pipeline.md:83`, `styling/compact-cache.md` (x3), `styling/css-parser.md:298` | `core/src/compact_cache_builder.rs` | `core/src/compact.rs`, renamed in `a0d295796` |
| `layout/fragmentation.md:52` | `layout/src/paged.rs` | `core/src/paged.rs`, moved in `c94d0f5fa` |
| `events/hit-testing.md:88` | `core/src/hit_test_tag.rs` | `core/src/hit_test.rs`, merged in `15d61efdc` |
| `styling/css-parser.md:106` | `dll/src/web/cb_gen.rs` | `dll/src/web/mod.rs`, merged in `edb8ee4e7` |

Each commit message says what happened in its own words: *"rename compact_cache_builder -> compact"*, *"move paged-media primitives from layout to core"*, *"merge hit_test_tag into hit_test"*, *"merge cb_gen.rs stub into web/mod.rs"*. Ten lines across five files, no prose changes.

## What is deliberately not in this

Six more stale paths remain and each needs a judgement I should not make from outside:

- `layout/fragmentation.md:49` names `layout/src/fragmentation.rs`, gone in `f3151a0e4`. There is a `css/src/props/layout/fragmentation.rs`, but that is a CSS property module and may not be what the sentence means.
- `pdf.md:62` names `examples/azul-doc`, gone in `8564dc2f4`. No obvious successor among the current examples.
- `internals/web.md:1110` and `:1112` name two dated session logs removed by `9b55eeea2` ("remove 58 dated session-log/handoff/sprint s"). Deleting the references is probably right and it is an editorial call.
- `SUPER_PLAN_0.2.0.md:175` names two UDP transport paths removed in `1f5cbd437`. A plan document describing what was planned is not obviously wrong for naming them.

Happy to send any of those as a follow-up if you say which way they should go.

Found by [docproof](https://github.com/melbinjp/docproof), a documentation checker that resolves documented paths against the repository and its git history. Verified against `master` at `d60e0e5d4` before opening.
