### PR TITLE
feat: multi-monitor fixes + system tray foundation (stacked on transient-window)

### DIFF
--- a/.envrc.az
+++ b/.envrc.az
@@ -1,0 +1,18 @@
+# Build env for this worktree. Source with:  . ./.envrc.az
+#
+# Disk is tight (15Gi free at creation time) and the main checkout's target dir
+# is already 21G. Share it rather than growing a second one: cargo locks per
+# target dir, so a concurrent build in the main checkout serialises with this
+# one instead of corrupting it.
+export CARGO_TARGET_DIR=/Users/fschutt/Development/azul/target
+
+# dll/build.rs looks for the azul-doc-generated sources at ../target/codegen,
+# which does not exist inside a worktree.
+export AZ_CODEGEN_DIR=/Users/fschutt/Development/azul/target/codegen
+
+# Cross-compiling azul-dll to linux needs the homebrew GNU toolchain
+# (see memory: crosscompile_vkmem_toolchain_2026_06_19).
+export CC_x86_64_unknown_linux_gnu=x86_64-unknown-linux-gnu-gcc
+export CXX_x86_64_unknown_linux_gnu=x86_64-unknown-linux-gnu-g++
+export AR_x86_64_unknown_linux_gnu=x86_64-unknown-linux-gnu-ar
+export CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=x86_64-unknown-linux-gnu-gcc

--- a/api.json
+++ b/api.json
@@ -99946,6 +99946,206 @@
                             "returns": null
                         },
                         "repr": "C"
+                    },
+                    "TrayIconImageVecDestructor": {
+                        "external": "azul_core::tray::TrayIconImageVecDestructor",
+                        "derive": [
+                            "Debug"
+                        ],
+                        "enum_fields": [
+                            {
+                                "DefaultRust": {},
+                                "NoDestructor": {},
+                                "External": {
+                                    "type": "TrayIconImageVecDestructorType"
+                                },
+                                "AlreadyDestroyed": {}
+                            }
+                        ],
+                        "repr": "C, u8"
+                    },
+                    "TrayIconImageVecDestructorType": {
+                        "external": "azul_core::tray::TrayIconImageVecDestructorType",
+                        "callback_typedef": {
+                            "fn_args": [
+                                {
+                                    "type": "TrayIconImageVec",
+                                    "ref_kind": "mutptr"
+                                }
+                            ],
+                            "returns": null
+                        }
+                    },
+                    "TrayIconImageVec": {
+                        "external": "azul_core::tray::TrayIconImageVec",
+                        "custom_impls": [
+                            "Clone",
+                            "Debug",
+                            "PartialEq"
+                        ],
+                        "derive": [
+                            "Debug"
+                        ],
+                        "struct_fields": [
+                            {
+                                "ptr": {
+                                    "type": "TrayIconImage",
+                                    "ref_kind": "constptr"
+                                },
+                                "len": {
+                                    "type": "usize"
+                                },
+                                "cap": {
+                                    "type": "usize"
+                                },
+                                "destructor": {
+                                    "type": "TrayIconImageVecDestructor"
+                                }
+                            }
+                        ],
+                        "functions": {
+                            "create": {
+                                "doc": [
+                                    "Creates an empty `TrayIconImageVec`"
+                                ],
+                                "fn_args": [],
+                                "returns": {
+                                    "type": "TrayIconImageVec"
+                                },
+                                "fn_body": "Self::new()"
+                            },
+                            "with_capacity": {
+                                "doc": [
+                                    "Creates a `TrayIconImageVec` with a given capacity"
+                                ],
+                                "fn_args": [
+                                    {
+                                        "cap": "usize"
+                                    }
+                                ],
+                                "returns": {
+                                    "type": "TrayIconImageVec"
+                                },
+                                "fn_body": "Self::with_capacity(cap)"
+                            },
+                            "len": {
+                                "doc": [
+                                    "Returns the number of elements in the Vec"
+                                ],
+                                "fn_args": [
+                                    {
+                                        "self": "ref"
+                                    }
+                                ],
+                                "returns": {
+                                    "type": "usize"
+                                },
+                                "fn_body": "tray_icon_image_vec.len()"
+                            },
+                            "capacity": {
+                                "doc": [
+                                    "Returns the capacity of the Vec"
+                                ],
+                                "fn_args": [
+                                    {
+                                        "self": "ref"
+                                    }
+                                ],
+                                "returns": {
+                                    "type": "usize"
+                                },
+                                "fn_body": "tray_icon_image_vec.capacity()"
+                            },
+                            "is_empty": {
+                                "doc": [
+                                    "Returns whether the Vec is empty"
+                                ],
+                                "fn_args": [
+                                    {
+                                        "self": "ref"
+                                    }
+                                ],
+                                "returns": {
+                                    "type": "bool"
+                                },
+                                "fn_body": "tray_icon_image_vec.is_empty()"
+                            },
+                            "c_get": {
+                                "doc": [
+                                    "Returns a copy of the element at the given index, or None if out of bounds. C-API compatible."
+                                ],
+                                "fn_args": [
+                                    {
+                                        "self": "ref"
+                                    },
+                                    {
+                                        "index": "usize"
+                                    }
+                                ],
+                                "returns": {
+                                    "type": "OptionTrayIconImage"
+                                },
+                                "fn_body": "tray_icon_image_vec.c_get(index).into()"
+                            },
+                            "from_item": {
+                                "doc": [
+                                    "Creates a `TrayIconImageVec` containing a single element"
+                                ],
+                                "fn_args": [
+                                    {
+                                        "item": "TrayIconImage"
+                                    }
+                                ],
+                                "returns": {
+                                    "type": "TrayIconImageVec"
+                                },
+                                "fn_body": "Self::from_item(item)"
+                            },
+                            "copy_from_ptr": {
+                                "doc": [
+                                    "Copies elements from a C array into a `TrayIconImageVec`. The array must be valid for `len` elements."
+                                ],
+                                "fn_args": [
+                                    {
+                                        "ptr": "*const TrayIconImage"
+                                    },
+                                    {
+                                        "len": "usize"
+                                    }
+                                ],
+                                "returns": {
+                                    "type": "TrayIconImageVec"
+                                },
+                                "fn_body": "unsafe { Self::copy_from_ptr(ptr, len) }"
+                            }
+                        },
+                        "repr": "C"
+                    },
+                    "TrayIconImageVecSlice": {
+                        "external": "azul_core::tray::TrayIconImageVecSlice",
+                        "derive": [
+                            "Debug",
+                            "Clone",
+                            "Copy"
+                        ],
+                        "struct_fields": [
+                            {
+                                "ptr": {
+                                    "type": "TrayIconImage",
+                                    "ref_kind": "constptr",
+                                    "doc": [
+                                        "Pointer to the slice data"
+                                    ]
+                                },
+                                "len": {
+                                    "type": "usize",
+                                    "doc": [
+                                        "Number of elements in the slice"
+                                    ]
+                                }
+                            }
+                        ],
+                        "repr": "C"
                     }
                 }
             },
@@ -105421,6 +105621,24 @@
                             }
                         ],
                         "repr": "C, u8"
+                    },
+                    "OptionTrayIconImage": {
+                        "external": "azul_core::tray::OptionTrayIconImage",
+                        "derive": [
+                            "Debug",
+                            "Clone",
+                            "PartialEq",
+                            "Eq"
+                        ],
+                        "enum_fields": [
+                            {
+                                "None": {},
+                                "Some": {
+                                    "type": "TrayIconImage"
+                                }
+                            }
+                        ],
+                        "repr": "C, u8"
                     }
                 }
             },
@@ -108195,6 +108413,30 @@
                                     }
                                 ],
                                 "fn_body": "object.run(root_window)"
+                            },
+                            "set_tray": {
+                                "doc": [
+                                    "Ask for a system-tray icon. Takes effect when `run()` starts.",
+                                    "",
+                                    "Deferred rather than immediate because a tray cannot exist this early:",
+                                    "macOS needs `NSApplication`, and every backend needs the icon registry",
+                                    "published so a `TrayIconSource::Named` spec can resolve.",
+                                    "",
+                                    "This is best-effort by design. On a desktop with no tray  -  a vanilla",
+                                    "GNOME has no `StatusNotifierWatcher` at all  -  nothing appears and the",
+                                    "app still runs; the failure is logged. Use",
+                                    "[`crate::desktop::tray::TrayIcon::is_available`] beforehand if the app",
+                                    "needs to know."
+                                ],
+                                "fn_args": [
+                                    {
+                                        "self": "refmut"
+                                    },
+                                    {
+                                        "tray": "TrayIconData"
+                                    }
+                                ],
+                                "fn_body": "object.set_tray(tray)"
                             }
                         },
                         "repr": "C"
@@ -113687,6 +113929,383 @@
                             {
                                 "Popup": {},
                                 "Inline": {}
+                            }
+                        ],
+                        "repr": "C"
+                    }
+                }
+            },
+            "tray": {
+                "classes": {
+                    "TrayIconImage": {
+                        "external": "azul_core::tray::TrayIconImage",
+                        "custom_impls": [
+                            "Eq",
+                            "PartialEq"
+                        ],
+                        "derive": [
+                            "Debug",
+                            "Clone"
+                        ],
+                        "struct_fields": [
+                            {
+                                "key": {
+                                    "type": "IconKey"
+                                },
+                                "width": {
+                                    "type": "u32"
+                                },
+                                "height": {
+                                    "type": "u32"
+                                },
+                                "rgba": {
+                                    "type": "U8Vec"
+                                }
+                            }
+                        ],
+                        "functions": {
+                            "new": {
+                                "doc": [
+                                    "`rgba` must be exactly `width * height * 4` bytes; returns `None`",
+                                    "otherwise.",
+                                    "",
+                                    "Returns `OptionTrayIconImage` rather than `Option<Self>` so the",
+                                    "signature crosses the C ABI unchanged."
+                                ],
+                                "fn_args": [
+                                    {
+                                        "width": "u32"
+                                    },
+                                    {
+                                        "height": "u32"
+                                    },
+                                    {
+                                        "rgba": "U8Vec"
+                                    }
+                                ],
+                                "returns": {
+                                    "type": "OptionTrayIconImage"
+                                },
+                                "fn_body": "azul_core::tray::TrayIconImage::new(width, height, rgba)"
+                            },
+                            "to_argb32_be": {
+                                "doc": [
+                                    "The icon's pixels as ARGB32 in **network (big-endian) byte order**, the",
+                                    "wire format `org.kde.StatusNotifierItem`'s `IconPixmap` (`a(iiay)`)",
+                                    "requires. Nothing else uses this layout, so it is computed on demand."
+                                ],
+                                "fn_args": [
+                                    {
+                                        "self": "ref"
+                                    }
+                                ],
+                                "returns": {
+                                    "type": "U8Vec"
+                                },
+                                "fn_body": "object.to_argb32_be()"
+                            }
+                        },
+                        "repr": "C"
+                    },
+                    "TrayCategory": {
+                        "external": "azul_core::tray::TrayCategory",
+                        "derive": [
+                            "Debug",
+                            "Copy",
+                            "Clone",
+                            "PartialEq",
+                            "Eq",
+                            "PartialOrd",
+                            "Ord",
+                            "Hash",
+                            "Default"
+                        ],
+                        "enum_fields": [
+                            {
+                                "ApplicationStatus": {},
+                                "Communications": {},
+                                "SystemServices": {},
+                                "Hardware": {}
+                            }
+                        ],
+                        "repr": "C"
+                    },
+                    "TrayIconData": {
+                        "external": "azul_core::tray::TrayIconData",
+                        "custom_impls": [
+                            "Default"
+                        ],
+                        "derive": [
+                            "Debug",
+                            "Clone",
+                            "PartialEq"
+                        ],
+                        "struct_fields": [
+                            {
+                                "id": {
+                                    "type": "String"
+                                },
+                                "title": {
+                                    "type": "String"
+                                },
+                                "icon": {
+                                    "type": "TrayIconSource"
+                                },
+                                "attention_icon": {
+                                    "type": "TrayIconSource"
+                                },
+                                "tooltip": {
+                                    "type": "OptionString"
+                                },
+                                "category": {
+                                    "type": "TrayCategory"
+                                },
+                                "status": {
+                                    "type": "TrayStatus"
+                                },
+                                "menu": {
+                                    "type": "OptionMenu"
+                                }
+                            }
+                        ],
+                        "constructors": {
+                            "new": {
+                                "fn_args": [
+                                    {
+                                        "id": "String"
+                                    },
+                                    {
+                                        "title": "String"
+                                    }
+                                ],
+                                "fn_body": "azul_core::tray::TrayIconData::new(id, title)"
+                            }
+                        },
+                        "functions": {
+                            "with_icon": {
+                                "doc": [
+                                    "Use an explicit RGBA bitmap. Prefer [`Self::with_named_icon`] unless the",
+                                    "icon genuinely is not in a pack."
+                                ],
+                                "fn_args": [
+                                    {
+                                        "self": "value"
+                                    },
+                                    {
+                                        "icon": "TrayIconImage"
+                                    }
+                                ],
+                                "returns": {
+                                    "type": "TrayIconData"
+                                },
+                                "fn_body": "object.with_icon(icon)"
+                            },
+                            "with_menu": {
+                                "fn_args": [
+                                    {
+                                        "self": "value"
+                                    },
+                                    {
+                                        "menu": "Menu"
+                                    }
+                                ],
+                                "returns": {
+                                    "type": "TrayIconData"
+                                },
+                                "fn_body": "object.with_menu(menu)"
+                            },
+                            "with_tooltip": {
+                                "fn_args": [
+                                    {
+                                        "self": "value"
+                                    },
+                                    {
+                                        "tooltip": "String"
+                                    }
+                                ],
+                                "returns": {
+                                    "type": "TrayIconData"
+                                },
+                                "fn_body": "object.with_tooltip(tooltip)"
+                            },
+                            "with_named_icon": {
+                                "doc": [
+                                    "Use an icon from the icon registry, by the same spec an `<icon>` node",
+                                    "takes  -  `\"settings\"`, `\"mypack:logo\"`, or a fallback list. Preferred:",
+                                    "it renders at whatever size each platform asks for."
+                                ],
+                                "fn_args": [
+                                    {
+                                        "self": "value"
+                                    },
+                                    {
+                                        "spec": "String"
+                                    }
+                                ],
+                                "returns": {
+                                    "type": "TrayIconData"
+                                },
+                                "fn_body": "object.with_named_icon(spec)"
+                            },
+                            "best_icon": {
+                                "doc": [
+                                    "The icon closest to `target_px`, preferring the smallest one that is at",
+                                    "least `target_px` (upscaling a small icon looks far worse than",
+                                    "downscaling a large one  -  this is why Windows' own `LoadIconMetric`",
+                                    "scales down from a larger frame rather than up).",
+                                    "Only meaningful for [`TrayIconSource::Rgba`]; a `Named` icon is",
+                                    "rasterized at the exact size instead, so it never needs picking.",
+                                    "",
+                                    "Returns an owned `OptionTrayIconImage` rather than `Option<&_>` because",
+                                    "a borrow cannot cross the C ABI. The clone is one `U8Vec` bump."
+                                ],
+                                "fn_args": [
+                                    {
+                                        "self": "ref"
+                                    },
+                                    {
+                                        "target_px": "u32"
+                                    }
+                                ],
+                                "returns": {
+                                    "type": "OptionTrayIconImage"
+                                },
+                                "fn_body": "object.best_icon(target_px)"
+                            }
+                        },
+                        "repr": "C"
+                    },
+                    "TrayIconSource": {
+                        "external": "azul_core::tray::TrayIconSource",
+                        "derive": [
+                            "Debug",
+                            "Clone",
+                            "PartialEq",
+                            "Default"
+                        ],
+                        "enum_fields": [
+                            {
+                                "None": {},
+                                "Rgba": {
+                                    "type": "TrayIconImageVec"
+                                },
+                                "Named": {
+                                    "type": "String"
+                                }
+                            }
+                        ],
+                        "repr": "C, u8"
+                    },
+                    "TrayStatus": {
+                        "external": "azul_core::tray::TrayStatus",
+                        "derive": [
+                            "Debug",
+                            "Copy",
+                            "Clone",
+                            "PartialEq",
+                            "Eq",
+                            "PartialOrd",
+                            "Ord",
+                            "Hash",
+                            "Default"
+                        ],
+                        "enum_fields": [
+                            {
+                                "Passive": {},
+                                "Active": {},
+                                "NeedsAttention": {}
+                            }
+                        ],
+                        "repr": "C"
+                    },
+                    "TrayScrollAxis": {
+                        "external": "azul_core::tray::TrayScrollAxis",
+                        "derive": [
+                            "Debug",
+                            "Copy",
+                            "Clone",
+                            "PartialEq",
+                            "Eq",
+                            "PartialOrd",
+                            "Ord",
+                            "Hash",
+                            "Default"
+                        ],
+                        "enum_fields": [
+                            {
+                                "Vertical": {},
+                                "Horizontal": {}
+                            }
+                        ],
+                        "repr": "C"
+                    },
+                    "TrayEvent": {
+                        "external": "azul_core::tray::TrayEvent",
+                        "derive": [
+                            "Debug",
+                            "Copy",
+                            "Clone",
+                            "PartialEq",
+                            "Eq",
+                            "PartialOrd",
+                            "Ord",
+                            "Hash"
+                        ],
+                        "struct_fields": [
+                            {
+                                "kind": {
+                                    "type": "TrayEventType"
+                                },
+                                "menu_command": {
+                                    "type": "u32"
+                                },
+                                "scroll_delta": {
+                                    "type": "i32"
+                                },
+                                "scroll_axis": {
+                                    "type": "TrayScrollAxis"
+                                }
+                            }
+                        ],
+                        "constructors": {
+                            "simple": {
+                                "fn_args": [
+                                    {
+                                        "kind": "TrayEventType"
+                                    }
+                                ],
+                                "fn_body": "azul_core::tray::TrayEvent::simple(kind)"
+                            },
+                            "menu_item": {
+                                "fn_args": [
+                                    {
+                                        "command": "u32"
+                                    }
+                                ],
+                                "fn_body": "azul_core::tray::TrayEvent::menu_item(command)"
+                            }
+                        },
+                        "repr": "C"
+                    },
+                    "TrayEventType": {
+                        "external": "azul_core::tray::TrayEventType",
+                        "derive": [
+                            "Debug",
+                            "Copy",
+                            "Clone",
+                            "PartialEq",
+                            "Eq",
+                            "PartialOrd",
+                            "Ord",
+                            "Hash"
+                        ],
+                        "enum_fields": [
+                            {
+                                "Activate": {},
+                                "SecondaryActivate": {},
+                                "ContextMenu": {},
+                                "Scroll": {},
+                                "MenuItem": {}
                             }
                         ],
                         "repr": "C"

--- a/api.json
+++ b/api.json
@@ -5697,6 +5697,36 @@
                                 ],
                                 "fn_body": "azul_layout::icon::register_font_icon(iconproviderhandle, pack_name.as_str(), icon_name.as_str(), font, icon_char.as_str())"
                             },
+                            "register_dom_icon": {
+                                "doc": [
+                                    "Register an arbitrary `Dom` as an icon, in a pack.",
+                                    "",
+                                    "The general case: an icon is just a DOM, and image / font icons are",
+                                    "special cases of it. Whatever you register is spliced in wherever",
+                                    "that icon name is used - an `<icon>` node, a tray icon, an app icon -",
+                                    "and it keeps its own styling, because the DOM carries both inline",
+                                    "properties and its own stylesheets.",
+                                    "",
+                                    "That is how an icon gets a colour without any call site passing a",
+                                    "tint: the icon says what it looks like, the call site says how big."
+                                ],
+                                "priority": 85.0,
+                                "fn_args": [
+                                    {
+                                        "self": "refmut"
+                                    },
+                                    {
+                                        "pack_name": "String"
+                                    },
+                                    {
+                                        "icon_name": "String"
+                                    },
+                                    {
+                                        "dom": "Dom"
+                                    }
+                                ],
+                                "fn_body": "azul_layout::icon::register_dom_icon(iconproviderhandle, pack_name.as_str(), icon_name.as_str(), dom)"
+                            },
                             "debug_lookup": {
                                 "doc": [
                                     "Debug lookup: returns detailed info about an icon's RefAny contents.",

--- a/api.json
+++ b/api.json
@@ -108437,6 +108437,30 @@
                                     }
                                 ],
                                 "fn_body": "object.set_tray(tray)"
+                            },
+                            "set_app_icon": {
+                                "doc": [
+                                    "Ask for an application icon  -  the macOS Dock tile, and elsewhere",
+                                    "the process-wide default window icon. Takes effect when `run()` starts.",
+                                    "",
+                                    "`spec` is an icon-registry spec, exactly what an `<icon>` node takes:",
+                                    "a bare name (\"settings\"), a pack-qualified name (\"mypack:logo\"), or a",
+                                    "comma-separated fallback list. It renders through the SAME pipeline as",
+                                    "a tray icon and an in-DOM `<icon>`, so all three can never disagree.",
+                                    "",
+                                    "Best-effort, and deliberately narrower than it looks: macOS documents",
+                                    "`applicationIconImage` as TEMPORARY (process-local, resets on next",
+                                    "launch), and the Windows EXE icon cannot be changed at runtime at all."
+                                ],
+                                "fn_args": [
+                                    {
+                                        "self": "refmut"
+                                    },
+                                    {
+                                        "spec": "String"
+                                    }
+                                ],
+                                "fn_body": "object.set_app_icon(spec)"
                             }
                         },
                         "repr": "C"

--- a/api.json
+++ b/api.json
@@ -108461,6 +108461,27 @@
                                     }
                                 ],
                                 "fn_body": "object.set_app_icon(spec)"
+                            },
+                            "run_tray_only": {
+                                "doc": [
+                                    "Run with a tray and NO window, for a menu-bar / system-tray utility",
+                                    "that has no main window at all. `run()` always creates one, so such",
+                                    "an app previously had to open and then hide a window it never wanted.",
+                                    "",
+                                    "Requires `set_tray()` to have been called: without a tray there is no",
+                                    "way to interact with the app and nothing to keep it alive.",
+                                    "",
+                                    "macOS only for now. There it switches the process to Accessory",
+                                    "activation (the runtime equivalent of `LSUIElement`): no Dock tile and",
+                                    "no application menu bar, which also means an icon set via",
+                                    "`set_app_icon` has nowhere to appear."
+                                ],
+                                "fn_args": [
+                                    {
+                                        "self": "ref"
+                                    }
+                                ],
+                                "fn_body": "object.run_tray_only()"
                             }
                         },
                         "repr": "C"

--- a/core/src/icon.rs
+++ b/core/src/icon.rs
@@ -1054,6 +1054,35 @@ pub fn resolve_icons_in_styled_dom(
             }
         }
     }
+
+    // Step 4: rebuild the compact cache, because step 3 invalidated it.
+    //
+    // `apply_cached_resolution` rewrites a node's `NodeType` and inline `style`
+    // — a font icon's replacement carries `font-family: StyleFontFamily::Ref`,
+    // which is the ONLY place that face is named. But the compact cache is a
+    // PRECOMPUTED per-node array, built when the `StyledDom` was cascaded, and
+    // nothing above touches it. So after the splice it still describes the
+    // pre-resolution `<icon>` node.
+    //
+    // That matters because the compact cache is the source of truth for font
+    // resolution: `collect_font_stacks_from_styled_dom` keys on
+    // `tier2b_text[i].font_family_hash` and looks the families up in
+    // `font_hash_to_families`. With a stale hash it finds the ORIGINAL
+    // families, never sees the `Ref`, and so never registers the face as an
+    // embedded font. Shaping then falls back to a system face which has no
+    // glyph at the icon's private-use codepoint, and the icon rasterises to a
+    // `.notdef` tofu box — with every step in between reporting success.
+    //
+    // This was previously masked in the engine's own path: `regenerate_layout`
+    // wraps the DOM for client-side decorations right after this call, and that
+    // rebuild happened to refresh the cache. Anything that resolved icons
+    // WITHOUT a later rebuild — a frameless window, or rendering an icon
+    // straight to a bitmap, which is how this was found — got the tofu.
+    //
+    // Cost is bounded by the `icons.is_empty()` early return above: a DOM with
+    // no icons never reaches here, and one with icons pays a single rebuild
+    // rather than one per icon.
+    styled_dom.recompute_inheritance_and_compact_cache();
 }
 
 // FFI Option Types

--- a/core/src/icon.rs
+++ b/core/src/icon.rs
@@ -178,18 +178,17 @@ const FONT_ICON_DATA_TYPE_NAME: &str = "FontIconData";
 /// Note: `icon_name` is accessible via `original_icon_dom.node_data[0].get_node_type()` → `NodeType::Icon(name)`
 pub type IconResolverCallbackType = extern "C" fn(
     icon_data: OptionRefAny,
-    original_icon_dom: &StyledDom,
+    original_icon_node: &NodeData,
     system_style: &SystemStyle,
-) -> StyledDom;
+) -> Dom;
 
-/// Default resolver that returns an empty `StyledDom` (shows placeholder)
+/// Default resolver: an empty div, i.e. the icon renders as nothing.
 #[must_use] pub extern "C" fn default_icon_resolver(
     _icon_data: OptionRefAny,
-    _original_icon_dom: &StyledDom,
+    _original_icon_node: &NodeData,
     _system_style: &SystemStyle,
-) -> StyledDom {
-    // Default: return empty DOM (icon won't be visible)
-    StyledDom::default()
+) -> Dom {
+    Dom::create_div()
 }
 
 // Icon Provider Inner (single mutex)
@@ -488,38 +487,18 @@ pub struct SharedIconProvider {
 /// behaviour instead of growing without limit.
 const ICON_CACHE_CAP: usize = 512;
 
-/// A resolver result, stored DECONSTRUCTED into exactly what
-/// [`apply_cached_resolution`] consumes. See the module `# Caching` docs for
-/// why this is not a `StyledDom`.
-#[derive(Debug, Clone)]
-enum CachedIconResolution {
-    /// Resolver returned a zero-node `StyledDom` → the icon becomes an empty
-    /// `Div` placeholder (same as the uncached empty arm).
-    Empty,
-    /// The dominant case: a single-node replacement.
-    SingleNode {
-        node_type: NodeType,
-        style: azul_css::css::Css,
-        accessibility: Option<Box<crate::a11y::AccessibilityInfo>>,
-        /// `None` = the replacement carried no styled node; keep the host's
-        /// (exact parity with the uncached path, which only overwrites when
-        /// the replacement's `styled_nodes` is non-empty).
-        styled_node: Option<Box<crate::styled_dom::StyledNode>>,
-    },
-    /// Multi-node subtree, cloned wholesale on hit. Rare — and today's
-    /// splicing uses only its root (see `apply_multi_node_replacement`) — but
-    /// stored complete so implementing real splicing later cannot be silently
-    /// truncated by this cache.
-    Subtree(Box<StyledDom>),
-}
 
 /// One cached resolution. `original`/`original_styled` are the KEY (together
 /// with the spec, the map key one level up); `resolution` is the value.
 #[derive(Debug)]
 struct IconCacheEntry {
+    /// The icon node as it was BEFORE resolution. Two `<icon>` nodes with the
+    /// same spec but different inline styles resolve differently, so the node
+    /// itself is part of the key.
     original: NodeData,
-    original_styled: crate::styled_dom::StyledNode,
-    resolution: CachedIconResolution,
+    /// The resolved replacement, spliced in whole. A `Dom` rather than a
+    /// flattened single node: an icon may be an arbitrary styled subtree.
+    resolution: Dom,
 }
 
 /// See the module-level `# Caching` section.
@@ -563,28 +542,18 @@ impl SharedIconProvider {
 
     /// Cache hit test. `None` = miss (resolve for real, then
     /// [`Self::store_resolution`]).
-    fn cached_resolution(
-        &self,
-        spec: &str,
-        node: &NodeData,
-        styled: &crate::styled_dom::StyledNode,
-    ) -> Option<CachedIconResolution> {
+    fn cached_resolution(&self, spec: &str, node: &NodeData) -> Option<Dom> {
         let cache = self.cache.lock().ok()?;
-        cache.entries.get(spec)?.iter().find_map(|e| {
-            (e.original == *node && e.original_styled == *styled)
-                .then(|| e.resolution.clone())
-        })
+        cache
+            .entries
+            .get(spec)?
+            .iter()
+            .find_map(|e| (e.original == *node).then(|| e.resolution.clone()))
     }
 
     /// Insert a freshly-resolved entry, flushing everything first if the cap
     /// is reached (see [`ICON_CACHE_CAP`]).
-    fn store_resolution(
-        &self,
-        spec: &str,
-        node: &NodeData,
-        styled: &crate::styled_dom::StyledNode,
-        resolution: &CachedIconResolution,
-    ) {
+    fn store_resolution(&self, spec: &str, node: &NodeData, resolution: &Dom) {
         let Ok(mut cache) = self.cache.lock() else { return };
         if cache.total >= ICON_CACHE_CAP {
             cache.entries.clear();
@@ -596,7 +565,6 @@ impl SharedIconProvider {
             .or_default()
             .push(IconCacheEntry {
                 original: node.clone(),
-                original_styled: styled.clone(),
                 resolution: resolution.clone(),
             });
         cache.total += 1;
@@ -604,14 +572,14 @@ impl SharedIconProvider {
     
     /// Resolve an icon to a `StyledDom` using the registered callback
     #[must_use] pub fn resolve(
-        &self, 
-        original_icon_dom: &StyledDom,
+        &self,
+        original_icon_node: &NodeData,
         icon_name: &str,
         system_style: &SystemStyle,
-    ) -> StyledDom {
+    ) -> Dom {
         let (resolver, lookup_result) = {
             let Ok(guard) = self.inner.lock() else {
-                return StyledDom::default();
+                return Dom::create_div();
             };
 
             let resolver = guard.resolver;
@@ -620,7 +588,26 @@ impl SharedIconProvider {
             (resolver, lookup_result)
         };
 
-        resolver(lookup_result.into(), original_icon_dom, system_style)
+        resolver(lookup_result.into(), original_icon_node, system_style)
+    }
+
+    /// [`Self::resolve`], memoised on `(spec, icon node)`.
+    ///
+    /// The system style is not part of the key: a change to it clears the whole
+    /// cache once per pass (`validate_cache_for_style`), which is cheaper than
+    /// carrying it in every entry.
+    #[must_use] fn resolve_cached(
+        &self,
+        original_icon_node: &NodeData,
+        icon_name: &str,
+        system_style: &SystemStyle,
+    ) -> Dom {
+        if let Some(hit) = self.cached_resolution(icon_name, original_icon_node) {
+            return hit;
+        }
+        let resolved = self.resolve(original_icon_node, icon_name, system_style);
+        self.store_resolution(icon_name, original_icon_node, &resolved);
+        resolved
     }
 
     /// Look up an icon by spec (bare name, `pack:name`, or a comma-separated
@@ -637,452 +624,143 @@ impl SharedIconProvider {
     }
 }
 
-// Icon Resolution in StyledDom
+// Icon Resolution in the Dom tree
 
-/// Collected icon node info for replacement
-struct CollectedIcon {
-    /// Index in the `node_data` array
-    node_idx: usize,
-    /// The icon spec (explicit name, or derived from the node's text children)
-    icon_name: AzString,
-    /// Text children that supplied the spec (`<icon>name</icon>` markup form);
-    /// their text is cleared once the icon node is replaced so the raw spec
-    /// never renders next to the resolved icon.
-    text_children: Vec<usize>,
-}
-
-/// Replacement result after resolving an icon
-struct IconReplacement {
-    /// Index of the icon node to replace
-    node_idx: usize,
-    /// The resolved replacement, already normalized for both the apply step
-    /// and the cache (empty / single node / subtree)
-    replacement: CachedIconResolution,
-    /// Spec-supplying text children to clear after the swap
-    text_children: Vec<usize>,
-}
-
-/// Collect all Icon nodes from the `StyledDom`.
+/// How many times an icon may resolve to another icon before we stop.
 ///
-/// An Icon node with an explicit non-empty name (`Dom::create_icon("x")`)
-/// uses that name directly. An Icon node with an EMPTY name — the markup
-/// form `<icon>content_copy</icon>`, where the tag itself carries no name —
-/// derives its spec from its direct text children, exactly like a ligature
-/// icon font turns glyph text into an icon. The arena is in DFS order, so a
-/// node's children always appear after the node itself.
-fn collect_icon_nodes(styled_dom: &StyledDom) -> Vec<CollectedIcon> {
-    use alloc::collections::BTreeMap;
+/// Chains are legitimate - restyling an existing icon by registering a `Dom`
+/// that contains it is the obvious way to do it - but a resolver is user code,
+/// so a cycle has to terminate. Direct self-reference is caught exactly; this
+/// bounds everything longer.
+const MAX_ICON_INDIRECTION: usize = 8;
 
-    let mut icons: Vec<CollectedIcon> = Vec::new();
-    let mut specs: Vec<String> = Vec::new();
-    // node_idx of un-named icon → position in `icons`
-    let mut unnamed_icon_pos: BTreeMap<usize, usize> = BTreeMap::new();
-
-    let node_data = styled_dom.node_data.as_ref();
-    let hierarchy = styled_dom.node_hierarchy.as_ref();
-
-    for (idx, node) in node_data.iter().enumerate() {
-        match node.get_node_type() {
-            NodeType::Icon(icon_name) => {
-                if icon_name.as_ref().as_str().is_empty() {
-                    unnamed_icon_pos.insert(idx, icons.len());
-                }
-                icons.push(CollectedIcon {
-                    node_idx: idx,
-                    icon_name: icon_name.clone_self(),
-                    text_children: Vec::new(),
-                });
-                specs.push(String::new());
-            }
-            NodeType::Text(text) => {
-                let Some(parent) = hierarchy
-                    .get(idx)
-                    .and_then(crate::styled_dom::NodeHierarchyItem::parent_id)
-                else {
-                    continue;
-                };
-                // A text leaf directly under an icon: for an un-named icon it
-                // is the spec; for every icon it is the slot the resolved
-                // glyph is written into (see `resolve_icons_in_styled_dom`).
-                let Some(icon_pos) = unnamed_icon_pos.get(&parent.index()).copied().or_else(|| {
-                    icons.iter().rposition(|i| i.node_idx == parent.index())
-                }) else {
-                    continue;
-                };
-                if unnamed_icon_pos.contains_key(&parent.index()) {
-                    specs[icon_pos].push_str(text.as_ref().as_str());
-                }
-                icons[icon_pos].text_children.push(idx);
-            }
-            _ => {}
-        }
-    }
-
-    for &icon_pos in unnamed_icon_pos.values() {
-        let spec = specs[icon_pos].trim();
-        if !spec.is_empty() {
-            icons[icon_pos].icon_name = AzString::from(spec);
-        }
-    }
-
-    icons
-}
-
-/// Extract a single-node `StyledDom` from a parent `StyledDom` at the given index.
-/// This creates a minimal `StyledDom` containing just that node for the resolver.
-fn extract_single_node_styled_dom(styled_dom: &StyledDom, node_idx: usize) -> StyledDom {
-    use crate::dom::{NodeDataVec, DomId};
-    use crate::id::NodeId;
-    use crate::styled_dom::{
-        StyledNodeVec, NodeHierarchyItemIdVec, TagIdToNodeIdMappingVec,
-        NodeHierarchyItemVec, NodeHierarchyItem, NodeHierarchyItemId,
-        ParentWithNodeDepthVec, ParentWithNodeDepth,
-    };
-    use crate::style::{CascadeInfoVec, CascadeInfo};
-    use crate::prop_cache::{CssPropertyCachePtr, CssPropertyCache};
-    
-    let node_data = styled_dom.node_data.as_ref();
-    let styled_nodes = styled_dom.styled_nodes.as_ref();
-    
-    if node_idx >= node_data.len() {
-        return StyledDom::default();
-    }
-    
-    // Clone the single node
-    let single_node = node_data[node_idx].clone();
-    let single_styled = if node_idx < styled_nodes.len() {
-        styled_nodes[node_idx].clone()
-    } else {
-        crate::styled_dom::StyledNode::default()
-    };
-    
-    StyledDom {
-        root: NodeHierarchyItemId::from_crate_internal(Some(NodeId::ZERO)),
-        node_hierarchy: NodeHierarchyItemVec::from_vec(vec![NodeHierarchyItem {
-            parent: 0,
-            previous_sibling: 0,
-            next_sibling: 0,
-            last_child: 0,
-        }]),
-        node_data: NodeDataVec::from_vec(vec![single_node]),
-        styled_nodes: StyledNodeVec::from_vec(vec![single_styled]),
-        cascade_info: CascadeInfoVec::from_vec(vec![CascadeInfo { index_in_parent: 0, is_last_child: true }]),
-        nodes_with_window_callbacks: NodeHierarchyItemIdVec::from_vec(Vec::new()),
-        nodes_with_datasets: NodeHierarchyItemIdVec::from_vec(Vec::new()),
-        tag_ids_to_node_ids: TagIdToNodeIdMappingVec::from_vec(Vec::new()),
-        non_leaf_nodes: ParentWithNodeDepthVec::from_vec(Vec::new()),
-        css_property_cache: CssPropertyCachePtr::new(CssPropertyCache::empty(1)),
-        dom_id: DomId::ROOT_ID,
-    }
-}
-
-/// Resolve all collected icons, consulting the provider's cache first.
+/// Replace every `NodeType::Icon` node in `dom` with whatever the registered
+/// resolver returns for it.
 ///
-/// On a HIT nothing is built at all: no single-node extraction (which clones
-/// the node's inline `Css` and allocates a throwaway `CssPropertyCache`), no
-/// pack lookup, no resolver call, no cascade. The 66-icon ribbon that
-/// motivated this (`RSS_MAP` §36c) turns from 66 resolver round-trips per DOM
-/// regeneration into 66 key comparisons.
-fn resolve_collected_icons(
-    icons: &[CollectedIcon],
-    styled_dom: &StyledDom,
+/// # Why this runs on a `Dom`, BEFORE the cascade
+///
+/// This used to run on a `StyledDom`, after the cascade, and it is worth
+/// recording why that was wrong - the shape of the old code is still visible in
+/// the git history and in several comments elsewhere.
+///
+/// A `StyledDom` is a FLAT ARENA in DFS order: a node's first child is the next
+/// index. So a replacement's children could not be attached to the icon node
+/// after the fact without inserting mid-arena and shifting every index after
+/// them. The old code therefore flattened every replacement down to its ROOT
+/// node's `node_type` / `style` / `accessibility` plus a single glyph character
+/// threaded into a text leaf, and threw the rest away - including the whole
+/// `CssPropertyCache` that the resolver's own cascade had just built. Its own
+/// comment said so: "everything else in the returned `StyledDom` ... was always
+/// discarded".
+///
+/// That cost three things:
+///
+/// * **A wasted cascade per icon**, whose result was discarded.
+/// * **Any icon that is not one node was impossible.** Registering a styled
+///   `Dom` as an icon could not work, because only the root survived.
+/// * **A stale property cache.** Rewriting a node's inline `style` after the
+///   cascade left the precomputed per-node arrays describing the PRE-resolution
+///   node. For a font icon that hid `font-family: StyleFontFamily::Ref(face)` -
+///   the only place that face is named - from font collection, so shaping fell
+///   back to a face with no glyph at the icon's private-use codepoint and drew
+///   `.notdef`. It needed an explicit cache rebuild to paper over.
+///
+/// Running on the `Dom` removes all three by construction. A `Dom` is a real
+/// tree (`root` + `children` + its own `css`), so a replacement is spliced whole;
+/// nothing is cascaded twice because the cascade has not happened yet; and there
+/// is no property cache to invalidate. An icon is now free to be an arbitrary
+/// styled subtree, which is what makes "register a `Dom` as an icon" work -
+/// including the colour it should be, which travels with the icon rather than
+/// having to be threaded through every call site as a tint parameter.
+pub fn resolve_icons_in_dom(
+    dom: &mut Dom,
     provider: &SharedIconProvider,
     system_style: &SystemStyle,
-) -> Vec<IconReplacement> {
-    let node_data = styled_dom.node_data.as_ref();
-    let styled_nodes = styled_dom.styled_nodes.as_ref();
-    let default_styled = crate::styled_dom::StyledNode::default();
-
-    icons.iter().map(|icon| {
-        let spec = icon.icon_name.as_str();
-        // The key mirrors what `extract_single_node_styled_dom` would hand the
-        // resolver: this node's data + styled state (default when absent,
-        // matching the extraction's own fallback).
-        let key_node = node_data.get(icon.node_idx);
-        let key_styled = styled_nodes.get(icon.node_idx).unwrap_or(&default_styled);
-
-        if let Some(node) = key_node {
-            if let Some(hit) = provider.cached_resolution(spec, node, key_styled) {
-                return IconReplacement {
-                    node_idx: icon.node_idx,
-                    replacement: hit,
-                    text_children: icon.text_children.clone(),
-                };
-            }
-        }
-
-        // MISS: the uncached path, exactly as before — extract, resolve —
-        // followed by normalize + store.
-        let original_icon_dom = extract_single_node_styled_dom(styled_dom, icon.node_idx);
-        let resolved = provider.resolve(&original_icon_dom, spec, system_style);
-        let resolution = normalize_replacement(resolved);
-        if let Some(node) = key_node {
-            provider.store_resolution(spec, node, key_styled, &resolution);
-        }
-        IconReplacement {
-            node_idx: icon.node_idx,
-            replacement: resolution,
-            text_children: icon.text_children.clone(),
-        }
-    }).collect()
-}
-
-/// Deconstruct a resolver-returned `StyledDom` into [`CachedIconResolution`].
-///
-/// The single-node arm takes the SAME fields, by move, that
-/// `apply_single_node_replacement` takes — everything else in the returned
-/// `StyledDom` (notably the `CssPropertyCache` its cascade just built) was
-/// always discarded, which is precisely why the result is cacheable in this
-/// reduced form.
-fn normalize_replacement(replacement: StyledDom) -> CachedIconResolution {
-    match replacement.node_data.as_ref().len() {
-        0 => CachedIconResolution::Empty,
-        1 => {
-            let StyledDom { node_data, styled_nodes, .. } = replacement;
-            let mut roots = node_data.into_library_owned_vec();
-            let root = roots.swap_remove(0);
-            let NodeData { node_type, style, accessibility, .. } = root;
-            let mut styled_vec = styled_nodes.into_library_owned_vec();
-            let styled_node = if styled_vec.is_empty() {
-                None
-            } else {
-                Some(Box::new(styled_vec.swap_remove(0)))
-            };
-            CachedIconResolution::SingleNode { node_type, style, accessibility, styled_node }
-        }
-        _ => CachedIconResolution::Subtree(Box::new(replacement)),
-    }
-}
-
-/// Apply a normalized resolution to the icon node at `node_idx`. Semantics
-/// are bit-for-bit those of the pre-cache code: `Empty` → placeholder `Div`
-/// (old `apply_single_node_replacement` empty arm), `SingleNode` → move the
-/// four fields in (old non-empty arm), `Subtree` → root-only splice via
-/// `apply_multi_node_replacement`.
-fn apply_cached_resolution(
-    styled_dom: &mut StyledDom,
-    node_idx: usize,
-    resolution: CachedIconResolution,
 ) {
-    match resolution {
-        CachedIconResolution::Empty => {
-            if let Some(node) = styled_dom.node_data.as_mut().get_mut(node_idx) {
-                node.set_node_type(NodeType::Div);
-            }
-        }
-        CachedIconResolution::SingleNode { node_type, style, accessibility, styled_node } => {
-            if let Some(node) = styled_dom.node_data.as_mut().get_mut(node_idx) {
-                node.set_node_type(node_type);
-                node.set_style(style);
-                if let Some(a11y) = accessibility {
-                    node.set_accessibility_info(*a11y);
-                }
-            }
-            if let Some(replacement_styled) = styled_node {
-                if let Some(styled) = styled_dom.styled_nodes.as_mut().get_mut(node_idx) {
-                    *styled = *replacement_styled;
-                }
-            }
-        }
-        CachedIconResolution::Subtree(replacement) => {
-            apply_multi_node_replacement(styled_dom, node_idx, *replacement);
-        }
-    }
+    // A SystemStyle change (theme flip, tint, grayscale) invalidates every
+    // cached resolution. Checked once per pass, not once per icon.
+    provider.validate_cache_for_style(system_style);
+    resolve_icons_in_dom_inner(dom, provider, system_style);
 }
 
-/// Check if a replacement is a single-node replacement (fast path)
-fn is_single_node_replacement(replacement: &StyledDom) -> bool {
-    replacement.node_data.as_ref().len() == 1
-}
-
-/// Apply a single-node replacement (fast path: swap `NodeType` and MOVE properties).
-///
-/// Takes the replacement BY VALUE. It was previously borrowed and every field
-/// deep-copied out of it — `NodeType`, the inline `Css`, the accessibility
-/// box, and the `StyledNode` — even though the caller already owns each
-/// replacement (`replacements.into_iter()`) and drops it immediately after.
-///
-/// Cloning a `Css` is not cheap: it is a `CssRuleBlockVec`, each block holding
-/// a `CssDeclarationVec`, and `Css::from(CssPropertyWithConditionsVec)`
-/// (`css/src/css.rs:171`) builds ONE rule block with a ONE-ELEMENT declaration
-/// vec per property — so a widget with N inline properties is N separate heap
-/// allocations, and cloning it re-allocates all N. Measured on an icon-dense
-/// ribbon: 304 style clones cascading into **14 690** `CssDeclarationVec`
-/// clones, ~2 MB of transient churn that glibc never returns to the OS.
-///
-/// Moving costs nothing and cannot fail. This is a memory AND a latency fix.
-fn apply_single_node_replacement(
-    styled_dom: &mut StyledDom,
-    node_idx: usize,
-    replacement: StyledDom,
+/// The recursive half of [`resolve_icons_in_dom`].
+fn resolve_icons_in_dom_inner(
+    dom: &mut Dom,
+    provider: &SharedIconProvider,
+    system_style: &SystemStyle,
 ) {
-    if replacement.node_data.as_ref().is_empty() {
-        // Empty replacement - convert to empty div
-        let node_data = styled_dom.node_data.as_mut();
-        if let Some(node) = node_data.get_mut(node_idx) {
-            node.set_node_type(NodeType::Div);
+    // An icon may resolve TO another icon - registering
+    // `Dom::create_icon("favorite").with_css("color: red")` under another name
+    // is the natural way to restyle an existing icon - so this iterates rather
+    // than resolving once.
+    //
+    // Bounded two ways, because a resolver is user code and can trivially cycle:
+    // a resolution that yields the SAME spec is a self-reference and stops
+    // immediately, and any longer cycle stops at `MAX_ICON_INDIRECTION`. In both
+    // cases the node is left as-is rather than looping forever.
+    let mut seen = 0;
+    while let Some(spec) = icon_spec_of(dom) {
+        if seen >= MAX_ICON_INDIRECTION {
+            break;
         }
-        return;
+        let replacement = provider.resolve_cached(&dom.root, spec.as_str(), system_style);
+        if icon_spec_of(&replacement).as_ref().map(AzString::as_str) == Some(spec.as_str()) {
+            // Resolves to itself: replacing would spin.
+            break;
+        }
+        // The whole node is replaced, children included: an `<icon>name</icon>`
+        // carries its spec as a text child, and leaving it would render the raw
+        // spec next to the resolved icon.
+        //
+        // Its STYLESHEETS are carried forward, though. `Dom::with_css` attaches
+        // a scoped stylesheet to `Dom::css` rather than inline properties, so
+        // `Dom::create_icon("favorite").with_css("color: red")` - the natural
+        // way to register a recoloured icon - keeps the colour in `css`, not on
+        // the node. Dropping it with the node made the replacement render in the
+        // default colour and silently ignore the caller's styling.
+        //
+        // The replaced node's sheets go FIRST so the replacement's own
+        // declarations still win on conflict.
+        let mut css = dom.css.clone().into_library_owned_vec();
+        let mut replacement = replacement;
+        css.extend(replacement.css.clone().into_library_owned_vec());
+        replacement.css = css.into();
+        *dom = replacement;
+        seen += 1;
     }
 
-    // Consume the replacement so its root's fields can be MOVED rather than
-    // cloned. `swap_remove(0)` is fine: only index 0 is read, and the vec is
-    // dropped immediately after.
-    let StyledDom { node_data, styled_nodes, .. } = replacement;
-    let mut roots = node_data.into_library_owned_vec();
-    let root = roots.swap_remove(0);
-    let NodeData { node_type, style, accessibility, .. } = root;
-
-    if let Some(node) = styled_dom.node_data.as_mut().get_mut(node_idx) {
-        node.set_node_type(node_type);
-        node.set_style(style);
-        if let Some(a11y) = accessibility {
-            node.set_accessibility_info(*a11y);
-        }
-    }
-
-    // Also update the styled_nodes to reflect the new styling.
-    let mut styled_vec = styled_nodes.into_library_owned_vec();
-    if !styled_vec.is_empty() {
-        let replacement_styled = styled_vec.swap_remove(0);
-        if let Some(styled) = styled_dom.styled_nodes.as_mut().get_mut(node_idx) {
-            *styled = replacement_styled;
-        }
+    for child in dom.children.as_mut() {
+        resolve_icons_in_dom_inner(child, provider, system_style);
     }
 }
 
-/// Apply multi-node replacement using subtree splicing
-fn apply_multi_node_replacement(
-    styled_dom: &mut StyledDom,
-    node_idx: usize,
-    replacement: StyledDom,
-) {
-    // Read the length BEFORE moving — it is used again after the call.
-    let replacement_len = replacement.node_data.as_ref().len();
-    if replacement_len == 0 {
-        let node_data = styled_dom.node_data.as_mut();
-        if let Some(node) = node_data.get_mut(node_idx) {
-            node.set_node_type(NodeType::Div);
-        }
-        return;
-    }
-
-    // The ROOT's fields move onto the icon node. The arena is in DFS order
-    // (a node's first child is the next index), so a replacement's children
-    // cannot be appended under the icon node after the fact — they would
-    // have to be INSERTED mid-arena with every index after them shifted.
-    // Instead the one child a resolution has, the glyph text leaf of a font
-    // icon, travels through [`glyph_of`] into the text leaf every icon node
-    // carries (`Dom::create_icon` creates it; `<icon>name</icon>` has it).
-    apply_single_node_replacement(styled_dom, node_idx, replacement);
-}
-
-/// The glyph a resolution wants rendered inside the icon node: the text of
-/// the first text leaf under the replacement's root (a font icon's
-/// `<span>glyph</span>`). `None` for image icons and empty resolutions.
-fn glyph_of(resolution: &CachedIconResolution) -> Option<AzString> {
-    let CachedIconResolution::Subtree(sd) = resolution else {
+/// The icon spec for a node, or `None` if it is not an icon node.
+///
+/// An icon with an explicit non-empty name (`Dom::create_icon("x")`) uses it
+/// directly. One with an EMPTY name - the markup form `<icon>content_copy</icon>`,
+/// where the tag carries no name - derives the spec from its direct text
+/// children, exactly like a ligature icon font turns glyph text into an icon.
+fn icon_spec_of(dom: &Dom) -> Option<AzString> {
+    let NodeType::Icon(name) = dom.root.get_node_type() else {
         return None;
     };
-    let root = sd.root.into_crate_internal().unwrap_or(crate::id::NodeId::ZERO);
-    let hierarchy = sd.node_hierarchy.as_container();
-    let nodes = sd.node_data.as_container();
-    let mut child = hierarchy.get(root).and_then(|h| h.first_child_id(root));
-    while let Some(c) = child {
-        if let Some(NodeType::Text(t)) = nodes.get(c).map(NodeData::get_node_type) {
-            return Some(t.clone_self());
-        }
-        child = hierarchy.get(c).and_then(super::styled_dom::NodeHierarchyItem::next_sibling_id);
-    }
-    None
-}
-
-/// Resolve all Icon nodes in a `StyledDom` to their actual content.
-///
-/// This function:
-/// 1. Collects all Icon nodes from the `StyledDom`
-/// 2. Resolves each icon via the provider's callback (passing original icon DOM)
-/// 3. Applies replacements (single-node fast path or multi-node splicing)
-///
-/// This should be called after `StyledDom` creation but before layout.
-pub fn resolve_icons_in_styled_dom(
-    styled_dom: &mut StyledDom,
-    provider: &SharedIconProvider,
-    system_style: &SystemStyle,
-) {
-    // Step 1: Collect all icon nodes
-    let icons = collect_icon_nodes(styled_dom);
-
-    if icons.is_empty() {
-        return;
+    let name = name.as_str();
+    if !name.is_empty() {
+        return Some(AzString::from(name));
     }
 
-    // Step 1.5: A SystemStyle change (theme flip, tint, grayscale) invalidates
-    // every cached resolution. Checked once per batch, not once per icon.
-    provider.validate_cache_for_style(system_style);
-
-    // Step 2: Resolve all icons (cache-first; see resolve_collected_icons)
-    let replacements = resolve_collected_icons(&icons, styled_dom, provider, system_style);
-
-    // Step 3: Apply replacements (reverse order to preserve indices)
-    for replacement in replacements.into_iter().rev() {
-        let mut glyph = glyph_of(&replacement.replacement);
-        if glyph.is_some() && replacement.text_children.is_empty() {
-            // A bare `NodeType::Icon` built without `Dom::create_icon`: it
-            // has no text leaf to carry the glyph, so the glyph is lost.
-            #[cfg(all(debug_assertions, feature = "std"))]
-            eprintln!(
-                "Warning: icon node {} has no text child to hold its glyph; \
-                 build icons with Dom::create_icon",
-                replacement.node_idx
-            );
-        }
-        apply_cached_resolution(
-            styled_dom,
-            replacement.node_idx,
-            replacement.replacement,
-        );
-
-        // The icon's text leaves: the first one carries the resolved glyph
-        // (a font icon), the rest - and all of them for an image icon - are
-        // cleared so the raw `<icon>name</icon>` spec never renders next to
-        // (or instead of) the resolved icon.
-        for &child_idx in &replacement.text_children {
-            if let Some(node) = styled_dom.node_data.as_mut().get_mut(child_idx) {
-                let text = glyph.take().unwrap_or_else(|| AzString::from_const_str(""));
-                node.set_node_type(NodeType::Text(azul_css::css::BoxOrStatic::heap(text)));
-            }
+    let mut derived = alloc::string::String::new();
+    for child in dom.children.as_ref() {
+        if let NodeType::Text(t) = child.root.get_node_type() {
+            derived.push_str(t.as_str());
         }
     }
-
-    // Step 4: rebuild the compact cache, because step 3 invalidated it.
-    //
-    // `apply_cached_resolution` rewrites a node's `NodeType` and inline `style`
-    // — a font icon's replacement carries `font-family: StyleFontFamily::Ref`,
-    // which is the ONLY place that face is named. But the compact cache is a
-    // PRECOMPUTED per-node array, built when the `StyledDom` was cascaded, and
-    // nothing above touches it. So after the splice it still describes the
-    // pre-resolution `<icon>` node.
-    //
-    // That matters because the compact cache is the source of truth for font
-    // resolution: `collect_font_stacks_from_styled_dom` keys on
-    // `tier2b_text[i].font_family_hash` and looks the families up in
-    // `font_hash_to_families`. With a stale hash it finds the ORIGINAL
-    // families, never sees the `Ref`, and so never registers the face as an
-    // embedded font. Shaping then falls back to a system face which has no
-    // glyph at the icon's private-use codepoint, and the icon rasterises to a
-    // `.notdef` tofu box — with every step in between reporting success.
-    //
-    // This was previously masked in the engine's own path: `regenerate_layout`
-    // wraps the DOM for client-side decorations right after this call, and that
-    // rebuild happened to refresh the cache. Anything that resolved icons
-    // WITHOUT a later rebuild — a frameless window, or rendering an icon
-    // straight to a bitmap, which is how this was found — got the tofu.
-    //
-    // Cost is bounded by the `icons.is_empty()` early return above: a DOM with
-    // no icons never reaches here, and one with icons pays a single rebuild
-    // rather than one per icon.
-    styled_dom.recompute_inheritance_and_compact_cache();
+    let derived = derived.trim();
+    if derived.is_empty() {
+        None
+    } else {
+        Some(AzString::from(derived))
+    }
 }
 
 // FFI Option Types
@@ -1145,48 +823,15 @@ mod autotest_generated {
         ]
     }
 
-    fn styled_dom_with_icons(names: &[&str]) -> StyledDom {
-        let mut body = Dom::create_body();
-        for n in names {
-            body.add_child(Dom::create_icon(*n));
-        }
-        StyledDom::create_from_dom(body)
-    }
-
-    /// A `StyledDom` with *zero* nodes — `StyledDom::default()` has one (a Body),
-    /// so the truly-empty case has to be built by hand.
-    fn zero_node_styled_dom() -> StyledDom {
-        StyledDom {
-            node_data: NodeDataVec::from_vec(Vec::new()),
-            styled_nodes: StyledNodeVec::from_vec(Vec::new()),
-            ..StyledDom::default()
-        }
-    }
-
-    fn node_type_at(sd: &StyledDom, idx: usize) -> NodeType {
-        sd.node_data.as_ref()[idx].get_node_type().clone()
-    }
-
-    fn icon_indices(sd: &StyledDom) -> Vec<usize> {
-        collect_icon_nodes(sd).iter().map(|i| i.node_idx).collect()
-    }
-
     // Resolvers
+
 
     extern "C" fn div_resolver(
         _icon_data: OptionRefAny,
-        _original_icon_dom: &StyledDom,
+        _original_icon_node: &NodeData,
         _system_style: &SystemStyle,
-    ) -> StyledDom {
-        StyledDom::create_from_dom(Dom::create_div())
-    }
-
-    extern "C" fn zero_node_resolver(
-        _icon_data: OptionRefAny,
-        _original_icon_dom: &StyledDom,
-        _system_style: &SystemStyle,
-    ) -> StyledDom {
-        zero_node_styled_dom()
+    ) -> Dom {
+        Dom::create_div()
     }
 
     // Statics for `shared_resolve_receives_icon_data_and_original_dom` ONLY.
@@ -1199,20 +844,18 @@ mod autotest_generated {
 
     extern "C" fn recording_resolver(
         icon_data: OptionRefAny,
-        original_icon_dom: &StyledDom,
+        original_icon_node: &NodeData,
         _system_style: &SystemStyle,
-    ) -> StyledDom {
+    ) -> Dom {
         REC_CALLS.fetch_add(1, AtomicOrdering::SeqCst);
         if matches!(icon_data, OptionRefAny::Some(_)) {
             REC_SAW_DATA.store(true, AtomicOrdering::SeqCst);
         }
-        if let Some(node) = original_icon_dom.node_data.as_ref().first() {
-            if let NodeType::Icon(name) = node.get_node_type() {
-                REC_SAW_ICON_NODE.store(true, AtomicOrdering::SeqCst);
-                REC_NAME_LEN.store(name.as_ref().as_str().len(), AtomicOrdering::SeqCst);
-            }
+        if let NodeType::Icon(name) = original_icon_node.get_node_type() {
+            REC_SAW_ICON_NODE.store(true, AtomicOrdering::SeqCst);
+            REC_NAME_LEN.store(name.as_ref().as_str().len(), AtomicOrdering::SeqCst);
         }
-        StyledDom::create_from_dom(Dom::create_div())
+        Dom::create_div()
     }
 
     // Mutex (the no_std spinlock under `no_std`, `std::sync::Mutex` otherwise)
@@ -1242,30 +885,23 @@ mod autotest_generated {
     // default_icon_resolver
 
     #[test]
-    fn default_resolver_returns_one_body_node_for_none_and_some() {
-        let orig = StyledDom::default();
+    fn default_resolver_returns_a_single_empty_div_for_none_and_some() {
+        let orig = Dom::create_div().root;
         let style = SystemStyle::default();
 
+        // The core default resolver renders nothing; azul-layout installs the
+        // real one that understands image / font / Dom icon data.
         let none = default_icon_resolver(OptionRefAny::None, &orig, &style);
-        // NOTE: the doc calls this an "empty StyledDom", but `StyledDom::default()`
-        // carries exactly one node (a Body), so the result is single-node, NOT empty.
-        assert_eq!(none.node_data.as_ref().len(), 1);
-        assert!(is_single_node_replacement(&none));
+        assert!(matches!(none.root.get_node_type(), NodeType::Div));
+        assert!(none.children.as_ref().is_empty());
 
         let some = default_icon_resolver(
             OptionRefAny::Some(RefAny::new(TestIconData { id: 1 })),
             &orig,
             &style,
         );
-        assert_eq!(some.node_data.as_ref().len(), 1);
-    }
-
-    #[test]
-    fn default_resolver_no_panic_on_zero_node_original_dom() {
-        let orig = zero_node_styled_dom();
-        let style = SystemStyle::default();
-        let out = default_icon_resolver(OptionRefAny::None, &orig, &style);
-        assert_eq!(out.node_data.as_ref().len(), 1);
+        assert!(matches!(some.root.get_node_type(), NodeType::Div));
+        assert!(some.children.as_ref().is_empty());
     }
 
     // IconProviderHandle: construction / invariants
@@ -1294,8 +930,8 @@ mod autotest_generated {
         let mut h = IconProviderHandle::with_resolver(div_resolver);
         h.register_icon("p", "home", RefAny::new(TestIconData { id: 1 }));
         let shared = SharedIconProvider::from_handle(h);
-        let out = shared.resolve(&StyledDom::default(), "home", &SystemStyle::default());
-        assert!(matches!(node_type_at(&out, 0), NodeType::Div));
+        let out = shared.resolve(&Dom::create_div().root, "home", &SystemStyle::default());
+        assert!(matches!(out.root.get_node_type(), NodeType::Div));
     }
 
     #[test]
@@ -1304,8 +940,8 @@ mod autotest_generated {
         h.set_resolver(div_resolver);
         let shared = SharedIconProvider::from_handle(h);
         // Unregistered icon: resolver still runs, just with `None` data.
-        let out = shared.resolve(&StyledDom::default(), "missing", &SystemStyle::default());
-        assert!(matches!(node_type_at(&out, 0), NodeType::Div));
+        let out = shared.resolve(&Dom::create_div().root, "missing", &SystemStyle::default());
+        assert!(matches!(out.root.get_node_type(), NodeType::Div));
     }
 
     #[test]
@@ -1742,17 +1378,17 @@ mod autotest_generated {
         h.register_icon("p", "home", RefAny::new(TestIconData { id: 1 }));
         let shared = SharedIconProvider::from_handle(h);
 
-        let original = styled_dom_with_icons(&["home"]);
-        let icon_idx = icon_indices(&original)[0];
-        let single = extract_single_node_styled_dom(&original, icon_idx);
+        // The resolver is handed the ICON NODE itself now, not a one-node
+        // StyledDom carved out of the tree.
+        let icon_node = Dom::create_icon("home").root;
 
-        let out = shared.resolve(&single, "HOME", &SystemStyle::default());
+        let out = shared.resolve(&icon_node, "HOME", &SystemStyle::default());
 
         assert!(REC_CALLS.load(AtomicOrdering::SeqCst) >= 1);
         assert!(REC_SAW_DATA.load(AtomicOrdering::SeqCst), "case-folded lookup must pass Some(data)");
-        assert!(REC_SAW_ICON_NODE.load(AtomicOrdering::SeqCst), "node 0 of the original dom is the Icon");
+        assert!(REC_SAW_ICON_NODE.load(AtomicOrdering::SeqCst), "the resolver must receive the Icon node");
         assert_eq!(REC_NAME_LEN.load(AtomicOrdering::SeqCst), "home".len());
-        assert!(matches!(node_type_at(&out, 0), NodeType::Div));
+        assert!(matches!(out.root.get_node_type(), NodeType::Div));
     }
 
     #[test]
@@ -1762,8 +1398,8 @@ mod autotest_generated {
         // Empty name, huge name, unicode name: resolver still returns its DOM.
         let huge = "x".repeat(100_000);
         for name in ["", "\u{1F600}", huge.as_str()] {
-            let out = shared.resolve(&StyledDom::default(), name, &SystemStyle::default());
-            assert!(matches!(node_type_at(&out, 0), NodeType::Div));
+            let out = shared.resolve(&Dom::create_div().root, name, &SystemStyle::default());
+            assert!(matches!(out.root.get_node_type(), NodeType::Div));
         }
     }
 
@@ -1798,341 +1434,163 @@ mod autotest_generated {
         assert!(shared.has_icon("icon0"), "table intact after contention");
     }
 
-    // collect_icon_nodes
+    // resolve_icons_in_dom (end to end)
 
-    #[test]
-    fn collect_icon_nodes_is_empty_when_there_are_no_icons() {
-        assert!(collect_icon_nodes(&StyledDom::default()).is_empty());
-        assert!(collect_icon_nodes(&zero_node_styled_dom()).is_empty());
-        assert!(collect_icon_nodes(&StyledDom::create_from_dom(Dom::create_div())).is_empty());
-    }
-
-    #[test]
-    fn collect_icon_nodes_finds_every_icon_in_ascending_index_order_with_verbatim_names() {
-        let names = ["HOME", "\u{1F600}", ""];
-        let sd = styled_dom_with_icons(&names);
-        let collected = collect_icon_nodes(&sd);
-
-        assert_eq!(collected.len(), names.len());
-        for (i, c) in collected.iter().enumerate() {
-            // Node names are NOT folded at DOM-construction time (only at lookup).
-            assert_eq!(c.icon_name.as_str(), names[i]);
-            if i > 0 {
-                assert!(c.node_idx > collected[i - 1].node_idx, "indices must ascend");
+    /// Every icon node in the tree, by the path of child indices that reaches it.
+    fn icon_paths(dom: &Dom) -> Vec<Vec<usize>> {
+        fn walk(d: &Dom, path: &mut Vec<usize>, out: &mut Vec<Vec<usize>>) {
+            if matches!(d.root.get_node_type(), NodeType::Icon(_)) {
+                out.push(path.clone());
+            }
+            for (i, c) in d.children.as_ref().iter().enumerate() {
+                path.push(i);
+                walk(c, path, out);
+                path.pop();
             }
         }
+        let mut out = Vec::new();
+        walk(dom, &mut Vec::new(), &mut out);
+        out
     }
 
-    #[test]
-    fn collect_icon_nodes_handles_a_very_long_icon_name() {
-        let long = "x".repeat(100_000);
-        let sd = styled_dom_with_icons(&[&long]);
-        let collected = collect_icon_nodes(&sd);
-        assert_eq!(collected.len(), 1);
-        assert_eq!(collected[0].icon_name.as_str().len(), 100_000);
-    }
-
-    // extract_single_node_styled_dom (numeric / index boundaries)
-
-    #[test]
-    fn extract_single_node_at_index_zero() {
-        let sd = styled_dom_with_icons(&["home"]);
-        let out = extract_single_node_styled_dom(&sd, 0);
-        assert_eq!(out.node_data.as_ref().len(), 1);
-        assert_eq!(out.styled_nodes.as_ref().len(), 1);
-        assert_eq!(node_type_at(&out, 0), node_type_at(&sd, 0));
-    }
-
-    #[test]
-    fn extract_single_node_of_the_icon_keeps_the_icon_node_type() {
-        let sd = styled_dom_with_icons(&["home"]);
-        let idx = icon_indices(&sd)[0];
-        let out = extract_single_node_styled_dom(&sd, idx);
-        assert_eq!(out.node_data.as_ref().len(), 1);
-        assert!(matches!(node_type_at(&out, 0), NodeType::Icon(_)));
-    }
-
-    #[test]
-    fn extract_single_node_out_of_bounds_falls_back_to_default_without_panicking() {
-        let sd = styled_dom_with_icons(&["home"]);
-        let len = sd.node_data.as_ref().len();
-
-        for idx in [len, len + 1, usize::MAX / 2, usize::MAX - 1, usize::MAX] {
-            let out = extract_single_node_styled_dom(&sd, idx);
-            // Falls back to StyledDom::default() -> exactly one (Body) node.
-            assert_eq!(out.node_data.as_ref().len(), 1, "idx {idx} must not panic");
-            assert!(!matches!(node_type_at(&out, 0), NodeType::Icon(_)));
+    /// The node at a child path.
+    fn node_at<'a>(dom: &'a Dom, path: &[usize]) -> &'a Dom {
+        let mut cur = dom;
+        for &i in path {
+            cur = &cur.children.as_ref()[i];
         }
-        // Zero-node input: even index 0 is out of bounds.
-        let empty = zero_node_styled_dom();
-        assert_eq!(extract_single_node_styled_dom(&empty, 0).node_data.as_ref().len(), 1);
+        cur
     }
 
-    #[test]
-    fn extract_single_node_tolerates_styled_nodes_shorter_than_node_data() {
-        let sd_full = styled_dom_with_icons(&["home"]);
-        let idx = icon_indices(&sd_full)[0];
-
-        let mut sd = sd_full;
-        sd.styled_nodes = StyledNodeVec::from_vec(Vec::new()); // desynced arrays
-
-        let out = extract_single_node_styled_dom(&sd, idx);
-        assert_eq!(out.node_data.as_ref().len(), 1);
-        assert_eq!(out.styled_nodes.as_ref().len(), 1, "must synthesize a default StyledNode");
-        assert!(matches!(node_type_at(&out, 0), NodeType::Icon(_)));
-    }
-
-    // is_single_node_replacement
-
-    #[test]
-    fn is_single_node_replacement_true_false_and_edges() {
-        assert!(is_single_node_replacement(&StyledDom::default()));
-        assert!(is_single_node_replacement(&StyledDom::create_from_dom(Dom::create_div())));
-
-        // Zero nodes is NOT "single node" (callers treat it as the empty case).
-        assert!(!is_single_node_replacement(&zero_node_styled_dom()));
-
-        let multi = StyledDom::create_from_dom(
-            Dom::create_div().with_child(Dom::create_div()).with_child(Dom::create_div()),
-        );
-        assert!(multi.node_data.as_ref().len() > 1);
-        assert!(!is_single_node_replacement(&multi));
-    }
-
-    // apply_single_node_replacement (index boundaries)
-
-    #[test]
-    fn apply_single_node_replacement_with_zero_node_dom_turns_the_icon_into_a_div() {
-        let mut sd = styled_dom_with_icons(&["home"]);
-        let idx = icon_indices(&sd)[0];
-        let empty = zero_node_styled_dom();
-
-        apply_single_node_replacement(&mut sd, idx, empty);
-        assert!(matches!(node_type_at(&sd, idx), NodeType::Div));
-        assert!(collect_icon_nodes(&sd).is_empty());
-    }
-
-    #[test]
-    fn apply_single_node_replacement_copies_the_replacement_root_node_type() {
-        let mut sd = styled_dom_with_icons(&["home"]);
-        let idx = icon_indices(&sd)[0];
-        let before_len = sd.node_data.as_ref().len();
-        let repl = StyledDom::create_from_dom(Dom::create_div());
-
-        apply_single_node_replacement(&mut sd, idx, repl);
-        assert!(matches!(node_type_at(&sd, idx), NodeType::Div));
-        assert_eq!(sd.node_data.as_ref().len(), before_len, "node count must not change");
-    }
-
-    #[test]
-    fn apply_single_node_replacement_out_of_bounds_index_is_a_no_op() {
-        let repl = StyledDom::create_from_dom(Dom::create_div());
-        let empty = zero_node_styled_dom();
-
-        let base = styled_dom_with_icons(&["home"]);
-        let icon_idx = icon_indices(&base)[0];
-        let len = base.node_data.as_ref().len();
-
-        for idx in [len, len + 1, usize::MAX / 2, usize::MAX] {
-            let mut sd = styled_dom_with_icons(&["home"]);
-            // Cloned because the loop reuses them; production MOVES.
-            apply_single_node_replacement(&mut sd, idx, repl.clone());
-            apply_single_node_replacement(&mut sd, idx, empty.clone());
-            assert_eq!(sd.node_data.as_ref().len(), len, "idx {idx} must not resize");
-            assert!(
-                matches!(node_type_at(&sd, icon_idx), NodeType::Icon(_)),
-                "idx {idx} must leave the icon untouched"
-            );
+    fn dom_with_icons(names: &[&str]) -> Dom {
+        let mut body = Dom::create_body();
+        for n in names {
+            body = body.with_child(Dom::create_icon(AzString::from(*n)));
         }
-    }
-
-    // apply_multi_node_replacement (index boundaries)
-
-    #[test]
-    fn apply_multi_node_replacement_with_zero_node_dom_turns_the_icon_into_a_div() {
-        let mut sd = styled_dom_with_icons(&["home"]);
-        let idx = icon_indices(&sd)[0];
-
-        apply_multi_node_replacement(&mut sd, idx, zero_node_styled_dom());
-        assert!(matches!(node_type_at(&sd, idx), NodeType::Div));
+        body
     }
 
     #[test]
-    fn apply_multi_node_replacement_applies_only_the_root_and_does_not_splice() {
-        let mut sd = styled_dom_with_icons(&["home"]);
-        let idx = icon_indices(&sd)[0];
-        let before_len = sd.node_data.as_ref().len();
-
-        let repl = StyledDom::create_from_dom(
-            Dom::create_div().with_child(Dom::create_div()).with_child(Dom::create_div()),
-        );
-        assert!(repl.node_data.as_ref().len() > 1);
-        apply_multi_node_replacement(&mut sd, idx, repl);
-
-        assert!(matches!(node_type_at(&sd, idx), NodeType::Div));
-        // The arena is DFS-ordered: children cannot be appended after the
-        // fact, so the replacement's own children are NOT spliced in. A font
-        // icon's glyph travels through the icon's text leaf instead.
-        assert_eq!(sd.node_data.as_ref().len(), before_len);
-    }
-
-    #[test]
-    fn a_font_icons_glyph_lands_in_the_icons_text_leaf() {
-        // `Dom::create_icon` gives the icon node a text leaf; a resolver that
-        // answers with <span>glyph</span> must put the glyph THERE (the span's
-        // fields on the icon node, the text in the leaf), not lose it.
-        extern "C" fn span_glyph_resolver(
-            _data: OptionRefAny,
-            _original: &StyledDom,
-            _style: &SystemStyle,
-        ) -> StyledDom {
-            StyledDom::create_from_dom(Dom::create_span_with_text("\u{e3b8}"))
-        }
-        let shared = SharedIconProvider::from_handle(IconProviderHandle::with_resolver(span_glyph_resolver));
-        let mut sd = StyledDom::create_from_dom(Dom::create_body().with_child(Dom::create_icon("colorize")));
-        let icon = icon_indices(&sd)[0];
-        let hierarchy = sd.node_hierarchy.as_container();
-        let leaf = hierarchy.get(crate::id::NodeId::new(icon)).and_then(|h| h.first_child_id(crate::id::NodeId::new(icon)))
-            .expect("create_icon gives the icon a text leaf");
-        // `hierarchy` borrows `sd`; its last use is above, so NLL releases the
-        // borrow here — the next line needs `&mut sd`. (A `drop()` would be a
-        // no-op: NodeDataContainerRef is not Drop.)
-        resolve_icons_in_styled_dom(&mut sd, &shared, &SystemStyle::default());
-        assert!(matches!(node_type_at(&sd, icon), NodeType::Span), "the span's type moved onto the icon node");
-        match sd.node_data.as_ref()[leaf.index()].get_node_type() {
-            NodeType::Text(t) => assert_eq!(t.as_ref().as_str(), "\u{e3b8}", "the glyph is in the leaf"),
-            other => panic!("the leaf is not text: {other:?}"),
-        }
-    }
-
-    #[test]
-    fn apply_multi_node_replacement_out_of_bounds_index_is_a_no_op() {
-        let repl = StyledDom::create_from_dom(Dom::create_div().with_child(Dom::create_div()));
-        let base = styled_dom_with_icons(&["home"]);
-        let icon_idx = icon_indices(&base)[0];
-        let len = base.node_data.as_ref().len();
-
-        for idx in [len, usize::MAX] {
-            let mut sd = styled_dom_with_icons(&["home"]);
-            // Cloned because the loop reuses it; production MOVES.
-            apply_multi_node_replacement(&mut sd, idx, repl.clone());
-            apply_multi_node_replacement(&mut sd, idx, zero_node_styled_dom());
-            assert_eq!(sd.node_data.as_ref().len(), len);
-            assert!(matches!(node_type_at(&sd, icon_idx), NodeType::Icon(_)));
-        }
-    }
-
-    // resolve_collected_icons
-
-    #[test]
-    fn resolve_collected_icons_preserves_indices_and_resolves_each_icon() {
-        let mut h = IconProviderHandle::with_resolver(div_resolver);
-        h.register_icon("p", "home", RefAny::new(TestIconData { id: 1 }));
-        let shared = SharedIconProvider::from_handle(h);
-
-        let sd = styled_dom_with_icons(&["home", "missing", "\u{1F600}"]);
-        let icons = collect_icon_nodes(&sd);
-        let replacements =
-            resolve_collected_icons(&icons, &sd, &shared, &SystemStyle::default());
-
-        assert_eq!(replacements.len(), icons.len());
-        for (r, i) in replacements.iter().zip(icons.iter()) {
-            assert_eq!(r.node_idx, i.node_idx);
-            // The custom resolver ignores the data, so even unregistered icons
-            // resolve. Replacements are pre-normalized now: a one-node div
-            // arrives as `SingleNode { node_type: Div, .. }`.
-            assert!(matches!(
-                &r.replacement,
-                CachedIconResolution::SingleNode { node_type: NodeType::Div, .. }
-            ));
-        }
-    }
-
-    #[test]
-    fn resolve_collected_icons_with_no_icons_returns_no_replacements() {
-        let shared = SharedIconProvider::from_handle(IconProviderHandle::new());
-        let sd = StyledDom::default();
-        let out = resolve_collected_icons(&[], &sd, &shared, &SystemStyle::default());
-        assert!(out.is_empty());
-    }
-
-    // resolve_icons_in_styled_dom (end to end)
-
-    #[test]
-    fn resolve_icons_in_styled_dom_is_a_no_op_without_icons() {
+    fn resolve_icons_in_dom_is_a_no_op_without_icons() {
         let shared = SharedIconProvider::from_handle(IconProviderHandle::with_resolver(div_resolver));
-        let mut sd = StyledDom::create_from_dom(Dom::create_body().with_child(Dom::create_text_do_not_use_without_block_level_wrapper("hi")));
-        let before_len = sd.node_data.as_ref().len();
-        let before_root = node_type_at(&sd, 0);
+        let mut dom = Dom::create_body()
+            .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("hi"));
+        let before = dom.clone();
 
-        resolve_icons_in_styled_dom(&mut sd, &shared, &SystemStyle::default());
+        resolve_icons_in_dom(&mut dom, &shared, &SystemStyle::default());
 
-        assert_eq!(sd.node_data.as_ref().len(), before_len);
-        assert_eq!(node_type_at(&sd, 0), before_root);
+        assert_eq!(dom.children.as_ref().len(), before.children.as_ref().len());
+        assert_eq!(dom.root.get_node_type(), before.root.get_node_type());
     }
 
     #[test]
-    fn resolve_icons_in_styled_dom_replaces_every_icon_case_insensitively() {
+    fn resolve_icons_in_dom_replaces_every_icon_case_insensitively() {
         let mut h = IconProviderHandle::with_resolver(div_resolver);
         h.register_icon("p", "home", RefAny::new(TestIconData { id: 1 }));
         let shared = SharedIconProvider::from_handle(h);
 
         // Mixed case in the DOM, lowercase in the pack, plus one unregistered icon.
-        let mut sd = styled_dom_with_icons(&["HOME", "unregistered", "HoMe"]);
-        let idxs = icon_indices(&sd);
-        let before_len = sd.node_data.as_ref().len();
+        let mut dom = dom_with_icons(&["HOME", "unregistered", "HoMe"]);
+        let paths = icon_paths(&dom);
+        assert_eq!(paths.len(), 3);
 
-        resolve_icons_in_styled_dom(&mut sd, &shared, &SystemStyle::default());
+        resolve_icons_in_dom(&mut dom, &shared, &SystemStyle::default());
 
-        assert_eq!(sd.node_data.as_ref().len(), before_len);
-        assert!(collect_icon_nodes(&sd).is_empty(), "no Icon node may survive resolution");
-        for idx in idxs {
-            assert!(matches!(node_type_at(&sd, idx), NodeType::Div));
+        assert!(icon_paths(&dom).is_empty(), "no Icon node may survive resolution");
+        for p in paths {
+            assert!(matches!(node_at(&dom, &p).root.get_node_type(), NodeType::Div));
         }
     }
 
     #[test]
-    fn resolve_icons_in_styled_dom_with_the_default_resolver_removes_the_icon_nodes() {
-        // The default resolver returns `StyledDom::default()` (one Body node), so
-        // icons are replaced by that root's node type rather than being cleared.
+    fn resolve_icons_in_dom_with_the_default_resolver_removes_the_icon_nodes() {
+        // The default resolver returns an empty div, so an icon with no
+        // registered data becomes that rather than staying an Icon node.
         let shared = SharedIconProvider::from_handle(IconProviderHandle::new());
-        let mut sd = styled_dom_with_icons(&["home"]);
-        let idx = icon_indices(&sd)[0];
+        let mut dom = dom_with_icons(&["home"]);
 
-        resolve_icons_in_styled_dom(&mut sd, &shared, &SystemStyle::default());
+        resolve_icons_in_dom(&mut dom, &shared, &SystemStyle::default());
 
-        assert!(!matches!(node_type_at(&sd, idx), NodeType::Icon(_)));
-        assert!(collect_icon_nodes(&sd).is_empty());
+        assert!(icon_paths(&dom).is_empty());
     }
 
+    /// The whole point of resolving on the tree: a replacement may be MORE than
+    /// one node, and all of it survives. The old StyledDom splice flattened
+    /// every replacement to its root plus a single glyph character, which is
+    /// why registering a `Dom` as an icon was impossible.
     #[test]
-    fn resolve_icons_in_styled_dom_handles_a_zero_node_replacement() {
-        let shared =
-            SharedIconProvider::from_handle(IconProviderHandle::with_resolver(zero_node_resolver));
-        let mut sd = styled_dom_with_icons(&["home", "other"]);
-        let idxs = icon_indices(&sd);
-        let before_len = sd.node_data.as_ref().len();
-
-        resolve_icons_in_styled_dom(&mut sd, &shared, &SystemStyle::default());
-
-        assert_eq!(sd.node_data.as_ref().len(), before_len);
-        for idx in idxs {
-            assert!(matches!(node_type_at(&sd, idx), NodeType::Div), "empty => Div placeholder");
+    fn a_multi_node_replacement_is_spliced_in_whole() {
+        extern "C" fn subtree_resolver(
+            _d: OptionRefAny,
+            _n: &NodeData,
+            _s: &SystemStyle,
+        ) -> Dom {
+            Dom::create_div()
+                .with_child(Dom::create_div())
+                .with_child(Dom::create_div())
         }
+
+        let shared =
+            SharedIconProvider::from_handle(IconProviderHandle::with_resolver(subtree_resolver));
+        let mut dom = dom_with_icons(&["home"]);
+        let path = icon_paths(&dom)[0].clone();
+
+        resolve_icons_in_dom(&mut dom, &shared, &SystemStyle::default());
+
+        let replaced = node_at(&dom, &path);
+        assert!(matches!(replaced.root.get_node_type(), NodeType::Div));
+        assert_eq!(
+            replaced.children.as_ref().len(),
+            2,
+            "both children of the replacement must survive the splice"
+        );
+    }
+
+    /// REGRESSION: an icon that resolves to ANOTHER icon must keep the
+    /// stylesheets attached along the way.
+    ///
+    /// `Dom::with_css` attaches a scoped stylesheet to `Dom::css`, NOT inline
+    /// properties - so `Dom::create_icon("favorite").with_css("color: red")`,
+    /// the natural way to register a recoloured icon, carries the colour in
+    /// `css`. Replacing the node wholesale dropped it, and the icon rendered in
+    /// the default colour while every step reported success.
+    ///
+    /// This is the mechanism that lets an icon carry its own appearance instead
+    /// of every call site threading a tint parameter down to the renderer.
+    #[test]
+    fn stylesheets_survive_an_icon_resolving_to_another_icon() {
+        extern "C" fn to_div(_d: OptionRefAny, _n: &NodeData, _s: &SystemStyle) -> Dom {
+            Dom::create_div()
+        }
+
+        let shared = SharedIconProvider::from_handle(IconProviderHandle::with_resolver(to_div));
+        let mut dom = Dom::create_body().with_child(
+            Dom::create_icon("outer").with_css("color: #d7263d;"),
+        );
+
+        resolve_icons_in_dom(&mut dom, &shared, &SystemStyle::default());
+
+        let resolved = &dom.children.as_ref()[0];
+        assert!(matches!(resolved.root.get_node_type(), NodeType::Div));
+        assert!(
+            !resolved.css.as_ref().is_empty(),
+            "the icon's own stylesheet must survive resolution; losing it is \
+             how a styled icon silently renders unstyled"
+        );
     }
 
     #[test]
-    fn resolve_icons_in_styled_dom_scales_to_many_icons() {
+    fn resolve_icons_in_dom_scales_to_many_icons() {
         let shared = SharedIconProvider::from_handle(IconProviderHandle::with_resolver(div_resolver));
         let names: Vec<String> = (0..500).map(|i| format!("icon{i}")).collect();
         let refs: Vec<&str> = names.iter().map(String::as_str).collect();
-        let mut sd = styled_dom_with_icons(&refs);
-        let before_len = sd.node_data.as_ref().len();
+        let mut dom = dom_with_icons(&refs);
+        let before_children = dom.children.as_ref().len();
 
-        resolve_icons_in_styled_dom(&mut sd, &shared, &SystemStyle::default());
+        resolve_icons_in_dom(&mut dom, &shared, &SystemStyle::default());
 
-        assert_eq!(sd.node_data.as_ref().len(), before_len);
-        assert!(collect_icon_nodes(&sd).is_empty());
+        assert_eq!(dom.children.as_ref().len(), before_children);
+        assert!(icon_paths(&dom).is_empty());
     }
 }
 
@@ -2156,16 +1614,14 @@ mod icon_cache_tests {
         id: u32,
     }
 
-    fn dom_with_icons(names: &[&str]) -> StyledDom {
+    /// A body whose direct children are the named icons, so child index N is
+    /// icon N both before and after resolution.
+    fn dom_with_icons(names: &[&str]) -> Dom {
         let mut body = Dom::create_body();
         for n in names {
             body.add_child(Dom::create_icon(*n));
         }
-        StyledDom::create_from_dom(body)
-    }
-
-    fn icon_indices(sd: &StyledDom) -> Vec<usize> {
-        collect_icon_nodes(sd).iter().map(|i| i.node_idx).collect()
+        body
     }
 
     // Per-test statics: `extern "C" fn` cannot capture, and tests run in
@@ -2175,11 +1631,11 @@ mod icon_cache_tests {
     static FRAME_CALLS: AtomicUsize = AtomicUsize::new(0);
     extern "C" fn frame_counting_resolver(
         _icon_data: OptionRefAny,
-        _original: &StyledDom,
+        _original: &NodeData,
         _style: &SystemStyle,
-    ) -> StyledDom {
+    ) -> Dom {
         FRAME_CALLS.fetch_add(1, AtomicOrdering::SeqCst);
-        StyledDom::create_from_dom(Dom::create_div())
+        Dom::create_div()
     }
 
     /// THE REPRODUCTION. Before the cache, this counted one resolver call per
@@ -2196,11 +1652,10 @@ mod icon_cache_tests {
 
         for frame in 0..3 {
             let mut sd = dom_with_icons(&["home", "home", "home"]);
-            let idxs = icon_indices(&sd);
-            resolve_icons_in_styled_dom(&mut sd, &shared, &style);
-            for idx in idxs {
+            resolve_icons_in_dom(&mut sd, &shared, &style);
+            for child in sd.children.as_ref() {
                 assert!(
-                    matches!(sd.node_data.as_ref()[idx].get_node_type(), NodeType::Div),
+                    matches!(child.root.get_node_type(), NodeType::Div),
                     "frame {frame}: icon must be resolved on the cached path too"
                 );
             }
@@ -2217,11 +1672,11 @@ mod icon_cache_tests {
     static STYLE_VARIANT_CALLS: AtomicUsize = AtomicUsize::new(0);
     extern "C" fn style_variant_resolver(
         _icon_data: OptionRefAny,
-        _original: &StyledDom,
+        _original: &NodeData,
         _style: &SystemStyle,
-    ) -> StyledDom {
+    ) -> Dom {
         STYLE_VARIANT_CALLS.fetch_add(1, AtomicOrdering::SeqCst);
-        StyledDom::create_from_dom(Dom::create_div())
+        Dom::create_div()
     }
 
     /// The resolver copies inline styles off the original node, so the same
@@ -2247,11 +1702,11 @@ mod icon_cache_tests {
                 ))]
                 .into(),
             ));
-            StyledDom::create_from_dom(body)
+            body
         };
 
         let mut frame1 = build();
-        resolve_icons_in_styled_dom(&mut frame1, &shared, &style);
+        resolve_icons_in_dom(&mut frame1, &shared, &style);
         assert_eq!(
             STYLE_VARIANT_CALLS.load(AtomicOrdering::SeqCst),
             2,
@@ -2259,7 +1714,7 @@ mod icon_cache_tests {
         );
 
         let mut frame2 = build();
-        resolve_icons_in_styled_dom(&mut frame2, &shared, &style);
+        resolve_icons_in_dom(&mut frame2, &shared, &style);
         assert_eq!(
             STYLE_VARIANT_CALLS.load(AtomicOrdering::SeqCst),
             2,
@@ -2270,11 +1725,11 @@ mod icon_cache_tests {
     static SYS_STYLE_CALLS: AtomicUsize = AtomicUsize::new(0);
     extern "C" fn sys_style_resolver(
         _icon_data: OptionRefAny,
-        _original: &StyledDom,
+        _original: &NodeData,
         _style: &SystemStyle,
-    ) -> StyledDom {
+    ) -> Dom {
         SYS_STYLE_CALLS.fetch_add(1, AtomicOrdering::SeqCst);
-        StyledDom::create_from_dom(Dom::create_div())
+        Dom::create_div()
     }
 
     /// Resolvers read the SystemStyle (theme, tint, grayscale), so a style
@@ -2292,15 +1747,15 @@ mod icon_cache_tests {
         assert_ne!(style_a, style_b);
 
         let mut sd = dom_with_icons(&["home"]);
-        resolve_icons_in_styled_dom(&mut sd, &shared, &style_a);
+        resolve_icons_in_dom(&mut sd, &shared, &style_a);
         assert_eq!(SYS_STYLE_CALLS.load(AtomicOrdering::SeqCst), 1);
 
         let mut sd = dom_with_icons(&["home"]);
-        resolve_icons_in_styled_dom(&mut sd, &shared, &style_b);
+        resolve_icons_in_dom(&mut sd, &shared, &style_b);
         assert_eq!(SYS_STYLE_CALLS.load(AtomicOrdering::SeqCst), 2, "style change => re-resolve");
 
         let mut sd = dom_with_icons(&["home"]);
-        resolve_icons_in_styled_dom(&mut sd, &shared, &style_a);
+        resolve_icons_in_dom(&mut sd, &shared, &style_a);
         assert_eq!(
             SYS_STYLE_CALLS.load(AtomicOrdering::SeqCst),
             3,
@@ -2311,9 +1766,9 @@ mod icon_cache_tests {
     static PARITY_CALLS: AtomicUsize = AtomicUsize::new(0);
     extern "C" fn parity_resolver(
         _icon_data: OptionRefAny,
-        original: &StyledDom,
+        original: &NodeData,
         _style: &SystemStyle,
-    ) -> StyledDom {
+    ) -> Dom {
         use azul_css::dynamic_selector::CssPropertyWithConditions;
         use azul_css::props::layout::dimensions::LayoutWidth;
         use azul_css::props::property::CssProperty;
@@ -2325,12 +1780,10 @@ mod icon_cache_tests {
             vec![CssPropertyWithConditions::simple(CssProperty::width(LayoutWidth::px(16.0)))]
                 .into(),
         );
-        if let Some(orig) = original.node_data.as_ref().first() {
-            if let Some(a11y) = orig.get_accessibility_info() {
-                dom = dom.with_accessibility_info(a11y.clone());
-            }
+        if let Some(a11y) = original.get_accessibility_info() {
+            dom = dom.with_accessibility_info(a11y.clone());
         }
-        StyledDom::create(&mut dom, azul_css::css::Css::empty())
+        dom
     }
 
     /// A cache hit must produce a node BIT-IDENTICAL to what the fresh
@@ -2342,38 +1795,28 @@ mod icon_cache_tests {
         let style = SystemStyle::default();
 
         let mut frame1 = dom_with_icons(&["save"]);
-        let idx1 = icon_indices(&frame1)[0];
-        resolve_icons_in_styled_dom(&mut frame1, &shared, &style);
+        resolve_icons_in_dom(&mut frame1, &shared, &style);
         assert_eq!(PARITY_CALLS.load(AtomicOrdering::SeqCst), 1);
 
         let mut frame2 = dom_with_icons(&["save"]);
-        let idx2 = icon_indices(&frame2)[0];
-        resolve_icons_in_styled_dom(&mut frame2, &shared, &style);
+        resolve_icons_in_dom(&mut frame2, &shared, &style);
         assert_eq!(PARITY_CALLS.load(AtomicOrdering::SeqCst), 1, "frame 2 must be a hit");
 
         assert_eq!(
-            frame1.node_data.as_ref()[idx1],
-            frame2.node_data.as_ref()[idx2],
+            frame1.children.as_ref()[0].root,
+            frame2.children.as_ref()[0].root,
             "cached and freshly-resolved node must be indistinguishable"
-        );
-        assert_eq!(
-            frame1.styled_nodes.as_ref()[idx1],
-            frame2.styled_nodes.as_ref()[idx2],
         );
     }
 
     static EMPTY_CALLS: AtomicUsize = AtomicUsize::new(0);
     extern "C" fn empty_resolver(
         _icon_data: OptionRefAny,
-        _original: &StyledDom,
+        _original: &NodeData,
         _style: &SystemStyle,
-    ) -> StyledDom {
+    ) -> Dom {
         EMPTY_CALLS.fetch_add(1, AtomicOrdering::SeqCst);
-        StyledDom {
-            node_data: crate::dom::NodeDataVec::from_vec(Vec::new()),
-            styled_nodes: crate::styled_dom::StyledNodeVec::from_vec(Vec::new()),
-            ..StyledDom::default()
-        }
+        Dom::create_div()
     }
 
     /// "Icon not found → empty div" is also a resolution and is also cached.
@@ -2385,9 +1828,11 @@ mod icon_cache_tests {
 
         for _ in 0..2 {
             let mut sd = dom_with_icons(&["missing"]);
-            let idx = icon_indices(&sd)[0];
-            resolve_icons_in_styled_dom(&mut sd, &shared, &style);
-            assert!(matches!(sd.node_data.as_ref()[idx].get_node_type(), NodeType::Div));
+            resolve_icons_in_dom(&mut sd, &shared, &style);
+            assert!(matches!(
+                sd.children.as_ref()[0].root.get_node_type(),
+                NodeType::Div
+            ));
         }
         assert_eq!(EMPTY_CALLS.load(AtomicOrdering::SeqCst), 1);
     }
@@ -2395,20 +1840,18 @@ mod icon_cache_tests {
     static SUBTREE_CALLS: AtomicUsize = AtomicUsize::new(0);
     extern "C" fn subtree_resolver(
         _icon_data: OptionRefAny,
-        _original: &StyledDom,
+        _original: &NodeData,
         _style: &SystemStyle,
-    ) -> StyledDom {
+    ) -> Dom {
         SUBTREE_CALLS.fetch_add(1, AtomicOrdering::SeqCst);
-        StyledDom::create_from_dom(
-            Dom::create_body()
-                .with_child(Dom::create_div())
-                .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("x")),
-        )
+        Dom::create_body()
+            .with_child(Dom::create_div())
+            .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("x"))
     }
 
-    /// Multi-node replacements go through the same cache (stored as a whole
-    /// `StyledDom`, cloned per hit). Splicing itself is root-only today; the
-    /// cache must not change that behaviour either way.
+    /// Multi-node replacements go through the same cache, stored as a whole
+    /// `Dom` and cloned per hit - and, unlike the old arena splice, they are
+    /// spliced in ENTIRELY, children and all.
     #[test]
     fn subtree_resolutions_are_cached() {
         let shared =
@@ -2418,9 +1861,14 @@ mod icon_cache_tests {
         let mut first_type = None;
         for _ in 0..2 {
             let mut sd = dom_with_icons(&["multi"]);
-            let idx = icon_indices(&sd)[0];
-            resolve_icons_in_styled_dom(&mut sd, &shared, &style);
-            let t = sd.node_data.as_ref()[idx].get_node_type().clone();
+            resolve_icons_in_dom(&mut sd, &shared, &style);
+            let replaced = &sd.children.as_ref()[0];
+            assert_eq!(
+                replaced.children.as_ref().len(),
+                2,
+                "the cached subtree keeps BOTH children, not just its root"
+            );
+            let t = replaced.root.get_node_type().clone();
             match &first_type {
                 None => first_type = Some(t),
                 Some(prev) => assert_eq!(prev, &t, "cached subtree must apply identically"),
@@ -2432,11 +1880,11 @@ mod icon_cache_tests {
     static CAP_CALLS: AtomicUsize = AtomicUsize::new(0);
     extern "C" fn cap_resolver(
         _icon_data: OptionRefAny,
-        _original: &StyledDom,
+        _original: &NodeData,
         _style: &SystemStyle,
-    ) -> StyledDom {
+    ) -> Dom {
         CAP_CALLS.fetch_add(1, AtomicOrdering::SeqCst);
-        StyledDom::create_from_dom(Dom::create_div())
+        Dom::create_div()
     }
 
     /// Unbounded distinct specs must not grow the cache without limit; the
@@ -2451,10 +1899,16 @@ mod icon_cache_tests {
         let names: Vec<String> = (0..(ICON_CACHE_CAP + 100)).map(|i| format!("icon{i}")).collect();
         let refs: Vec<&str> = names.iter().map(String::as_str).collect();
         let mut sd = dom_with_icons(&refs);
-        resolve_icons_in_styled_dom(&mut sd, &shared, &style);
+        resolve_icons_in_dom(&mut sd, &shared, &style);
 
         assert_eq!(CAP_CALLS.load(AtomicOrdering::SeqCst), ICON_CACHE_CAP + 100);
-        assert!(collect_icon_nodes(&sd).is_empty(), "every icon still resolved");
+        assert!(
+            sd.children
+                .as_ref()
+                .iter()
+                .all(|c| !matches!(c.root.get_node_type(), NodeType::Icon(_))),
+            "every icon still resolved"
+        );
 
         let cache = shared.cache.lock().unwrap();
         assert!(

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -382,6 +382,9 @@ pub mod styled_dom;
 pub mod svg;
 /// Timer, thread, and async task management.
 pub mod task;
+/// System tray / status icon POD types — icon bitmaps, category/status, and
+/// the tray event kinds. The OS plumbing lives in `azul-dll` (`desktop/tray`).
+pub mod tray;
 /// 3D transform matrix computation for CSS transforms.
 pub mod transform;
 /// Built-in user-agent default stylesheet.

--- a/core/src/tray.rs
+++ b/core/src/tray.rs
@@ -1,0 +1,478 @@
+//! System tray / status icon — platform-agnostic model.
+//!
+//! The actual OS plumbing lives in `azul-dll` (`desktop/tray/`). This module
+//! only defines the data the three backends agree on.
+//!
+//! # Why the API has this shape
+//!
+//! The three platforms share almost nothing below the "icon + retained menu
+//! tree" level, and two of their constraints leak into any honest API:
+//!
+//! 1. **On Linux the menu is not a popup — it is a remote model.** SNI's `Menu`
+//!    property points at a `com.canonical.dbusmenu` object, and the *panel*
+//!    draws the menu, calling back into us with `GetLayout` / `AboutToShow`.
+//!    So the menu must be a RETAINED tree with stable ids and a revision
+//!    counter. An API shaped as `show_context_menu_at(x, y)` cannot be
+//!    implemented on Linux and would have to be redone — hence
+//!    [`TrayIconData::menu`] is state, not a call.
+//!
+//! 2. **`ContextMenu` is a REQUEST, not a command.** On Linux the panel may
+//!    open the menu itself and never tell us; on Windows and macOS we open it.
+//!    Callers must not assume their handler is the only thing that runs.
+//!
+//! Two more platform truths that the API deliberately does NOT hide:
+//!
+//! * **A tray may genuinely not exist.** On a vanilla GNOME there is no
+//!   `org.kde.StatusNotifierWatcher` at all: registration fails silently and no
+//!   icon ever appears. [`TrayIconData`] is therefore accepted on a best-effort
+//!   basis and the app must have a story for "no tray" — see
+//!   `App::tray_available()` in azul-dll.
+//! * **Click semantics differ.** The SNI spec does not say which gesture
+//!   activates an item; some desktops use single left click, some double. Never
+//!   document a precise gesture for [`TrayEventType::Activate`].
+
+use alloc::string::String;
+
+use crate::{
+    menu::{Menu, OptionMenu},
+    window::IconKey,
+};
+use azul_css::{corety::U8Vec, AzString, OptionString};
+
+/// RGBA8 image for a tray icon, at one specific size.
+///
+/// Unlike [`crate::window::WindowIcon`], which is fixed at 16x16 / 32x32, a
+/// tray icon needs arbitrary sizes: Windows wants
+/// `GetSystemMetricsForDpi(SM_CXSMICON)` (16 / 20 / 24 / 32 px as the taskbar's
+/// DPI changes), macOS wants an 18x18 *point* template image (so 36x36 px on a
+/// 2x display), and SNI wants an array of whatever sizes we care to publish so
+/// the panel can pick.
+///
+/// `rgba` is straight, non-premultiplied RGBA8, `width * height * 4` bytes, top
+/// row first. Every backend converts from this one representation:
+/// Windows builds a BGRA `HBITMAP` + mask, macOS an `NSBitmapImageRep`, and
+/// Linux byte-swaps to the ARGB32-big-endian that `IconPixmap` requires.
+#[derive(Debug, Clone)]
+#[repr(C)]
+pub struct TrayIconImage {
+    /// Cache key — lets a backend skip re-uploading an unchanged icon.
+    pub key: IconKey,
+    pub width: u32,
+    pub height: u32,
+    pub rgba: U8Vec,
+}
+
+impl PartialEq for TrayIconImage {
+    fn eq(&self, other: &Self) -> bool {
+        self.key == other.key
+    }
+}
+impl Eq for TrayIconImage {}
+
+impl TrayIconImage {
+    /// `rgba` must be exactly `width * height * 4` bytes; returns `None` otherwise.
+    #[must_use]
+    pub fn new(width: u32, height: u32, rgba: U8Vec) -> Option<Self> {
+        if width == 0 || height == 0 {
+            return None;
+        }
+        let expected = (width as usize).checked_mul(height as usize)?.checked_mul(4)?;
+        if rgba.as_ref().len() != expected {
+            return None;
+        }
+        Some(Self { key: IconKey::new(), width, height, rgba })
+    }
+
+    /// The icon's pixels as ARGB32 in **network (big-endian) byte order**, the
+    /// wire format `org.kde.StatusNotifierItem`'s `IconPixmap` (`a(iiay)`)
+    /// requires. Nothing else uses this layout, so it is computed on demand.
+    #[must_use]
+    pub fn to_argb32_be(&self) -> Vec<u8> {
+        let src = self.rgba.as_ref();
+        let mut out = Vec::with_capacity(src.len());
+        for px in src.chunks_exact(4) {
+            // RGBA -> ARGB, big-endian == [A, R, G, B] in memory order.
+            out.extend_from_slice(&[px[3], px[0], px[1], px[2]]);
+        }
+        out
+    }
+}
+
+impl_option!(
+    TrayIconImage,
+    OptionTrayIconImage,
+    copy = false,
+    [Debug, Clone, PartialEq, Eq]
+);
+
+impl_vec!(
+    TrayIconImage,
+    TrayIconImageVec,
+    TrayIconImageVecDestructor,
+    TrayIconImageVecDestructorType,
+    TrayIconImageVecSlice,
+    OptionTrayIconImage
+);
+impl_vec_debug!(TrayIconImage, TrayIconImageVec);
+impl_vec_clone!(TrayIconImage, TrayIconImageVec, TrayIconImageVecDestructor);
+impl_vec_partialeq!(TrayIconImage, TrayIconImageVec);
+
+/// A named icon from an icon pack — the same namespace `<icon>` DOM nodes and
+/// `Dom::create_icon()` resolve against.
+///
+/// This is the preferred way to give a tray an icon: a tray needs the SAME
+/// glyph at several different pixel sizes (Windows re-asks at every taskbar DPI,
+/// macOS wants 18pt = 36px on a 2x display, SNI publishes an array), and a
+/// name can be rasterized at any size on demand where a fixed bitmap cannot.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(C)]
+pub struct TrayIconName {
+    /// Icon pack to look in. `None` searches every registered pack, first
+    /// match wins — which for a default build means `"material-icons"`.
+    pub pack: OptionString,
+    /// Icon name within the pack, e.g. `"settings"`, `"notifications"`.
+    pub name: AzString,
+}
+
+impl TrayIconName {
+    #[must_use]
+    pub fn new(name: &str) -> Self {
+        Self {
+            pack: OptionString::None,
+            name: AzString::from(String::from(name)),
+        }
+    }
+
+    #[must_use]
+    pub fn in_pack(pack: &str, name: &str) -> Self {
+        Self {
+            pack: OptionString::Some(AzString::from(String::from(pack))),
+            name: AzString::from(String::from(name)),
+        }
+    }
+}
+
+/// Where a tray icon's pixels come from.
+#[derive(Debug, Clone, PartialEq)]
+#[repr(C, u8)]
+#[derive(Default)]
+pub enum TrayIconSource {
+    /// No icon. Most desktops render this as an invisible item, so it is
+    /// almost never what you want.
+    #[default]
+    None,
+    /// Explicit RGBA bitmaps, ideally at several sizes so each platform can
+    /// pick — see [`TrayIconData::best_icon`].
+    Rgba(TrayIconImageVec),
+    /// Resolved through the icon provider and rasterized at whatever size the
+    /// platform asks for.
+    Named(TrayIconName),
+}
+
+/// Hint about what the tray item represents. Maps to SNI's `Category`; Windows
+/// and macOS have no equivalent and ignore it.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(C)]
+#[derive(Default)]
+pub enum TrayCategory {
+    #[default]
+    ApplicationStatus,
+    Communications,
+    SystemServices,
+    Hardware,
+}
+
+impl TrayCategory {
+    /// The exact string the SNI `Category` property expects.
+    #[must_use]
+    pub const fn sni_name(self) -> &'static str {
+        match self {
+            Self::ApplicationStatus => "ApplicationStatus",
+            Self::Communications => "Communications",
+            Self::SystemServices => "SystemServices",
+            Self::Hardware => "Hardware",
+        }
+    }
+}
+
+/// Attention state. Maps to SNI's `Status`.
+///
+/// On Windows and macOS only `Passive` is meaningful (it hides the icon);
+/// `Active` and `NeedsAttention` both simply show it, because neither platform
+/// has a "demanding attention" tray state.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(C)]
+#[derive(Default)]
+pub enum TrayStatus {
+    /// The host MAY hide the item.
+    Passive,
+    #[default]
+    Active,
+    /// Draws attention; SNI hosts swap in `AttentionIcon`.
+    NeedsAttention,
+}
+
+impl TrayStatus {
+    #[must_use]
+    pub const fn sni_name(self) -> &'static str {
+        match self {
+            Self::Passive => "Passive",
+            Self::Active => "Active",
+            Self::NeedsAttention => "NeedsAttention",
+        }
+    }
+}
+
+/// What the user did to the tray icon.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(C)]
+pub enum TrayEventType {
+    /// Primary activation. **Do not document a precise gesture**: it is left
+    /// click or keyboard Enter on Windows, a click on macOS, and entirely
+    /// desktop-dependent on Linux (the SNI spec does not specify it).
+    Activate,
+    /// Middle click on Windows/Linux; not emitted on macOS.
+    SecondaryActivate,
+    /// The user asked for the context menu. On Windows and macOS we then open
+    /// it; **on Linux the panel already opened it itself** from the exported
+    /// dbusmenu, so this is informational there.
+    ContextMenu,
+    /// Scroll wheel over the icon. Linux only (SNI `Scroll`); Windows and
+    /// macOS never emit it.
+    Scroll,
+    /// A menu item was chosen. Carries the item's command id.
+    MenuItem,
+}
+
+/// Scroll axis for [`TrayEventType::Scroll`].
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(C)]
+#[derive(Default)]
+pub enum TrayScrollAxis {
+    #[default]
+    Vertical,
+    Horizontal,
+}
+
+/// One thing that happened on the tray icon.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(C)]
+pub struct TrayEvent {
+    pub kind: TrayEventType,
+    /// Set for [`TrayEventType::MenuItem`]; the chosen item's command id.
+    pub menu_command: u32,
+    /// Set for [`TrayEventType::Scroll`].
+    pub scroll_delta: i32,
+    pub scroll_axis: TrayScrollAxis,
+}
+
+impl TrayEvent {
+    #[must_use]
+    pub const fn simple(kind: TrayEventType) -> Self {
+        Self {
+            kind,
+            menu_command: 0,
+            scroll_delta: 0,
+            scroll_axis: TrayScrollAxis::Vertical,
+        }
+    }
+    #[must_use]
+    pub const fn menu_item(command: u32) -> Self {
+        Self {
+            kind: TrayEventType::MenuItem,
+            menu_command: command,
+            scroll_delta: 0,
+            scroll_axis: TrayScrollAxis::Vertical,
+        }
+    }
+}
+
+impl_option!(
+    TrayEvent,
+    OptionTrayEvent,
+    [Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash]
+);
+
+/// Everything a tray icon shows. This is *state*: set it, mutate it, and the
+/// backend republishes. It is deliberately not a set of imperative calls,
+/// because the Linux backend has to be able to answer the panel's `GetLayout`
+/// at any moment.
+#[derive(Debug, Clone, PartialEq)]
+#[repr(C)]
+pub struct TrayIconData {
+    /// Stable identifier for this app's tray item. Used as SNI's `Id`, and as
+    /// the seed for macOS's `NSStatusItem.autosaveName` (which is what makes
+    /// the item keep its position in the menu bar across launches).
+    ///
+    /// Must be stable across runs and must NOT be derived from a path or pid.
+    /// Reverse-DNS is the convention: `"org.example.myapp"`.
+    pub id: AzString,
+    /// Human-readable application name (SNI `Title`).
+    pub title: AzString,
+    /// Where the icon's pixels come from — a named icon-pack entry (preferred)
+    /// or explicit RGBA bitmaps.
+    pub icon: TrayIconSource,
+    /// Shown when `status == NeedsAttention` on SNI hosts. Ignored elsewhere.
+    pub attention_icon: TrayIconSource,
+    pub tooltip: OptionString,
+    pub category: TrayCategory,
+    pub status: TrayStatus,
+    /// The retained context menu. `None` means "no menu": on Windows and macOS
+    /// a context-menu request then just reports [`TrayEventType::ContextMenu`],
+    /// and on Linux the `Menu` property is left unset and hosts fall back to
+    /// calling `ContextMenu()`.
+    pub menu: OptionMenu,
+}
+
+impl Default for TrayIconData {
+    fn default() -> Self {
+        Self {
+            id: AzString::from_const_str("azul.tray"),
+            title: AzString::from_const_str(""),
+            icon: TrayIconSource::None,
+            attention_icon: TrayIconSource::None,
+            tooltip: OptionString::None,
+            category: TrayCategory::ApplicationStatus,
+            status: TrayStatus::Active,
+            menu: OptionMenu::None,
+        }
+    }
+}
+
+impl TrayIconData {
+    #[must_use]
+    pub fn new(id: &str, title: &str) -> Self {
+        Self {
+            id: AzString::from(String::from(id)),
+            title: AzString::from(String::from(title)),
+            ..Self::default()
+        }
+    }
+
+    /// Use a named icon from an icon pack — `"settings"`, `"notifications"`,
+    /// any Material Icons name in a default build. This is the preferred form:
+    /// it can be rasterized at whatever size each platform asks for.
+    #[must_use]
+    pub fn with_named_icon(mut self, name: &str) -> Self {
+        self.icon = TrayIconSource::Named(TrayIconName::new(name));
+        self
+    }
+
+    /// Use an explicit RGBA bitmap. Prefer [`Self::with_named_icon`] unless the
+    /// icon genuinely is not in a pack.
+    #[must_use]
+    pub fn with_icon(mut self, icon: TrayIconImage) -> Self {
+        self.icon = TrayIconSource::Rgba(TrayIconImageVec::from_vec(alloc::vec![icon]));
+        self
+    }
+
+    #[must_use]
+    pub fn with_menu(mut self, menu: Menu) -> Self {
+        self.menu = OptionMenu::Some(menu);
+        self
+    }
+
+    #[must_use]
+    pub fn with_tooltip(mut self, tooltip: &str) -> Self {
+        self.tooltip = OptionString::Some(AzString::from(String::from(tooltip)));
+        self
+    }
+
+    /// The icon closest to `target_px`, preferring the smallest one that is at
+    /// least `target_px` (upscaling a small icon looks far worse than
+    /// downscaling a large one — this is why Windows' own `LoadIconMetric`
+    /// scales down from a larger frame rather than up).
+    /// Only meaningful for [`TrayIconSource::Rgba`]; a `Named` icon is
+    /// rasterized at the exact size instead, so it never needs picking.
+    #[must_use]
+    pub fn best_icon(&self, target_px: u32) -> Option<&TrayIconImage> {
+        let TrayIconSource::Rgba(ref icons) = self.icon else {
+            return None;
+        };
+        let icons = icons.as_ref();
+        icons
+            .iter()
+            .filter(|i| i.width >= target_px)
+            .min_by_key(|i| i.width)
+            .or_else(|| icons.iter().max_by_key(|i| i.width))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn img(w: u32, h: u32) -> TrayIconImage {
+        TrayIconImage::new(w, h, vec![0u8; (w * h * 4) as usize].into()).unwrap()
+    }
+
+    #[test]
+    fn new_rejects_a_buffer_that_is_not_w_times_h_times_4() {
+        assert!(TrayIconImage::new(2, 2, vec![0u8; 16].into()).is_some());
+        assert!(TrayIconImage::new(2, 2, vec![0u8; 15].into()).is_none());
+        assert!(TrayIconImage::new(2, 2, vec![0u8; 17].into()).is_none());
+        // A zero dimension would make `expected` 0 and let an empty buffer
+        // through, which every backend would then read as a valid icon.
+        assert!(TrayIconImage::new(0, 4, U8Vec::from_const_slice(&[])).is_none());
+        assert!(TrayIconImage::new(4, 0, U8Vec::from_const_slice(&[])).is_none());
+    }
+
+    #[test]
+    fn argb32_be_reorders_rgba_to_a_r_g_b() {
+        // One pixel: R=1 G=2 B=3 A=4  ->  A=4 R=1 G=2 B=3
+        let i = TrayIconImage::new(1, 1, vec![1, 2, 3, 4].into()).unwrap();
+        assert_eq!(i.to_argb32_be(), vec![4, 1, 2, 3]);
+    }
+
+    #[test]
+    fn best_icon_prefers_the_smallest_that_still_covers_the_target() {
+        let d = TrayIconData {
+            icon: TrayIconSource::Rgba(TrayIconImageVec::from_vec(vec![
+                img(16, 16),
+                img(32, 32),
+                img(64, 64),
+            ])),
+            ..Default::default()
+        };
+        // Exact match wins.
+        assert_eq!(d.best_icon(32).unwrap().width, 32);
+        // Between sizes: scale DOWN from 32, never up from 16.
+        assert_eq!(d.best_icon(20).unwrap().width, 32);
+        // Larger than everything we have: take the biggest.
+        assert_eq!(d.best_icon(256).unwrap().width, 64);
+        // No icons at all is not a panic.
+        assert!(TrayIconData::default().best_icon(16).is_none());
+        // A named icon has no bitmap to pick from — it is rasterized at the
+        // exact size instead, so best_icon must not invent one.
+        assert!(
+            TrayIconData::default()
+                .with_named_icon("settings")
+                .best_icon(16)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn named_icon_defaults_to_searching_every_pack() {
+        let d = TrayIconData::new("org.example.app", "App").with_named_icon("settings");
+        let TrayIconSource::Named(ref n) = d.icon else {
+            panic!("expected a named icon source");
+        };
+        // `None` pack = first match across all packs, which in a default build
+        // resolves to material-icons.
+        assert!(n.pack.is_none());
+        assert_eq!(n.name.as_str(), "settings");
+
+        let p = TrayIconName::in_pack("my-pack", "logo");
+        assert_eq!(p.pack.as_ref().map(|s| s.as_str()), Some("my-pack"));
+    }
+
+    #[test]
+    fn sni_names_match_the_spec_spelling_exactly() {
+        // These strings go on the wire; a typo silently breaks the item.
+        assert_eq!(TrayCategory::ApplicationStatus.sni_name(), "ApplicationStatus");
+        assert_eq!(TrayCategory::SystemServices.sni_name(), "SystemServices");
+        assert_eq!(TrayStatus::NeedsAttention.sni_name(), "NeedsAttention");
+        assert_eq!(TrayStatus::Passive.sni_name(), "Passive");
+    }
+}

--- a/core/src/tray.rs
+++ b/core/src/tray.rs
@@ -117,41 +117,6 @@ impl_vec_debug!(TrayIconImage, TrayIconImageVec);
 impl_vec_clone!(TrayIconImage, TrayIconImageVec, TrayIconImageVecDestructor);
 impl_vec_partialeq!(TrayIconImage, TrayIconImageVec);
 
-/// A named icon from an icon pack — the same namespace `<icon>` DOM nodes and
-/// `Dom::create_icon()` resolve against.
-///
-/// This is the preferred way to give a tray an icon: a tray needs the SAME
-/// glyph at several different pixel sizes (Windows re-asks at every taskbar DPI,
-/// macOS wants 18pt = 36px on a 2x display, SNI publishes an array), and a
-/// name can be rasterized at any size on demand where a fixed bitmap cannot.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[repr(C)]
-pub struct TrayIconName {
-    /// Icon pack to look in. `None` searches every registered pack, first
-    /// match wins — which for a default build means `"material-icons"`.
-    pub pack: OptionString,
-    /// Icon name within the pack, e.g. `"settings"`, `"notifications"`.
-    pub name: AzString,
-}
-
-impl TrayIconName {
-    #[must_use]
-    pub fn new(name: &str) -> Self {
-        Self {
-            pack: OptionString::None,
-            name: AzString::from(String::from(name)),
-        }
-    }
-
-    #[must_use]
-    pub fn in_pack(pack: &str, name: &str) -> Self {
-        Self {
-            pack: OptionString::Some(AzString::from(String::from(pack))),
-            name: AzString::from(String::from(name)),
-        }
-    }
-}
-
 /// Where a tray icon's pixels come from.
 #[derive(Debug, Clone, PartialEq)]
 #[repr(C, u8)]
@@ -163,10 +128,29 @@ pub enum TrayIconSource {
     None,
     /// Explicit RGBA bitmaps, ideally at several sizes so each platform can
     /// pick — see [`TrayIconData::best_icon`].
+    ///
+    /// Only needed for an icon that genuinely is not in a pack — typically one
+    /// generated at runtime, since the icon registry is frozen once the
+    /// provider is shared (`App::run` consumes the handle).
     Rgba(TrayIconImageVec),
-    /// Resolved through the icon provider and rasterized at whatever size the
-    /// platform asks for.
-    Named(TrayIconName),
+    /// An **icon spec** — exactly the string an `<icon>` node takes: a bare
+    /// name (`"settings"`), a pack-qualified name (`"mypack:logo"`), or a
+    /// comma-separated fallback list (`"mypack:logo, settings"`).
+    ///
+    /// This is the preferred form, for two reasons.
+    ///
+    /// It resolves through the SAME registry and resolver `<icon>` DOM nodes
+    /// use, so anything registered there works with no tray-specific icon path
+    /// — Material Icons (the default pack), an image pack loaded from a ZIP, or
+    /// a custom resolver. Because resolution yields a `StyledDom` which is then
+    /// rendered, an icon can be anything expressible as a DOM: a font glyph, a
+    /// bitmap, later an SVG or an emoji.
+    ///
+    /// And a spec can be rendered at ANY size on demand, which a fixed bitmap
+    /// cannot — a tray needs the same icon at several sizes and cannot know
+    /// them up front (Windows re-asks at every taskbar DPI: 16/20/24/32; macOS
+    /// wants 18pt, which is 36px on a 2x display; SNI publishes an array).
+    Named(AzString),
 }
 
 /// Hint about what the tray item represents. Maps to SNI's `Category`; Windows
@@ -349,12 +333,12 @@ impl TrayIconData {
         }
     }
 
-    /// Use a named icon from an icon pack — `"settings"`, `"notifications"`,
-    /// any Material Icons name in a default build. This is the preferred form:
-    /// it can be rasterized at whatever size each platform asks for.
+    /// Use an icon from the icon registry, by the same spec an `<icon>` node
+    /// takes — `"settings"`, `"mypack:logo"`, or a fallback list. Preferred:
+    /// it renders at whatever size each platform asks for.
     #[must_use]
-    pub fn with_named_icon(mut self, name: &str) -> Self {
-        self.icon = TrayIconSource::Named(TrayIconName::new(name));
+    pub fn with_named_icon(mut self, spec: &str) -> Self {
+        self.icon = TrayIconSource::Named(AzString::from(String::from(spec)));
         self
     }
 
@@ -453,18 +437,17 @@ mod tests {
     }
 
     #[test]
-    fn named_icon_defaults_to_searching_every_pack() {
-        let d = TrayIconData::new("org.example.app", "App").with_named_icon("settings");
-        let TrayIconSource::Named(ref n) = d.icon else {
-            panic!("expected a named icon source");
-        };
-        // `None` pack = first match across all packs, which in a default build
-        // resolves to material-icons.
-        assert!(n.pack.is_none());
-        assert_eq!(n.name.as_str(), "settings");
-
-        let p = TrayIconName::in_pack("my-pack", "logo");
-        assert_eq!(p.pack.as_ref().map(|s| s.as_str()), Some("my-pack"));
+    fn named_icon_stores_the_spec_verbatim() {
+        // The spec is passed through untouched: parsing pack-qualification and
+        // fallback lists is the icon registry's job, not the tray's, so that
+        // `<icon>` and a tray icon can never disagree about what a spec means.
+        for spec in ["settings", "mypack:logo", "missing:x, settings"] {
+            let d = TrayIconData::new("org.example.app", "App").with_named_icon(spec);
+            let TrayIconSource::Named(ref s) = d.icon else {
+                panic!("expected a named icon source");
+            };
+            assert_eq!(s.as_str(), spec);
+        }
     }
 
     #[test]

--- a/core/src/tray.rs
+++ b/core/src/tray.rs
@@ -1,4 +1,4 @@
-//! System tray / status icon — platform-agnostic model.
+//! System tray / status icon  -  platform-agnostic model.
 //!
 //! The actual OS plumbing lives in `azul-dll` (`desktop/tray/`). This module
 //! only defines the data the three backends agree on.
@@ -8,12 +8,12 @@
 //! The three platforms share almost nothing below the "icon + retained menu
 //! tree" level, and two of their constraints leak into any honest API:
 //!
-//! 1. **On Linux the menu is not a popup — it is a remote model.** SNI's `Menu`
+//! 1. **On Linux the menu is not a popup  -  it is a remote model.** SNI's `Menu`
 //!    property points at a `com.canonical.dbusmenu` object, and the *panel*
 //!    draws the menu, calling back into us with `GetLayout` / `AboutToShow`.
 //!    So the menu must be a RETAINED tree with stable ids and a revision
 //!    counter. An API shaped as `show_context_menu_at(x, y)` cannot be
-//!    implemented on Linux and would have to be redone — hence
+//!    implemented on Linux and would have to be redone  -  hence
 //!    [`TrayIconData::menu`] is state, not a call.
 //!
 //! 2. **`ContextMenu` is a REQUEST, not a command.** On Linux the panel may
@@ -25,7 +25,7 @@
 //! * **A tray may genuinely not exist.** On a vanilla GNOME there is no
 //!   `org.kde.StatusNotifierWatcher` at all: registration fails silently and no
 //!   icon ever appears. [`TrayIconData`] is therefore accepted on a best-effort
-//!   basis and the app must have a story for "no tray" — see
+//!   basis and the app must have a story for "no tray"  -  see
 //!   `App::tray_available()` in azul-dll.
 //! * **Click semantics differ.** The SNI spec does not say which gesture
 //!   activates an item; some desktops use single left click, some double. Never
@@ -55,7 +55,7 @@ use azul_css::{corety::U8Vec, AzString, OptionString};
 #[derive(Debug, Clone)]
 #[repr(C)]
 pub struct TrayIconImage {
-    /// Cache key — lets a backend skip re-uploading an unchanged icon.
+    /// Cache key  -  lets a backend skip re-uploading an unchanged icon.
     pub key: IconKey,
     pub width: u32,
     pub height: u32,
@@ -70,31 +70,40 @@ impl PartialEq for TrayIconImage {
 impl Eq for TrayIconImage {}
 
 impl TrayIconImage {
-    /// `rgba` must be exactly `width * height * 4` bytes; returns `None` otherwise.
+    /// `rgba` must be exactly `width * height * 4` bytes; returns `None`
+    /// otherwise.
+    ///
+    /// Returns `OptionTrayIconImage` rather than `Option<Self>` so the
+    /// signature crosses the C ABI unchanged.
     #[must_use]
-    pub fn new(width: u32, height: u32, rgba: U8Vec) -> Option<Self> {
+    pub fn new(width: u32, height: u32, rgba: U8Vec) -> OptionTrayIconImage {
         if width == 0 || height == 0 {
-            return None;
+            return OptionTrayIconImage::None;
         }
-        let expected = (width as usize).checked_mul(height as usize)?.checked_mul(4)?;
+        let Some(expected) = (width as usize)
+            .checked_mul(height as usize)
+            .and_then(|n| n.checked_mul(4))
+        else {
+            return OptionTrayIconImage::None;
+        };
         if rgba.as_ref().len() != expected {
-            return None;
+            return OptionTrayIconImage::None;
         }
-        Some(Self { key: IconKey::new(), width, height, rgba })
+        OptionTrayIconImage::Some(Self { key: IconKey::new(), width, height, rgba })
     }
 
     /// The icon's pixels as ARGB32 in **network (big-endian) byte order**, the
     /// wire format `org.kde.StatusNotifierItem`'s `IconPixmap` (`a(iiay)`)
     /// requires. Nothing else uses this layout, so it is computed on demand.
     #[must_use]
-    pub fn to_argb32_be(&self) -> Vec<u8> {
+    pub fn to_argb32_be(&self) -> U8Vec {
         let src = self.rgba.as_ref();
         let mut out = Vec::with_capacity(src.len());
         for px in src.chunks_exact(4) {
             // RGBA -> ARGB, big-endian == [A, R, G, B] in memory order.
             out.extend_from_slice(&[px[3], px[0], px[1], px[2]]);
         }
-        out
+        U8Vec::from_vec(out)
     }
 }
 
@@ -127,13 +136,13 @@ pub enum TrayIconSource {
     #[default]
     None,
     /// Explicit RGBA bitmaps, ideally at several sizes so each platform can
-    /// pick — see [`TrayIconData::best_icon`].
+    /// pick  -  see [`TrayIconData::best_icon`].
     ///
-    /// Only needed for an icon that genuinely is not in a pack — typically one
+    /// Only needed for an icon that genuinely is not in a pack  -  typically one
     /// generated at runtime, since the icon registry is frozen once the
     /// provider is shared (`App::run` consumes the handle).
     Rgba(TrayIconImageVec),
-    /// An **icon spec** — exactly the string an `<icon>` node takes: a bare
+    /// An **icon spec**  -  exactly the string an `<icon>` node takes: a bare
     /// name (`"settings"`), a pack-qualified name (`"mypack:logo"`), or a
     /// comma-separated fallback list (`"mypack:logo, settings"`).
     ///
@@ -141,13 +150,13 @@ pub enum TrayIconSource {
     ///
     /// It resolves through the SAME registry and resolver `<icon>` DOM nodes
     /// use, so anything registered there works with no tray-specific icon path
-    /// — Material Icons (the default pack), an image pack loaded from a ZIP, or
+    ///  -  Material Icons (the default pack), an image pack loaded from a ZIP, or
     /// a custom resolver. Because resolution yields a `StyledDom` which is then
     /// rendered, an icon can be anything expressible as a DOM: a font glyph, a
     /// bitmap, later an SVG or an emoji.
     ///
     /// And a spec can be rendered at ANY size on demand, which a fixed bitmap
-    /// cannot — a tray needs the same icon at several sizes and cannot know
+    /// cannot  -  a tray needs the same icon at several sizes and cannot know
     /// them up front (Windows re-asks at every taskbar DPI: 16/20/24/32; macOS
     /// wants 18pt, which is 36px on a 2x display; SNI publishes an array).
     Named(AzString),
@@ -293,7 +302,7 @@ pub struct TrayIconData {
     pub id: AzString,
     /// Human-readable application name (SNI `Title`).
     pub title: AzString,
-    /// Where the icon's pixels come from — a named icon-pack entry (preferred)
+    /// Where the icon's pixels come from  -  a named icon-pack entry (preferred)
     /// or explicit RGBA bitmaps.
     pub icon: TrayIconSource,
     /// Shown when `status == NeedsAttention` on SNI hosts. Ignored elsewhere.
@@ -325,20 +334,20 @@ impl Default for TrayIconData {
 
 impl TrayIconData {
     #[must_use]
-    pub fn new(id: &str, title: &str) -> Self {
+    pub fn new(id: AzString, title: AzString) -> Self {
         Self {
-            id: AzString::from(String::from(id)),
-            title: AzString::from(String::from(title)),
+            id,
+            title,
             ..Self::default()
         }
     }
 
     /// Use an icon from the icon registry, by the same spec an `<icon>` node
-    /// takes — `"settings"`, `"mypack:logo"`, or a fallback list. Preferred:
+    /// takes  -  `"settings"`, `"mypack:logo"`, or a fallback list. Preferred:
     /// it renders at whatever size each platform asks for.
     #[must_use]
-    pub fn with_named_icon(mut self, spec: &str) -> Self {
-        self.icon = TrayIconSource::Named(AzString::from(String::from(spec)));
+    pub fn with_named_icon(mut self, spec: AzString) -> Self {
+        self.icon = TrayIconSource::Named(spec);
         self
     }
 
@@ -357,21 +366,24 @@ impl TrayIconData {
     }
 
     #[must_use]
-    pub fn with_tooltip(mut self, tooltip: &str) -> Self {
-        self.tooltip = OptionString::Some(AzString::from(String::from(tooltip)));
+    pub fn with_tooltip(mut self, tooltip: AzString) -> Self {
+        self.tooltip = OptionString::Some(tooltip);
         self
     }
 
     /// The icon closest to `target_px`, preferring the smallest one that is at
     /// least `target_px` (upscaling a small icon looks far worse than
-    /// downscaling a large one — this is why Windows' own `LoadIconMetric`
+    /// downscaling a large one  -  this is why Windows' own `LoadIconMetric`
     /// scales down from a larger frame rather than up).
     /// Only meaningful for [`TrayIconSource::Rgba`]; a `Named` icon is
     /// rasterized at the exact size instead, so it never needs picking.
+    ///
+    /// Returns an owned `OptionTrayIconImage` rather than `Option<&_>` because
+    /// a borrow cannot cross the C ABI. The clone is one `U8Vec` bump.
     #[must_use]
-    pub fn best_icon(&self, target_px: u32) -> Option<&TrayIconImage> {
+    pub fn best_icon(&self, target_px: u32) -> OptionTrayIconImage {
         let TrayIconSource::Rgba(ref icons) = self.icon else {
-            return None;
+            return OptionTrayIconImage::None;
         };
         let icons = icons.as_ref();
         icons
@@ -379,6 +391,8 @@ impl TrayIconData {
             .filter(|i| i.width >= target_px)
             .min_by_key(|i| i.width)
             .or_else(|| icons.iter().max_by_key(|i| i.width))
+            .cloned()
+            .into()
     }
 }
 
@@ -387,7 +401,9 @@ mod tests {
     use super::*;
 
     fn img(w: u32, h: u32) -> TrayIconImage {
-        TrayIconImage::new(w, h, vec![0u8; (w * h * 4) as usize].into()).unwrap()
+        TrayIconImage::new(w, h, vec![0u8; (w * h * 4) as usize].into())
+            .into_option()
+            .expect("w*h*4 buffer must be accepted")
     }
 
     #[test]
@@ -404,8 +420,10 @@ mod tests {
     #[test]
     fn argb32_be_reorders_rgba_to_a_r_g_b() {
         // One pixel: R=1 G=2 B=3 A=4  ->  A=4 R=1 G=2 B=3
-        let i = TrayIconImage::new(1, 1, vec![1, 2, 3, 4].into()).unwrap();
-        assert_eq!(i.to_argb32_be(), vec![4, 1, 2, 3]);
+        let i = TrayIconImage::new(1, 1, vec![1, 2, 3, 4].into())
+            .into_option()
+            .expect("1x1 RGBA is 4 bytes");
+        assert_eq!(i.to_argb32_be().as_ref(), &[4u8, 1, 2, 3]);
     }
 
     #[test]
@@ -419,18 +437,18 @@ mod tests {
             ..Default::default()
         };
         // Exact match wins.
-        assert_eq!(d.best_icon(32).unwrap().width, 32);
+        assert_eq!(d.best_icon(32).into_option().unwrap().width, 32);
         // Between sizes: scale DOWN from 32, never up from 16.
-        assert_eq!(d.best_icon(20).unwrap().width, 32);
+        assert_eq!(d.best_icon(20).into_option().unwrap().width, 32);
         // Larger than everything we have: take the biggest.
-        assert_eq!(d.best_icon(256).unwrap().width, 64);
+        assert_eq!(d.best_icon(256).into_option().unwrap().width, 64);
         // No icons at all is not a panic.
         assert!(TrayIconData::default().best_icon(16).is_none());
         // A named icon has no bitmap to pick from — it is rasterized at the
         // exact size instead, so best_icon must not invent one.
         assert!(
             TrayIconData::default()
-                .with_named_icon("settings")
+                .with_named_icon(AzString::from_const_str("settings"))
                 .best_icon(16)
                 .is_none()
         );
@@ -442,7 +460,11 @@ mod tests {
         // fallback lists is the icon registry's job, not the tray's, so that
         // `<icon>` and a tray icon can never disagree about what a spec means.
         for spec in ["settings", "mypack:logo", "missing:x, settings"] {
-            let d = TrayIconData::new("org.example.app", "App").with_named_icon(spec);
+            let d = TrayIconData::new(
+                AzString::from_const_str("org.example.app"),
+                AzString::from_const_str("App"),
+            )
+            .with_named_icon(AzString::from(String::from(spec)));
             let TrayIconSource::Named(ref s) = d.icon else {
                 panic!("expected a named icon source");
             };

--- a/dll/src/desktop/app.rs
+++ b/dll/src/desktop/app.rs
@@ -306,7 +306,7 @@ impl App {
         }
 
         // Use shell2 for the actual run loop
-        let err = crate::desktop::shell2::run(data, undo_manager, config, fc_cache, font_registry, root_window, self.ptr.tray.clone());
+        let err = crate::desktop::shell2::run(data, undo_manager, config, fc_cache, font_registry, root_window, self.ptr.tray.clone(), self.ptr.font_manager.clone());
 
         // Telemetry: persist + upload whatever the interval uploader has not
         // sent yet. Without this a SHORT run (an e2e drive, a screenshot
@@ -359,6 +359,27 @@ pub struct AppInternal {
     /// At layout time, `request_fonts()` blocks until the needed fonts are ready,
     /// then snapshots into `fc_cache`. This eliminates the ~700ms startup block.
     pub font_registry: Option<Arc<FcFontRegistry>>,
+    /// THE font manager for this app  -  built once here, shared by every window
+    /// and by the tray.
+    ///
+    /// A `FontManager` is not just a cache handle: it owns the `parsed_fonts` and
+    /// `embedded_fonts` pools, and `embedded_fonts` is the ONLY place a face
+    /// handed over as `StyleFontFamily::Ref` (Material Icons, and anything a
+    /// font-backed icon pack resolves to) is ever named. Two managers therefore
+    /// disagree about which faces exist, and whoever registers a face is often
+    /// not whoever later shapes with it  -  a child window, a tray icon, an
+    /// off-screen render. The result is a `.notdef` tofu box with every
+    /// intermediate step reporting success.
+    ///
+    /// Consumers take `clone_shared()` copies: those share the two pools while
+    /// keeping a private `fc_cache` field, so each window can still swap in its
+    /// own registry snapshot at layout time (`replace_fc_cache`) without
+    /// disturbing anyone else.
+    ///
+    /// `Option` because building it can fail; the app still runs, callers fall
+    /// back to constructing their own as before. `Arc` so this stays a thin
+    /// pointer across the C ABI, exactly like `fc_cache` and `font_registry`.
+    pub font_manager: Option<Arc<azul_layout::font_traits::FontManager<azul_css::props::basic::FontRef>>>,
     /// App-global undo/redo manager. Owned by the App; a shared clone is threaded
     /// to every window so a callback's `undo_app_state` / `redo_app_state` /
     /// `commit_undo_snapshot` operates on one shared history.
@@ -476,6 +497,12 @@ impl AppInternal {
             data: initial_data,
             config: app_config,
             tray: None,
+            // ONE manager, built here rather than per-window. `FcFontCache` is
+            // internally Arc-shared, so the clone tracks whatever the scout
+            // threads discover later.
+            font_manager: azul_layout::font_traits::FontManager::new((*fc_cache).clone())
+                .ok()
+                .map(Arc::new),
             fc_cache: Box::new(fc_cache),
             font_registry,
             undo_manager: crate::desktop::shell2::common::event::SharedUndoManager::new(),

--- a/dll/src/desktop/app.rs
+++ b/dll/src/desktop/app.rs
@@ -20,8 +20,8 @@ use crate::desktop::shell2::common::debug_server;
 /// Wait (off the calling thread) for the font scan to finish, then write the
 /// on-disk font manifest.
 ///
-/// Persisting must not happen on the layout thread — the serialize + write is
-/// real I/O — and it must not happen before the scan is complete: a manifest
+/// Persisting must not happen on the layout thread  -  the serialize + write is
+/// real I/O  -  and it must not happen before the scan is complete: a manifest
 /// written mid-scan would describe a PARTIAL font set, and the next launch
 /// would load it, see `cache_loaded == true`, and lay out against a font
 /// universe missing most of the system's families. A partial cache is strictly
@@ -91,7 +91,7 @@ impl Default for App {
 /// A C/C++/Python host that `dlopen`s libazul never runs Rust's runtime, which
 /// is what normally installs this. Without it the default `SIGPIPE` disposition
 /// (`SIG_DFL` = terminate) kills the whole process on the first write to a
-/// closed socket/pipe — e.g. the D-Bus theme probe in `discover_system_style`,
+/// closed socket/pipe  -  e.g. the D-Bus theme probe in `discover_system_style`,
 /// or a dropped Wayland/X11/debug-server connection. Idempotent, and harmless
 /// for Rust hosts (whose runtime already ignores SIGPIPE).
 #[cfg(unix)]
@@ -180,6 +180,21 @@ impl App {
 
     pub fn get_monitors(&self) -> MonitorVec {
         crate::desktop::display::get_monitors()
+    }
+
+    /// Ask for a system-tray icon. Takes effect when `run()` starts.
+    ///
+    /// Deferred rather than immediate because a tray cannot exist this early:
+    /// macOS needs `NSApplication`, and every backend needs the icon registry
+    /// published so a `TrayIconSource::Named` spec can resolve.
+    ///
+    /// This is best-effort by design. On a desktop with no tray  -  a vanilla
+    /// GNOME has no `StatusNotifierWatcher` at all  -  nothing appears and the
+    /// app still runs; the failure is logged. Use
+    /// [`crate::desktop::tray::TrayIcon::is_available`] beforehand if the app
+    /// needs to know.
+    pub fn set_tray(&mut self, tray: azul_core::tray::TrayIconData) {
+        self.ptr.tray = Some(tray);
     }
 
     pub fn run(&self, root_window: WindowCreateOptions) {
@@ -280,6 +295,9 @@ impl App {
                 fc_cache,
                 font_registry,
                 dialog,
+                // The crash reporter is a standalone dialog, not the app: it
+                // must not inherit the app's tray.
+                None,
             );
             if let Err(e) = err {
                 eprintln!("[azul] crash-reporter dialog failed: {e:?}");
@@ -288,7 +306,7 @@ impl App {
         }
 
         // Use shell2 for the actual run loop
-        let err = crate::desktop::shell2::run(data, undo_manager, config, fc_cache, font_registry, root_window);
+        let err = crate::desktop::shell2::run(data, undo_manager, config, fc_cache, font_registry, root_window, self.ptr.tray.clone());
 
         // Telemetry: persist + upload whatever the interval uploader has not
         // sent yet. Without this a SHORT run (an e2e drive, a screenshot
@@ -335,7 +353,7 @@ pub struct AppInternal {
     /// No window is actually shown until the `.run_inner()` method is called.
     pub windows: WindowCreateOptionsVec,
     /// Font configuration cache (shared across all windows)
-    /// Initially empty — populated from the registry at first layout time
+    /// Initially empty  -  populated from the registry at first layout time
     pub fc_cache: Box<Arc<FcFontCache>>,
     /// Async font registry: background threads race to discover and parse fonts.
     /// At layout time, `request_fonts()` blocks until the needed fonts are ready,
@@ -345,12 +363,17 @@ pub struct AppInternal {
     /// to every window so a callback's `undo_app_state` / `redo_app_state` /
     /// `commit_undo_snapshot` operates on one shared history.
     pub undo_manager: crate::desktop::shell2::common::event::SharedUndoManager,
+    /// Tray requested via [`App::set_tray`], applied when `run()` starts.
+    ///
+    /// Owned by the App rather than a process global: it is per-App state, and
+    /// a global would silently pick the wrong one if a process ever ran two.
+    pub tray: Option<azul_core::tray::TrayIconData>,
 }
 
 impl AppInternal {
     /// Creates a new, empty application.
     ///
-    /// Does not open any windows — call `App::run` to enter the event loop.
+    /// Does not open any windows  -  call `App::run` to enter the event loop.
     pub fn create(initial_data: RefAny, app_config: AppConfig) -> Self {
 
         debug_server::log(
@@ -452,6 +475,7 @@ impl AppInternal {
             windows: WindowCreateOptionsVec::from_const_slice(&[]),
             data: initial_data,
             config: app_config,
+            tray: None,
             fc_cache: Box::new(fc_cache),
             font_registry,
             undo_manager: crate::desktop::shell2::common::event::SharedUndoManager::new(),

--- a/dll/src/desktop/app.rs
+++ b/dll/src/desktop/app.rs
@@ -197,6 +197,32 @@ impl App {
         self.ptr.tray = Some(tray);
     }
 
+    /// Ask for an application icon  -  the macOS Dock tile, and elsewhere the
+    /// process-wide default window icon. Takes effect when `run()` starts.
+    ///
+    /// `spec` is an icon-registry spec, exactly what an `<icon>` node takes: a
+    /// bare name (`"settings"`), a pack-qualified name (`"mypack:logo"`), or a
+    /// comma-separated fallback list. It renders through the SAME pipeline as a
+    /// tray icon and an in-DOM `<icon>`, so all three can never disagree.
+    ///
+    /// Deferred for the same reason as `set_tray`: the icon registry has to be
+    /// published before a spec can resolve, and macOS needs `NSApplication`.
+    ///
+    /// Best-effort, and deliberately narrower than it looks:
+    ///
+    /// * macOS sets `applicationIconImage`, which Apple documents as TEMPORARY -
+    ///   it is process-local and resets on next launch. Persisting it needs an
+    ///   `NSDockTilePlugIn`, which the App Store bans, and writing the bundle
+    ///   icon breaks the code signature, so neither is offered.
+    /// * The Windows EXE icon CANNOT be changed at runtime at all
+    ///   (`BeginUpdateResource` requires the target not be executing, and
+    ///   rewriting resources invalidates Authenticode).
+    ///
+    /// See `scripts/APP_AND_WINDOW_ICON_RESEARCH_2026_08_24.md`.
+    pub fn set_app_icon(&mut self, spec: azul_css::AzString) {
+        self.ptr.app_icon = Some(spec);
+    }
+
     pub fn run(&self, root_window: WindowCreateOptions) {
         debug_server::log(
             debug_server::LogLevel::Info,
@@ -306,7 +332,7 @@ impl App {
         }
 
         // Use shell2 for the actual run loop
-        let err = crate::desktop::shell2::run(data, undo_manager, config, fc_cache, font_registry, root_window, self.ptr.tray.clone(), self.ptr.font_manager.clone());
+        let err = crate::desktop::shell2::run(data, undo_manager, config, fc_cache, font_registry, root_window, self.ptr.tray.clone(), self.ptr.font_manager.clone(), self.ptr.app_icon.clone());
 
         // Telemetry: persist + upload whatever the interval uploader has not
         // sent yet. Without this a SHORT run (an e2e drive, a screenshot
@@ -389,6 +415,9 @@ pub struct AppInternal {
     /// Owned by the App rather than a process global: it is per-App state, and
     /// a global would silently pick the wrong one if a process ever ran two.
     pub tray: Option<azul_core::tray::TrayIconData>,
+    /// App icon requested via `set_app_icon()`, applied once `run()` has a font
+    /// manager to render the spec with. `None` means leave the platform default.
+    pub app_icon: Option<azul_css::AzString>,
 }
 
 impl AppInternal {
@@ -497,6 +526,7 @@ impl AppInternal {
             data: initial_data,
             config: app_config,
             tray: None,
+            app_icon: None,
             // ONE manager, built here rather than per-window. `FcFontCache` is
             // internally Arc-shared, so the clone tracks whatever the scout
             // threads discover later.

--- a/dll/src/desktop/app.rs
+++ b/dll/src/desktop/app.rs
@@ -223,6 +223,52 @@ impl App {
         self.ptr.app_icon = Some(spec);
     }
 
+
+    /// Run with a tray and NO window.
+    ///
+    /// For a menu-bar / system-tray utility that has no main window at all.
+    /// `run()` always creates one, so such an app previously had to open and
+    /// then hide a window it never wanted.
+    ///
+    /// Requires `set_tray()` to have been called - without a tray there would be
+    /// no way to interact with the app and nothing to keep it alive.
+    ///
+    /// macOS only for now; other platforms return without running. On macOS this
+    /// switches the process to `Accessory` activation (the runtime equivalent of
+    /// `LSUIElement`): no Dock tile and no application menu bar, which also means
+    /// an icon set via `set_app_icon` has nowhere to appear.
+    pub fn run_tray_only(&self) {
+        let Some(tray) = self.ptr.tray.clone() else {
+            crate::plog_error!("[azul] run_tray_only() called without set_tray(); nothing to run");
+            return;
+        };
+        let data = self.ptr.data.clone();
+        let config = self.ptr.config.clone();
+        let fc_cache = (*self.ptr.fc_cache).clone();
+        let font_registry = self.ptr.font_registry.clone();
+        let undo_manager = self.ptr.undo_manager.clone();
+
+        #[cfg(target_os = "macos")]
+        {
+            if let Err(e) = crate::desktop::shell2::run_tray_only(
+                data,
+                undo_manager,
+                config,
+                fc_cache,
+                font_registry,
+                tray,
+                self.ptr.font_manager.clone(),
+            ) {
+                crate::plog_error!("[azul] run_tray_only failed: {:?}", e);
+            }
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            let _ = (data, config, fc_cache, font_registry, undo_manager, tray);
+            crate::plog_error!("[azul] run_tray_only() is macOS-only for now");
+        }
+    }
+
     pub fn run(&self, root_window: WindowCreateOptions) {
         debug_server::log(
             debug_server::LogLevel::Info,

--- a/dll/src/desktop/app_icon.rs
+++ b/dll/src/desktop/app_icon.rs
@@ -47,14 +47,18 @@ pub enum IconOutcome {
 /// process-wide default window icon.
 ///
 /// `spec` is an icon-registry spec, exactly as an `<icon>` node takes.
-pub fn set_app_icon(spec: &str) -> IconOutcome {
+pub fn set_app_icon(
+    spec: &str,
+    provider: &azul_core::icon::SharedIconProvider,
+    font_manager: &azul_layout::font_traits::FontManager<azul_css::props::basic::FontRef>,
+) -> IconOutcome {
     #[cfg(target_os = "macos")]
     {
-        macos::set_app_icon(spec)
+        macos::set_app_icon(spec, provider, font_manager)
     }
     #[cfg(not(target_os = "macos"))]
     {
-        let _ = spec;
+        let _ = (spec, provider, font_manager);
         IconOutcome::Unsupported
     }
 }
@@ -93,11 +97,15 @@ mod macos {
     const APP_ICON_PIXELS: u32 = 1024;
     const APP_ICON_POINTS: u32 = 512;
 
-    pub(super) fn set_app_icon(spec: &str) -> IconOutcome {
+    pub(super) fn set_app_icon(
+        spec: &str,
+        provider: &azul_core::icon::SharedIconProvider,
+        font_manager: &azul_layout::font_traits::FontManager<azul_css::props::basic::FontRef>,
+    ) -> IconOutcome {
         let Some(mtm) = MainThreadMarker::new() else {
             return IconOutcome::Unsupported;
         };
-        let Some(rendered) = crate::desktop::tray::render_named_icon(spec, APP_ICON_PIXELS) else {
+        let Some(rendered) = crate::desktop::tray::render_named_icon(spec, APP_ICON_PIXELS, provider, font_manager) else {
             return IconOutcome::NotFound;
         };
         let Some(image) = crate::desktop::tray::macos::nsimage_from_rgba(

--- a/dll/src/desktop/app_icon.rs
+++ b/dll/src/desktop/app_icon.rs
@@ -1,0 +1,143 @@
+//! Application / dock / taskbar icon, set at runtime from an icon-registry spec.
+//!
+//! Same pipeline as the tray: a spec resolves through the icon registry, renders
+//! as a DOM, and comes out as RGBA — so an app icon can be any registered icon,
+//! including one a custom resolver expresses as an SVG or an emoji.
+//!
+//! # What "app icon" means per platform, and what it does NOT mean
+//!
+//! Full detail in `scripts/APP_AND_WINDOW_ICON_RESEARCH_2026_08_24.md`. The
+//! parts that shape this API:
+//!
+//! * **The Windows EXE icon cannot be changed at runtime.** `BeginUpdateResource`
+//!   documents that the target "cannot be currently executing", and rewriting
+//!   resources invalidates Authenticode anyway. What IS settable is the *window*
+//!   icon (title bar, Alt+Tab, and the taskbar button of a running, un-pinned
+//!   window). A pinned taskbar entry shows the shortcut's icon and is not ours.
+//! * **macOS windows have no icon** beyond the document proxy icon, which only
+//!   exists when the window represents a file. So `set_window_icon` is a no-op
+//!   there by design rather than being faked through the proxy-icon button.
+//! * **macOS `applicationIconImage` is explicitly temporary** — Apple's word.
+//!   It is process-local and resets on next launch; persisting it requires an
+//!   `NSDockTilePlugIn`, which is banned from the App Store. This does not touch
+//!   the bundle: `NSWorkspace.setIcon:forFile:` would, and it breaks the code
+//!   signature ("app is damaged" on Ventura+), so it is deliberately not offered.
+//! * **Wayland cannot set a window icon from pixels** unless the compositor
+//!   implements `xdg-toplevel-icon-v1` — which Mutter/GNOME still does not in
+//!   2026. The fallback is `set_app_id` + a matching `.desktop` file, i.e. no
+//!   runtime pixels at all.
+//!
+//! Everything here therefore reports what it actually did rather than returning
+//! `()`, so a caller can tell "set" from "silently nothing" — which is exactly
+//! how the Wayland generic-icon bug survives in other toolkits.
+
+/// What a platform managed to do with an icon request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IconOutcome {
+    /// The icon is now showing.
+    Applied,
+    /// The platform has no such slot at all (a macOS window icon, a Wayland
+    /// window icon with no `xdg-toplevel-icon-v1`). Not an error.
+    Unsupported,
+    /// The spec resolved to nothing, or no icon registry has been published.
+    NotFound,
+}
+
+/// Set the application icon — the macOS Dock tile, and on other platforms the
+/// process-wide default window icon.
+///
+/// `spec` is an icon-registry spec, exactly as an `<icon>` node takes.
+pub fn set_app_icon(spec: &str) -> IconOutcome {
+    #[cfg(target_os = "macos")]
+    {
+        macos::set_app_icon(spec)
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = spec;
+        IconOutcome::Unsupported
+    }
+}
+
+/// Set the Dock/taskbar badge — macOS `NSDockTile.badgeLabel`.
+///
+/// `None` clears it. Windows' equivalent is `ITaskbarList3::SetOverlayIcon`
+/// (an icon, not a string) and Linux's is a de-facto D-Bus interface; neither
+/// is wired yet, so both report `Unsupported`.
+pub fn set_badge(label: Option<&str>) -> IconOutcome {
+    #[cfg(target_os = "macos")]
+    {
+        macos::set_badge(label)
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = label;
+        IconOutcome::Unsupported
+    }
+}
+
+#[cfg(target_os = "macos")]
+mod macos {
+    use objc2::MainThreadMarker;
+    use objc2_app_kit::NSApplication;
+    use objc2_foundation::NSString;
+
+    use super::IconOutcome;
+
+    /// Rendered once at 1024 so the Dock never has to upscale. `NSImage.size` is
+    /// set in POINTS by `nsimage_from_rgba`, and the pixel/point ratio is the
+    /// scale factor, so one large representation covers every display.
+    ///
+    /// Mission Control and the About panel ask for larger sizes than the 128pt
+    /// Dock tile, which is why this is not simply 256.
+    const APP_ICON_PIXELS: u32 = 1024;
+    const APP_ICON_POINTS: u32 = 512;
+
+    pub(super) fn set_app_icon(spec: &str) -> IconOutcome {
+        let Some(mtm) = MainThreadMarker::new() else {
+            return IconOutcome::Unsupported;
+        };
+        let Some(rendered) = crate::desktop::tray::render_named_icon(spec, APP_ICON_PIXELS) else {
+            return IconOutcome::NotFound;
+        };
+        let Some(image) = crate::desktop::tray::macos::nsimage_from_rgba(
+            &rendered.rgba,
+            rendered.width,
+            rendered.height,
+            APP_ICON_POINTS,
+            mtm,
+        ) else {
+            return IconOutcome::NotFound;
+        };
+
+        let app = NSApplication::sharedApplication(mtm);
+        // NOT a template image, unlike the status item: the Dock tile is drawn
+        // in full colour and is never tinted by AppKit.
+        //
+        // Note macOS 26 enforces a squircle for BUNDLE icons but draws a runtime
+        // applicationIconImage exactly as supplied — so a caller wanting the
+        // native look has to draw the rounded square itself. We do not impose one.
+        unsafe { app.setApplicationIconImage(Some(&image)) };
+        IconOutcome::Applied
+    }
+
+    pub(super) fn set_badge(label: Option<&str>) -> IconOutcome {
+        let Some(mtm) = MainThreadMarker::new() else {
+            return IconOutcome::Unsupported;
+        };
+        let app = NSApplication::sharedApplication(mtm);
+        let tile = unsafe { app.dockTile() };
+        unsafe {
+            match label {
+                Some(l) => tile.setBadgeLabel(Some(&NSString::from_str(l))),
+                None => tile.setBadgeLabel(None),
+            }
+            // MANDATORY. NSDockTile does not redraw itself: "In order to
+            // initiate drawing in the view, you must call -[NSDockTile
+            // display]". Omitting this is the single most common "my dock icon
+            // doesn't update" cause.
+            tile.display();
+        }
+        IconOutcome::Applied
+    }
+}

--- a/dll/src/desktop/display.rs
+++ b/dll/src/desktop/display.rs
@@ -12,6 +12,9 @@ use azul_css::{
     AzString, OptionString,
 };
 
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
 use crate::desktop::shell2::common::debug_server::LogCategory;
 use crate::log_debug;
 
@@ -44,6 +47,52 @@ pub struct DisplayInfo {
 /// - **X11**: Uses XRandR extension (fallback to single display if unavailable)
 /// - **Wayland**: Not directly available - compositor manages positioning
 pub fn get_displays() -> Vec<DisplayInfo> {
+    // Short-lived memo in front of the real enumeration.
+    //
+    // WHY: `get_display_at_point` is called from the X11 ConfigureNotify arm,
+    // which fires once per PIXEL of pointer travel during a window drag. Each
+    // uncached call there costs XOpenDisplay + XRRGetScreenResourcesCurrent +
+    // N * XRRGetCrtcInfo + XCloseDisplay, so a 400px drag paid 400 of them.
+    // (mod wayland has had its own 15s cache for exactly this reason; it just
+    // never covered X11, Windows or macOS.)
+    //
+    // The TTL is deliberately short. It is a within-one-gesture memo, not a
+    // topology cache: anything longer would let a monitor hotplug go unseen.
+    // Backends that KNOW the topology changed call `invalidate_display_cache()`
+    // first, so a refresh never reads through a stale entry regardless of TTL.
+    const DISPLAY_MEMO_TTL: Duration = Duration::from_millis(250);
+
+    if let Ok(guard) = DISPLAY_MEMO.lock() {
+        if let Some((at, ref cached)) = *guard {
+            if at.elapsed() < DISPLAY_MEMO_TTL {
+                return cached.clone();
+            }
+        }
+    }
+
+    let fresh = get_displays_uncached();
+
+    if let Ok(mut guard) = DISPLAY_MEMO.lock() {
+        *guard = Some((Instant::now(), fresh.clone()));
+    }
+    fresh
+}
+
+/// Drop the [`get_displays`] memo.
+///
+/// Call this from a backend's display-change handler BEFORE re-reading the
+/// monitor list (`WM_DISPLAYCHANGE`, `RRScreenChangeNotify`,
+/// `NSApplicationDidChangeScreenParameters`, wl_registry global add/remove),
+/// so the refresh cannot be served a pre-change entry.
+pub fn invalidate_display_cache() {
+    if let Ok(mut guard) = DISPLAY_MEMO.lock() {
+        *guard = None;
+    }
+}
+
+static DISPLAY_MEMO: Mutex<Option<(Instant, Vec<DisplayInfo>)>> = Mutex::new(None);
+
+fn get_displays_uncached() -> Vec<DisplayInfo> {
     #[cfg(target_os = "windows")]
     return windows::get_displays();
 
@@ -110,6 +159,17 @@ impl DisplayInfo {
             is_primary_monitor: self.is_primary,
         }
     }
+}
+
+/// Re-read the monitor list, bypassing the [`get_displays`] memo.
+///
+/// This is what a display-change handler wants: `WM_DISPLAYCHANGE`,
+/// `RRScreenChangeNotify`, `windowDidChangeScreen:` and the wl_registry
+/// output add/remove all mean "the topology you have is wrong", so serving
+/// them a memo entry from before the change would defeat the refresh entirely.
+pub fn refresh_monitors() -> MonitorVec {
+    invalidate_display_cache();
+    get_monitors()
 }
 
 /// Get the display containing the given point
@@ -440,7 +500,24 @@ mod macos {
     use super::*;
 
     pub fn get_displays() -> Vec<DisplayInfo> {
-        let mtm = MainThreadMarker::new().expect("Must be called on main thread");
+        // AppKit screen enumeration is main-thread only. This used to be
+        // `.expect("Must be called on main thread")`, which made the PUBLIC
+        // `App::get_monitors()` a hard panic when called from a worker thread
+        // or a headless test. Only `transient.rs::placement_bounds` guarded
+        // against it; every other caller was one thread-hop from aborting.
+        //
+        // Degrade to "no monitors known" instead. Callers already handle an
+        // empty list (it is what the headless and web backends always return),
+        // and an empty list is honest, where a synthesised 1920x1080 would
+        // silently place windows against a monitor that does not exist.
+        let Some(mtm) = MainThreadMarker::new() else {
+            log_debug!(
+                LogCategory::Window,
+                "[display] get_displays() called off the main thread; returning an empty \
+                 monitor list (AppKit screen enumeration is main-thread only)"
+            );
+            return Vec::new();
+        };
         let screens = NSScreen::screens(mtm);
         let mut displays = Vec::new();
 

--- a/dll/src/desktop/mod.rs
+++ b/dll/src/desktop/mod.rs
@@ -134,6 +134,10 @@ pub mod menu;
 pub mod menu_renderer;
 /// New windowing backend (shell2) - modern, clean architecture
 pub mod shell2;
+/// Application / dock / taskbar icon, set at runtime from an icon-registry spec
+pub mod app_icon;
+/// System tray / status icon — NSStatusItem, Shell_NotifyIcon, StatusNotifierItem
+pub mod tray;
 /// WebRender type translations and hit-testing for shell2
 pub mod wr_translate2;
 /// Shader disk cache for WebRender program binaries

--- a/dll/src/desktop/shell2/common/layout.rs
+++ b/dll/src/desktop/shell2/common/layout.rs
@@ -1923,3 +1923,37 @@ pub(crate) fn reconcile_transient_windows(
     // pair the backend never saw, so nothing flashes.
     layout_window.pending_transient_diff.merge(diff);
 }
+
+/// Build a `LayoutWindow` that SHARES the app-level font manager.
+///
+/// This is the single decision point for "where does a window's `FontManager`
+/// come from", and it exists because there are four window backends that each
+/// used to answer it independently with `LayoutWindow::new(fc_cache)` - i.e.
+/// a brand-new `FontManager` per window.
+///
+/// That is not merely wasteful. A `FontManager` owns the `embedded_fonts` pool,
+/// which is the ONLY place a face handed over as `StyleFontFamily::Ref`
+/// (Material Icons, and anything a font-backed icon pack resolves to) is ever
+/// named. Two windows with two managers therefore disagree about which faces
+/// exist, and a face registered while laying out one window is invisible to the
+/// next - which surfaces as a `.notdef` tofu box, with every intermediate step
+/// reporting success.
+///
+/// `clone_shared()` shares the `parsed_fonts` and `embedded_fonts` pools while
+/// giving the window a private `fc_cache` field, so it can still swap in its own
+/// registry snapshot at layout time (`replace_fc_cache`) without disturbing
+/// anyone else.
+///
+/// Falls back to a private manager when there is no app-level one, which is the
+/// old behaviour and keeps this infallible to adopt.
+pub fn layout_window_sharing_fonts(
+    app_font_manager: Option<&std::sync::Arc<azul_layout::font_traits::FontManager<azul_css::props::basic::FontRef>>>,
+    fc_cache: &rust_fontconfig::FcFontCache,
+) -> Result<azul_layout::window::LayoutWindow, azul_layout::solver3::LayoutError> {
+    match app_font_manager {
+        Some(fm) => Ok(azul_layout::window::LayoutWindow::from_font_manager(
+            fm.clone_shared(),
+        )),
+        None => azul_layout::window::LayoutWindow::new(fc_cache.clone()),
+    }
+}

--- a/dll/src/desktop/shell2/common/layout.rs
+++ b/dll/src/desktop/shell2/common/layout.rs
@@ -597,6 +597,18 @@ phases.mark("after_callback");
     // We collect all CSS objects, flatten the tree, and run a single cascade pass.
     // E2E `mount` override: replace the app's DOM wholesale with the test's
     // inline XML+CSS document (reusing the existing XML→StyledDom parser).
+    // 1a. Resolve icon nodes BEFORE the cascade.
+    //
+    // Icons used to be resolved after `create_from_dom`, by splicing
+    // already-cascaded fragments into the flat StyledDom arena. That forced
+    // every icon to collapse to a single node and left the property cache
+    // describing the pre-resolution node (the `.notdef` tofu bug). Resolving on
+    // the `Dom` splices whole subtrees and cascades everything exactly once.
+    let mut user_dom = user_dom;
+    azul_core::icon::resolve_icons_in_dom(&mut user_dom, icon_provider, system_style);
+    azul_layout::probe::emit_phase_heap("after_icons");
+phases.mark("after_icons");
+
     let e2e_mount_xml = layout_window.e2e_mount.xml().map(str::to_string);
     let e2e_mount_dirty = layout_window.e2e_mount.take_dirty();
     let mut user_styled_dom = match e2e_mount_xml {
@@ -614,7 +626,11 @@ phases.mark("after_callback");
                 // Keep the already-mounted DOM (with any debug DOM mutations
                 // applied to it) instead of rebuilding it from the XML.
                 Some(styled) => styled,
-                None => match azul_layout::xml::parse_xml_to_styled_dom(&xml) {
+                None => match azul_layout::xml::parse_xml_to_styled_dom_resolving_icons(
+                    &xml,
+                    icon_provider,
+                    system_style,
+                ) {
                     Ok(styled) => {
                         log_debug!(
                             LogCategory::Layout,
@@ -639,11 +655,7 @@ phases.mark("after_callback");
     azul_layout::probe::emit_phase_heap("after_create_from_dom");
 phases.mark("after_create_from_dom");
 
-    // 2. Resolve icon nodes to their actual content (text glyphs, images, etc.)
-    // This must happen after the user's layout callback and before CSD injection
-    azul_core::icon::resolve_icons_in_styled_dom(&mut user_styled_dom, icon_provider, system_style);
-    azul_layout::probe::emit_phase_heap("after_icons");
-phases.mark("after_icons");
+
 
     // 3. Conditionally inject Client-Side Decorations (CSD)
     //

--- a/dll/src/desktop/shell2/linux/resources.rs
+++ b/dll/src/desktop/shell2/linux/resources.rs
@@ -33,6 +33,14 @@ pub struct AppResources {
     /// Async font registry for background font scanning
     pub font_registry: Option<Arc<FcFontRegistry>>,
 
+    /// THE app-level font manager, shared by every window on this connection.
+    ///
+    /// Without it each window built its own via `LayoutWindow::new(fc_cache)`,
+    /// giving every window a private `embedded_fonts` pool - so a face
+    /// registered while laying out one window was invisible to the next. See
+    /// `layout_window_sharing_fonts`.
+    pub font_manager: Option<std::sync::Arc<azul_layout::font_traits::FontManager<azul_css::props::basic::FontRef>>>,
+
     /// Application data (user's global state)
     pub app_data: Arc<RefCell<RefAny>>,
 
@@ -53,6 +61,17 @@ impl AppResources {
     ///
     /// This should be called once at application startup.
     pub fn new(config: AppConfig, fc_cache: Arc<FcFontCache>, font_registry: Option<Arc<FcFontRegistry>>) -> Self {
+        Self::new_with_font_manager(config, fc_cache, font_registry, None)
+    }
+
+    /// As `new`, but adopting the app-level font manager so every window on this
+    /// connection shares one set of font pools.
+    pub fn new_with_font_manager(
+        config: AppConfig,
+        fc_cache: Arc<FcFontCache>,
+        font_registry: Option<Arc<FcFontRegistry>>,
+        font_manager: Option<std::sync::Arc<azul_layout::font_traits::FontManager<azul_css::props::basic::FontRef>>>,
+    ) -> Self {
         // Create empty app data (user can set this later)
         let app_data = Arc::new(RefCell::new(RefAny::new(())));
 
@@ -73,6 +92,7 @@ impl AppResources {
 
         Self {
             config,
+            font_manager,
             fc_cache,
             font_registry,
             app_data,

--- a/dll/src/desktop/shell2/linux/wayland/events.rs
+++ b/dll/src/desktop/shell2/linux/wayland/events.rs
@@ -531,6 +531,7 @@ pub(super) extern "C" fn registry_global_handler(
             use super::MonitorState;
             window.known_outputs.push(MonitorState {
                 proxy: output,
+                global_name: name,
                 name: format!("output-{}", name),
                 scale: 1,
                 x: 0,
@@ -753,11 +754,73 @@ pub(super) extern "C" fn toplevel_decoration_configure_handler(
     }
 }
 
+/// A global went away. In practice: a monitor was unplugged, powered off over
+/// DisplayPort (which the link treats as an unplug), or the compositor dropped
+/// a virtual output.
+///
+/// This used to be an empty stub, which leaked in three separate ways:
+///   * `known_outputs` grew monotonically across replug cycles, so every index
+///     after the removed one shifted — and `get_current_monitor()` correlates
+///     `known_outputs` against `display::get_displays()` BY INDEX.
+///   * the `wl_output` proxy was never destroyed.
+///   * the tracked-listener entry kept pointing at a dead proxy, so a later
+///     event on a recycled id could dispatch into freed state.
 pub(super) extern "C" fn registry_global_remove_handler(
-    _data: *mut c_void,
+    data: *mut c_void,
     _registry: *mut wl_registry,
-    _name: u32,
+    name: u32,
 ) {
+    let window = unsafe { &mut *(data as *mut super::WaylandWindow) };
+
+    let Some(idx) = window
+        .known_outputs
+        .iter()
+        .position(|m| m.global_name == name)
+    else {
+        // Not an output — seats, shells and every other global share this
+        // event, and we only track outputs here.
+        return;
+    };
+
+    let removed = window.known_outputs.remove(idx);
+
+    // The surface may still list this output as one it had entered; drop it,
+    // or `calculate_current_scale_factor()` keeps folding a dead output's
+    // scale into the max forever.
+    window.current_outputs.retain(|p| *p != removed.proxy);
+
+    // Drop the rebind entry before destroying the proxy, or the next
+    // `rebind_listeners()` re-registers a listener on freed memory.
+    let dead = removed.proxy.cast::<super::defines::wl_proxy>();
+    window.listener_proxies.retain(|p| *p != dead);
+    unsafe { (window.wayland.wl_proxy_destroy)(removed.proxy.cast()) };
+
+    log_info!(
+        LogCategory::Window,
+        "[Wayland] output {} ({}) removed; {} left",
+        name,
+        removed.name,
+        window.known_outputs.len()
+    );
+
+    // The topology changed, so the memoised display list is now wrong.
+    if let Some(ref lw) = window.common.layout_window {
+        if let Ok(mut guard) = lw.monitors.lock() {
+            *guard = crate::desktop::display::refresh_monitors();
+        }
+    }
+
+    // Losing the output the window was on changes its effective scale — same
+    // recompute as the `leave` handler. The fractional-scale protocol owns
+    // size.dpi outright when active, so leave it alone there.
+    if window.preferred_scale_120.is_some() {
+        return;
+    }
+    let new_dpi = (window.calculate_current_scale_factor() * 96.0) as u32;
+    let old_dpi = window.common.current_window_state().size.dpi;
+    if new_dpi > 0 && (new_dpi as i32 - old_dpi as i32).abs() > 1 {
+        apply_os_dpi_change(window, new_dpi);
+    }
 }
 
 // wl_seat listener

--- a/dll/src/desktop/shell2/linux/wayland/mod.rs
+++ b/dll/src/desktop/shell2/linux/wayland/mod.rs
@@ -1627,7 +1627,7 @@ impl WaylandWindow {
         unsafe { (wayland.wl_proxy_set_queue)(registry as _, event_queue) };
 
         // Initialize LayoutWindow
-        let mut layout_window = LayoutWindow::new((*resources.fc_cache).clone()).map_err(|e| {
+        let mut layout_window = crate::desktop::shell2::common::layout::layout_window_sharing_fonts(resources.font_manager.as_ref(), &resources.fc_cache).map_err(|e| {
             WindowError::PlatformError(format!("LayoutWindow::new failed: {:?}", e))
         })?;
         layout_window.routes = resources.config.routes.clone();
@@ -2219,7 +2219,7 @@ impl WaylandWindow {
             // Initialize LayoutWindow if not already done
             if window.common.layout_window.is_none() {
                 let mut layout_window =
-                    azul_layout::window::LayoutWindow::new((*window.resources.fc_cache).clone())
+                    crate::desktop::shell2::common::layout::layout_window_sharing_fonts(window.resources.font_manager.as_ref(), &window.resources.fc_cache)
                         .map_err(|e| {
                             WindowError::PlatformError(format!(
                                 "Failed to create LayoutWindow: {:?}",
@@ -2279,7 +2279,7 @@ impl WaylandWindow {
             // Initialize LayoutWindow if not already done
             if window.common.layout_window.is_none() {
                 if let Ok(mut layout_window) =
-                    azul_layout::window::LayoutWindow::new((*window.resources.fc_cache).clone())
+                    crate::desktop::shell2::common::layout::layout_window_sharing_fonts(window.resources.font_manager.as_ref(), &window.resources.fc_cache)
                 {
                     if let Some(doc_id) = window.common.document_id {
                         layout_window.document_id = doc_id;
@@ -7266,8 +7266,19 @@ impl WaylandPopup {
             window_focused: true,
             active_route: azul_core::resources::OptionRouteMatch::None,
         };
-        let mut layout_window = LayoutWindow::new((*parent.common.fc_cache).clone())
-            .map_err(|e| format!("LayoutWindow::new failed: {e:?}"))?;
+        // A popup is a CHILD: share the PARENT's already-warmed manager, which
+        // is both the warmest option and the one whose embedded (icon) faces the
+        // popup is most likely to need. Falls back to the app-level manager.
+        let mut layout_window = match parent.common.layout_window.as_ref() {
+            Some(parent_lw) => {
+                LayoutWindow::from_font_manager(parent_lw.font_manager.clone_shared())
+            }
+            None => crate::desktop::shell2::common::layout::layout_window_sharing_fonts(
+                parent.resources.font_manager.as_ref(),
+                &parent.resources.fc_cache,
+            )
+            .map_err(|e| format!("LayoutWindow::new failed: {e:?}"))?,
+        };
         layout_window.routes = parent.resources.config.routes.clone();
         // Seed with the parent window's image map so css-id / url("...")
         // images inside the popup resolve (whole-map seed at creation).

--- a/dll/src/desktop/shell2/linux/wayland/mod.rs
+++ b/dll/src/desktop/shell2/linux/wayland/mod.rs
@@ -334,6 +334,10 @@ static WL_BUFFER_RELEASE_LISTENER: defines::wl_buffer_listener = defines::wl_buf
 #[derive(Debug, Clone)]
 pub struct MonitorState {
     pub proxy: *mut defines::wl_output,
+    /// The `wl_registry` global id this output was advertised under. This is
+    /// the ONLY handle `wl_registry.global_remove` gives us, so without it a
+    /// monitor unplug cannot be matched to the entry it should drop.
+    pub global_name: u32,
     pub name: String,
     pub scale: i32,
     pub x: i32,
@@ -2234,7 +2238,7 @@ impl WaylandWindow {
                 layout_window.routes = window.resources.config.routes.clone();
                 // Initialize monitor cache once at window creation
                 if let Ok(mut guard) = layout_window.monitors.lock() {
-                    *guard = crate::desktop::display::get_monitors();
+                    *guard = crate::desktop::display::refresh_monitors();
                 }
                 window.common.layout_window = Some(layout_window);
             }
@@ -2288,7 +2292,7 @@ impl WaylandWindow {
                     layout_window.routes = window.resources.config.routes.clone();
                     // Initialize monitor cache once at window creation
                     if let Ok(mut guard) = layout_window.monitors.lock() {
-                        *guard = crate::desktop::display::get_monitors();
+                        *guard = crate::desktop::display::refresh_monitors();
                     }
                     window.common.layout_window = Some(layout_window);
                 }

--- a/dll/src/desktop/shell2/linux/x11/defines.rs
+++ b/dll/src/desktop/shell2/linux/x11/defines.rs
@@ -349,8 +349,11 @@ pub const SubstructureNotifyMask: c_long = 1 << 19;
 pub const PropModeReplace: c_int = 0;
 pub const PropModeAppend: c_int = 2;
 
-// Predefined atoms
+// Predefined atoms. These are fixed by the protocol (X.h), not interned:
+// PRIMARY=1, SECONDARY=2, ARC=3, ATOM=4, BITMAP=5, CARDINAL=6.
 pub const XA_ATOM: Atom = 4;
+/// The type `_NET_WM_ICON` and most other EWMH numeric properties carry.
+pub const XA_CARDINAL: Atom = 6;
 /// `AnyPropertyType` wildcard for `XGetWindowProperty` (accept any type).
 pub const AnyPropertyType: Atom = 0;
 

--- a/dll/src/desktop/shell2/linux/x11/mod.rs
+++ b/dll/src/desktop/shell2/linux/x11/mod.rs
@@ -2096,9 +2096,11 @@ impl X11Window {
             );
         }
         let position = options.window_state.position;
-        // Monitor ID is now stored in FullWindowState.monitor_id, not in WindowState
-        // For now, we default to monitor 0
-        let monitor_id = 0; // TODO: Get from options or detect primary monitor
+        // The monitor the caller asked to open on, as an index into the list
+        // display::get_monitors() builds. This was hardcoded to 0, so
+        // `WindowCreateOptions.window_state.monitor_id` was silently ignored
+        // and every X11 window opened on the first CRTC.
+        let monitor_id = options.window_state.monitor_id.into_option().unwrap_or(0);
 
         // Try to create window with ARGB visual for true background transparency
         // This allows background-only transparency where the background is transparent
@@ -2482,7 +2484,13 @@ impl X11Window {
                 background_color: options.window_state.background_color,
                 layout_callback: options.window_state.layout_callback,
                 close_callback: options.window_state.close_callback.clone(),
-                monitor_id: OptionU32::None,
+                // Seed with the monitor we are actually placing the window on.
+                // This was `None` and was never written afterwards, so on X11
+                // `CallbackInfo::get_current_monitor()` returned None for the
+                // window's whole life and `WindowMonitorChanged` could never
+                // fire (the event rule needs BOTH sides Some). The
+                // ConfigureNotify handler keeps it current from here on.
+                monitor_id: OptionU32::Some(monitor_id as u32),
                 window_id: options.window_state.window_id.clone(),
                 window_focused: true,
                 active_route: azul_core::resources::OptionRouteMatch::None,
@@ -3803,6 +3811,34 @@ impl X11Window {
                     if let Some(display) =
                         crate::desktop::display::get_display_at_point(window_center)
                     {
+                        // Keep `ws.monitor_id` current so get_current_monitor()
+                        // and WindowMonitorChanged track the move. Resolve the
+                        // INDEX out of the cached list by matching the origin,
+                        // the same way the Win32 WM_MOVE handler does — the
+                        // cache and get_display_at_point() are built from the
+                        // same enumeration, so origins compare exactly.
+                        #[allow(clippy::cast_possible_truncation)]
+                        let found_index = self.common.layout_window.as_ref().and_then(|lw| {
+                            let guard = lw.monitors.lock().ok()?;
+                            guard
+                                .as_ref()
+                                .iter()
+                                .find(|m| {
+                                    m.position.x == display.bounds.origin.x as isize
+                                        && m.position.y == display.bounds.origin.y as isize
+                                })
+                                .map(|m| m.monitor_id.index as u32)
+                        });
+                        if let Some(index) = found_index {
+                            if self.common.current_window_state().monitor_id
+                                != OptionU32::Some(index)
+                            {
+                                self.common.update_window_state(
+                                    crate::desktop::shell2::common::event::WindowStateSource::Os,
+                                    |ws| ws.monitor_id = OptionU32::Some(index),
+                                );
+                            }
+                        }
                         // Same 0.25-step quantization as detect_initial_dpi, so a
                         // noisy mm-based estimate (~1.04) stays at exactly 96 DPI.
                         let new_dpi =
@@ -3864,7 +3900,7 @@ impl X11Window {
                         );
                         if let Some(ref lw) = self.common.layout_window {
                             if let Ok(mut guard) = lw.monitors.lock() {
-                                *guard = crate::desktop::display::get_monitors();
+                                *guard = crate::desktop::display::refresh_monitors();
                             }
                         }
                     }

--- a/dll/src/desktop/shell2/linux/x11/mod.rs
+++ b/dll/src/desktop/shell2/linux/x11/mod.rs
@@ -302,6 +302,74 @@ fn xft_dpi(xlib: &Xlib, display: *mut Display) -> Option<u32> {
     None
 }
 
+/// Publish `_NET_WM_ICON` from whatever icon sizes the caller supplied.
+///
+/// EWMH format is `[w1, h1, w1*h1 pixels..., w2, h2, ...]`, one entry per size,
+/// each pixel `0xAARRGGBB`, rows top-down. The WM picks whichever size it wants,
+/// so passing several is better than picking for it.
+///
+/// TWO traps, both of which produce silent garbage rather than an error:
+///
+/// 1. **`format = 32` does NOT mean 4 bytes here.** Xlib's `XChangeProperty`
+///    reads `data` as an array of C `long`, which is EIGHT bytes on LP64. Passing
+///    a `&[u32]` makes the server read two pixels per element and render noise or
+///    nothing. Hence `c_ulong` and the zero-extend below. (XCB is exempt - it
+///    takes raw bytes - which is why ports between the two keep reintroducing
+///    this.) The same trap is noted on the `_NET_WM_WINDOW_TYPE` write.
+/// 2. **Channel order is ARGB packed into the word, not the RGBA byte order we
+///    are handed.** The alpha is straight, not premultiplied.
+unsafe fn apply_net_wm_icon(
+    xlib: &Xlib,
+    display: *mut defines::Display,
+    window: defines::Window,
+    icons: &[(u32, u32, &[u8])],
+) {
+    use std::os::raw::c_ulong;
+
+    if icons.is_empty() {
+        return;
+    }
+
+    let mut data: Vec<c_ulong> = Vec::new();
+    for (w, h, rgba) in icons {
+        let (w, h) = (*w as usize, *h as usize);
+        // A truncated buffer would be read past the end below; skip rather than
+        // publish a half-decoded icon.
+        if w == 0 || h == 0 || rgba.len() < w * h * 4 {
+            continue;
+        }
+        data.push(w as c_ulong);
+        data.push(h as c_ulong);
+        for px in rgba[..w * h * 4].chunks_exact(4) {
+            let (r, g, b, a) = (px[0] as c_ulong, px[1] as c_ulong, px[2] as c_ulong, px[3] as c_ulong);
+            data.push((a << 24) | (r << 16) | (g << 8) | b);
+        }
+    }
+    if data.is_empty() {
+        return;
+    }
+
+    let atom = (xlib.XInternAtom)(
+        display,
+        b"_NET_WM_ICON\0".as_ptr() as *const c_char,
+        0,
+    );
+    if atom == 0 {
+        return;
+    }
+
+    (xlib.XChangeProperty)(
+        display,
+        window,
+        atom,
+        defines::XA_CARDINAL,
+        32,
+        defines::PropModeReplace,
+        data.as_ptr() as *const u8,
+        data.len() as i32,
+    );
+}
+
 /// See: https://stackoverflow.com/a/9215724 (inspired by datenwolf/FTB)
 ///
 /// MWA-B5: `_MOTIF_WM_HINTS` — tell the WM which decorations to draw.
@@ -2205,6 +2273,34 @@ impl X11Window {
                 window_handle,
                 options.window_state.flags.decorations,
             );
+        }
+
+        // Window icon. `LinuxWindowOptions::window_icon` was public API that NO
+        // backend read - setting it did nothing, silently - which is the failure
+        // mode this codebase keeps finding in icon paths.
+        //
+        // On X11 the window icon and the taskbar icon are the SAME property, so
+        // there is one field here where Win32 has two slots. Every supplied size
+        // goes into one `_NET_WM_ICON` and the WM picks.
+        {
+            use azul_core::window::WindowIcon;
+
+            let mut icons: Vec<(u32, u32, &[u8])> = Vec::new();
+            let linux_opts = &options
+                .window_state
+                .platform_specific_options
+                .linux_options;
+            if let Some(icon) = linux_opts.window_icon.as_ref() {
+                match icon {
+                    WindowIcon::Small(i) => icons.push((16, 16, i.rgba_bytes.as_ref())),
+                    WindowIcon::Large(i) => icons.push((32, 32, i.rgba_bytes.as_ref())),
+                }
+            }
+            if !icons.is_empty() {
+                unsafe {
+                    apply_net_wm_icon(&xlib, display, window_handle, &icons);
+                }
+            }
         }
 
         // WM_CLASS hint (instance + class) from the window options, so the WM / taskbar

--- a/dll/src/desktop/shell2/linux/x11/mod.rs
+++ b/dll/src/desktop/shell2/linux/x11/mod.rs
@@ -1892,7 +1892,7 @@ impl X11Window {
             return Ok(());
         }
         let mut layout_window =
-            azul_layout::window::LayoutWindow::new((*self.resources.fc_cache).clone())
+            crate::desktop::shell2::common::layout::layout_window_sharing_fonts(self.resources.font_manager.as_ref(), &self.resources.fc_cache)
                 .map_err(|e| {
                     WindowError::PlatformError(format!(
                         "Failed to create LayoutWindow: {:?}",

--- a/dll/src/desktop/shell2/macos/menu.rs
+++ b/dll/src/desktop/shell2/macos/menu.rs
@@ -208,6 +208,18 @@ impl MenuState {
         self.command_map.get(&tag)
     }
 
+    /// Every tag this menu owns.
+    ///
+    /// Menu clicks land in one process-wide queue shared by every window's menu
+    /// bar and by the tray, and `take_pending_menu_actions_matching` needs an
+    /// ownership predicate to route them. Callers build that predicate from
+    /// this — asking `get_callback_for_tag(t).is_some()` would work too, but
+    /// only for items that HAVE a callback, so a separator or a callback-less
+    /// parent would leak into another owner's drain.
+    pub fn known_tags(&self) -> impl Iterator<Item = isize> + '_ {
+        self.command_map.keys().copied()
+    }
+
     /// Register a callback and return a unique tag for it
     /// Used by context menus to register callbacks dynamically
     pub fn register_callback(&mut self, callback: azul_core::menu::CoreMenuCallback) -> isize {

--- a/dll/src/desktop/shell2/macos/menu.rs
+++ b/dll/src/desktop/shell2/macos/menu.rs
@@ -254,6 +254,12 @@ fn create_nsmenu(
     HashMap<isize, azul_core::menu::CoreMenuCallback>,
 ) {
     let ns_menu = NSMenu::new(mtm);
+    // `setEnabled:` below is a no-op while this is YES (the default): AppKit
+    // re-validates every item as the menu opens and overwrites whatever we set,
+    // so `MenuItemState::Disabled` / `Greyed` were silently ignored. Turning
+    // auto-enabling off makes the model authoritative, which is what a caller
+    // setting an explicit state means.
+    ns_menu.setAutoenablesItems(false);
     let mut command_map = HashMap::new();
 
     // Build menu items recursively
@@ -381,23 +387,39 @@ pub(crate) fn build_menu_items(
                 if !string_item.children.is_empty() {
                     // Submenu
                     let submenu = NSMenu::new(mtm);
+                    // Same reason as the root menu: without this, an explicitly
+                    // disabled item inside a submenu re-enables itself on open.
+                    submenu.setAutoenablesItems(false);
                     submenu.setTitle(&title);
                     build_menu_items(string_item.children.as_slice(), &submenu, command_map, next_tag, mtm);
                     menu_item.setSubmenu(Some(&submenu));
                 } else {
-                    // Leaf item - wire up callback
+                    // EVERY leaf gets a tag, a target and an action - not just
+                    // the ones carrying a Rust callback.
+                    //
+                    // AppKit disables any item whose target/action pair does not
+                    // resolve, so gating this on `callback.is_some()` greyed out
+                    // every callback-less item. That is fatal for the TRAY, whose
+                    // items are identified purely by tag: the click comes back as
+                    // `TrayEvent::menu_item(tag)` through the shared queue, and an
+                    // item with no tag can neither be delivered nor recognised as
+                    // one this tray owns.
+                    //
+                    // The callback map stays optional - an item without one simply
+                    // has no entry, and `get_callback_for_tag` returns None - but
+                    // the item is now clickable and identifiable either way.
+                    let tag = *next_tag;
+                    *next_tag += 1;
+                    menu_item.setTag(tag);
+
                     if let Some(callback) = string_item.callback.as_option() {
-                        let tag = *next_tag;
-                        *next_tag += 1;
-
-                        menu_item.setTag(tag);
                         command_map.insert(tag, callback.clone());
+                    }
 
-                        let target = AzulMenuTarget::shared_instance(mtm);
-                        unsafe {
-                            menu_item.setTarget(Some(&target));
-                            menu_item.setAction(Some(objc2::sel!(menuItemAction:)));
-                        }
+                    let target = AzulMenuTarget::shared_instance(mtm);
+                    unsafe {
+                        menu_item.setTarget(Some(&target));
+                        menu_item.setAction(Some(objc2::sel!(menuItemAction:)));
                     }
 
                     // Set keyboard accelerator if present

--- a/dll/src/desktop/shell2/macos/mod.rs
+++ b/dll/src/desktop/shell2/macos/mod.rs
@@ -3084,7 +3084,7 @@ define_class!(
                     window.surface_needs_update = true;
                     if let Some(ref lw) = window.common.layout_window {
                         if let Ok(mut guard) = lw.monitors.lock() {
-                            *guard = crate::desktop::display::get_monitors();
+                            *guard = crate::desktop::display::refresh_monitors();
                         }
                     }
                 }
@@ -3100,7 +3100,7 @@ define_class!(
                     let window = &mut *(window_ptr as *mut MacOSWindow);
                     if let Some(ref lw) = window.common.layout_window {
                         if let Ok(mut guard) = lw.monitors.lock() {
-                            *guard = crate::desktop::display::get_monitors();
+                            *guard = crate::desktop::display::refresh_monitors();
                         }
                     }
                 }

--- a/dll/src/desktop/shell2/macos/mod.rs
+++ b/dll/src/desktop/shell2/macos/mod.rs
@@ -4083,10 +4083,13 @@ impl MacOSWindow {
         shared_icon_provider: azul_core::icon::SharedIconProvider,
         fc_cache: Arc<rust_fontconfig::FcFontCache>,
         font_registry: Option<Arc<rust_fontconfig::registry::FcFontRegistry>>,
+        // THE app-level font manager. A top-level window shares it rather than
+        // building a private one; see `layout_window_sharing_fonts`.
+        app_font_manager: Option<Arc<azul_layout::font_traits::FontManager<azul_css::props::basic::FontRef>>>,
         parent_lw: Option<&LayoutWindow>,
         mtm: MainThreadMarker,
     ) -> Result<Self, WindowError> {
-        Self::new_with_options_internal(options, app_data, undo_manager, config, shared_icon_provider, Some(fc_cache), font_registry, parent_lw, mtm)
+        Self::new_with_options_internal(options, app_data, undo_manager, config, shared_icon_provider, Some(fc_cache), font_registry, app_font_manager, parent_lw, mtm)
     }
 
     /// Create a new macOS window with given options.
@@ -4098,7 +4101,7 @@ impl MacOSWindow {
         shared_icon_provider: azul_core::icon::SharedIconProvider,
         mtm: MainThreadMarker,
     ) -> Result<Self, WindowError> {
-        Self::new_with_options_internal(options, app_data, undo_manager, config, shared_icon_provider, None, None, None, mtm)
+        Self::new_with_options_internal(options, app_data, undo_manager, config, shared_icon_provider, None, None, None, None, mtm)
     }
 
     /// Internal constructor with optional fc_cache parameter
@@ -4110,6 +4113,7 @@ impl MacOSWindow {
         shared_icon_provider: azul_core::icon::SharedIconProvider,
         fc_cache_opt: Option<Arc<rust_fontconfig::FcFontCache>>,
         font_registry: Option<Arc<rust_fontconfig::registry::FcFontRegistry>>,
+        app_font_manager: Option<Arc<azul_layout::font_traits::FontManager<azul_css::props::basic::FontRef>>>,
         parent_lw: Option<&LayoutWindow>,
         mtm: MainThreadMarker,
     ) -> Result<Self, WindowError> {
@@ -4706,7 +4710,13 @@ impl MacOSWindow {
             fc_cache_opt.unwrap_or_else(|| Arc::new(rust_fontconfig::FcFontCache::build()));
         let mut layout_window = match parent_lw {
             Some(parent) => LayoutWindow::from_font_manager(parent.font_manager.clone_shared()),
-            None => LayoutWindow::new((*fc_cache).clone()).map_err(|e| {
+            // Shares the app-level manager's font pools instead of starting a
+            // private universe; falls back to a fresh one when there is none.
+            None => crate::desktop::shell2::common::layout::layout_window_sharing_fonts(
+                app_font_manager.as_ref(),
+                &fc_cache,
+            )
+            .map_err(|e| {
                 WindowError::PlatformError(format!("Failed to create LayoutWindow: {:?}", e))
             })?,
         };

--- a/dll/src/desktop/shell2/macos/mod.rs
+++ b/dll/src/desktop/shell2/macos/mod.rs
@@ -91,7 +91,7 @@ mod coregraphics;
 mod corevideo;
 mod events;
 mod gl;
-mod menu;
+pub(crate) mod menu;
 pub mod registry;
 pub(crate) mod system_style;
 mod tooltip;

--- a/dll/src/desktop/shell2/macos/mod.rs
+++ b/dll/src/desktop/shell2/macos/mod.rs
@@ -3865,12 +3865,36 @@ impl MacOSWindow {
                 // Compute stable hash
                 let hash = coregraphics::compute_monitor_hash(display_id, bounds);
 
-                // For now, use display_id as index (not perfect but reasonable)
-                // In a full implementation, we would enumerate all displays and assign indices
-                let monitor_id = MonitorId {
-                    index: display_id as usize,
-                    hash,
+                // `ws.monitor_id` is an INDEX into the monitor list that
+                // `display::get_monitors()` builds — every consumer looks it up
+                // that way (`CallbackInfo::get_current_monitor` matches on
+                // `m.monitor_id.index`, `position_window_on_monitor` likewise).
+                //
+                // This used to store `display_id as usize`, i.e. a raw
+                // `CGDirectDisplayID` like 69733382, which never matched an
+                // index in 0..n — so `get_current_monitor()` returned `None` on
+                // macOS in practice and `position_window_on_monitor` always
+                // fell through to `monitors[0]`.
+                //
+                // `display::macos::get_displays()` enumerates `NSScreen::screens`
+                // in order, so this screen's position in that same array IS the
+                // index. Match by CGDirectDisplayID rather than by frame, since
+                // mirrored displays can share a frame.
+                let index = MainThreadMarker::new().and_then(|mtm| {
+                    NSScreen::screens(mtm).iter().position(|s| {
+                        coregraphics::get_display_id_from_screen(&s) == Some(display_id)
+                    })
+                });
+                let Some(index) = index else {
+                    log_warn!(
+                        LogCategory::Window,
+                        "[MacOSWindow] display_id={} not found in NSScreen::screens; \
+                         leaving monitor_id unchanged",
+                        display_id
+                    );
+                    return;
                 };
+                let monitor_id = MonitorId { index, hash };
 
                 self.common
                     .update_unsynced_state(|ws| {
@@ -8143,11 +8167,28 @@ fn position_window_on_monitor(
 
     let (x, y) = match position {
         WindowPosition::Initialized(pos) => {
-            // Explicit position requested - use it relative to monitor
-            // Note: macOS y-axis is flipped (0 at bottom)
-            (
-                screen_frame.origin.x + pos.x as f64,
-                screen_frame.origin.y + pos.y as f64,
+            // `Initialized` is an ABSOLUTE top-left in the global top-down
+            // space — the same convention `windowDidMove:` reads back and
+            // `sync_window_state` writes. So it is NOT monitor-relative: do
+            // not add `screen_frame.origin`.
+            //
+            // MWA-B9: AppKit wants the frame's BOTTOM-left in the bottom-up
+            // space anchored at the PRIMARY screen, so flip against the
+            // primary screen's height and shed the window's own height.
+            //
+            // This arm previously added a top-down y to a bottom-up screen
+            // origin with no flip at all (its own comment said "macOS y-axis
+            // is flipped" and then didn't flip), so a window asked to open at
+            // (0, 0) opened at the BOTTOM of the screen — and it was the one
+            // site in this backend that broke the MWA-B9 convention.
+            primary_screen_height().map_or(
+                (f64::from(pos.x), f64::from(pos.y)),
+                |primary_height| {
+                    (
+                        f64::from(pos.x),
+                        primary_height - f64::from(pos.y) - window_frame.size.height,
+                    )
+                },
             )
         }
         WindowPosition::Uninitialized => {

--- a/dll/src/desktop/shell2/mod.rs
+++ b/dll/src/desktop/shell2/mod.rs
@@ -49,6 +49,8 @@ pub use common::{
 };
 // Re-export run function
 pub use run::run;
+#[cfg(target_os = "macos")]
+pub use run::run_tray_only;
 
 // Platform-specific window type selection
 cfg_if::cfg_if! {

--- a/dll/src/desktop/shell2/run.rs
+++ b/dll/src/desktop/shell2/run.rs
@@ -405,6 +405,10 @@ fn run_headless(
     fc_cache: Arc<FcFontCache>,
     font_registry: Option<Arc<FcFontRegistry>>,
     root_window: WindowCreateOptions,
+    // Tray requested via `App::set_tray()`, threaded rather than stashed in a
+    // global: it is per-App state, and a global would silently pick the wrong
+    // one if a process ever ran two Apps.
+    tray: Option<azul_core::tray::TrayIconData>,
     debug_request_rx: Option<spmc::Receiver<debug_server::DebugRequest>>,
     component_map: Option<Arc<Mutex<azul_core::xml::ComponentMap>>>,
 ) -> Result<(), WindowError> {
@@ -420,10 +424,6 @@ fn run_headless(
     // Extract icon_provider from config (same as real platforms do)
     let icon_provider_handle = core::mem::take(&mut config.icon_provider);
     let shared_icon_provider = SharedIconProvider::from_handle(icon_provider_handle);
-    // Publish it for app-level consumers that outlive any window — the tray
-    // (and later the app icon), which resolve an icon spec through the same
-    // registry `<icon>` nodes use.
-    crate::desktop::tray::set_icon_provider(shared_icon_provider.clone());
 
     let app_data_arc = Arc::new(RefCell::new(app_data));
     let mut window = HeadlessWindow::new(root_window, app_data_arc, undo_manager, config, shared_icon_provider, fc_cache, font_registry)?;
@@ -517,6 +517,10 @@ pub fn run(
     fc_cache: Arc<FcFontCache>,
     font_registry: Option<Arc<FcFontRegistry>>,
     root_window: WindowCreateOptions,
+    // Tray requested via `App::set_tray()`, threaded rather than stashed in a
+    // global: it is per-App state, and a global would silently pick the wrong
+    // one if a process ever ran two Apps.
+    tray: Option<azul_core::tray::TrayIconData>,
 ) -> Result<(), WindowError> {
     crate::plog_info!(
         "[macOS] run() entry — AZ_BACKEND={:?} (logging on by default; AZ_LOG=off to silence, AZ_LOG=trace for everything)",
@@ -559,7 +563,7 @@ pub fn run(
 
     // Headless mode — no native window, CPU rendering only
     if backend == super::AzBackend::Headless {
-        return run_headless(app_data, undo_manager, config, fc_cache, font_registry, root_window, debug_request_rx, component_map);
+        return run_headless(app_data, undo_manager, config, fc_cache, font_registry, root_window, tray, debug_request_rx, component_map);
     }
 
     use azul_core::icon::SharedIconProvider;
@@ -582,10 +586,6 @@ pub fn run(
     
     // Convert IconProviderHandle to SharedIconProvider once - this will be cloned to all windows
     let shared_icon_provider = SharedIconProvider::from_handle(icon_provider_handle);
-    // Publish it for app-level consumers that outlive any window — the tray
-    // (and later the app icon), which resolve an icon spec through the same
-    // registry `<icon>` nodes use.
-    crate::desktop::tray::set_icon_provider(shared_icon_provider.clone());
 
     autoreleasepool(|_| {
         let mtm = MainThreadMarker::new()
@@ -616,6 +616,7 @@ pub fn run(
             crate::desktop::shell2::macos::setup_main_menu(&app, mtm);
         }
 
+
         // Create the root window with fc_cache and app_data
         // The window is automatically made visible after the first frame is ready
         debug_server::log(
@@ -632,6 +633,24 @@ pub fn run(
             "MacOSWindow created successfully",
             None,
         );
+
+        // Install the tray requested by `App::set_tray()`.
+        //
+        // AFTER the first window, not before, for two reasons that both bit:
+        //
+        // 1. It needs the app's real `FontManager`, and that lives on the
+        //    window's `LayoutWindow`. Building a fresh one here means a second,
+        //    disconnected font universe (see `tray_icon::render_icon_to_rgba`).
+        // 2. The font registry scans in a BACKGROUND thread, and `fc_cache` is
+        //    only snapshotted from it at layout time. Rendering an icon before
+        //    the first layout therefore shapes against an empty/partial font
+        //    set, which comes out as a `.notdef` tofu box rather than as a
+        //    visible failure.
+        //
+        // By this point the window has laid out once, so the manager is warm.
+        if let (Some(tray), Some(lw)) = (tray, window.common.layout_window.as_ref()) {
+            crate::desktop::tray::install_tray(tray, &shared_icon_provider, &lw.font_manager);
+        }
 
         // Register debug timer with explicit channel + component map (no globals)
         if let (Some(rx), Some(cm)) = (debug_request_rx, component_map) {
@@ -703,6 +722,11 @@ pub fn run(
                     let fc_cache = fc_cache.clone();
                     let font_registry = font_registry.clone();
                     let drain = RcBlock::new(move || {
+                        // Tray menu clicks land in the process-wide menu-action
+                        // queue; drain the ones this tray owns into the tray
+                        // event mailbox. Self-gating when there is no tray.
+                        crate::desktop::tray::pump_tray();
+
                         for wptr in super::macos::registry::get_all_window_ptrs() {
                             let window = unsafe { &mut *wptr };
                             window.drain_loop_work();
@@ -1036,6 +1060,10 @@ pub fn run(
     fc_cache: Arc<FcFontCache>,
     font_registry: Option<Arc<FcFontRegistry>>,
     root_window: WindowCreateOptions,
+    // Tray requested via `App::set_tray()`, threaded rather than stashed in a
+    // global: it is per-App state, and a global would silently pick the wrong
+    // one if a process ever ran two Apps.
+    tray: Option<azul_core::tray::TrayIconData>,
 ) -> Result<(), WindowError> {
     let (_debug_request_rx, _component_map) = setup_debug_and_e2e(&config);
     #[cfg(feature = "web")]
@@ -1074,6 +1102,10 @@ pub fn run(
     fc_cache: Arc<FcFontCache>,
     font_registry: Option<Arc<FcFontRegistry>>,
     root_window: WindowCreateOptions,
+    // Tray requested via `App::set_tray()`, threaded rather than stashed in a
+    // global: it is per-App state, and a global would silently pick the wrong
+    // one if a process ever ran two Apps.
+    tray: Option<azul_core::tray::TrayIconData>,
 ) -> Result<(), WindowError> {
     let (_debug_request_rx, _component_map) = setup_debug_and_e2e(&config);
     if resolve_backend(&root_window) == super::AzBackend::Headless {
@@ -1097,6 +1129,10 @@ pub fn run(
     fc_cache: Arc<FcFontCache>,
     font_registry: Option<Arc<FcFontRegistry>>,
     root_window: WindowCreateOptions,
+    // Tray requested via `App::set_tray()`, threaded rather than stashed in a
+    // global: it is per-App state, and a global would silently pick the wrong
+    // one if a process ever ran two Apps.
+    tray: Option<azul_core::tray::TrayIconData>,
 ) -> Result<(), WindowError> {
     let (debug_request_rx, component_map) = setup_debug_and_e2e(&config);
     #[cfg(feature = "web")]
@@ -1104,7 +1140,7 @@ pub fn run(
         return crate::web::run_web(app_data, config, fc_cache, font_registry, root_window, web_cfg);
     }
     if resolve_backend(&root_window) == super::AzBackend::Headless {
-        return run_headless(app_data, undo_manager, config, fc_cache, font_registry, root_window, debug_request_rx, component_map);
+        return run_headless(app_data, undo_manager, config, fc_cache, font_registry, root_window, tray, debug_request_rx, component_map);
     }
     log_trace!(LogCategory::Window, "[shell2::run] Windows run() called");
     crate::plog_info!(
@@ -1519,6 +1555,10 @@ pub fn run(
     fc_cache: Arc<FcFontCache>,
     font_registry: Option<Arc<FcFontRegistry>>,
     root_window: WindowCreateOptions,
+    // Tray requested via `App::set_tray()`, threaded rather than stashed in a
+    // global: it is per-App state, and a global would silently pick the wrong
+    // one if a process ever ran two Apps.
+    tray: Option<azul_core::tray::TrayIconData>,
 ) -> Result<(), WindowError> {
     // Same reasoning as the environment dump below, for the knobs this build
     // cannot honour at all.
@@ -1559,7 +1599,7 @@ pub fn run(
     }
     if resolve_backend(&root_window) == super::AzBackend::Headless {
         crate::plog_info!("[Linux] backend resolved to Headless (AZ_BACKEND=headless)");
-        return run_headless(app_data, undo_manager, config, fc_cache, font_registry, root_window, debug_request_rx, component_map);
+        return run_headless(app_data, undo_manager, config, fc_cache, font_registry, root_window, tray, debug_request_rx, component_map);
     }
     use std::cell::RefCell;
 

--- a/dll/src/desktop/shell2/run.rs
+++ b/dll/src/desktop/shell2/run.rs
@@ -409,6 +409,9 @@ fn run_headless(
     // global: it is per-App state, and a global would silently pick the wrong
     // one if a process ever ran two Apps.
     tray: Option<azul_core::tray::TrayIconData>,
+    // THE app-level font manager, so windows and the tray share one set of font
+    // pools instead of each building a private universe. See `AppInternal`.
+    font_manager: Option<std::sync::Arc<azul_layout::font_traits::FontManager<azul_css::props::basic::FontRef>>>,
     debug_request_rx: Option<spmc::Receiver<debug_server::DebugRequest>>,
     component_map: Option<Arc<Mutex<azul_core::xml::ComponentMap>>>,
 ) -> Result<(), WindowError> {
@@ -521,6 +524,9 @@ pub fn run(
     // global: it is per-App state, and a global would silently pick the wrong
     // one if a process ever ran two Apps.
     tray: Option<azul_core::tray::TrayIconData>,
+    // THE app-level font manager, so windows and the tray share one set of font
+    // pools instead of each building a private universe. See `AppInternal`.
+    font_manager: Option<std::sync::Arc<azul_layout::font_traits::FontManager<azul_css::props::basic::FontRef>>>,
 ) -> Result<(), WindowError> {
     crate::plog_info!(
         "[macOS] run() entry — AZ_BACKEND={:?} (logging on by default; AZ_LOG=off to silence, AZ_LOG=trace for everything)",
@@ -563,7 +569,7 @@ pub fn run(
 
     // Headless mode — no native window, CPU rendering only
     if backend == super::AzBackend::Headless {
-        return run_headless(app_data, undo_manager, config, fc_cache, font_registry, root_window, tray, debug_request_rx, component_map);
+        return run_headless(app_data, undo_manager, config, fc_cache, font_registry, root_window, tray, font_manager, debug_request_rx, component_map);
     }
 
     use azul_core::icon::SharedIconProvider;
@@ -626,7 +632,7 @@ pub fn run(
             None,
         );
         let mut window =
-            MacOSWindow::new_with_fc_cache(root_window, app_data.clone(), undo_manager.clone(), config.clone(), shared_icon_provider.clone(), fc_cache.clone(), font_registry.clone(), None, mtm)?;
+            MacOSWindow::new_with_fc_cache(root_window, app_data.clone(), undo_manager.clone(), config.clone(), shared_icon_provider.clone(), fc_cache.clone(), font_registry.clone(), font_manager.clone(), None, mtm)?;
         debug_server::log(
             debug_server::LogLevel::Info,
             debug_server::LogCategory::Window,
@@ -648,8 +654,45 @@ pub fn run(
         //    visible failure.
         //
         // By this point the window has laid out once, so the manager is warm.
-        if let (Some(tray), Some(lw)) = (tray, window.common.layout_window.as_ref()) {
-            crate::desktop::tray::install_tray(tray, &shared_icon_provider, &lw.font_manager);
+        if let Some(tray) = tray {
+            // ONE font universe. `font_manager` is the app-level manager built
+            // in `AppInternal::create`; `clone_shared()` shares its `parsed_fonts`
+            // and `embedded_fonts` pools while giving us a private `fc_cache`
+            // field to warm, so registering the icon's face here is visible to
+            // every window and vice versa.
+            //
+            // Warming matters because the font registry scans on BACKGROUND
+            // threads and `fc_cache` is only snapshotted from it at layout time.
+            // Taking the window's already-laid-out manager was how this used to
+            // get a warm cache - and that is exactly what tied the tray to a
+            // window existing. Blocking on `request_fonts` here is the same wait
+            // the window does, just done for ourselves.
+            let own = font_manager.as_ref().map(|fm| {
+                let mut fm = fm.clone_shared();
+                if let Some(reg) = font_registry.as_ref() {
+                    let stacks = rust_fontconfig::config::tokenize_common_families(
+                        rust_fontconfig::OperatingSystem::current(),
+                    );
+                    reg.request_fonts(&stacks);
+                    fm.replace_fc_cache(reg.shared_cache());
+                }
+                fm
+            });
+
+            match own
+                .as_ref()
+                .or_else(|| window.common.layout_window.as_ref().map(|lw| &lw.font_manager))
+            {
+                Some(fm) => {
+                    crate::desktop::tray::install_tray(tray, &shared_icon_provider, fm);
+                }
+                None => {
+                    log_debug!(
+                        debug_server::LogCategory::Resources,
+                        "[tray] no font manager available; tray not installed"
+                    );
+                }
+            }
         }
 
         // Register debug timer with explicit channel + component map (no globals)
@@ -721,6 +764,7 @@ pub fn run(
                     let shared_icon_provider = shared_icon_provider.clone();
                     let fc_cache = fc_cache.clone();
                     let font_registry = font_registry.clone();
+                    let font_manager_c = font_manager.clone();
                     let drain = RcBlock::new(move || {
                         // Tray menu clicks land in the process-wide menu-action
                         // queue; drain the ones this tray owns. Items carrying a
@@ -749,6 +793,7 @@ pub fn run(
                                     shared_icon_provider.clone(),
                                     fc_cache.clone(),
                                     font_registry.clone(),
+                                    font_manager_c.clone(),
                                     // A queued create is always a CHILD of this
                                     // window (a transient popup / torn panel) —
                                     // share its warmed font pool so text/icons
@@ -935,6 +980,7 @@ pub fn run(
                                         shared_icon_provider.clone(),
                                         fc_cache.clone(),
                                         font_registry.clone(),
+                                        font_manager.clone(),
                                         // A queued create is a CHILD of this
                                         // window — share its warmed font pool.
                                         window.common.layout_window.as_ref(),
@@ -1073,6 +1119,9 @@ pub fn run(
     // global: it is per-App state, and a global would silently pick the wrong
     // one if a process ever ran two Apps.
     tray: Option<azul_core::tray::TrayIconData>,
+    // THE app-level font manager, so windows and the tray share one set of font
+    // pools instead of each building a private universe. See `AppInternal`.
+    font_manager: Option<std::sync::Arc<azul_layout::font_traits::FontManager<azul_css::props::basic::FontRef>>>,
 ) -> Result<(), WindowError> {
     let (_debug_request_rx, _component_map) = setup_debug_and_e2e(&config);
     #[cfg(feature = "web")]
@@ -1115,6 +1164,9 @@ pub fn run(
     // global: it is per-App state, and a global would silently pick the wrong
     // one if a process ever ran two Apps.
     tray: Option<azul_core::tray::TrayIconData>,
+    // THE app-level font manager, so windows and the tray share one set of font
+    // pools instead of each building a private universe. See `AppInternal`.
+    font_manager: Option<std::sync::Arc<azul_layout::font_traits::FontManager<azul_css::props::basic::FontRef>>>,
 ) -> Result<(), WindowError> {
     let (_debug_request_rx, _component_map) = setup_debug_and_e2e(&config);
     if resolve_backend(&root_window) == super::AzBackend::Headless {
@@ -1142,6 +1194,9 @@ pub fn run(
     // global: it is per-App state, and a global would silently pick the wrong
     // one if a process ever ran two Apps.
     tray: Option<azul_core::tray::TrayIconData>,
+    // THE app-level font manager, so windows and the tray share one set of font
+    // pools instead of each building a private universe. See `AppInternal`.
+    font_manager: Option<std::sync::Arc<azul_layout::font_traits::FontManager<azul_css::props::basic::FontRef>>>,
 ) -> Result<(), WindowError> {
     let (debug_request_rx, component_map) = setup_debug_and_e2e(&config);
     #[cfg(feature = "web")]
@@ -1149,7 +1204,7 @@ pub fn run(
         return crate::web::run_web(app_data, config, fc_cache, font_registry, root_window, web_cfg);
     }
     if resolve_backend(&root_window) == super::AzBackend::Headless {
-        return run_headless(app_data, undo_manager, config, fc_cache, font_registry, root_window, tray, debug_request_rx, component_map);
+        return run_headless(app_data, undo_manager, config, fc_cache, font_registry, root_window, tray, font_manager, debug_request_rx, component_map);
     }
     log_trace!(LogCategory::Window, "[shell2::run] Windows run() called");
     crate::plog_info!(
@@ -1176,7 +1231,7 @@ pub fn run(
         LogCategory::Window,
         "[shell2::run] calling Win32Window::new"
     );
-    let mut window = Win32Window::new(root_window, config.clone(), fc_cache.clone(), font_registry.clone(), app_data_arc.clone(), undo_manager.clone())?;
+    let mut window = Win32Window::new(root_window, config.clone(), fc_cache.clone(), font_registry.clone(), app_data_arc.clone(), undo_manager.clone(), font_manager.clone())?;
     log_trace!(
         LogCategory::Window,
         "[shell2::run] Win32Window::new returned successfully"
@@ -1409,6 +1464,11 @@ pub fn run(
                             window.font_registry.clone(),
                             window.common.app_data.clone(),
                             window.common.undo_manager.clone(),
+                            // The app-level manager: the parent derived from it
+                            // too, so parent and child share the same font pools
+                            // and only the fc_cache snapshot differs (warmed at
+                            // this window's first layout).
+                            font_manager.clone(),
                         ) {
                             Ok(new_window) => {
                                 // Box and leak for stable pointer
@@ -1568,6 +1628,9 @@ pub fn run(
     // global: it is per-App state, and a global would silently pick the wrong
     // one if a process ever ran two Apps.
     tray: Option<azul_core::tray::TrayIconData>,
+    // THE app-level font manager, so windows and the tray share one set of font
+    // pools instead of each building a private universe. See `AppInternal`.
+    font_manager: Option<std::sync::Arc<azul_layout::font_traits::FontManager<azul_css::props::basic::FontRef>>>,
 ) -> Result<(), WindowError> {
     // Same reasoning as the environment dump below, for the knobs this build
     // cannot honour at all.
@@ -1608,7 +1671,7 @@ pub fn run(
     }
     if resolve_backend(&root_window) == super::AzBackend::Headless {
         crate::plog_info!("[Linux] backend resolved to Headless (AZ_BACKEND=headless)");
-        return run_headless(app_data, undo_manager, config, fc_cache, font_registry, root_window, tray, debug_request_rx, component_map);
+        return run_headless(app_data, undo_manager, config, fc_cache, font_registry, root_window, tray, font_manager, debug_request_rx, component_map);
     }
     use std::cell::RefCell;
 
@@ -1617,7 +1680,14 @@ pub fn run(
     use super::linux::{registry, AppResources, LinuxWindow};
 
     // Initialize shared resources once at startup
-    let resources = Arc::new(AppResources::new(config.clone(), fc_cache, font_registry));
+    let resources = Arc::new(AppResources::new_with_font_manager(
+        config.clone(),
+        fc_cache,
+        font_registry,
+        // Adopt the app-level manager so every window on this connection
+        // shares one set of font pools.
+        font_manager,
+    ));
 
     log_debug!(
         debug_server::LogCategory::EventLoop,

--- a/dll/src/desktop/shell2/run.rs
+++ b/dll/src/desktop/shell2/run.rs
@@ -723,11 +723,15 @@ pub fn run(
                     let font_registry = font_registry.clone();
                     let drain = RcBlock::new(move || {
                         // Tray menu clicks land in the process-wide menu-action
-                        // queue; drain the ones this tray owns into the tray
-                        // event mailbox. Self-gating when there is no tray.
-                        crate::desktop::tray::pump_tray();
+                        // queue; drain the ones this tray owns. Items carrying a
+                        // callback come back here to be invoked, the rest go to
+                        // the tray event mailbox. Self-gating when there is no
+                        // tray.
+                        pump_tray_into_windows();
 
-                        for wptr in super::macos::registry::get_all_window_ptrs() {
+                        let window_ptrs = super::macos::registry::get_all_window_ptrs();
+
+                        for wptr in window_ptrs {
                             let window = unsafe { &mut *wptr };
                             window.drain_loop_work();
 
@@ -824,6 +828,11 @@ pub fn run(
 
                 loop {
                     autoreleasepool(|_| {
+                        // Tray menu clicks, before native events: this loop is
+                        // what runs for the DEFAULT termination behaviour, so
+                        // skipping it here is what made the tray menu inert.
+                        pump_tray_into_windows();
+
                         // --- Drain pending native events (non-blocking) ---
                         // We need to dispatch events BOTH to the system (sendEvent) and to our handlers
                         loop {
@@ -1999,4 +2008,56 @@ fn wait_for_linux_window_activity() -> Result<(), WindowError> {
     }
 
     Ok(())
+}
+
+/// Drain tray menu clicks and run the callbacks they carry.
+///
+/// This lives in ONE place and is called from EVERY macOS event-loop branch on
+/// purpose. It was originally inlined into the `RunForever` timer, which meant
+/// it never ran for the DEFAULT termination behaviour (`EndProcess`) - the tray
+/// appeared, its menu opened, `menuItemAction:` fired and pushed the tag, and
+/// then nothing consumed it. The menu looked dead for the most common config
+/// while working in the one that is rarely used.
+///
+/// A tray menu item is invoked through the SAME path as a window menu item:
+/// `invoke_menu_callback` builds the `CallbackInfo`, hands over the caller's
+/// `RefAny`, applies whatever the callback changed and asks for a rebuild.
+/// It needs a window because a `CallbackInfo` does, and the tray has none of
+/// its own, so the first window stands in.
+#[cfg(target_os = "macos")]
+fn pump_tray_into_windows() {
+    let tray_callbacks = crate::desktop::tray::pump_tray();
+    if tray_callbacks.is_empty() {
+        return;
+    }
+
+    use crate::desktop::shell2::common::event::{MenuInvocation, PlatformWindow};
+    use azul_core::events::ProcessEventResult;
+
+    let window_ptrs = crate::desktop::shell2::macos::registry::get_all_window_ptrs();
+    match window_ptrs.first() {
+        Some(&wptr) => {
+            let window = unsafe { &mut *wptr };
+            for cb in tray_callbacks {
+                if !matches!(
+                    window.invoke_menu_callback(
+                        cb,
+                        MenuInvocation::Native { site: "macos.tray_menu" },
+                    ),
+                    ProcessEventResult::DoNothing
+                ) {
+                    window.request_redraw();
+                }
+            }
+        }
+        None => {
+            // A tray-first app has no window to run against yet. Say so rather
+            // than dropping a user's callback in silence.
+            log_debug!(
+                debug_server::LogCategory::Callbacks,
+                "[tray] {} menu callback(s) had no window to run against",
+                tray_callbacks.len()
+            );
+        }
+    }
 }

--- a/dll/src/desktop/shell2/run.rs
+++ b/dll/src/desktop/shell2/run.rs
@@ -2140,21 +2140,14 @@ fn pump_tray_into_windows() {
     match window_ptrs.first() {
         Some(&wptr) => {
             let window = unsafe { &mut *wptr };
-            for cb in tray_callbacks {
-                if !matches!(
-                    window.invoke_menu_callback(
-                        cb,
-                        MenuInvocation::Native { site: "macos.tray_menu" },
-                    ),
-                    ProcessEventResult::DoNothing
-                ) {
-                    window.request_redraw();
-                }
+            if invoke_tray_callbacks(window, tray_callbacks) {
+                window.request_redraw();
             }
         }
         None => {
-            // A tray-first app has no window to run against yet. Say so rather
-            // than dropping a user's callback in silence.
+            // A tray-first app has no OS window to run against. Say so rather
+            // than dropping a user's callback in silence; `run_tray_only` uses
+            // a HeadlessWindow instead and never reaches this branch.
             log_debug!(
                 debug_server::LogCategory::Callbacks,
                 "[tray] {} menu callback(s) had no window to run against",
@@ -2162,4 +2155,159 @@ fn pump_tray_into_windows() {
             );
         }
     }
+}
+
+/// Run tray menu callbacks against SOME window - a real one, or the headless
+/// stub a tray-only app uses.
+///
+/// A `CallbackInfo` is built from a window (its `LayoutWindow`, raw handle, GL
+/// context, window state), so a callback needs one to exist even when the click
+/// came from a menu bar item that belongs to no window. `HeadlessWindow`
+/// satisfies that without any OS window being created, which is what makes a
+/// genuinely windowless tray app possible.
+#[cfg(target_os = "macos")]
+///
+/// Returns whether anything asked for a repaint; `request_redraw` is not on the
+/// `PlatformWindow` trait, and a windowless app has nothing to repaint anyway,
+/// so the decision belongs to the caller.
+#[cfg(target_os = "macos")]
+#[must_use]
+fn invoke_tray_callbacks<W: crate::desktop::shell2::common::event::PlatformWindow>(
+    window: &mut W,
+    callbacks: Vec<azul_core::menu::CoreMenuCallback>,
+) -> bool {
+    use crate::desktop::shell2::common::event::MenuInvocation;
+    use azul_core::events::ProcessEventResult;
+
+    let mut needs_redraw = false;
+    for cb in callbacks {
+        if !matches!(
+            window.invoke_menu_callback(cb, MenuInvocation::Native { site: "macos.tray_menu" }),
+            ProcessEventResult::DoNothing
+        ) {
+            needs_redraw = true;
+        }
+    }
+    needs_redraw
+}
+
+/// Run an app that has a tray and NO window at all.
+///
+/// The regular `run()` creates a root window unconditionally, which is what made
+/// "tray-first" impossible: a menu-bar-only utility had to open (and then hide) a
+/// window it never wanted.
+///
+/// Two things make a windowless app work:
+///
+/// * **`NSApplicationActivationPolicy::Accessory`** - the runtime equivalent of
+///   `LSUIElement` in an Info.plist. No Dock tile, no application menu bar. A
+///   `Regular` app with no windows is a worse experience than a window: it owns
+///   the menu bar and shows a Dock icon that does nothing. (This also means an
+///   app icon set via `set_app_icon` has nowhere to appear - there is no Dock
+///   tile to draw it on.)
+/// * **A `HeadlessWindow` as the callback context.** A `CallbackInfo` is built
+///   from a window, so a tray menu callback needs one even though the click came
+///   from an item belonging to no window. The headless stub provides the
+///   `LayoutWindow` and state without creating an OS window, and it shares the
+///   app-level font pools like every other consumer.
+///
+/// The event loop is `NSApplication::run`, which does not require any window;
+/// a repeating timer drains tray clicks, exactly as the windowed path does.
+#[cfg(target_os = "macos")]
+pub fn run_tray_only(
+    app_data: RefAny,
+    undo_manager: SharedUndoManager,
+    mut config: AppConfig,
+    fc_cache: Arc<FcFontCache>,
+    font_registry: Option<Arc<FcFontRegistry>>,
+    tray: azul_core::tray::TrayIconData,
+    font_manager: Option<std::sync::Arc<azul_layout::font_traits::FontManager<azul_css::props::basic::FontRef>>>,
+) -> Result<(), WindowError> {
+    use std::cell::RefCell;
+
+    use objc2::MainThreadMarker;
+    use objc2_app_kit::{NSApplication, NSApplicationActivationPolicy};
+
+    use super::headless::HeadlessWindow;
+
+    let mtm = MainThreadMarker::new()
+        .ok_or_else(|| WindowError::PlatformError("Not on main thread".into()))?;
+
+    let icon_provider_handle = core::mem::take(&mut config.icon_provider);
+    let shared_icon_provider =
+        azul_core::icon::SharedIconProvider::from_handle(icon_provider_handle);
+
+    let app = NSApplication::sharedApplication(mtm);
+    unsafe {
+        // Accessory, NOT Regular: see the note above.
+        app.setActivationPolicy(NSApplicationActivationPolicy::Accessory);
+    }
+
+    // The callback context. `WindowCreateOptions::default()` is never shown -
+    // HeadlessWindow creates no OS window - it only shapes the stub's state.
+    let app_data_arc = Arc::new(RefCell::new(app_data));
+    let mut headless = HeadlessWindow::new(
+        WindowCreateOptions::default(),
+        app_data_arc,
+        undo_manager,
+        config,
+        shared_icon_provider.clone(),
+        fc_cache,
+        font_registry.clone(),
+    )?;
+
+    // Same warm-then-install as the windowed path: the registry scans on
+    // background threads, so block on the fonts this icon needs rather than
+    // shaping against a half-built cache and drawing a tofu box.
+    let own = font_manager.as_ref().map(|fm| {
+        let mut fm = fm.clone_shared();
+        if let Some(reg) = font_registry.as_ref() {
+            let stacks = rust_fontconfig::config::tokenize_common_families(
+                rust_fontconfig::OperatingSystem::current(),
+            );
+            reg.request_fonts(&stacks);
+            fm.replace_fc_cache(reg.shared_cache());
+        }
+        fm
+    });
+    match own
+        .as_ref()
+        .or(headless.common.layout_window.as_ref().map(|lw| &lw.font_manager))
+    {
+        Some(fm) => crate::desktop::tray::install_tray(tray, &shared_icon_provider, fm),
+        None => {
+            return Err(WindowError::PlatformError(
+                "tray-only app has no font manager to render its icon".into(),
+            ))
+        }
+    }
+
+    // Drain tray clicks into the headless window. 33ms matches the windowed
+    // path's timer.
+    let headless_ptr: *mut HeadlessWindow = &mut headless;
+    let drain = block2::RcBlock::new(move |_timer: core::ptr::NonNull<objc2_foundation::NSTimer>| {
+        let callbacks = crate::desktop::tray::pump_tray();
+        if !callbacks.is_empty() {
+            // Safe: single-threaded main-loop timer, and `headless` outlives the
+            // run loop below (it is dropped only after `app.run()` returns).
+            let window = unsafe { &mut *headless_ptr };
+            // Nothing to repaint: there is no window on screen.
+            let _ = invoke_tray_callbacks(window, callbacks);
+        }
+    });
+    let _timer: objc2::rc::Retained<objc2_foundation::NSTimer> = unsafe {
+        objc2::msg_send![
+            objc2::class!(NSTimer),
+            scheduledTimerWithTimeInterval: 0.033f64,
+            repeats: true,
+            block: &*drain
+        ]
+    };
+
+    log_info!(
+        LogCategory::EventLoop,
+        "[tray-only] no window; entering NSApplication run loop"
+    );
+    unsafe { app.run() };
+    Ok(())
 }

--- a/dll/src/desktop/shell2/run.rs
+++ b/dll/src/desktop/shell2/run.rs
@@ -412,6 +412,8 @@ fn run_headless(
     // THE app-level font manager, so windows and the tray share one set of font
     // pools instead of each building a private universe. See `AppInternal`.
     font_manager: Option<std::sync::Arc<azul_layout::font_traits::FontManager<azul_css::props::basic::FontRef>>>,
+    // App / Dock icon spec requested via `App::set_app_icon`.
+    app_icon: Option<azul_css::AzString>,
     debug_request_rx: Option<spmc::Receiver<debug_server::DebugRequest>>,
     component_map: Option<Arc<Mutex<azul_core::xml::ComponentMap>>>,
 ) -> Result<(), WindowError> {
@@ -527,6 +529,8 @@ pub fn run(
     // THE app-level font manager, so windows and the tray share one set of font
     // pools instead of each building a private universe. See `AppInternal`.
     font_manager: Option<std::sync::Arc<azul_layout::font_traits::FontManager<azul_css::props::basic::FontRef>>>,
+    // App / Dock icon spec requested via `App::set_app_icon`.
+    app_icon: Option<azul_css::AzString>,
 ) -> Result<(), WindowError> {
     crate::plog_info!(
         "[macOS] run() entry — AZ_BACKEND={:?} (logging on by default; AZ_LOG=off to silence, AZ_LOG=trace for everything)",
@@ -569,7 +573,7 @@ pub fn run(
 
     // Headless mode — no native window, CPU rendering only
     if backend == super::AzBackend::Headless {
-        return run_headless(app_data, undo_manager, config, fc_cache, font_registry, root_window, tray, font_manager, debug_request_rx, component_map);
+        return run_headless(app_data, undo_manager, config, fc_cache, font_registry, root_window, tray, font_manager, app_icon, debug_request_rx, component_map);
     }
 
     use azul_core::icon::SharedIconProvider;
@@ -654,6 +658,26 @@ pub fn run(
         //    visible failure.
         //
         // By this point the window has laid out once, so the manager is warm.
+        // The app/Dock icon uses the SAME resolved manager as the tray, for the
+        // same reason: the icon renders through the DOM, so it needs a manager
+        // whose `embedded_fonts` pool holds the icon face.
+        if let Some(spec) = app_icon.as_ref() {
+            let fm_for_icon = font_manager.as_ref().map(|fm| fm.clone_shared());
+            if let Some(fm) = fm_for_icon
+                .as_ref()
+                .or_else(|| window.common.layout_window.as_ref().map(|lw| &lw.font_manager))
+            {
+                let outcome =
+                    crate::desktop::app_icon::set_app_icon(spec.as_str(), &shared_icon_provider, fm);
+                log_debug!(
+                    debug_server::LogCategory::Resources,
+                    "[app-icon] {:?} -> {:?}",
+                    spec.as_str(),
+                    outcome
+                );
+            }
+        }
+
         if let Some(tray) = tray {
             // ONE font universe. `font_manager` is the app-level manager built
             // in `AppInternal::create`; `clone_shared()` shares its `parsed_fonts`
@@ -1122,6 +1146,8 @@ pub fn run(
     // THE app-level font manager, so windows and the tray share one set of font
     // pools instead of each building a private universe. See `AppInternal`.
     font_manager: Option<std::sync::Arc<azul_layout::font_traits::FontManager<azul_css::props::basic::FontRef>>>,
+    // App / Dock icon spec requested via `App::set_app_icon`.
+    app_icon: Option<azul_css::AzString>,
 ) -> Result<(), WindowError> {
     let (_debug_request_rx, _component_map) = setup_debug_and_e2e(&config);
     #[cfg(feature = "web")]
@@ -1167,6 +1193,8 @@ pub fn run(
     // THE app-level font manager, so windows and the tray share one set of font
     // pools instead of each building a private universe. See `AppInternal`.
     font_manager: Option<std::sync::Arc<azul_layout::font_traits::FontManager<azul_css::props::basic::FontRef>>>,
+    // App / Dock icon spec requested via `App::set_app_icon`.
+    app_icon: Option<azul_css::AzString>,
 ) -> Result<(), WindowError> {
     let (_debug_request_rx, _component_map) = setup_debug_and_e2e(&config);
     if resolve_backend(&root_window) == super::AzBackend::Headless {
@@ -1197,6 +1225,8 @@ pub fn run(
     // THE app-level font manager, so windows and the tray share one set of font
     // pools instead of each building a private universe. See `AppInternal`.
     font_manager: Option<std::sync::Arc<azul_layout::font_traits::FontManager<azul_css::props::basic::FontRef>>>,
+    // App / Dock icon spec requested via `App::set_app_icon`.
+    app_icon: Option<azul_css::AzString>,
 ) -> Result<(), WindowError> {
     let (debug_request_rx, component_map) = setup_debug_and_e2e(&config);
     #[cfg(feature = "web")]
@@ -1204,7 +1234,7 @@ pub fn run(
         return crate::web::run_web(app_data, config, fc_cache, font_registry, root_window, web_cfg);
     }
     if resolve_backend(&root_window) == super::AzBackend::Headless {
-        return run_headless(app_data, undo_manager, config, fc_cache, font_registry, root_window, tray, font_manager, debug_request_rx, component_map);
+        return run_headless(app_data, undo_manager, config, fc_cache, font_registry, root_window, tray, font_manager, app_icon, debug_request_rx, component_map);
     }
     log_trace!(LogCategory::Window, "[shell2::run] Windows run() called");
     crate::plog_info!(
@@ -1631,6 +1661,8 @@ pub fn run(
     // THE app-level font manager, so windows and the tray share one set of font
     // pools instead of each building a private universe. See `AppInternal`.
     font_manager: Option<std::sync::Arc<azul_layout::font_traits::FontManager<azul_css::props::basic::FontRef>>>,
+    // App / Dock icon spec requested via `App::set_app_icon`.
+    app_icon: Option<azul_css::AzString>,
 ) -> Result<(), WindowError> {
     // Same reasoning as the environment dump below, for the knobs this build
     // cannot honour at all.
@@ -1671,7 +1703,7 @@ pub fn run(
     }
     if resolve_backend(&root_window) == super::AzBackend::Headless {
         crate::plog_info!("[Linux] backend resolved to Headless (AZ_BACKEND=headless)");
-        return run_headless(app_data, undo_manager, config, fc_cache, font_registry, root_window, tray, font_manager, debug_request_rx, component_map);
+        return run_headless(app_data, undo_manager, config, fc_cache, font_registry, root_window, tray, font_manager, app_icon, debug_request_rx, component_map);
     }
     use std::cell::RefCell;
 

--- a/dll/src/desktop/shell2/run.rs
+++ b/dll/src/desktop/shell2/run.rs
@@ -420,6 +420,10 @@ fn run_headless(
     // Extract icon_provider from config (same as real platforms do)
     let icon_provider_handle = core::mem::take(&mut config.icon_provider);
     let shared_icon_provider = SharedIconProvider::from_handle(icon_provider_handle);
+    // Publish it for app-level consumers that outlive any window — the tray
+    // (and later the app icon), which resolve an icon spec through the same
+    // registry `<icon>` nodes use.
+    crate::desktop::tray::set_icon_provider(shared_icon_provider.clone());
 
     let app_data_arc = Arc::new(RefCell::new(app_data));
     let mut window = HeadlessWindow::new(root_window, app_data_arc, undo_manager, config, shared_icon_provider, fc_cache, font_registry)?;
@@ -578,6 +582,10 @@ pub fn run(
     
     // Convert IconProviderHandle to SharedIconProvider once - this will be cloned to all windows
     let shared_icon_provider = SharedIconProvider::from_handle(icon_provider_handle);
+    // Publish it for app-level consumers that outlive any window — the tray
+    // (and later the app icon), which resolve an icon spec through the same
+    // registry `<icon>` nodes use.
+    crate::desktop::tray::set_icon_provider(shared_icon_provider.clone());
 
     autoreleasepool(|_| {
         let mtm = MainThreadMarker::new()

--- a/dll/src/desktop/shell2/windows/dlopen.rs
+++ b/dll/src/desktop/shell2/windows/dlopen.rs
@@ -513,6 +513,14 @@ pub struct User32Functions {
 
     // Messages
     pub SendMessageW: unsafe extern "system" fn(HWND, u32, WPARAM, LPARAM) -> LRESULT,
+    /// Build an HICON from an ICONINFO (a 32bpp colour bitmap + a mask).
+    /// The colour bitmap carries STRAIGHT alpha, not premultiplied - the
+    /// opposite of what `UpdateLayeredWindow` and `AlphaBlend` want, which is
+    /// why icons built by copying that code come out with dark fringes.
+    pub CreateIconIndirect: unsafe extern "system" fn(*const IconInfo) -> HICON,
+    /// `WM_SETICON` does NOT take ownership and returns the PREVIOUS icon, so
+    /// the caller destroys both the old one and its own on teardown.
+    pub DestroyIcon: unsafe extern "system" fn(HICON) -> BOOL,
     pub PostMessageW: unsafe extern "system" fn(HWND, u32, WPARAM, LPARAM) -> BOOL,
     pub GetMessageW: unsafe extern "system" fn(*mut MSG, HWND, u32, u32) -> BOOL,
     pub PeekMessageW: unsafe extern "system" fn(*mut MSG, HWND, u32, u32, u32) -> BOOL,
@@ -525,10 +533,28 @@ pub struct User32Functions {
     pub KillTimer: unsafe extern "system" fn(HWND, usize) -> BOOL,
 }
 
+/// `ICONINFO`. `fIcon = TRUE` means an icon (hotspot ignored); FALSE means a
+/// cursor. Both bitmaps are owned by the CALLER - `CreateIconIndirect` copies
+/// them, so they must be deleted afterwards or they leak on every icon change.
+#[repr(C)]
+pub struct IconInfo {
+    pub fIcon: BOOL,
+    pub xHotspot: u32,
+    pub yHotspot: u32,
+    pub hbmMask: *mut core::ffi::c_void,
+    pub hbmColor: *mut core::ffi::c_void,
+}
+
 /// Win32 gdi32.dll function pointers for brushes, regions, and pixel blitting
 #[derive(Copy, Clone)]
 pub struct Gdi32Functions {
     pub CreateSolidBrush: unsafe extern "system" fn(u32) -> HBRUSH,
+    /// (w, h, planes, bpp, bits) - used for an icon's 1bpp AND mask. With a
+    /// 32bpp colour bitmap the mask is ignored for blending, but ICONINFO still
+    /// requires one, so it is supplied all-zero.
+    pub CreateBitmap:
+        unsafe extern "system" fn(i32, i32, u32, u32, *const core::ffi::c_void)
+            -> *mut core::ffi::c_void,
     pub DeleteObject: unsafe extern "system" fn(*mut core::ffi::c_void) -> BOOL,
     /// Create a rectangular region - used for DwmEnableBlurBehindWindow
     /// CreateRectRgn(0, 0, -1, -1) creates a minimal region for transparent backgrounds
@@ -835,6 +861,8 @@ impl Win32Libraries {
 
                 // Messages
                 SendMessageW: user32_dll.get_symbol("SendMessageW")?,
+                CreateIconIndirect: user32_dll.get_symbol("CreateIconIndirect")?,
+                DestroyIcon: user32_dll.get_symbol("DestroyIcon")?,
                 PostMessageW: user32_dll.get_symbol("PostMessageW")?,
                 GetMessageW: user32_dll.get_symbol("GetMessageW")?,
                 PeekMessageW: user32_dll.get_symbol("PeekMessageW")?,
@@ -852,6 +880,7 @@ impl Win32Libraries {
         let gdi32 = unsafe {
             Gdi32Functions {
                 CreateSolidBrush: gdi32_dll.get_symbol("CreateSolidBrush")?,
+                CreateBitmap: gdi32_dll.get_symbol("CreateBitmap")?,
                 DeleteObject: gdi32_dll.get_symbol("DeleteObject")?,
                 CreateRectRgn: gdi32_dll.get_symbol("CreateRectRgn")?,
                 CombineRgn: gdi32_dll.get_symbol("CombineRgn")?,

--- a/dll/src/desktop/shell2/windows/dpi.rs
+++ b/dll/src/desktop/shell2/windows/dpi.rs
@@ -60,9 +60,29 @@ pub type AdjustWindowRectExForDpi = unsafe extern "system" fn(
 ) -> BOOL;
 
 /// Runtime-loaded Win32 DPI functions for backward-compatible DPI awareness.
+///
+/// NOTE ON WHICH DLL EACH SYMBOL LIVES IN — this is not uniform, and getting it
+/// wrong fails SILENTLY (`GetProcAddress` returns NULL, the `Option` stays
+/// `None`, and the fallback tier is taken forever):
+///
+/// | symbol                          | dll        | since        |
+/// |---------------------------------|------------|--------------|
+/// | `SetProcessDPIAware`            | user32     | Vista        |
+/// | `SetProcessDpiAwareness`        | **shcore** | 8.1          |
+/// | `SetProcessDpiAwarenessContext` | user32     | 10 1703      |
+/// | `GetDpiForMonitor`              | **shcore** | 8.1          |
+/// | `GetDpiForWindow`               | user32     | 10 1607      |
+/// | `AdjustWindowRectExForDpi`      | user32     | 10 1607      |
+/// | `EnableNonClientDpiScaling`     | user32     | 10 1607      |
+///
+/// The two shcore ones were previously looked up in user32 and were therefore
+/// permanently `None`: on 8.1 / pre-1607 Win10 the process silently degraded to
+/// `SetProcessDPIAware()` (SYSTEM-dpi aware, not per-monitor), and `hwnd_dpi`'s
+/// `GetDpiForMonitor` tier was dead code.
 #[derive(Default, Debug)]
 pub struct DpiFunctions {
     user32_dll_handle: Option<HINSTANCE>,
+    shcore_dll_handle: Option<HINSTANCE>,
     get_dpi_for_window: Option<GetDpiForWindow>,
     adjust_window_rect_ex_for_dpi: Option<AdjustWindowRectExForDpi>,
     get_dpi_for_monitor: Option<GetDpiForMonitor>,
@@ -80,17 +100,28 @@ impl Drop for DpiFunctions {
                 FreeLibrary(user32);
             }
         }
+        if let Some(shcore) = self.shcore_dll_handle {
+            unsafe {
+                FreeLibrary(shcore);
+            }
+        }
     }
 }
 
 impl DpiFunctions {
-    /// Loads DPI-related functions from user32.dll at runtime.
+    /// Loads DPI-related functions from user32.dll and shcore.dll at runtime.
+    ///
+    /// shcore.dll is absent on Windows 7 and earlier; `load_dll` returns `None`
+    /// there and the two shcore symbols stay `None`, which is exactly the
+    /// pre-8.1 behaviour the fallback tiers already handle.
     pub fn init() -> Self {
         let user32_dll = super::load_dll("user32.dll").map(|dll| dll as HINSTANCE);
+        let shcore_dll = super::load_dll("shcore.dll").map(|dll| dll as HINSTANCE);
 
         unsafe {
             Self {
                 user32_dll_handle: user32_dll,
+                shcore_dll_handle: shcore_dll,
                 get_dpi_for_window: Self::get_func(user32_dll, "GetDpiForWindow")
                     .map(|e| mem::transmute(e)),
                 adjust_window_rect_ex_for_dpi: Self::get_func(
@@ -98,7 +129,8 @@ impl DpiFunctions {
                     "AdjustWindowRectExForDpi",
                 )
                 .map(|e| mem::transmute(e)),
-                get_dpi_for_monitor: Self::get_func(user32_dll, "GetDpiForMonitor")
+                // shcore.dll, NOT user32 — see the table on `DpiFunctions`.
+                get_dpi_for_monitor: Self::get_func(shcore_dll, "GetDpiForMonitor")
                     .map(|e| mem::transmute(e)),
                 enable_non_client_dpi_scaling: Self::get_func(
                     user32_dll,
@@ -110,7 +142,8 @@ impl DpiFunctions {
                     "SetProcessDpiAwarenessContext",
                 )
                 .map(|e| mem::transmute(e)),
-                set_process_dpi_awareness: Self::get_func(user32_dll, "SetProcessDpiAwareness")
+                // shcore.dll, NOT user32 — see the table on `DpiFunctions`.
+                set_process_dpi_awareness: Self::get_func(shcore_dll, "SetProcessDpiAwareness")
                     .map(|e| mem::transmute(e)),
                 set_process_dpi_aware: Self::get_func(user32_dll, "SetProcessDPIAware")
                     .map(|e| mem::transmute(e)),

--- a/dll/src/desktop/shell2/windows/mod.rs
+++ b/dll/src/desktop/shell2/windows/mod.rs
@@ -780,6 +780,19 @@ impl Win32Window {
             // Send first frame: regenerate layout + full transaction.
             // Epoch captured BEFORE the pass so the retirement below cannot eat
             // a request raised by a lifecycle callback running inside it.
+            // Window / taskbar icon, before the first show so the title bar and
+            // Alt+Tab never flash the default icon.
+            unsafe {
+                apply_window_icons(
+                    &result.win32,
+                    result.hwnd,
+                    &options
+                        .window_state
+                        .platform_specific_options
+                        .windows_options,
+                );
+            }
+
             let regen_epoch_seen = result.common.regen_epoch();
             if let Err(e) = result.regenerate_layout() {
                 log_error!(LogCategory::Layout, "First frame layout error: {:?}", e);
@@ -6896,5 +6909,155 @@ mod tests {
             win32_xbutton_to_mouse_button(0x0002 << 16),
             Some(MouseButton::Other(4))
         );
+    }
+}
+
+/// Build an `HICON` from straight-alpha RGBA8, or `None` if GDI refuses.
+///
+/// Three traps, each of which silently produces a wrong icon rather than an
+/// error (see `scripts/APP_AND_WINDOW_ICON_RESEARCH_2026_08_24.md`):
+///
+/// 1. **`CreateIconIndirect` wants STRAIGHT alpha**, unlike `AlphaBlend` /
+///    `UpdateLayeredWindow` which want premultiplied. Feeding it premultiplied
+///    pixels gives dark fringes on every antialiased edge.
+/// 2. **Channel order is B,G,R,A**, not the R,G,B,A we are handed.
+/// 3. **Rows are bottom-up unless the height is NEGATIVE.** A positive height
+///    with top-down data yields a vertically mirrored icon, which reads as
+///    "wrong icon" rather than as a bug.
+///
+/// The 1bpp AND mask is required by `ICONINFO` even though a 32bpp colour
+/// bitmap blends by its own alpha; all-zero means "draw every pixel".
+///
+/// Both bitmaps are owned by US - `CreateIconIndirect` copies them - so they are
+/// deleted before returning, or every icon update leaks two GDI objects.
+unsafe fn hicon_from_rgba(
+    win32: &dlopen::Win32Libraries,
+    rgba: &[u8],
+    width: u32,
+    height: u32,
+) -> Option<dlopen::HICON> {
+    use dlopen::IconInfo;
+
+    let (w, h) = (width as usize, height as usize);
+    if w == 0 || h == 0 || rgba.len() < w * h * 4 {
+        return None;
+    }
+
+    // BGRA, straight alpha.
+    let mut bgra = alloc::vec::Vec::<u8>::with_capacity(w * h * 4);
+    for px in rgba[..w * h * 4].chunks_exact(4) {
+        bgra.extend_from_slice(&[px[2], px[1], px[0], px[3]]);
+    }
+
+    let header = dlopen::BitmapInfoHeader {
+        biSize: core::mem::size_of::<dlopen::BitmapInfoHeader>() as u32,
+        biWidth: width as i32,
+        // NEGATIVE: our rows are top-down. See trap 3.
+        biHeight: -(height as i32),
+        biPlanes: 1,
+        biBitCount: 32,
+        biCompression: 0, // BI_RGB
+        biSizeImage: 0,
+        biXPelsPerMeter: 0,
+        biYPelsPerMeter: 0,
+        biClrUsed: 0,
+        biClrImportant: 0,
+    };
+
+    let mut bits: *mut core::ffi::c_void = core::ptr::null_mut();
+    let color = (win32.gdi32.CreateDIBSection)(
+        core::ptr::null_mut(),
+        &header,
+        0, // DIB_RGB_COLORS
+        &mut bits,
+        core::ptr::null_mut(),
+        0,
+    );
+    if color.is_null() || bits.is_null() {
+        if !color.is_null() {
+            (win32.gdi32.DeleteObject)(color);
+        }
+        return None;
+    }
+    core::ptr::copy_nonoverlapping(bgra.as_ptr(), bits.cast::<u8>(), bgra.len());
+
+    // 1bpp AND mask, all zero.
+    let mask_stride = ((w + 31) / 32) * 4; // 1bpp rows are DWORD-aligned
+    let mask_bits = alloc::vec![0u8; mask_stride * h];
+    let mask = (win32.gdi32.CreateBitmap)(
+        width as i32,
+        height as i32,
+        1,
+        1,
+        mask_bits.as_ptr().cast(),
+    );
+    if mask.is_null() {
+        (win32.gdi32.DeleteObject)(color);
+        return None;
+    }
+
+    let info = IconInfo {
+        fIcon: 1,
+        xHotspot: 0,
+        yHotspot: 0,
+        hbmMask: mask,
+        hbmColor: color,
+    };
+    let icon = (win32.user32.CreateIconIndirect)(&info);
+
+    // CreateIconIndirect COPIES both bitmaps; ours leak otherwise.
+    (win32.gdi32.DeleteObject)(color);
+    (win32.gdi32.DeleteObject)(mask);
+
+    if icon.is_null() {
+        None
+    } else {
+        Some(icon)
+    }
+}
+
+/// Apply `WindowsWindowOptions::{window_icon, taskbar_icon}` to a live HWND.
+///
+/// Both fields were public API that NO backend read - setting them did nothing,
+/// silently.
+///
+/// `WM_SETICON` has exactly two settable slots: `ICON_SMALL` (title bar, Alt+Tab)
+/// and `ICON_BIG` (the taskbar button of a running, un-pinned window).
+/// `ICON_SMALL2` is NOT settable - Windows derives it - so there is no third
+/// call to make. A PINNED taskbar entry shows the shortcut's icon and is not
+/// ours to change, and the EXE resource icon cannot be rewritten while the
+/// process is running at all.
+///
+/// `WM_SETICON` does not take ownership and RETURNS the previous icon; that one
+/// is destroyed here so repeated updates do not leak.
+unsafe fn apply_window_icons(
+    win32: &dlopen::Win32Libraries,
+    hwnd: HWND,
+    options: &azul_core::window::WindowsWindowOptions,
+) {
+    use azul_core::window::WindowIcon;
+
+    const WM_SETICON: u32 = 0x0080;
+    const ICON_SMALL: usize = 0;
+    const ICON_BIG: usize = 1;
+
+    let mut set = |slot: usize, rgba: &[u8], w: u32, h: u32| {
+        if let Some(icon) = hicon_from_rgba(win32, rgba, w, h) {
+            let previous =
+                (win32.user32.SendMessageW)(hwnd, WM_SETICON, slot, icon as isize);
+            if previous != 0 {
+                (win32.user32.DestroyIcon)(previous as dlopen::HICON);
+            }
+        }
+    };
+
+    if let Some(icon) = options.window_icon.as_ref() {
+        match icon {
+            WindowIcon::Small(i) => set(ICON_SMALL, i.rgba_bytes.as_ref(), 16, 16),
+            WindowIcon::Large(i) => set(ICON_BIG, i.rgba_bytes.as_ref(), 32, 32),
+        }
+    }
+    if let Some(t) = options.taskbar_icon.as_ref() {
+        set(ICON_BIG, t.rgba_bytes.as_ref(), 256, 256);
     }
 }

--- a/dll/src/desktop/shell2/windows/mod.rs
+++ b/dll/src/desktop/shell2/windows/mod.rs
@@ -622,12 +622,20 @@ impl Win32Window {
             should_show_window
         );
 
-        // Position window on requested monitor (or center on primary)
-        // This can be done before showing
-        // TODO: Use monitor_id to look up actual Monitor from global state
+        // Position window on the REQUESTED monitor (or centre on the first
+        // one). `Monitor::default().monitor_id` is MonitorId::PRIMARY, so
+        // passing it here threw `options.window_state.monitor_id` away and
+        // opened every window on monitors[0] regardless of what the caller
+        // asked for. `hash: 0` is right: position_window_on_monitor matches on
+        // index first and only falls back to a NON-zero hash, so a
+        // hash-less id means "resolve me by index".
+        let target_monitor_id = azul_core::window::MonitorId {
+            index: current_window_state.monitor_id.into_option().unwrap_or(0) as usize,
+            hash: 0,
+        };
         position_window_on_monitor(
             hwnd,
-            Monitor::default().monitor_id,
+            target_monitor_id,
             current_window_state.position,
             current_window_state.size,
             options.parent_window_id,
@@ -5744,7 +5752,7 @@ unsafe extern "system" fn window_proc(
             // Refresh the cached monitor list
             if let Some(ref lw) = window.common.layout_window {
                 if let Ok(mut guard) = lw.monitors.lock() {
-                    *guard = crate::desktop::display::get_monitors();
+                    *guard = crate::desktop::display::refresh_monitors();
                 }
             }
             0

--- a/dll/src/desktop/shell2/windows/mod.rs
+++ b/dll/src/desktop/shell2/windows/mod.rs
@@ -271,6 +271,9 @@ impl Win32Window {
         font_registry: Option<Arc<rust_fontconfig::registry::FcFontRegistry>>,
         app_data: Arc<std::cell::RefCell<RefAny>>,
         undo_manager: event::SharedUndoManager,
+        // THE app-level font manager, so every window shares one set of font
+        // pools; see `layout_window_sharing_fonts`.
+        app_font_manager: Option<Arc<azul_layout::font_traits::FontManager<azul_css::props::basic::FontRef>>>,
     ) -> Result<Self, WindowError> {
         // If background_color is None and no material effect, use system window background
         // Note: When a material is set, the renderer will use transparent clear color automatically
@@ -549,7 +552,13 @@ impl Win32Window {
         let initial_window_state = options.window_state.clone();
 
         // Create LayoutWindow with initial UI callback
-        let mut layout_window = LayoutWindow::new((*fc_cache).clone()).map_err(|e| {
+        // Shares the app-level manager's font pools rather than starting a
+        // private universe; falls back to a fresh one when there is none.
+        let mut layout_window = crate::desktop::shell2::common::layout::layout_window_sharing_fonts(
+            app_font_manager.as_ref(),
+            &fc_cache,
+        )
+        .map_err(|e| {
             WindowError::PlatformError(format!("Failed to create LayoutWindow: {:?}", e))
         })?;
 
@@ -3451,7 +3460,7 @@ fn pump_modal_loop_work() {
                 break;
             };
 
-            match Win32Window::new(options, config, fc_cache, font_registry, app_data, undo_manager)
+            match Win32Window::new(options, config, fc_cache, font_registry, app_data, undo_manager, None)
             {
                 Ok(new_window) => unsafe {
                     let new_window_ptr = Box::into_raw(Box::new(new_window));

--- a/dll/src/desktop/tray/linux.rs
+++ b/dll/src/desktop/tray/linux.rs
@@ -1,0 +1,129 @@
+//! Linux system tray — `org.kde.StatusNotifierItem` over D-Bus.
+//! **NOT IMPLEMENTED YET.**
+//!
+//! This stub exists so the branch cross-compiles while the backend is written.
+//! It reports the tray as unavailable rather than pretending to work — which,
+//! on this platform, is also frequently the TRUE answer (see below).
+//!
+//! Full recipe: `scripts/MULTIMONITOR_AND_TRAY_RESEARCH_2026_08_24.md` §2.2
+//! (Linux section) and §2.1 for what in `linux/dbus/` is reusable.
+//!
+//! # The thing to know before starting
+//!
+//! **`linux/gnome_menu/` implements `org.gtk.Menus` + `org.gtk.Actions`, NOT
+//! `com.canonical.dbusmenu`.** SNI's `Menu` property points at a *dbusmenu*
+//! object — a recursive `(id, a{sv}, av)` tree served through
+//! `GetLayout(parentId, recursionDepth, propertyNames)` — which is a different
+//! model from `org.gtk.Menus`' flat `(group_id, menu_id)` scheme. The protocol
+//! layer is a rewrite, not an adaptation. Roughly 30% of the existing D-Bus
+//! code carries over, and it is the boring 30%.
+//!
+//! # Reusable as-is
+//!
+//! * `dbus/dlopen.rs` — the whole `DBusLib` wrapper (the "no compile-time
+//!   libdbus" property comes free).
+//! * `gnome_menu/shared_dbus.rs::get_shared_dbus_lib()` — genuinely generic.
+//! * `dbus/mod.rs:25-47` — the `dbus_bus_name_has_owner` probe; retarget one
+//!   string literal to `org.kde.StatusNotifierWatcher`.
+//! * `gnome_menu/actions_protocol.rs:31-63` — the deferred-callback mailbox
+//!   (`PendingMenuCallback` + `LazyLock<Mutex<Vec<_>>>`). Exactly the pattern
+//!   needed here, since a D-Bus handler thread cannot hold a `CallbackInfo`.
+//!   `super::queue_tray_event` is the tray's equivalent.
+//!
+//! # Blockers to clear first
+//!
+//! None of these symbols are in `dbus/dlopen.rs` today:
+//!
+//! * **`dbus_message_new_signal` — hard blocker.** SNI requires emitting
+//!   `NewIcon`/`NewStatus`/`NewAttentionIcon`/`NewToolTip`; dbusmenu requires
+//!   `LayoutUpdated`/`ItemsPropertiesUpdated`. The code can currently only
+//!   *reply*, never *emit*.
+//! * `dbus_bus_add_match` + `dbus_connection_add_filter` — to watch
+//!   `NameOwnerChanged` for the watcher and re-register when the tray applet
+//!   restarts (plasmashell/waybar restarts are routine).
+//! * `dbus_message_iter_append_fixed_array` — for `IconPixmap` (`a(iiay)`).
+//! * `dbus_message_get_path` / `_get_sender`.
+//! * **An `org.freedesktop.DBus.Properties` handler — SNI is ~90% properties**,
+//!   and there is none anywhere in the tree today. `Introspectable` too; several
+//!   hosts call it first.
+//!
+//! `GnomeMenuManager::new` also fuses connect + `request_name` + register-two-
+//! fixed-interfaces into one non-parameterisable function with the bus name and
+//! object path hardcoded to the GTK convention (`manager.rs:79-80`), so a
+//! generic `register_service(bus_name, path, vtable)` has to be extracted.
+//!
+//! # Registration sequence
+//!
+//! 1. Own `org.kde.StatusNotifierItem-<pid>-<n>` on the session bus. **Use
+//!    `org.kde.*`, not `org.freedesktop.*`** — the published fd.o text says the
+//!    latter but the reference implementation and the entire KDE stack use the
+//!    former, and Electron 43 broke Waybar by switching (Waybar#5240).
+//! 2. Export `org.kde.StatusNotifierItem` at `/StatusNotifierItem`.
+//! 3. Export `com.canonical.dbusmenu` (conventionally `/MenuBar`); point the
+//!    `Menu` property at it.
+//! 4. `org.kde.StatusNotifierWatcher.RegisterStatusNotifierItem` at
+//!    `/StatusNotifierWatcher`.
+//! 5. Watch `NameOwnerChanged` for the watcher and **redo step 4** when it
+//!    returns. Make that the same code path as initial creation so it cannot rot.
+//!
+//! # Availability is a real question here
+//!
+//! `is_available()` must check that the watcher name is owned **AND** that
+//! `IsStatusNotifierHostRegistered` is true — a watcher with no host is a real
+//! state, because the watcher can win the startup race against the panel
+//! (cinnamon#13740). Poll/retry rather than deciding once at startup.
+//!
+//! **On a vanilla GNOME there is no watcher at all**: registration fails
+//! silently and no icon ever appears. That is not a bug to work around; the app
+//! needs a story for having no tray.
+//!
+//! # Icons
+//!
+//! Prefer `IconPixmap` (`a(iiay)`, ARGB32 **big-endian** — use
+//! `TrayIconImage::to_argb32_be`, which exists for exactly this) over
+//! `IconName`. `IconName` needs the icon installed in an XDG theme, and
+//! `IconThemePath` is non-standard and ignored by several hosts. Publish 2-3
+//! sizes (22/24/48) and let the host pick.
+//!
+//! Emit **both** the `New*` signals and `PropertiesChanged` — several hosts
+//! (notably KDE historically) ignore the latter for SNI.
+//!
+//! Model to copy: [`ksni`](https://github.com/iovxw/ksni) — pure D-Bus, no GTK,
+//! correct watcher offline/online handling. Model to avoid: Tauri's `tray-icon`
+//! (GTK + libxdo + libayatana; its bug list is a catalogue of why).
+//!
+//! # Do NOT implement XEmbed
+//!
+//! X11-only (dead under Wayland), makes us responsible for rendering into a
+//! reparented window with the tray's `_NET_SYSTEM_TRAY_VISUAL`, and duplicates
+//! icons where a bridge already exists (Cinnamon). Point users at `snixembed`.
+
+use azul_core::tray::TrayIconData;
+
+use super::TrayError;
+
+/// Whether a tray exists is a genuine question on Linux, but this backend does
+/// not exist yet, so the answer is a flat no rather than a probe that would
+/// then fail to produce an icon.
+pub(super) fn is_available() -> bool {
+    false
+}
+
+#[derive(Debug)]
+pub(super) struct PlatformTray {
+    _never: core::convert::Infallible,
+}
+
+impl PlatformTray {
+    pub(super) fn new(_data: &TrayIconData) -> Result<Self, TrayError> {
+        Err(TrayError::Unsupported)
+    }
+
+    pub(super) fn update(
+        &mut self,
+        _old: &TrayIconData,
+        _new: &TrayIconData,
+    ) -> Result<(), TrayError> {
+        match self._never {}
+    }
+}

--- a/dll/src/desktop/tray/linux.rs
+++ b/dll/src/desktop/tray/linux.rs
@@ -136,7 +136,13 @@ impl PlatformTray {
 
 impl PlatformTray {
     /// Unreachable — `new()` never returns a value on this platform yet.
-    pub(super) fn pump(&mut self) {
+    pub(super) fn pump(&mut self) -> Vec<azul_core::menu::CoreMenuCallback> {
+        // No menu backend yet, so nothing can be delivered.
+        Vec::new()
+    }
+
+    #[allow(dead_code)]
+    fn pump_unused(&mut self) {
         match self._never {}
     }
 }

--- a/dll/src/desktop/tray/linux.rs
+++ b/dll/src/desktop/tray/linux.rs
@@ -115,7 +115,11 @@ pub(super) struct PlatformTray {
 }
 
 impl PlatformTray {
-    pub(super) fn new(_data: &TrayIconData) -> Result<Self, TrayError> {
+    pub(super) fn new(
+        _data: &TrayIconData,
+        _provider: &azul_core::icon::SharedIconProvider,
+        _font_manager: &azul_layout::font_traits::FontManager<azul_css::props::basic::FontRef>,
+    ) -> Result<Self, TrayError> {
         Err(TrayError::Unsupported)
     }
 
@@ -123,7 +127,16 @@ impl PlatformTray {
         &mut self,
         _old: &TrayIconData,
         _new: &TrayIconData,
+        _provider: &azul_core::icon::SharedIconProvider,
+        _font_manager: &azul_layout::font_traits::FontManager<azul_css::props::basic::FontRef>,
     ) -> Result<(), TrayError> {
+        match self._never {}
+    }
+}
+
+impl PlatformTray {
+    /// Unreachable — `new()` never returns a value on this platform yet.
+    pub(super) fn pump(&mut self) {
         match self._never {}
     }
 }

--- a/dll/src/desktop/tray/macos.rs
+++ b/dll/src/desktop/tray/macos.rs
@@ -184,14 +184,29 @@ impl PlatformTray {
     /// Menu items post their tag to a process-wide queue shared with every
     /// window's menu bar, so this takes only the tags it owns and leaves the
     /// rest for whoever does.
-    pub(super) fn pump(&mut self) {
+    pub(super) fn pump(&mut self) -> Vec<azul_core::menu::CoreMenuCallback> {
         if self.owned_tags.is_empty() {
-            return;
+            return Vec::new();
         }
+        // An item carrying a callback is DELIVERED to that callback and is not
+        // also queued as an event; an item without one is queued for polling.
+        // Splitting here keeps a tray menu item behaving exactly like a window
+        // menu item when the caller attached a callback - same RefAny, same
+        // CallbackInfo, same single invocation path - while leaving bare items
+        // observable through `drain_tray_events`.
+        //
+        // Invoking is the caller's job, not ours: a CallbackInfo needs a window
+        // and the tray has none of its own.
+        let mut to_invoke = Vec::new();
         for tag in take_pending_menu_actions_matching(|t| self.owned_tags.contains_key(&t)) {
             #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-            queue_tray_event(TrayEvent::menu_item(tag as u32));
+            let command = tag as u32;
+            match self.menu_callback(command) {
+                Some(cb) => to_invoke.push(cb.clone()),
+                None => queue_tray_event(TrayEvent::menu_item(command)),
+            }
         }
+        to_invoke
     }
 
     /// The callback registered for a menu command, so the integration layer can

--- a/dll/src/desktop/tray/macos.rs
+++ b/dll/src/desktop/tray/macos.rs
@@ -1,4 +1,4 @@
-//! macOS system tray — `NSStatusItem` in the menu bar.
+//! macOS system tray  -  `NSStatusItem` in the menu bar.
 //!
 //! # The lifetime rule this whole file is built around
 //!
@@ -53,13 +53,17 @@ impl core::fmt::Debug for PlatformTray {
 }
 
 /// macOS always has a menu bar. Unlike Linux there is no "is a tray running"
-/// question to answer — the only failure mode is being off the main thread.
+/// question to answer  -  the only failure mode is being off the main thread.
 pub(super) fn is_available() -> bool {
     MainThreadMarker::new().is_some()
 }
 
 impl PlatformTray {
-    pub(super) fn new(data: &TrayIconData) -> Result<Self, TrayError> {
+    pub(super) fn new(
+        data: &TrayIconData,
+        provider: &azul_core::icon::SharedIconProvider,
+        font_manager: &azul_layout::font_traits::FontManager<azul_css::props::basic::FontRef>,
+    ) -> Result<Self, TrayError> {
         let Some(mtm) = MainThreadMarker::new() else {
             return Err(TrayError::Platform(
                 "NSStatusItem must be created on the main thread".into(),
@@ -87,7 +91,7 @@ impl PlatformTray {
                 .setAutosaveName(Some(&NSString::from_str(data.id.as_str())));
         }
 
-        this.apply(data, mtm)?;
+        this.apply(data, mtm, provider, font_manager)?;
         Ok(this)
     }
 
@@ -95,16 +99,24 @@ impl PlatformTray {
         &mut self,
         _old: &TrayIconData,
         new: &TrayIconData,
+        provider: &azul_core::icon::SharedIconProvider,
+        font_manager: &azul_layout::font_traits::FontManager<azul_css::props::basic::FontRef>,
     ) -> Result<(), TrayError> {
         let Some(mtm) = MainThreadMarker::new() else {
             return Err(TrayError::Platform(
                 "NSStatusItem must be updated on the main thread".into(),
             ));
         };
-        self.apply(new, mtm)
+        self.apply(new, mtm, provider, font_manager)
     }
 
-    fn apply(&mut self, data: &TrayIconData, mtm: MainThreadMarker) -> Result<(), TrayError> {
+    fn apply(
+        &mut self,
+        data: &TrayIconData,
+        mtm: MainThreadMarker,
+        provider: &azul_core::icon::SharedIconProvider,
+        font_manager: &azul_layout::font_traits::FontManager<azul_css::props::basic::FontRef>,
+    ) -> Result<(), TrayError> {
         use azul_core::tray::TrayStatus;
 
         // `Passive` means "the host may hide this". macOS has no such state, so
@@ -122,7 +134,7 @@ impl PlatformTray {
         };
 
         // ---- icon ----
-        match rgba_for(data, mtm) {
+        match rgba_for(data, mtm, provider, font_manager) {
             Some(image) => unsafe {
                 button.setImage(Some(&image));
                 button.setImagePosition(NSCellImagePosition::ImageOnly);
@@ -194,16 +206,21 @@ impl PlatformTray {
 }
 
 /// Build an `NSImage` for the tray, or `None` if the data carries no icon.
-fn rgba_for(data: &TrayIconData, mtm: MainThreadMarker) -> Option<Retained<NSImage>> {
+fn rgba_for(
+    data: &TrayIconData,
+    mtm: MainThreadMarker,
+    provider: &azul_core::icon::SharedIconProvider,
+    font_manager: &azul_layout::font_traits::FontManager<azul_css::props::basic::FontRef>,
+) -> Option<Retained<NSImage>> {
     let (w, h, rgba) = match data.icon {
         TrayIconSource::None => return None,
         TrayIconSource::Rgba(ref v) => {
-            let img = data.best_icon(ICON_PIXELS)?;
+            let img = data.best_icon(ICON_PIXELS).into_option()?;
             let _ = v;
             (img.width, img.height, img.rgba.as_ref().to_vec())
         }
         TrayIconSource::Named(ref spec) => {
-            let rendered = crate::desktop::tray::render_named_icon(spec.as_str(), ICON_PIXELS)?;
+            let rendered = crate::desktop::tray::render_named_icon(spec.as_str(), ICON_PIXELS, provider, font_manager)?;
             (rendered.width, rendered.height, rendered.rgba)
         }
     };

--- a/dll/src/desktop/tray/macos.rs
+++ b/dll/src/desktop/tray/macos.rs
@@ -1,0 +1,281 @@
+//! macOS system tray — `NSStatusItem` in the menu bar.
+//!
+//! # The lifetime rule this whole file is built around
+//!
+//! Apple, on `statusItemWithLength:`:
+//!
+//! > "Because the system status bar is shared by all applications, it cannot
+//! > retain references to each application's status item objects. Instead, each
+//! > application is responsible for retaining its own status items... When
+//! > deallocated, the status item removes itself from the status bar."
+//!
+//! So the `Retained<NSStatusItem>` held here IS what keeps the icon on screen,
+//! and dropping it is the removal API. There is no "hide" call to forget.
+//!
+//! Everything here is main-thread only.
+
+use std::collections::HashMap;
+
+use objc2::{rc::Retained, AnyThread, MainThreadMarker};
+use objc2_app_kit::{
+    NSBitmapFormat, NSBitmapImageRep, NSCellImagePosition, NSImage, NSStatusBar, NSStatusItem,
+    NSVariableStatusItemLength,
+};
+use objc2_foundation::{NSPoint, NSSize, NSString};
+
+use azul_core::tray::{TrayEvent, TrayEventType, TrayIconData, TrayIconSource};
+
+use super::{queue_tray_event, TrayError};
+use crate::desktop::shell2::macos::menu::{take_pending_menu_actions_matching, MenuState};
+
+/// The menu bar is ~22pt tall; 18pt is the conventional artwork box.
+const ICON_POINTS: u32 = 18;
+/// Render at 2x so the item is sharp on Retina. AppKit downscales for 1x
+/// displays, which is always better than upscaling an 18px original.
+const ICON_PIXELS: u32 = ICON_POINTS * 2;
+
+pub(super) struct PlatformTray {
+    /// Dropping this removes the item from the menu bar. See the module docs.
+    item: Retained<NSStatusItem>,
+    /// Owns the NSMenu and the tag -> callback map.
+    menu: MenuState,
+    /// Tags this tray owns, so the shared menu-action queue can be drained
+    /// without stealing another window's actions.
+    owned_tags: HashMap<isize, ()>,
+}
+
+impl core::fmt::Debug for PlatformTray {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PlatformTray")
+            .field("owned_tags", &self.owned_tags.len())
+            .finish_non_exhaustive()
+    }
+}
+
+/// macOS always has a menu bar. Unlike Linux there is no "is a tray running"
+/// question to answer — the only failure mode is being off the main thread.
+pub(super) fn is_available() -> bool {
+    MainThreadMarker::new().is_some()
+}
+
+impl PlatformTray {
+    pub(super) fn new(data: &TrayIconData) -> Result<Self, TrayError> {
+        let Some(mtm) = MainThreadMarker::new() else {
+            return Err(TrayError::Platform(
+                "NSStatusItem must be created on the main thread".into(),
+            ));
+        };
+
+        let bar = unsafe { NSStatusBar::systemStatusBar() };
+        // Variable rather than square: a square item is exactly `bar.thickness`
+        // wide, which clips a wider-than-tall icon. Variable sizes to content
+        // and still collapses to roughly square for a square icon.
+        let item = unsafe { bar.statusItemWithLength(NSVariableStatusItemLength) };
+
+        let mut this = Self {
+            item,
+            menu: MenuState::new(),
+            owned_tags: HashMap::new(),
+        };
+
+        // `autosaveName` persists the item's POSITION in the menu bar across
+        // launches. Without one the system invents a name, which is why
+        // third-party items lost their order on Big Sur (FB8732253). Keyed on
+        // the caller's stable id, never on a path or pid.
+        unsafe {
+            this.item
+                .setAutosaveName(Some(&NSString::from_str(data.id.as_str())));
+        }
+
+        this.apply(data, mtm)?;
+        Ok(this)
+    }
+
+    pub(super) fn update(
+        &mut self,
+        _old: &TrayIconData,
+        new: &TrayIconData,
+    ) -> Result<(), TrayError> {
+        let Some(mtm) = MainThreadMarker::new() else {
+            return Err(TrayError::Platform(
+                "NSStatusItem must be updated on the main thread".into(),
+            ));
+        };
+        self.apply(new, mtm)
+    }
+
+    fn apply(&mut self, data: &TrayIconData, mtm: MainThreadMarker) -> Result<(), TrayError> {
+        use azul_core::tray::TrayStatus;
+
+        // `Passive` means "the host may hide this". macOS has no such state, so
+        // the honest mapping is to actually remove the item — which, per the
+        // module docs, means clearing `isVisible` rather than dropping `item`
+        // (we still need the object to bring it back).
+        unsafe {
+            self.item
+                .setVisible(!matches!(data.status, TrayStatus::Passive));
+        }
+
+        let Some(button) = (unsafe { self.item.button(mtm) }) else {
+            // Documented as optional; in practice always present since 10.10.
+            return Err(TrayError::Platform("NSStatusItem has no button".into()));
+        };
+
+        // ---- icon ----
+        match rgba_for(data, mtm) {
+            Some(image) => unsafe {
+                button.setImage(Some(&image));
+                button.setImagePosition(NSCellImagePosition::ImageOnly);
+            },
+            None => unsafe { button.setImage(None) },
+        }
+
+        // ---- tooltip ----
+        unsafe {
+            match data.tooltip.as_ref() {
+                Some(t) => button.setToolTip(Some(&NSString::from_str(t.as_str()))),
+                None => button.setToolTip(None),
+            }
+        }
+
+        // ---- menu ----
+        //
+        // Assigning a menu means AppKit opens it on mouse-DOWN for BOTH buttons
+        // and the button's action never fires — so `Activate` is not
+        // observable while a menu is attached. That is AppKit's behaviour, not
+        // a limitation we can code around (Qt documents the same consequence),
+        // and it is why `TrayEventType::ContextMenu` is documented as a
+        // request rather than a command.
+        match data.menu.as_ref() {
+            Some(menu) => {
+                if self.menu.update_if_changed(menu, mtm) {
+                    self.owned_tags.clear();
+                    // Record which tags are ours BEFORE any click can arrive,
+                    // so the filtered drain never misses one.
+                    for tag in self.menu.known_tags() {
+                        self.owned_tags.insert(tag, ());
+                    }
+                }
+                unsafe { self.item.setMenu(self.menu.get_nsmenu().map(|m| &**m)) };
+            }
+            None => {
+                unsafe { self.item.setMenu(None) };
+                self.owned_tags.clear();
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Drain menu clicks that belong to THIS tray and turn them into events.
+    ///
+    /// Menu items post their tag to a process-wide queue shared with every
+    /// window's menu bar, so this takes only the tags it owns and leaves the
+    /// rest for whoever does.
+    pub(super) fn pump(&mut self) {
+        if self.owned_tags.is_empty() {
+            return;
+        }
+        for tag in take_pending_menu_actions_matching(|t| self.owned_tags.contains_key(&t)) {
+            #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+            queue_tray_event(TrayEvent::menu_item(tag as u32));
+        }
+    }
+
+    /// The callback registered for a menu command, so the integration layer can
+    /// invoke it against a window (a tray click has no window of its own, and a
+    /// `CallbackInfo` needs one).
+    pub(super) fn menu_callback(
+        &self,
+        command: u32,
+    ) -> Option<&azul_core::menu::CoreMenuCallback> {
+        self.menu.get_callback_for_tag(command as isize)
+    }
+}
+
+/// Build an `NSImage` for the tray, or `None` if the data carries no icon.
+fn rgba_for(data: &TrayIconData, mtm: MainThreadMarker) -> Option<Retained<NSImage>> {
+    let (w, h, rgba) = match data.icon {
+        TrayIconSource::None => return None,
+        TrayIconSource::Rgba(ref v) => {
+            let img = data.best_icon(ICON_PIXELS)?;
+            let _ = v;
+            (img.width, img.height, img.rgba.as_ref().to_vec())
+        }
+        TrayIconSource::Named(ref spec) => {
+            let rendered = crate::desktop::tray::render_named_icon(spec.as_str(), ICON_PIXELS)?;
+            (rendered.width, rendered.height, rendered.rgba)
+        }
+    };
+
+    let image = nsimage_from_rgba(&rgba, w, h, ICON_POINTS, mtm)?;
+
+    // A TEMPLATE image is drawn as an alpha mask and tinted by AppKit per
+    // appearance (light/dark menu bar), per highlight state, and per accent
+    // colour. Without this the icon keeps its own colour and is invisible on
+    // one of the two menu-bar appearances. The consequence for the caller is
+    // that colour is DISCARDED — which is correct for a status item, and is
+    // why the renderer is asked for an opaque-black glyph.
+    unsafe { image.setTemplate(true) };
+    Some(image)
+}
+
+/// Wrap straight (non-premultiplied) RGBA8 in an `NSImage` of `points` square.
+///
+/// `NSImage.size` is in POINTS and `pixelsWide` in PIXELS; the ratio is the
+/// scale factor, so a 36px buffer at 18pt is a 2x image and AppKit picks the
+/// right one per display.
+pub(crate) fn nsimage_from_rgba(
+    rgba: &[u8],
+    width: u32,
+    height: u32,
+    points: u32,
+    _mtm: MainThreadMarker,
+) -> Option<Retained<NSImage>> {
+    let expected = (width as usize).checked_mul(height as usize)?.checked_mul(4)?;
+    if rgba.len() != expected {
+        return None;
+    }
+
+    let rep = unsafe {
+        NSBitmapImageRep::initWithBitmapDataPlanes_pixelsWide_pixelsHigh_bitsPerSample_samplesPerPixel_hasAlpha_isPlanar_colorSpaceName_bitmapFormat_bytesPerRow_bitsPerPixel(
+            NSBitmapImageRep::alloc(),
+            // NULL, so the rep allocates and OWNS its buffer.
+            //
+            // This is load-bearing: NSBitmapImageRep does NOT copy a `planes`
+            // buffer you hand it, it aliases the pointer. Passing a Rust
+            // slice's pointer here is a use-after-free the moment the owner
+            // drops. We memcpy into `bitmapData()` below instead.
+            core::ptr::null_mut(),
+            width as isize,
+            height as isize,
+            8,  // bitsPerSample
+            4,  // samplesPerPixel: R,G,B,A
+            true,  // hasAlpha
+            false, // isPlanar (interleaved)
+            // NSDeviceRGB, not NSCalibratedRGB — the latter shifts colours on
+            // modern displays.
+            objc2_app_kit::NSDeviceRGBColorSpace,
+            // Straight alpha, R first in memory. Setting neither AlphaFirst nor
+            // an endian flag means byte-order RGBA, which is what our renderer
+            // produces.
+            NSBitmapFormat::AlphaNonpremultiplied,
+            (width as isize) * 4, // bytesPerRow
+            32,                   // bitsPerPixel
+        )
+    }?;
+
+    unsafe {
+        let dst = rep.bitmapData();
+        if dst.is_null() {
+            return None;
+        }
+        core::ptr::copy_nonoverlapping(rgba.as_ptr(), dst, rgba.len());
+    }
+
+    #[allow(clippy::cast_precision_loss)] // icon sizes are small
+    let pts = points as f64;
+    let image = unsafe { NSImage::initWithSize(NSImage::alloc(), NSSize::new(pts, pts)) };
+    unsafe { image.addRepresentation(&rep) };
+    Some(image)
+}

--- a/dll/src/desktop/tray/mod.rs
+++ b/dll/src/desktop/tray/mod.rs
@@ -138,12 +138,18 @@ pub fn install_tray(
 
 /// Per-iteration tray work — currently draining menu clicks into the event
 /// mailbox. Cheap and self-gating when there is no tray.
-pub fn pump_tray() {
+///
+/// Returns the callbacks of any menu items clicked since the last pump, for the
+/// caller to invoke against a window - the tray has no window of its own, and a
+/// `CallbackInfo` needs one.
+#[must_use]
+pub fn pump_tray() -> Vec<azul_core::menu::CoreMenuCallback> {
     LIVE_TRAY.with(|c| {
-        if let Some(t) = c.borrow_mut().as_mut() {
-            t.pump();
-        }
-    });
+        c.borrow_mut()
+            .as_mut()
+            .map(TrayIcon::pump)
+            .unwrap_or_default()
+    })
 }
 
 /// Render a registry icon spec to RGBA at `size_px` square.
@@ -277,14 +283,21 @@ impl TrayIcon {
 
     /// Per-iteration work. On macOS this drains menu clicks that belong to this
     /// tray out of the process-wide menu-action queue.
-    pub fn pump(&mut self) {
+    #[must_use]
+    pub fn pump(&mut self) -> Vec<azul_core::menu::CoreMenuCallback> {
         #[cfg(any(
             target_os = "windows",
             target_os = "macos",
             all(target_os = "linux", not(target_arch = "wasm32"))
         ))]
         {
-            self.inner.pump();
+            return self.inner.pump();
         }
+        #[cfg(not(any(
+            target_os = "windows",
+            target_os = "macos",
+            all(target_os = "linux", not(target_arch = "wasm32"))
+        )))]
+        Vec::new()
     }
 }

--- a/dll/src/desktop/tray/mod.rs
+++ b/dll/src/desktop/tray/mod.rs
@@ -99,23 +99,51 @@ pub fn drain_tray_events() -> Vec<TrayEvent> {
         .unwrap_or_default()
 }
 
-/// The app's icon registry, so a tray can resolve a named icon.
-///
-/// `OnceLock` rather than a mutex because the icon SET and the resolver are
-/// frozen once the provider is shared — `App::run` consumes the
-/// `IconProviderHandle` and `SharedIconProvider` exposes no registration — so
-/// there is nothing to update after this is set.
-///
-/// A global rather than a parameter because the tray is app-level and outlives
-/// any window, while the provider is currently threaded through per-window
-/// state.
-static ICON_PROVIDER: std::sync::OnceLock<azul_core::icon::SharedIconProvider> =
-    std::sync::OnceLock::new();
+thread_local! {
+    /// The live tray, owned by the event-loop thread.
+    ///
+    /// A thread-local rather than a global because `TrayIcon` is not `Send` on
+    /// macOS — it holds a `Retained<NSStatusItem>`, and AppKit objects belong
+    /// to the main thread. Everything that touches it (install, pump, drop)
+    /// already runs there.
+    static LIVE_TRAY: core::cell::RefCell<Option<TrayIcon>> =
+        const { core::cell::RefCell::new(None) };
+}
 
-/// Publish the icon registry for tray (and later app-icon) rendering. Called
-/// once from `run()` after the provider is built. Subsequent calls are ignored.
-pub fn set_icon_provider(provider: azul_core::icon::SharedIconProvider) {
-    let _ = ICON_PROVIDER.set(provider);
+/// Create the tray requested by `App::set_tray`, if any. Called once from
+/// `run()` after the icon registry is published and the platform's app object
+/// exists.
+///
+/// A failure here is logged, not propagated: "there is no tray on this desktop"
+/// is a normal state (a vanilla GNOME has no StatusNotifierWatcher at all), and
+/// it must not stop the app from starting.
+pub fn install_tray(
+    data: TrayIconData,
+    provider: &azul_core::icon::SharedIconProvider,
+    font_manager: &azul_layout::font_traits::FontManager<azul_css::props::basic::FontRef>,
+) {
+    match TrayIcon::new(data, provider, font_manager) {
+        Ok(t) => {
+            LIVE_TRAY.with(|c| *c.borrow_mut() = Some(t));
+            crate::plog_info!("[tray] system tray icon installed");
+        }
+        Err(e) => {
+            // Loud on purpose. A silently missing tray icon is indistinguishable
+            // from a working one that the user simply cannot find, which is how
+            // this class of bug survives in other toolkits.
+            crate::plog_warn!("[tray] could not install the system tray icon: {e}");
+        }
+    }
+}
+
+/// Per-iteration tray work — currently draining menu clicks into the event
+/// mailbox. Cheap and self-gating when there is no tray.
+pub fn pump_tray() {
+    LIVE_TRAY.with(|c| {
+        if let Some(t) = c.borrow_mut().as_mut() {
+            t.pump();
+        }
+    });
 }
 
 /// Render a registry icon spec to RGBA at `size_px` square.
@@ -127,14 +155,16 @@ pub fn set_icon_provider(provider: azul_core::icon::SharedIconProvider) {
 pub(crate) fn render_named_icon(
     spec: &str,
     size_px: u32,
+    provider: &azul_core::icon::SharedIconProvider,
+    font_manager: &azul_layout::font_traits::FontManager<azul_css::props::basic::FontRef>,
 ) -> Option<azul_layout::tray_icon::RenderedIcon> {
-    let provider = ICON_PROVIDER.get()?;
     azul_layout::tray_icon::render_icon_to_rgba(
         spec,
         size_px,
         provider,
         &azul_css::system::SystemStyle::default(),
         None,
+        font_manager,
     )
 }
 
@@ -187,14 +217,18 @@ impl TrayIcon {
     /// # Errors
     /// [`TrayError::Unavailable`] when no tray exists (see [`Self::is_available`]),
     /// [`TrayError::Unsupported`] on a target with no backend.
-    pub fn new(data: TrayIconData) -> Result<Self, TrayError> {
+    pub fn new(
+        data: TrayIconData,
+        provider: &azul_core::icon::SharedIconProvider,
+        font_manager: &azul_layout::font_traits::FontManager<azul_css::props::basic::FontRef>,
+    ) -> Result<Self, TrayError> {
         #[cfg(any(
             target_os = "windows",
             target_os = "macos",
             all(target_os = "linux", not(target_arch = "wasm32"))
         ))]
         {
-            let inner = platform::PlatformTray::new(&data)?;
+            let inner = platform::PlatformTray::new(&data, provider, font_manager)?;
             Ok(Self { inner, data })
         }
         #[cfg(not(any(
@@ -203,7 +237,7 @@ impl TrayIcon {
             all(target_os = "linux", not(target_arch = "wasm32"))
         )))]
         {
-            let _ = data;
+            let _ = (data, provider, font_manager);
             Err(TrayError::Unsupported)
         }
     }
@@ -217,14 +251,19 @@ impl TrayIcon {
     ///
     /// # Errors
     /// Propagates whatever the platform reports.
-    pub fn update(&mut self, data: TrayIconData) -> Result<(), TrayError> {
+    pub fn update(
+        &mut self,
+        data: TrayIconData,
+        provider: &azul_core::icon::SharedIconProvider,
+        font_manager: &azul_layout::font_traits::FontManager<azul_css::props::basic::FontRef>,
+    ) -> Result<(), TrayError> {
         #[cfg(any(
             target_os = "windows",
             target_os = "macos",
             all(target_os = "linux", not(target_arch = "wasm32"))
         ))]
         {
-            self.inner.update(&self.data, &data)?;
+            self.inner.update(&self.data, &data, provider, font_manager)?;
         }
         self.data = data;
         Ok(())
@@ -234,5 +273,18 @@ impl TrayIcon {
     #[must_use]
     pub const fn data(&self) -> &TrayIconData {
         &self.data
+    }
+
+    /// Per-iteration work. On macOS this drains menu clicks that belong to this
+    /// tray out of the process-wide menu-action queue.
+    pub fn pump(&mut self) {
+        #[cfg(any(
+            target_os = "windows",
+            target_os = "macos",
+            all(target_os = "linux", not(target_arch = "wasm32"))
+        ))]
+        {
+            self.inner.pump();
+        }
     }
 }

--- a/dll/src/desktop/tray/mod.rs
+++ b/dll/src/desktop/tray/mod.rs
@@ -1,0 +1,238 @@
+//! System tray / status icon — platform dispatch.
+//!
+//! The data model lives in `azul_core::tray`; this module is the OS plumbing.
+//!
+//! # Architecture
+//!
+//! One `TrayIcon` owns one platform handle. The three backends look nothing
+//! alike, so the shared surface is deliberately thin:
+//!
+//! | | Windows | macOS | Linux |
+//! |---|---|---|---|
+//! | mechanism | `Shell_NotifyIconW` on a hidden top-level HWND | `NSStatusItem` retained by us | `org.kde.StatusNotifierItem` over D-Bus |
+//! | menu | `HMENU` we pop with `TrackPopupMenu` | `NSMenu` AppKit draws | `com.canonical.dbusmenu` the PANEL draws |
+//! | re-register on | `TaskbarCreated` broadcast | never | watcher `NameOwnerChanged` |
+//! | can it be absent? | practically no | no | **yes** — vanilla GNOME has no watcher |
+//!
+//! # Events
+//!
+//! Tray callbacks arrive on whatever thread the OS feels like (a D-Bus
+//! dispatch on Linux, the message pump on Windows, the main run loop on
+//! macOS), and none of them can hold a `CallbackInfo`. So they post into a
+//! process-wide mailbox and the run loop drains it — the same shape
+//! `gnome_menu::actions_protocol` already uses for menu activations.
+
+use azul_core::tray::{TrayEvent, TrayIconData};
+
+#[cfg(target_os = "windows")]
+mod windows;
+#[cfg(target_os = "macos")]
+pub(crate) mod macos;
+#[cfg(all(target_os = "linux", not(target_arch = "wasm32")))]
+mod linux;
+
+#[cfg(target_os = "windows")]
+use windows as platform;
+#[cfg(target_os = "macos")]
+use macos as platform;
+#[cfg(all(target_os = "linux", not(target_arch = "wasm32")))]
+use linux as platform;
+
+/// Why a tray icon could not be created or updated.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TrayError {
+    /// No tray exists on this desktop. The overwhelmingly common case is a
+    /// vanilla GNOME session, where `org.kde.StatusNotifierWatcher` is simply
+    /// not owned by anybody and nothing will ever display the item.
+    ///
+    /// This is NOT a bug and must not be treated as one: the app needs a story
+    /// for running without a tray.
+    Unavailable,
+    /// The OS refused the call.
+    Platform(String),
+    /// This build has no tray backend for the target (web, android, ios).
+    Unsupported,
+}
+
+impl core::fmt::Display for TrayError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Unavailable => write!(
+                f,
+                "no system tray is available on this desktop (on GNOME this usually means the \
+                 AppIndicator extension is not installed)"
+            ),
+            Self::Platform(m) => write!(f, "system tray error: {m}"),
+            Self::Unsupported => write!(f, "system tray is not supported on this platform"),
+        }
+    }
+}
+
+/// Process-wide tray event mailbox.
+///
+/// Tray callbacks cannot hold a `CallbackInfo` — they run on a D-Bus dispatch
+/// thread, inside a `TrackPopupMenu` modal loop, or in an AppKit action — so
+/// they queue here and the run loop drains it between frames.
+static TRAY_EVENTS: std::sync::LazyLock<std::sync::Mutex<Vec<TrayEvent>>> =
+    std::sync::LazyLock::new(|| std::sync::Mutex::new(Vec::new()));
+
+/// Post an event from a platform callback. Never blocks the caller for long
+/// and never panics across an FFI boundary (a poisoned lock is dropped, not
+/// unwrapped — losing one tray click beats aborting the process from inside an
+/// objc / D-Bus / Win32 callback).
+pub(crate) fn queue_tray_event(ev: TrayEvent) {
+    if let Ok(mut q) = TRAY_EVENTS.lock() {
+        // A tray the app never drains must not grow without bound.
+        const MAX_QUEUED: usize = 256;
+        if q.len() < MAX_QUEUED {
+            q.push(ev);
+        }
+    }
+}
+
+/// Take everything queued since the last call. Called by the run loop.
+#[must_use]
+pub fn drain_tray_events() -> Vec<TrayEvent> {
+    TRAY_EVENTS
+        .lock()
+        .map(|mut q| core::mem::take(&mut *q))
+        .unwrap_or_default()
+}
+
+/// The app's icon registry, so a tray can resolve a named icon.
+///
+/// `OnceLock` rather than a mutex because the icon SET and the resolver are
+/// frozen once the provider is shared — `App::run` consumes the
+/// `IconProviderHandle` and `SharedIconProvider` exposes no registration — so
+/// there is nothing to update after this is set.
+///
+/// A global rather than a parameter because the tray is app-level and outlives
+/// any window, while the provider is currently threaded through per-window
+/// state.
+static ICON_PROVIDER: std::sync::OnceLock<azul_core::icon::SharedIconProvider> =
+    std::sync::OnceLock::new();
+
+/// Publish the icon registry for tray (and later app-icon) rendering. Called
+/// once from `run()` after the provider is built. Subsequent calls are ignored.
+pub fn set_icon_provider(provider: azul_core::icon::SharedIconProvider) {
+    let _ = ICON_PROVIDER.set(provider);
+}
+
+/// Render a registry icon spec to RGBA at `size_px` square.
+///
+/// Returns `None` when no provider has been published (a headless or
+/// pre-`run()` caller), or when the spec resolves to nothing — the latter is
+/// deliberately distinguished from a blank bitmap, since an all-transparent
+/// icon in a tray looks exactly like a working one.
+pub(crate) fn render_named_icon(
+    spec: &str,
+    size_px: u32,
+) -> Option<azul_layout::tray_icon::RenderedIcon> {
+    let provider = ICON_PROVIDER.get()?;
+    azul_layout::tray_icon::render_icon_to_rgba(
+        spec,
+        size_px,
+        provider,
+        &azul_css::system::SystemStyle::default(),
+        None,
+    )
+}
+
+/// A live system-tray icon.
+///
+/// Dropping it removes the icon. On macOS that is the ONLY removal API —
+/// `NSStatusBar` does not retain status items, so the `Retained<NSStatusItem>`
+/// this owns is what keeps the icon on screen.
+#[derive(Debug)]
+pub struct TrayIcon {
+    #[cfg(any(
+        target_os = "windows",
+        target_os = "macos",
+        all(target_os = "linux", not(target_arch = "wasm32"))
+    ))]
+    inner: platform::PlatformTray,
+    data: TrayIconData,
+}
+
+impl TrayIcon {
+    /// Is there anything on this system that would display a tray icon?
+    ///
+    /// Returns `true` on Windows and macOS (the notification area / menu bar
+    /// always exist). On Linux this is a real question: it checks that
+    /// `org.kde.StatusNotifierWatcher` is owned AND that a host has registered
+    /// with it. Both halves matter — a watcher with no host is a real state,
+    /// because the watcher can win the startup race against the panel.
+    #[must_use]
+    pub fn is_available() -> bool {
+        #[cfg(any(
+            target_os = "windows",
+            target_os = "macos",
+            all(target_os = "linux", not(target_arch = "wasm32"))
+        ))]
+        {
+            platform::is_available()
+        }
+        #[cfg(not(any(
+            target_os = "windows",
+            target_os = "macos",
+            all(target_os = "linux", not(target_arch = "wasm32"))
+        )))]
+        {
+            false
+        }
+    }
+
+    /// Create and show the tray icon.
+    ///
+    /// # Errors
+    /// [`TrayError::Unavailable`] when no tray exists (see [`Self::is_available`]),
+    /// [`TrayError::Unsupported`] on a target with no backend.
+    pub fn new(data: TrayIconData) -> Result<Self, TrayError> {
+        #[cfg(any(
+            target_os = "windows",
+            target_os = "macos",
+            all(target_os = "linux", not(target_arch = "wasm32"))
+        ))]
+        {
+            let inner = platform::PlatformTray::new(&data)?;
+            Ok(Self { inner, data })
+        }
+        #[cfg(not(any(
+            target_os = "windows",
+            target_os = "macos",
+            all(target_os = "linux", not(target_arch = "wasm32"))
+        )))]
+        {
+            let _ = data;
+            Err(TrayError::Unsupported)
+        }
+    }
+
+    /// Replace the icon's state — icon, tooltip, status, menu.
+    ///
+    /// This is a whole-state set rather than a set of individual mutators
+    /// because the Linux backend has to be able to answer the panel's
+    /// `GetLayout` at any moment, and because SNI wants one `New*` signal per
+    /// changed property rather than a stream of them.
+    ///
+    /// # Errors
+    /// Propagates whatever the platform reports.
+    pub fn update(&mut self, data: TrayIconData) -> Result<(), TrayError> {
+        #[cfg(any(
+            target_os = "windows",
+            target_os = "macos",
+            all(target_os = "linux", not(target_arch = "wasm32"))
+        ))]
+        {
+            self.inner.update(&self.data, &data)?;
+        }
+        self.data = data;
+        Ok(())
+    }
+
+    /// The state last successfully applied.
+    #[must_use]
+    pub const fn data(&self) -> &TrayIconData {
+        &self.data
+    }
+}

--- a/dll/src/desktop/tray/windows.rs
+++ b/dll/src/desktop/tray/windows.rs
@@ -99,7 +99,13 @@ impl PlatformTray {
 
 impl PlatformTray {
     /// Unreachable — `new()` never returns a value on this platform yet.
-    pub(super) fn pump(&mut self) {
+    pub(super) fn pump(&mut self) -> Vec<azul_core::menu::CoreMenuCallback> {
+        // No menu backend yet, so nothing can be delivered.
+        Vec::new()
+    }
+
+    #[allow(dead_code)]
+    fn pump_unused(&mut self) {
         match self._never {}
     }
 }

--- a/dll/src/desktop/tray/windows.rs
+++ b/dll/src/desktop/tray/windows.rs
@@ -78,7 +78,11 @@ pub(super) struct PlatformTray {
 }
 
 impl PlatformTray {
-    pub(super) fn new(_data: &TrayIconData) -> Result<Self, TrayError> {
+    pub(super) fn new(
+        _data: &TrayIconData,
+        _provider: &azul_core::icon::SharedIconProvider,
+        _font_manager: &azul_layout::font_traits::FontManager<azul_css::props::basic::FontRef>,
+    ) -> Result<Self, TrayError> {
         Err(TrayError::Unsupported)
     }
 
@@ -86,7 +90,16 @@ impl PlatformTray {
         &mut self,
         _old: &TrayIconData,
         _new: &TrayIconData,
+        _provider: &azul_core::icon::SharedIconProvider,
+        _font_manager: &azul_layout::font_traits::FontManager<azul_css::props::basic::FontRef>,
     ) -> Result<(), TrayError> {
+        match self._never {}
+    }
+}
+
+impl PlatformTray {
+    /// Unreachable — `new()` never returns a value on this platform yet.
+    pub(super) fn pump(&mut self) {
         match self._never {}
     }
 }

--- a/dll/src/desktop/tray/windows.rs
+++ b/dll/src/desktop/tray/windows.rs
@@ -1,0 +1,92 @@
+//! Windows system tray — `Shell_NotifyIconW`. **NOT IMPLEMENTED YET.**
+//!
+//! This stub exists so the branch cross-compiles while the backend is written;
+//! it reports the tray as unavailable rather than pretending to work. See
+//! `scripts/MULTIMONITOR_AND_TRAY_RESEARCH_2026_08_24.md` §2.2 and
+//! `scripts/APP_AND_WINDOW_ICON_RESEARCH_2026_08_24.md` §2 for the full recipe.
+//!
+//! # What this needs, in order
+//!
+//! 1. **A hidden top-level window — NOT `HWND_MESSAGE`.** Message-only windows
+//!    are children of `HWND_MESSAGE`, therefore not top-level, therefore
+//!    invisible to BROADCAST messages — and `TaskbarCreated` is a broadcast, so
+//!    the icon would never come back after an Explorer restart. Use a normal
+//!    `CreateWindowExW` with `WS_EX_TOOLWINDOW | WS_OVERLAPPED`, no
+//!    `WS_VISIBLE`, and simply never `ShowWindow` it.
+//!
+//! 2. **`Shell_NotifyIconW` in `Shell32Functions`** (`windows/dlopen.rs:623`).
+//!    shell32 is already dlopen'd there for drag-and-drop, on an
+//!    optional/graceful-degradation path, so this fits without new machinery.
+//!    `NOTIFYICONDATAW` has to be declared locally (winapi's `shellapi` feature
+//!    is not enabled and enabling it is not worth it for one struct).
+//!
+//! 3. **`NIM_ADD` then `NIM_SETVERSION` with `NOTIFYICON_VERSION_4`** — and
+//!    `NIM_SETVERSION` must be re-sent after EVERY `NIM_ADD`, including the
+//!    re-add on `TaskbarCreated`. Without v4 you get no cursor coordinates and
+//!    no `WM_CONTEXTMENU` for keyboard invocation.
+//!
+//! 4. **v4 message decoding — note the swap.** `LOWORD(lParam)` is the event,
+//!    `HIWORD(lParam)` the icon id (16-bit only, so keep `uID` small), and
+//!    `GET_X_LPARAM(wParam)`/`GET_Y_LPARAM(wParam)` are SCREEN coordinates.
+//!    Reading these off the wrong parameter is the classic v4 bug. Map
+//!    `NIN_SELECT`/`NIN_KEYSELECT` -> Activate, `WM_CONTEXTMENU` (0x007B) ->
+//!    ContextMenu, `WM_MBUTTONUP` -> SecondaryActivate.
+//!
+//! 5. **`RegisterWindowMessage("TaskbarCreated")`** in `WM_CREATE`, re-add on
+//!    receipt. It also fires when the primary display's DPI changes on Win10,
+//!    so it doubles as the cue to rebuild the `HICON`.
+//!
+//! 6. **RGBA -> `HICON`**: `BITMAPV5HEADER` with `bV5Height = -h` (top-down),
+//!    `BI_BITFIELDS`, `bV5AlphaMask = 0xff000000`, `CreateDIBSection`, copy
+//!    RGBA->BGRA **without premultiplying** (`CreateIconIndirect` wants STRAIGHT
+//!    alpha — the "GDI always premultiplies" rule is for `AlphaBlend`/layered
+//!    windows, not icons), plus a 1bpp AND mask that is actually COMPUTED
+//!    (`bit = alpha < 128`, where 1 means transparent). An all-zero mask is
+//!    invisible in the normal draw path and ugly wherever `DI_MASK` is used.
+//!    `CreateIconIndirect` COPIES both bitmaps, so `DeleteObject` both after,
+//!    and neither may be selected into a DC at call time.
+//!
+//! 7. **Context menu**: reuse `WindowsMenuBar::recursive_construct_menu` with
+//!    `CreatePopupMenu`, then `SetForegroundWindow(hwnd)` before
+//!    `TrackPopupMenu` (or the menu will not dismiss on an outside click) and
+//!    `PostMessage(hwnd, WM_NULL, 0, 0)` after it returns (or the NEXT
+//!    invocation flashes open and closes). `windows/mod.rs:5755` already has
+//!    the deferred-`TrackPopupMenu` half of this.
+//!
+//! 8. **Ownership**: we own the `HICON`; `NIM_ADD` does not take it.
+//!    `DestroyIcon` only after `NIM_MODIFY`/`NIM_DELETE` has replaced it.
+//!
+//! Every symbol needed is already dlopen'd except `Shell_NotifyIconW`,
+//! `RegisterWindowMessageW`, `CreateIconIndirect` and `DestroyIcon`
+//! (`CreatePopupMenu`, `TrackPopupMenu`, `SetForegroundWindow`,
+//! `CreateWindowExW`, `PostMessageW`, `CreateDIBSection` are all present).
+
+use azul_core::tray::TrayIconData;
+
+use super::TrayError;
+
+/// Windows always has a notification area, but this backend does not exist
+/// yet, so claiming availability would be a lie that produces a silently
+/// missing icon.
+pub(super) fn is_available() -> bool {
+    false
+}
+
+#[derive(Debug)]
+pub(super) struct PlatformTray {
+    _never: core::convert::Infallible,
+}
+
+impl PlatformTray {
+    pub(super) fn new(_data: &TrayIconData) -> Result<Self, TrayError> {
+        Err(TrayError::Unsupported)
+    }
+
+    pub(super) fn update(
+        &mut self,
+        _old: &TrayIconData,
+        _new: &TrayIconData,
+    ) -> Result<(), TrayError> {
+        match self._never {}
+    }
+}

--- a/doc/src/autofix/module_map.rs
+++ b/doc/src/autofix/module_map.rs
@@ -43,6 +43,7 @@ pub const MODULES: &[&str] = &[
     "sensor",
     "gamepad",
     "gesture",
+    "tray",
     "webtransport",
     "db",
     "file",
@@ -432,6 +433,23 @@ pub fn get_module_keywords() -> BTreeMap<&'static str, Vec<&'static str>> {
     );
 
     // Widgets module - UI components
+    // System tray. Every keyword is the FULL `tray`-prefixed stem rather than
+    // just "tray", because matching picks the LONGEST keyword and several of
+    // these would otherwise lose to a shorter-but-unrelated module:
+    // TrayIconImage/TrayIconData match "icon" (image), TrayScrollAxis matches
+    // "scroll" (widgets). Spelling the stems out makes tray win by length
+    // instead of relying on MODULES order to break a tie.
+    map.insert(
+        "tray",
+        vec![
+            "tray",
+            "trayicon",   // TrayIconData, TrayIconImage, TrayIconSource
+            "trayevent",  // TrayEvent, TrayEventType
+            "trayscroll", // TrayScrollAxis — beats "scroll"
+            "traycategory",
+            "traystatus",
+        ],
+    );
     map.insert(
         "widgets",
         vec![
@@ -686,6 +704,10 @@ fn module_from_external_path(path: &str) -> Option<String> {
     if path.starts_with("azul_core::sensors::") { return Some("sensor".to_string()); }
     if path.starts_with("azul_core::gamepad::") { return Some("gamepad".to_string()); }
     if path.starts_with("azul_core::db::") { return Some("db".to_string()); }
+    // Routed by path rather than by name: a `Tray*` name-keyword arm would also
+    // capture unrelated future types, and the module is small enough that the
+    // exact path is both safer and self-documenting.
+    if path.starts_with("azul_core::tray::") { return Some("tray".to_string()); }
     if path.starts_with("azul_core::url::") { return Some("url".to_string()); }
     if path.starts_with("azul_core::xml::") { return Some("xml".to_string()); }
     // azul_layout::*

--- a/examples/rust/Cargo.toml
+++ b/examples/rust/Cargo.toml
@@ -92,3 +92,7 @@ required-features = ["fluent", "icu"]
 name = "http_zip_demo"
 path = "src/http_zip_demo.rs"
 required-features = ["fluent", "http", "zip"]
+
+[[example]]
+name = "tray"
+path = "src/tray.rs"

--- a/examples/rust/Cargo.toml
+++ b/examples/rust/Cargo.toml
@@ -96,3 +96,7 @@ required-features = ["fluent", "http", "zip"]
 [[example]]
 name = "tray"
 path = "src/tray.rs"
+
+[[example]]
+name = "tray_only"
+path = "src/tray_only.rs"

--- a/examples/rust/src/tray.rs
+++ b/examples/rust/src/tray.rs
@@ -128,11 +128,22 @@ fn main() {
             ),
         ]));
 
-    let mut app = App::create(data, AppConfig::create());
+    // A DOM registered as an icon. The colour lives HERE, with the icon, not as
+    // a tint parameter threaded through every call site - which is the whole
+    // reason icons resolve on the Dom before the cascade.
+    let mut config = AppConfig::create();
+    config.icon_provider.register_dom_icon(
+        String::from("demo"),
+        String::from("red-heart"),
+        Dom::create_icon(String::from("favorite"))
+            .with_css("color: #d7263d;"),
+    );
+
+    let mut app = App::create(data, config);
     app.set_tray(tray);
     // The Dock tile, from the same registry + pipeline as the tray icon. macOS
     // documents this as temporary: it is process-local and resets next launch.
-    app.set_app_icon(String::from("favorite"));
+    app.set_app_icon(String::from("red-heart"));
 
     let mut window = WindowCreateOptions::create(layout);
     window.window_state.title = "Azul - tray demo".into();

--- a/examples/rust/src/tray.rs
+++ b/examples/rust/src/tray.rs
@@ -130,6 +130,9 @@ fn main() {
 
     let mut app = App::create(data, AppConfig::create());
     app.set_tray(tray);
+    // The Dock tile, from the same registry + pipeline as the tray icon. macOS
+    // documents this as temporary: it is process-local and resets next launch.
+    app.set_app_icon(String::from("favorite"));
 
     let mut window = WindowCreateOptions::create(layout);
     window.window_state.title = "Azul - tray demo".into();

--- a/examples/rust/src/tray.rs
+++ b/examples/rust/src/tray.rs
@@ -1,0 +1,100 @@
+//! System-tray demo.
+//!
+//! ```sh
+//! cargo run --release -p azul-examples --example tray
+//! ```
+//!
+//! **macOS only for now.** Windows and Linux report the tray as unavailable;
+//! this demo says so and keeps running, which is the behaviour every app needs
+//! anyway - on a vanilla GNOME there is genuinely no tray to talk to.
+//!
+//! Everything here goes through the ordinary public API (`azul::tray::*`,
+//! `App::set_tray`), i.e. the same C ABI every language binding sees. Nothing
+//! reaches into the crate internals.
+//!
+//! What it shows:
+//!
+//! * a tray icon whose image is an **icon-registry spec** - the same string an
+//!   `<icon>` node takes, resolved through the same pass, so any registered
+//!   icon works (Material Icons is the default pack) with no tray-specific
+//!   icon path;
+//! * a tray **menu**, built from the ordinary `Menu` type the menu bar uses.
+//!
+//! Note the menu is *state*: it is set once as part of `TrayIconData`, not
+//! shown on demand. That shape is forced by Linux, where the panel draws the
+//! menu itself and calls back asking for the layout.
+
+use azul::menu::{Menu, MenuItem, StringMenuItem};
+use azul::prelude::*;
+use azul::tray::TrayIconData;
+
+struct TrayDemo {
+    available: bool,
+}
+
+const ROOT: &str = "display: flex; flex-direction: column; height: 100%; \
+    padding: 24px; background: #fafafa; font-family: sans-serif;";
+const TITLE: &str = "font-size: 20px; color: #111; margin-bottom: 8px;";
+const OK: &str = "font-size: 13px; color: #228822; margin-bottom: 14px;";
+const WARN: &str = "font-size: 13px; color: #bb0000; margin-bottom: 14px;";
+const HINT: &str = "font-size: 13px; color: #555555;";
+
+extern "C" fn layout(mut data: RefAny, _info: LayoutCallbackInfo) -> Dom {
+    let available = data
+        .downcast_ref::<TrayDemo>()
+        .map(|d| d.available)
+        .unwrap_or(false);
+
+    let (status_text, status_css) = if available {
+        ("Tray available - look in the menu bar.", OK)
+    } else {
+        (
+            "No system tray on this platform yet - the app runs regardless.",
+            WARN,
+        )
+    };
+
+    Dom::create_body().with_child(
+        Dom::create_div()
+            .with_css(ROOT)
+            .with_child(Dom::create_div_with_text("System tray demo").with_css(TITLE))
+            .with_child(Dom::create_div_with_text(status_text).with_css(status_css))
+            .with_child(
+                Dom::create_div_with_text(
+                    "Click the icon to open its menu. Menu clicks are logged to stdout.",
+                )
+                .with_css(HINT),
+            ),
+    )
+}
+
+fn main() {
+    println!("azul - system tray demo");
+    println!("=======================");
+
+    // The icon is an icon-registry SPEC, not a bitmap: "settings" resolves
+    // through the same registry and resolver an `<icon>settings</icon>` node
+    // uses, then renders to RGBA at whatever size the platform asks for.
+    // Try any other Material Icons name - "home", "favorite", "cloud".
+    let tray = TrayIconData::new("rs.azul.tray-demo", "Azul Tray Demo")
+        .with_named_icon("settings")
+        .with_tooltip("Azul tray demo")
+        .with_menu(Menu::create(vec![
+            MenuItem::String(StringMenuItem::create("Open")),
+            MenuItem::Separator,
+            MenuItem::String(StringMenuItem::create("Quit")),
+        ]));
+
+    let data = RefAny::new(TrayDemo {
+        // set_tray is best-effort and never fails the app; this is read only so
+        // the window can be honest about whether an icon actually appeared.
+        available: cfg!(target_os = "macos"),
+    });
+
+    let mut app = App::create(data, AppConfig::create());
+    app.set_tray(tray);
+
+    let mut window = WindowCreateOptions::create(layout);
+    window.window_state.title = "Azul - tray demo".into();
+    app.run(window);
+}

--- a/examples/rust/src/tray.rs
+++ b/examples/rust/src/tray.rs
@@ -30,6 +30,27 @@ use azul::tray::TrayIconData;
 
 struct TrayDemo {
     available: bool,
+    /// Bumped by the tray menu, and rendered by the window - the point being
+    /// that a tray callback mutates the SAME state the window draws from.
+    clicks: usize,
+}
+
+/// Tray menu callbacks are ordinary azul callbacks: your `RefAny` comes back
+/// as the first argument, and returning `Update::RefreshDom` re-runs layout.
+extern "C" fn on_open(mut data: RefAny, _info: CallbackInfo) -> Update {
+    match data.downcast_mut::<TrayDemo>() {
+        Some(mut d) => {
+            d.clicks += 1;
+            println!("[tray] \"Open\" clicked ({} total)", d.clicks);
+            Update::RefreshDom
+        }
+        None => Update::DoNothing,
+    }
+}
+
+extern "C" fn on_quit(_data: RefAny, _info: CallbackInfo) -> Update {
+    println!("[tray] \"Quit\" clicked - exiting");
+    std::process::exit(0);
 }
 
 const ROOT: &str = "display: flex; flex-direction: column; height: 100%; \
@@ -40,10 +61,10 @@ const WARN: &str = "font-size: 13px; color: #bb0000; margin-bottom: 14px;";
 const HINT: &str = "font-size: 13px; color: #555555;";
 
 extern "C" fn layout(mut data: RefAny, _info: LayoutCallbackInfo) -> Dom {
-    let available = data
+    let (available, clicks) = data
         .downcast_ref::<TrayDemo>()
-        .map(|d| d.available)
-        .unwrap_or(false);
+        .map(|d| (d.available, d.clicks))
+        .unwrap_or((false, 0));
 
     let (status_text, status_css) = if available {
         ("Tray available - look in the menu bar.", OK)
@@ -64,6 +85,13 @@ extern "C" fn layout(mut data: RefAny, _info: LayoutCallbackInfo) -> Dom {
                     "Click the icon to open its menu. Menu clicks are logged to stdout.",
                 )
                 .with_css(HINT),
+            )
+            // The count is what makes the wiring visible: it is bumped by a
+            // callback fired from the TRAY, mutating the same RefAny this
+            // window lays out from.
+            .with_child(
+                Dom::create_div_with_text(format!("\"Open\" clicked {clicks} time(s)"))
+                    .with_css(HINT),
             ),
     )
 }
@@ -76,20 +104,29 @@ fn main() {
     // through the same registry and resolver an `<icon>settings</icon>` node
     // uses, then renders to RGBA at whatever size the platform asks for.
     // Try any other Material Icons name - "home", "favorite", "cloud".
-    let tray = TrayIconData::new("rs.azul.tray-demo", "Azul Tray Demo")
-        .with_named_icon("settings")
-        .with_tooltip("Azul tray demo")
-        .with_menu(Menu::create(vec![
-            MenuItem::String(StringMenuItem::create("Open")),
-            MenuItem::Separator,
-            MenuItem::String(StringMenuItem::create("Quit")),
-        ]));
-
     let data = RefAny::new(TrayDemo {
         // set_tray is best-effort and never fails the app; this is read only so
         // the window can be honest about whether an icon actually appeared.
         available: cfg!(target_os = "macos"),
+        clicks: 0,
     });
+
+    let tray = TrayIconData::new("rs.azul.tray-demo", "Azul Tray Demo")
+        .with_named_icon("settings")
+        .with_tooltip("Azul tray demo")
+        .with_menu(Menu::create(vec![
+            // A tray menu item takes the SAME callback a menu-bar item takes:
+            // your own RefAny plus a `CallbackInfo`. Without one the item is
+            // still clickable, but the click only shows up as a `TrayEvent` for
+            // you to poll - attaching a callback is what makes it act.
+            MenuItem::String(
+                StringMenuItem::create("Open").with_callback(data.clone(), on_open),
+            ),
+            MenuItem::Separator,
+            MenuItem::String(
+                StringMenuItem::create("Quit").with_callback(data.clone(), on_quit),
+            ),
+        ]));
 
     let mut app = App::create(data, AppConfig::create());
     app.set_tray(tray);

--- a/examples/rust/src/tray_only.rs
+++ b/examples/rust/src/tray_only.rs
@@ -1,0 +1,67 @@
+//! azul - a system-tray app with NO window at all.
+//!
+//! The ordinary `App::run()` creates a root window unconditionally, so a
+//! menu-bar utility used to have to open (and then hide) a window it never
+//! wanted. `run_tray_only()` skips window creation entirely.
+//!
+//! What that costs, and why it is deliberate:
+//!
+//! * On macOS the process switches to **Accessory** activation - the runtime
+//!   equivalent of `LSUIElement` in an Info.plist. No Dock tile, no application
+//!   menu bar. A `Regular` app with no windows is worse than having one: it owns
+//!   the menu bar and shows a Dock icon that does nothing.
+//! * Because there is no Dock tile, `set_app_icon` has nowhere to draw, so this
+//!   example does not call it.
+//!
+//! Tray menu callbacks still work exactly as they do in a windowed app - the
+//! same `RefAny`, the same `CallbackInfo` - because a headless stub window
+//! supplies the callback context without any OS window existing.
+//!
+//! Run it and look in the menu bar; there is no window and no Dock icon.
+
+use azul::menu::{Menu, MenuItem, StringMenuItem};
+use azul::prelude::*;
+use azul::tray::TrayIconData;
+
+struct TrayOnly {
+    clicks: usize,
+}
+
+extern "C" fn on_ping(mut data: RefAny, _info: CallbackInfo) -> Update {
+    match data.downcast_mut::<TrayOnly>() {
+        Some(mut d) => {
+            d.clicks += 1;
+            println!("[tray-only] ping ({} total) - no window involved", d.clicks);
+            Update::DoNothing
+        }
+        None => Update::DoNothing,
+    }
+}
+
+extern "C" fn on_quit(_data: RefAny, _info: CallbackInfo) -> Update {
+    println!("[tray-only] quit");
+    std::process::exit(0);
+}
+
+fn main() {
+    println!("azul - tray-only demo (no window)");
+    println!("=================================");
+    println!("Look in the menu bar. There is no window and no Dock icon.");
+
+    let data = RefAny::new(TrayOnly { clicks: 0 });
+
+    let tray = TrayIconData::new("rs.azul.tray-only", "Azul Tray Only")
+        .with_named_icon("bolt")
+        .with_tooltip("Azul tray-only demo")
+        .with_menu(Menu::create(vec![
+            MenuItem::String(StringMenuItem::create("Ping").with_callback(data.clone(), on_ping)),
+            MenuItem::Separator,
+            MenuItem::String(StringMenuItem::create("Quit").with_callback(data.clone(), on_quit)),
+        ]));
+
+    let mut app = App::create(data, AppConfig::create());
+    app.set_tray(tray);
+
+    // NOT `app.run(window)` - there is no window.
+    app.run_tray_only();
+}

--- a/layout/src/cpurender/raster.rs
+++ b/layout/src/cpurender/raster.rs
@@ -3962,6 +3962,20 @@ impl Default for ComponentPreviewOptions {
 pub struct ComponentPreviewResult {
     /// PNG-encoded image data.
     pub png_data: Vec<u8>,
+    /// The same pixels, straight RGBA8, `pixel_width * pixel_height * 4` bytes,
+    /// top row first.
+    ///
+    /// Exposed alongside `png_data` because several consumers want pixels, not
+    /// a container: the system tray hands RGBA to `CreateIconIndirect`
+    /// (Windows), `NSBitmapImageRep` (macOS) and SNI's `IconPixmap` (Linux),
+    /// and encoding a PNG only to decode it again on the next line is pure
+    /// waste. It is a plain clone of the pixmap buffer, so the cost is one
+    /// memcpy for callers that ignore it.
+    pub rgba: Vec<u8>,
+    /// Width of `rgba` in DEVICE pixels (i.e. `content_width * dpi_factor`).
+    pub pixel_width: u32,
+    /// Height of `rgba` in DEVICE pixels.
+    pub pixel_height: u32,
     /// Actual content width (logical pixels).
     pub content_width: f32,
     /// Actual content height (logical pixels).
@@ -4175,6 +4189,9 @@ pub fn render_component_preview(
             None => {
                 return Ok(ComponentPreviewResult {
                     png_data: Vec::new(),
+                    rgba: Vec::new(),
+                    pixel_width: 0,
+                    pixel_height: 0,
                     content_width: 0.0,
                     content_height: 0.0,
                 });
@@ -4209,12 +4226,19 @@ pub fn render_component_preview(
         &preview_render_state,
     )?;
 
+    let rgba = pixmap.data.to_vec();
+    let pixel_width = pixmap.width;
+    let pixel_height = pixmap.height;
+
     let png_data = pixmap
         .encode_png()
         .map_err(|e| format!("PNG encoding failed: {e}"))?;
 
     Ok(ComponentPreviewResult {
         png_data,
+        rgba,
+        pixel_width,
+        pixel_height,
         content_width: render_width,
         content_height: render_height,
     })

--- a/layout/src/icon.rs
+++ b/layout/src/icon.rs
@@ -76,6 +76,29 @@ pub struct FontIconData {
     pub icon_char: String,
 }
 
+/// An icon that IS a `Dom` - the general case, of which image and font icons
+/// are special cases.
+///
+/// Register any DOM as an icon and refer to it by name everywhere an icon spec
+/// is taken (`<icon>my-logo</icon>`, a tray icon, an app icon). Because the DOM
+/// carries its own inline styles AND its own stylesheets (`Dom::css`), the icon
+/// decides what it looks like - colour included - instead of every call site
+/// having to thread a tint parameter down to the renderer.
+///
+/// The whole subtree is spliced in before the cascade, so a DOM icon can be any
+/// number of nodes with any styling, not just a single glyph.
+#[derive(Debug, Clone)]
+pub struct DomIconData {
+    pub dom: Dom,
+}
+
+impl DomIconData {
+    #[must_use]
+    pub const fn new(dom: Dom) -> Self {
+        Self { dom }
+    }
+}
+
 // ============================================================================
 // Default Icon Resolver
 // ============================================================================
@@ -92,28 +115,55 @@ pub struct FontIconData {
 /// filtered based on `SystemStyle` preferences.
 #[must_use] pub extern "C" fn default_icon_resolver(
     icon_data: OptionRefAny,
-    original_icon_dom: &StyledDom,
+    original_icon_node: &NodeData,
     system_style: &SystemStyle,
-) -> StyledDom {
-    // No icon found → empty div
+) -> Dom {
+    // No icon found -> empty div
     let Some(mut data) = icon_data.into_option() else {
-        let mut dom = Dom::create_div();
-        return StyledDom::create(&mut dom, Css::empty());
+        return Dom::create_div();
     };
-    
+
+    // A registered Dom: the icon IS a DOM, spliced in whole. This is what lets
+    // an icon carry its own styling - colour above all - instead of every call
+    // site having to pass a tint down. Checked FIRST because it is the most
+    // specific: a caller who registered a whole DOM meant that DOM.
+    if let Some(dom_icon) = data.downcast_ref::<DomIconData>() {
+        return create_dom_icon_from_original(&dom_icon, original_icon_node);
+    }
+
     // Try ImageIconData
     if let Some(img) = data.downcast_ref::<ImageIconData>() {
-        return create_image_icon_from_original(&img, original_icon_dom, system_style);
+        return create_image_icon_from_original(&img, original_icon_node, system_style);
     }
-    
+
     // Try FontIconData
     if let Some(font_icon) = data.downcast_ref::<FontIconData>() {
-        return create_font_icon_from_original(&font_icon, original_icon_dom, system_style);
+        return create_font_icon_from_original(&font_icon, original_icon_node, system_style);
     }
-    
-    // Unknown data type → empty div
-    let mut dom = Dom::create_div();
-    StyledDom::create(&mut dom, Css::empty())
+
+    // Unknown data type -> empty div
+    Dom::create_div()
+}
+
+/// An icon that IS a `Dom`: whatever the caller registered, spliced in whole.
+///
+/// The call site's styles are applied FIRST and the registered DOM's own styles
+/// second, so the icon wins on anything it specifies (colour, background,
+/// borders) while still inheriting what it does not (the size the tray or the
+/// surrounding text asked for). That ordering is the point: an icon knows what
+/// it should look like, a call site knows how big it should be.
+fn create_dom_icon_from_original(icon: &DomIconData, original: &NodeData) -> Dom {
+    let mut dom = icon.dom.clone();
+
+    let mut props = copy_appropriate_styles_vec(original);
+    if props.is_empty() {
+        return dom;
+    }
+    // The registered DOM's own declarations go last so they override.
+    props.extend(copy_appropriate_styles_vec(&dom.root));
+    dom.root
+        .set_css_props(CssPropertyWithConditionsVec::from_vec(props));
+    dom
 }
 
 // Icon DOM Creation (from original)
@@ -125,13 +175,14 @@ pub struct FontIconData {
 /// - Tint color overlay if `tint_color` is set
 fn create_image_icon_from_original(
     img: &ImageIconData,
-    original: &StyledDom,
+    original: &NodeData,
     system_style: &SystemStyle,
-) -> StyledDom {
+) -> Dom {
     let mut dom = Dom::create_image(img.image.clone());
     
     // Copy appropriate styles from original
-    if let Some(original_node) = original.node_data.as_ref().first() {
+    {
+        let original_node = original;
         let mut props_vec = copy_appropriate_styles_vec(original_node);
         
         // Add default dimensions if not specified in original styles
@@ -158,20 +209,9 @@ fn create_image_icon_from_original(
         if let Some(a11y) = original_node.get_accessibility_info() {
             dom = dom.with_accessibility_info(a11y.clone());
         }
-    } else {
-        // No original node, use default dimensions
-        let mut props_vec = vec![
-            CssPropertyWithConditions::simple(CssProperty::width(LayoutWidth::px(img.width))),
-            CssPropertyWithConditions::simple(CssProperty::height(LayoutHeight::px(img.height))),
-        ];
-        
-        // Apply SystemStyle-aware filters even without original node
-        apply_icon_style_filters(&mut props_vec, system_style);
-        
-        dom.root.set_css_props(CssPropertyWithConditionsVec::from_vec(props_vec));
     }
     
-    StyledDom::create(&mut dom, Css::empty())
+    dom
 }
 
 /// Create a `StyledDom` for a font-based icon, copying styles from original.
@@ -181,9 +221,9 @@ fn create_image_icon_from_original(
 /// - Tint color if `tint_color` is set
 fn create_font_icon_from_original(
     font_icon: &FontIconData,
-    original: &StyledDom,
+    original: &NodeData,
     system_style: &SystemStyle,
-) -> StyledDom {
+) -> Dom {
     // A SPAN, not a bare text node and not a <p>.
     //
     // The glyph carries css (font-family, colour, tint) and frequently sits as
@@ -202,7 +242,8 @@ fn create_font_icon_from_original(
         ]))
     );
     
-    if let Some(original_node) = original.node_data.as_ref().first() {
+    {
+        let original_node = original;
         let mut props_vec = copy_appropriate_styles_vec(original_node);
         props_vec.push(font_prop);
         
@@ -215,17 +256,9 @@ fn create_font_icon_from_original(
         if let Some(a11y) = original_node.get_accessibility_info() {
             dom = dom.with_accessibility_info(a11y.clone());
         }
-    } else {
-        // No original node, just set the font
-        let mut props_vec = vec![font_prop];
-        
-        // Apply SystemStyle-aware color modifications
-        apply_font_icon_color(&mut props_vec, system_style);
-        
-        dom.root.set_css_props(CssPropertyWithConditionsVec::from_vec(props_vec));
     }
     
-    StyledDom::create(&mut dom, Css::empty())
+    dom
 }
 
 /// Copy styles from original node
@@ -364,6 +397,22 @@ pub fn register_icons_from_zip(_provider: &mut IconProviderHandle, _pack_name: &
 }
 
 /// Register a font icon in a pack
+/// Register an arbitrary `Dom` as an icon.
+///
+/// The general case: an icon is just a DOM, and image / font icons are special
+/// cases of it. Whatever you register is spliced in wherever that icon name is
+/// used - an `<icon>` node, a tray icon, an app icon - and it keeps its own
+/// styling, because the DOM carries both inline properties and its own
+/// stylesheets (`Dom::css`).
+///
+/// That is what makes colour work without a tint parameter: an icon that should
+/// be red says so itself, once, instead of every call site having to thread a
+/// colour down to the renderer. Sizing still comes from the call site, since the
+/// caller is the one who knows how big the icon has to be.
+pub fn register_dom_icon(provider: &mut IconProviderHandle, pack_name: &str, icon_name: &str, dom: Dom) {
+    provider.register_icon(pack_name, icon_name, RefAny::new(DomIconData::new(dom)));
+}
+
 pub fn register_font_icon(provider: &mut IconProviderHandle, pack_name: &str, icon_name: &str, font: FontRef, icon_char: &str) {
     let data = FontIconData { 
         font, 
@@ -550,12 +599,12 @@ mod tests {
     #[test]
     fn test_default_resolver_no_data() {
         let style = SystemStyle::default();
-        let original = StyledDom::default();
-        
+        let original = Dom::create_div().root;
+
         let result = default_icon_resolver(OptionRefAny::None, &original, &style);
         
         // Without data, should return empty div StyledDom
-        assert_eq!(result.node_data.as_ref().len(), 1);
+        assert_eq!(result.children.as_ref().len(), 0);
     }
     
     #[test]
@@ -643,30 +692,27 @@ mod autotest_generated {
         s
     }
 
-    /// A "normal" original icon DOM: a single div carrying `props` as inline style.
-    fn original_with(props: Vec<CssPropertyWithConditions>) -> StyledDom {
+    /// A "normal" original icon node: a single div carrying `props` as inline style.
+    fn original_with(props: Vec<CssPropertyWithConditions>) -> NodeData {
         let mut dom = Dom::create_div();
         dom.root
             .set_css_props(CssPropertyWithConditionsVec::from_vec(props));
-        StyledDom::create(&mut dom, Css::empty())
+        dom.root
     }
 
-    /// A degenerate `StyledDom` with **zero** nodes — drives the `else` branch of
-    /// `create_{image,font}_icon_from_original`, which `StyledDom::default()` never
-    /// reaches (it always has a body node).
-    fn original_without_nodes() -> StyledDom {
-        StyledDom {
-            node_data: Vec::new().into(),
-            ..StyledDom::default()
-        }
+    /// An original icon node with NO inline styles. The resolver takes a
+    /// `NodeData` now, so "no node at all" is no longer representable - and no
+    /// longer needs to be: the old `else` branch it drove existed only because
+    /// a `StyledDom` could be empty.
+    fn original_without_nodes() -> NodeData {
+        Dom::create_div().root
     }
 
     /// Every inline property on every node of the result, in document order.
     /// (Collected across all nodes rather than `node_data[0]` so the assertions
     /// survive any future anonymous-node insertion in `StyledDom::create`.)
-    fn all_props(dom: &StyledDom) -> Vec<CssPropertyWithConditions> {
-        dom.node_data
-            .as_ref()
+    fn all_props(dom: &Dom) -> Vec<CssPropertyWithConditions> {
+        all_nodes(dom)
             .iter()
             .flat_map(|nd| {
                 nd.get_style()
@@ -680,14 +726,14 @@ mod autotest_generated {
             .collect()
     }
 
-    fn width_px(dom: &StyledDom) -> Option<f32> {
+    fn width_px(dom: &Dom) -> Option<f32> {
         all_props(dom).into_iter().find_map(|p| match p.property {
             CssProperty::Width(CssPropertyValue::Exact(LayoutWidth::Px(px))) => Some(px.number.get()),
             _ => None,
         })
     }
 
-    fn height_px(dom: &StyledDom) -> Option<f32> {
+    fn height_px(dom: &Dom) -> Option<f32> {
         all_props(dom).into_iter().find_map(|p| match p.property {
             CssProperty::Height(CssPropertyValue::Exact(LayoutHeight::Px(px))) => {
                 Some(px.number.get())
@@ -696,26 +742,35 @@ mod autotest_generated {
         })
     }
 
-    fn count_widths(dom: &StyledDom) -> usize {
+    fn count_widths(dom: &Dom) -> usize {
         all_props(dom)
             .iter()
             .filter(|p| matches!(p.property, CssProperty::Width(_)))
             .count()
     }
 
-    fn text_of(dom: &StyledDom) -> Option<String> {
-        dom.node_data
-            .as_ref()
-            .iter()
-            .find_map(|nd| match nd.get_node_type() {
-                NodeType::Text(t) => Some(t.as_str().to_string()),
-                _ => None,
-            })
+    /// Every node of a `Dom` tree, in document order.
+    fn all_nodes(dom: &Dom) -> Vec<NodeData> {
+        let mut out = Vec::new();
+        fn walk(d: &Dom, out: &mut Vec<NodeData>) {
+            out.push(d.root.clone());
+            for c in d.children.as_ref() {
+                walk(c, out);
+            }
+        }
+        walk(dom, &mut out);
+        out
     }
 
-    fn has_image_node(dom: &StyledDom) -> bool {
-        dom.node_data
-            .as_ref()
+    fn text_of(dom: &Dom) -> Option<String> {
+        all_nodes(dom).iter().find_map(|nd| match nd.get_node_type() {
+            NodeType::Text(t) => Some(t.as_str().to_string()),
+            _ => None,
+        })
+    }
+
+    fn has_image_node(dom: &Dom) -> bool {
+        all_nodes(dom)
             .iter()
             .any(|nd| matches!(nd.get_node_type(), NodeType::Image(_)))
     }
@@ -739,7 +794,7 @@ mod autotest_generated {
         })
     }
 
-    fn resolve(data: RefAny, original: &StyledDom, style: &SystemStyle) -> StyledDom {
+    fn resolve(data: RefAny, original: &NodeData, style: &SystemStyle) -> Dom {
         default_icon_resolver(OptionRefAny::Some(data), original, style)
     }
 
@@ -751,12 +806,12 @@ mod autotest_generated {
     fn resolver_none_yields_single_unstyled_div() {
         let out = default_icon_resolver(
             OptionRefAny::None,
-            &StyledDom::default(),
+            &Dom::create_div().root,
             &SystemStyle::default(),
         );
-        assert_eq!(out.node_data.as_ref().len(), 1);
+        assert_eq!(all_nodes(&out).len(), 1);
         assert!(matches!(
-            out.node_data.as_ref()[0].get_node_type(),
+            out.root.get_node_type(),
             NodeType::Div
         ));
         // The "not found" placeholder must carry no styling at all — in particular
@@ -772,11 +827,11 @@ mod autotest_generated {
             _payload: [u64; 4],
         }
         let data = RefAny::new(NotAnIconAtAll { _payload: [7; 4] });
-        let out = resolve(data, &StyledDom::default(), &SystemStyle::default());
+        let out = resolve(data, &Dom::create_div().root, &SystemStyle::default());
 
-        assert_eq!(out.node_data.as_ref().len(), 1);
+        assert_eq!(all_nodes(&out).len(), 1);
         assert!(matches!(
-            out.node_data.as_ref()[0].get_node_type(),
+            out.root.get_node_type(),
             NodeType::Div
         ));
         assert!(!has_image_node(&out));
@@ -787,7 +842,7 @@ mod autotest_generated {
     fn resolver_image_icon_yields_image_node_with_default_dimensions() {
         let out = resolve(
             RefAny::new(image_icon(32.0, 24.0)),
-            &StyledDom::default(),
+            &Dom::create_div().root,
             &SystemStyle::default(),
         );
         assert!(has_image_node(&out));
@@ -802,18 +857,18 @@ mod autotest_generated {
             font: font.clone(),
             icon_char: "\u{e88a}".to_string(),
         });
-        let out = resolve(data, &StyledDom::default(), &SystemStyle::default());
+        let out = resolve(data, &Dom::create_div().root, &SystemStyle::default());
 
         // TWO nodes: the <span> and its text leaf. It was one when the glyph
         // was a BARE text node — which is what made its css inert and left it
         // competing as a flex item with no box ("text node ... is one of 2
         // items in a InlineFlex container"). The span is the box; the glyph
         // still reads through it.
-        assert_eq!(out.node_data.as_ref().len(), 2);
+        assert_eq!(all_nodes(&out).len(), 2);
         assert_eq!(text_of(&out).as_deref(), Some("\u{e88a}"));
         assert!(
             matches!(
-                out.node_data.as_ref()[0].get_node_type(),
+                out.root.get_node_type(),
                 azul_core::dom::NodeType::Span
             ),
             "the icon must be wrapped in a span — inline, and boxed"
@@ -869,7 +924,7 @@ mod autotest_generated {
         // so a NaN-sized icon degrades to a 0x0 box rather than poisoning layout.
         let out = resolve(
             RefAny::new(image_icon(f32::NAN, f32::NAN)),
-            &StyledDom::default(),
+            &Dom::create_div().root,
             &SystemStyle::default(),
         );
         let (w, h) = (
@@ -885,7 +940,7 @@ mod autotest_generated {
     fn image_icon_infinite_dimensions_saturate_to_finite_values() {
         let out = resolve(
             RefAny::new(image_icon(f32::INFINITY, f32::NEG_INFINITY)),
-            &StyledDom::default(),
+            &Dom::create_div().root,
             &SystemStyle::default(),
         );
         let w = width_px(&out).expect("width emitted");
@@ -901,7 +956,7 @@ mod autotest_generated {
         // it forwards them verbatim into `width` / `height`.
         let out = resolve(
             RefAny::new(image_icon(-32.0, -1.5)),
-            &StyledDom::default(),
+            &Dom::create_div().root,
             &SystemStyle::default(),
         );
         assert_eq!(width_px(&out), Some(-32.0));
@@ -920,7 +975,7 @@ mod autotest_generated {
             null_img(usize::MAX, usize::MAX),
         );
         let data = provider.lookup("big").expect("icon registered");
-        let out = resolve(data, &StyledDom::default(), &SystemStyle::default());
+        let out = resolve(data, &Dom::create_div().root, &SystemStyle::default());
 
         let w = width_px(&out).expect("width emitted");
         assert!(w.is_finite() && w > 0.0, "usize::MAX size must saturate finitely, got {w}");
@@ -930,7 +985,7 @@ mod autotest_generated {
     fn image_icon_zero_size_is_preserved() {
         let out = resolve(
             RefAny::new(image_icon(0.0, 0.0)),
-            &StyledDom::default(),
+            &Dom::create_div().root,
             &SystemStyle::default(),
         );
         assert_eq!(width_px(&out), Some(0.0));
@@ -997,8 +1052,9 @@ mod autotest_generated {
 
     #[test]
     fn accessibility_info_is_copied_onto_the_resolved_icon() {
-        let mut dom = Dom::create_div().with_accessibility_info(SmallAriaInfo::label("Save").to_full_info());
-        let original = StyledDom::create(&mut dom, Css::empty());
+        let original = Dom::create_div()
+            .with_accessibility_info(SmallAriaInfo::label("Save").to_full_info())
+            .root;
 
         let out = resolve(
             RefAny::new(image_icon(8.0, 8.0)),
@@ -1006,9 +1062,8 @@ mod autotest_generated {
             &SystemStyle::default(),
         );
 
-        let a11y = out
-            .node_data
-            .as_ref()
+        let nodes = all_nodes(&out);
+        let a11y = nodes
             .iter()
             .find_map(NodeData::get_accessibility_info)
             .expect("a11y info must survive icon resolution");
@@ -1110,7 +1165,7 @@ mod autotest_generated {
     fn image_icon_grayscale_reaches_the_resolved_dom() {
         let out = resolve(
             RefAny::new(image_icon(10.0, 10.0)),
-            &StyledDom::default(),
+            &Dom::create_div().root,
             &grayscale_style(),
         );
         let filters = filters_of(&all_props(&out));
@@ -1167,7 +1222,7 @@ mod autotest_generated {
         // would double-apply on top of the (inherited) text color.
         let out = resolve(
             RefAny::new(font_icon("\u{e88a}")),
-            &StyledDom::default(),
+            &Dom::create_div().root,
             &grayscale_style(),
         );
         assert!(filters_of(&all_props(&out)).is_empty());
@@ -1181,7 +1236,7 @@ mod autotest_generated {
     fn font_icon_empty_char_yields_empty_text_node() {
         let out = resolve(
             RefAny::new(font_icon("")),
-            &StyledDom::default(),
+            &Dom::create_div().root,
             &SystemStyle::default(),
         );
         assert_eq!(text_of(&out).as_deref(), Some(""));
@@ -1201,7 +1256,7 @@ mod autotest_generated {
         ] {
             let out = resolve(
                 RefAny::new(font_icon(s)),
-                &StyledDom::default(),
+                &Dom::create_div().root,
                 &SystemStyle::default(),
             );
             assert_eq!(text_of(&out).as_deref(), Some(s), "icon_char {s:?} was altered");
@@ -1213,7 +1268,7 @@ mod autotest_generated {
         let huge = "\u{e88a}".repeat(65_536);
         let out = resolve(
             RefAny::new(font_icon(&huge)),
-            &StyledDom::default(),
+            &Dom::create_div().root,
             &SystemStyle::default(),
         );
         assert_eq!(text_of(&out).map(|s| s.chars().count()), Some(65_536));
@@ -1238,7 +1293,7 @@ mod autotest_generated {
         assert!(provider.has_icon("hOmE"));
 
         let data = provider.lookup("HOME").expect("case-insensitive lookup");
-        let out = resolve(data, &StyledDom::default(), &SystemStyle::default());
+        let out = resolve(data, &Dom::create_div().root, &SystemStyle::default());
         assert_eq!(width_px(&out), Some(64.0));
         assert_eq!(height_px(&out), Some(32.0));
     }
@@ -1251,7 +1306,7 @@ mod autotest_generated {
         assert_eq!(provider.list_packs(), vec![String::new()]);
         assert!(provider.has_icon(""));
         let data = provider.lookup("").expect("empty-named icon is still addressable");
-        let out = resolve(data, &StyledDom::default(), &SystemStyle::default());
+        let out = resolve(data, &Dom::create_div().root, &SystemStyle::default());
         assert_eq!(text_of(&out).as_deref(), Some(""));
     }
 
@@ -1280,7 +1335,7 @@ mod autotest_generated {
         register_image_icon(&mut provider, "aaa", "dup", null_img(2, 2));
 
         let data = provider.lookup("dup").expect("icon registered");
-        let out = resolve(data, &StyledDom::default(), &SystemStyle::default());
+        let out = resolve(data, &Dom::create_div().root, &SystemStyle::default());
         assert_eq!(
             width_px(&out),
             Some(2.0),
@@ -1296,7 +1351,7 @@ mod autotest_generated {
 
         assert_eq!(provider.list_icons_in_pack("p").len(), 1);
         let data = provider.lookup("icon").expect("icon registered");
-        let out = resolve(data, &StyledDom::default(), &SystemStyle::default());
+        let out = resolve(data, &Dom::create_div().root, &SystemStyle::default());
         assert_eq!(width_px(&out), Some(5.0));
 
         provider.unregister_icon("p", "IcOn");
@@ -1313,10 +1368,10 @@ mod autotest_generated {
 
         let out = default_icon_resolver(
             OptionRefAny::from(provider.lookup("nope")),
-            &StyledDom::default(),
+            &Dom::create_div().root,
             &SystemStyle::default(),
         );
-        assert_eq!(out.node_data.as_ref().len(), 1);
+        assert_eq!(all_nodes(&out).len(), 1);
         assert!(all_props(&out).is_empty());
     }
 
@@ -1386,7 +1441,7 @@ mod autotest_generated {
         assert!(provider.has_icon("HOME"));
 
         let data = provider.lookup("home").expect("material 'home' icon");
-        let out = resolve(data, &StyledDom::default(), &SystemStyle::default());
+        let out = resolve(data, &Dom::create_div().root, &SystemStyle::default());
         assert!(text_of(&out).is_some(), "a material icon must resolve to a text node");
     }
 }

--- a/layout/src/lib.rs
+++ b/layout/src/lib.rs
@@ -498,6 +498,11 @@ pub mod thread;
 // Scoped (was crate-wide): hand-written `Ord`/`PartialOrd` on a timer type.
 #[allow(clippy::non_canonical_partial_ord_impl)]
 pub mod timer;
+/// Render an icon-registry entry to RGBA pixels, for the system tray.
+/// Goes through the same `<icon>` resolution + CPU renderer, so every icon
+/// kind (and any future DOM-expressible one) works without a special case.
+#[cfg(all(feature = "text_layout", feature = "std"))]
+pub mod tray_icon;
 /// Scroll physics timer for momentum-based smooth scrolling.
 #[cfg(feature = "text_layout")]
 pub mod scroll_timer;

--- a/layout/src/lib.rs
+++ b/layout/src/lib.rs
@@ -421,7 +421,7 @@ pub use icon::{
 // Re-export core icon types
 pub use azul_core::icon::{
     IconProviderHandle, IconResolverCallbackType,
-    resolve_icons_in_styled_dom, OptionIconProviderHandle,
+    resolve_icons_in_dom, OptionIconProviderHandle,
 };
 
 /// Callback handling for layout events (invocation, result processing).

--- a/layout/src/text3/cache.rs
+++ b/layout/src/text3/cache.rs
@@ -801,7 +801,7 @@ impl FontContext {
             parsed_fonts: self.parsed_fonts.clone(),
             condemned_fonts: Arc::new(Mutex::new(CondemnedFonts::default())),
             font_chain_cache: self.font_chain_cache.clone(),
-            embedded_fonts: Mutex::new(self.embedded_fonts.clone()),
+            embedded_fonts: Arc::new(Mutex::new(self.embedded_fonts.clone())),
             font_hash_to_families: self.font_hash_to_families.clone(),
             registry: self.registry.clone(),
             last_resolved_font_stacks_sig: None,
@@ -954,7 +954,13 @@ pub struct FontManager<T> {
     pub font_chain_cache: HashMap<FontChainKey, rust_fontconfig::FontFallbackChain>,
     /// Cache for direct `FontRefs` (embedded fonts like Material Icons)
     /// These are fonts referenced via `FontStack::Ref` that bypass fontconfig
-    pub embedded_fonts: Mutex<HashMap<u64, azul_css::props::basic::FontRef>>,
+    /// Faces handed to us directly by the DOM as `StyleFontFamily::Ref`
+    /// (Material Icons and every other `FontStack::Ref`).
+    ///
+    /// `Arc<Mutex<..>>`, NOT `Mutex<..>`, and that is load-bearing: this pool
+    /// must be SHARED by every manager cloned from this one, exactly like
+    /// `parsed_fonts` above. See `clone_shared`.
+    pub embedded_fonts: Arc<Mutex<HashMap<u64, azul_css::props::basic::FontRef>>>,
     /// Reverse map: `font_family_hash` → actual `StyleFontFamilyVec`.
     /// Accumulated across DOMs. Used by font collection and text shaping to
     /// resolve compact cache hashes without `get_property_slow`.
@@ -1011,12 +1017,19 @@ impl<T: ParsedFontTrait> FontManager<T> {
             parsed_fonts: Arc::clone(&self.parsed_fonts),
             condemned_fonts: Arc::clone(&self.condemned_fonts),
             font_chain_cache: self.font_chain_cache.clone(),
-            embedded_fonts: Mutex::new(
-                self.embedded_fonts
-                    .lock()
-                    .map(|m| m.clone())
-                    .unwrap_or_default(),
-            ),
+            // SHARED, not copied. This used to be
+            // `Mutex::new(self.embedded_fonts.lock().map(|m| m.clone())...)`,
+            // i.e. a fork: a face registered in one manager was invisible to
+            // every other, even though this method is documented as sharing
+            // font data and `parsed_fonts` right above genuinely does.
+            //
+            // That fork is a silent-tofu generator. Whoever registers an
+            // embedded face (the DOM's `StyleFontFamily::Ref`) and whoever
+            // later shapes with it are frequently different managers - a child
+            // window, a tray icon, an off-screen render - and the shaper then
+            // falls back to a system face with no glyph at the icon's
+            // private-use codepoint. Every step reports success.
+            embedded_fonts: Arc::clone(&self.embedded_fonts),
             font_hash_to_families: self.font_hash_to_families.clone(),
             registry: self.registry.clone(),
             // Deliberately reset: the sig gates a chain-resolver skip that is
@@ -1036,7 +1049,7 @@ impl<T: ParsedFontTrait> FontManager<T> {
             parsed_fonts: Arc::new(Mutex::new(HashMap::new())),
             condemned_fonts: Arc::new(Mutex::new(CondemnedFonts::default())),
             font_chain_cache: HashMap::new(),
-            embedded_fonts: Mutex::new(HashMap::new()),
+            embedded_fonts: Arc::new(Mutex::new(HashMap::new())),
             font_hash_to_families: HashMap::new(),
             registry: None,
             last_resolved_font_stacks_sig: None,
@@ -1340,7 +1353,7 @@ impl<T: ParsedFontTrait> FontManager<T> {
             parsed_fonts,
             condemned_fonts: Arc::new(Mutex::new(CondemnedFonts::default())),
             font_chain_cache: HashMap::new(),
-            embedded_fonts: Mutex::new(HashMap::new()),
+            embedded_fonts: Arc::new(Mutex::new(HashMap::new())),
             font_hash_to_families: HashMap::new(),
             registry: None,
             last_resolved_font_stacks_sig: None,
@@ -12894,6 +12907,48 @@ mod font_cache_swap_tests {
                 );
             }
         }
+    }
+
+    /// REGRESSION: `clone_shared` used to FORK `embedded_fonts` rather than
+    /// share it, so a face registered in one manager was invisible to every
+    /// other one cloned from it.
+    ///
+    /// That is a silent-tofu generator, because the manager that REGISTERS an
+    /// embedded face and the one that later SHAPES with it are routinely
+    /// different objects - a child window, a tray icon, an off-screen render.
+    /// When they disagree the shaper falls back to a system face with no glyph
+    /// at the icon's private-use codepoint and draws `.notdef`, while every
+    /// step in between reports success.
+    ///
+    /// BOTH directions are asserted on purpose: `Arc::clone` is the only
+    /// implementation that gives you parent->child AND child->parent, so a
+    /// one-directional test would still pass against a copy-on-clone.
+    #[test]
+    fn embedded_fonts_are_shared_between_cloned_managers_in_both_directions() {
+        static A: u8 = 0;
+        static B: u8 = 0;
+        extern "C" fn noop(_: *mut core::ffi::c_void) {}
+
+        let parent: FontManager<FontRef> =
+            FontManager::new(FcFontCache::default()).expect("FontManager::new must not fail");
+        let child = parent.clone_shared();
+
+        let from_parent =
+            FontRef::new(core::ptr::addr_of!(A).cast::<core::ffi::c_void>(), noop);
+        let from_child =
+            FontRef::new(core::ptr::addr_of!(B).cast::<core::ffi::c_void>(), noop);
+
+        parent.register_embedded_font(&from_parent);
+        child.register_embedded_font(&from_child);
+
+        assert!(
+            child.resolve_font_by_hash(from_parent.get_hash()).is_some(),
+            "a face registered on the PARENT must be visible to a clone"
+        );
+        assert!(
+            parent.resolve_font_by_hash(from_child.get_hash()).is_some(),
+            "a face registered on a CLONE must be visible to the parent"
+        );
     }
 
     #[test]

--- a/layout/src/tray_icon.rs
+++ b/layout/src/tray_icon.rs
@@ -14,7 +14,7 @@
 //! returns tomorrow.
 //!
 //! So instead this does what an `<icon>` node does: build a one-node icon DOM,
-//! run the SAME `resolve_icons_in_styled_dom` pass, and render the resulting
+//! run the SAME `resolve_icons_in_dom` pass, and render the resulting
 //! `StyledDom` with the CPU renderer. Every icon kind is handled because none
 //! of them is special-cased — and anything a future resolver can express as a
 //! DOM (an SVG, an emoji, a styled `<div>`) becomes a usable tray icon for
@@ -27,7 +27,7 @@ use alloc::{string::String, vec::Vec};
 
 use azul_core::{
     dom::Dom,
-    icon::{resolve_icons_in_styled_dom, SharedIconProvider},
+    icon::{resolve_icons_in_dom, SharedIconProvider},
     styled_dom::StyledDom,
 };
 use azul_css::{
@@ -115,13 +115,20 @@ pub fn render_icon_to_rgba(
     let dom = Dom::create_icon(String::from(spec))
         .with_css_props(CssPropertyWithConditionsVec::from_vec(props));
 
+    // Icons resolve on the Dom, BEFORE the cascade, so the replacement is
+    // spliced in whole and cascaded exactly once with everything else. Doing it
+    // the other way round - cascade, then splice into the flat StyledDom arena -
+    // is what used to flatten every icon to a single node and leave the property
+    // cache describing the pre-resolution node.
+    let mut dom = dom;
+    resolve_icons_in_dom(&mut dom, provider, system_style);
+
     // `create_from_dom`, NOT `create(&mut dom, Css::empty())`: the former also
     // runs `fixup_children_estimated` + `scope_inline_css` and collects the
     // tree's inline CSS, which is what the engine's own layout path
     // (`regenerate_layout`) uses. Building the StyledDom the other way produces
     // a subtly different property cache and the icon does not resolve the same.
-    let mut styled = StyledDom::create_from_dom(dom);
-    resolve_icons_in_styled_dom(&mut styled, provider, system_style);
+    let styled = StyledDom::create_from_dom(dom);
 
     // The caller's FontManager, NOT a fresh one.
     //
@@ -220,7 +227,7 @@ mod tests {
 
     /// REGRESSION (tray icons rendered as `.notdef` tofu boxes).
     ///
-    /// `resolve_icons_in_styled_dom` rewrites a font icon's inline style to
+    /// `resolve_icons_in_dom` rewrites a font icon's inline style to
     /// carry `font-family: StyleFontFamily::Ref(face)` — the only place that
     /// face is ever named. But the compact CSS cache is precomputed at cascade
     /// time, so before the fix it still described the pre-resolution `<icon>`
@@ -261,13 +268,13 @@ mod tests {
         );
         let provider = SharedIconProvider::from_handle(handle);
 
-        let dom = Dom::create_icon(String::from("gear"));
-        let mut styled = StyledDom::create_from_dom(dom);
-        azul_core::icon::resolve_icons_in_styled_dom(
-            &mut styled,
+        let mut dom = Dom::create_icon(String::from("gear"));
+        azul_core::icon::resolve_icons_in_dom(
+            &mut dom,
             &provider,
             &SystemStyle::default(),
         );
+        let styled = StyledDom::create_from_dom(dom);
 
         let collected = crate::solver3::getters::collect_font_stacks_from_styled_dom(
             &styled,

--- a/layout/src/tray_icon.rs
+++ b/layout/src/tray_icon.rs
@@ -1,0 +1,205 @@
+//! Rendering an icon-registry entry to RGBA pixels, at any size.
+//!
+//! This exists for the system tray, which is the one consumer that needs an
+//! icon as *pixels* rather than as part of a DOM: Windows hands RGBA to
+//! `CreateIconIndirect`, macOS to `NSBitmapImageRep`, and Linux to SNI's
+//! `IconPixmap` (`a(iiay)`).
+//!
+//! # Why it goes through the DOM
+//!
+//! The obvious implementation — look up the icon, notice it is a font glyph,
+//! rasterize the glyph — would work for Material Icons and nothing else. The
+//! registry holds `ImageIconData` (image packs loaded from a ZIP) and
+//! `FontIconData` (Material Icons) today, and whatever a custom resolver
+//! returns tomorrow.
+//!
+//! So instead this does what an `<icon>` node does: build a one-node icon DOM,
+//! run the SAME `resolve_icons_in_styled_dom` pass, and render the resulting
+//! `StyledDom` with the CPU renderer. Every icon kind is handled because none
+//! of them is special-cased — and anything a future resolver can express as a
+//! DOM (an SVG, an emoji, a styled `<div>`) becomes a usable tray icon for
+//! free, with no change here.
+//!
+//! It also means a tray icon and an in-DOM `<icon>` of the same spec can never
+//! disagree: they are literally the same code path up to rasterization.
+
+use alloc::{string::String, vec::Vec};
+
+use azul_core::{
+    dom::Dom,
+    icon::{resolve_icons_in_styled_dom, SharedIconProvider},
+    styled_dom::StyledDom,
+};
+use azul_css::{
+    css::{Css, CssPropertyValue},
+    dynamic_selector::{CssPropertyWithConditions, CssPropertyWithConditionsVec},
+    props::{
+        basic::{ColorU, StyleFontSize},
+        layout::{LayoutHeight, LayoutWidth},
+        property::CssProperty,
+        style::text::StyleTextColor,
+    },
+    system::SystemStyle,
+};
+
+/// A rendered icon: device-pixel dimensions plus straight RGBA8, top row first.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RenderedIcon {
+    pub width: u32,
+    pub height: u32,
+    /// `width * height * 4` bytes, non-premultiplied RGBA8.
+    pub rgba: Vec<u8>,
+}
+
+/// Render an icon spec to an RGBA bitmap of `size_px` square.
+///
+/// `spec` is exactly what an `<icon>` node takes: a bare name (`"settings"`),
+/// a pack-qualified name (`"mypack:logo"`), or a comma-separated fallback list.
+/// Parsing it is the registry's job — this passes it through untouched so that
+/// a tray icon and an `<icon>` can never resolve differently.
+///
+/// The background is fully transparent, which is what all three tray backends
+/// want. Note the consequence for **Material Icons specifically**: they resolve
+/// to a text node whose colour comes from the cascade, and the default is
+/// opaque black. That is correct for a light menu bar / taskbar and invisible
+/// on a dark one. Callers that know the tray's background — macOS, where a
+/// template image is tinted by AppKit anyway — should pass `tint`.
+///
+/// Returns `None` if the spec resolves to nothing (an unregistered icon), or if
+/// the renderer fails.
+#[must_use]
+pub fn render_icon_to_rgba(
+    spec: &str,
+    size_px: u32,
+    provider: &SharedIconProvider,
+    system_style: &SystemStyle,
+    tint: Option<ColorU>,
+) -> Option<RenderedIcon> {
+    use crate::{
+        cpurender::{render_component_preview, ComponentPreviewOptions},
+        font::loading::build_font_cache,
+        font_traits::FontManager,
+    };
+
+    if size_px == 0 || spec.is_empty() {
+        return None;
+    }
+
+    // Cheap reject before doing any layout work: an unregistered spec would
+    // otherwise resolve to an empty div and render a fully transparent square,
+    // which the caller cannot distinguish from a legitimately blank icon.
+    if !spec_resolves(spec, provider) {
+        return None;
+    }
+
+    #[allow(clippy::cast_precision_loss)] // icon sizes are small
+    let size = size_px as f32;
+
+    let mut props = alloc::vec![
+        CssPropertyWithConditions::simple(CssProperty::Width(CssPropertyValue::Exact(
+            LayoutWidth::px(size)
+        ))),
+        CssPropertyWithConditions::simple(CssProperty::Height(CssPropertyValue::Exact(
+            LayoutHeight::px(size)
+        ))),
+        // A font icon resolves to TEXT, and a glyph is sized by font-size, not
+        // by its box — without this the box would be size_px and the glyph
+        // whatever the cascade's default font-size happens to be.
+        CssPropertyWithConditions::simple(CssProperty::FontSize(CssPropertyValue::Exact(
+            StyleFontSize::px(size)
+        ))),
+    ];
+    if let Some(c) = tint {
+        props.push(CssPropertyWithConditions::simple(CssProperty::TextColor(
+            CssPropertyValue::Exact(StyleTextColor { inner: c }),
+        )));
+    }
+
+    let mut dom = Dom::create_icon(String::from(spec))
+        .with_css_props(CssPropertyWithConditionsVec::from_vec(props));
+
+    let mut styled = StyledDom::create(&mut dom, Css::empty());
+    resolve_icons_in_styled_dom(&mut styled, provider, system_style);
+
+    let fc_cache = build_font_cache();
+    let font_manager = FontManager::new(fc_cache).ok()?;
+
+    let result = render_component_preview(
+        &styled,
+        &font_manager,
+        ComponentPreviewOptions {
+            width: Some(size),
+            height: Some(size),
+            dpi_factor: 1.0,
+            // Transparent, NOT the white the preview renderer defaults to — a
+            // tray icon composited over a white square is a white square.
+            background_color: ColorU { r: 0, g: 0, b: 0, a: 0 },
+        },
+        None,
+    )
+    .ok()?;
+
+    if result.rgba.is_empty() || result.pixel_width == 0 || result.pixel_height == 0 {
+        return None;
+    }
+
+    Some(RenderedIcon {
+        width: result.pixel_width,
+        height: result.pixel_height,
+        rgba: result.rgba,
+    })
+}
+
+/// Does any pack hold this spec? Mirrors the registry's own lookup, including
+/// the comma-separated fallback list, so a spec that `<icon>` would resolve is
+/// never rejected here.
+fn spec_resolves(spec: &str, provider: &SharedIconProvider) -> bool {
+    spec.split(',').any(|alt| {
+        let alt = alt.trim();
+        !alt.is_empty() && provider.lookup(alt).is_some()
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use azul_core::icon::{IconProviderHandle, SharedIconProvider};
+
+    fn empty_provider() -> SharedIconProvider {
+        SharedIconProvider::from_handle(IconProviderHandle::new())
+    }
+
+    #[test]
+    fn degenerate_inputs_are_rejected_before_any_layout_work() {
+        let p = empty_provider();
+        let s = SystemStyle::default();
+        assert!(render_icon_to_rgba("settings", 0, &p, &s, None).is_none());
+        assert!(render_icon_to_rgba("", 16, &p, &s, None).is_none());
+    }
+
+    #[test]
+    fn an_unregistered_spec_is_none_not_a_blank_square() {
+        // The distinction matters: resolution turns an unknown icon into an
+        // empty div, which renders as a fully transparent square. Returning
+        // that as Some() would put an invisible icon in the tray and look
+        // exactly like a working one.
+        let p = empty_provider();
+        assert!(render_icon_to_rgba("definitely_not_registered", 16, &p, &SystemStyle::default(), None).is_none());
+    }
+
+    #[test]
+    fn spec_resolution_honours_the_fallback_list() {
+        use azul_core::refany::RefAny;
+        let mut h = IconProviderHandle::new();
+        h.register_icon("testpack", "logo", RefAny::new(1u8));
+        let p = SharedIconProvider::from_handle(h);
+
+        assert!(spec_resolves("logo", &p));
+        assert!(spec_resolves("testpack:logo", &p));
+        // First alternative missing, second present — must still resolve.
+        assert!(spec_resolves("missing:x, logo", &p));
+        assert!(!spec_resolves("missing:x", &p));
+        assert!(!spec_resolves("", &p));
+        assert!(!spec_resolves(" , ", &p));
+    }
+}

--- a/layout/src/tray_icon.rs
+++ b/layout/src/tray_icon.rs
@@ -106,16 +106,44 @@ pub fn render_icon_to_rgba(
             StyleFontSize::px(size)
         ))),
     ];
+    // Seed the icon's own font into the cascade, BEFORE the StyledDom is built.
+    //
+    // This is the difference between a visible icon and a `.notdef` tofu box.
+    // `resolve_icons_in_styled_dom` writes the resolved font family into the
+    // node's INLINE style (`apply_cached_resolution` -> `node.set_style`) and
+    // its `styled_nodes` entry, but it does NOT touch the CSS property cache -
+    // which was cascaded when the StyledDom was built and still describes the
+    // original `<icon>` node. `collect_font_stacks_from_styled_dom` reads that
+    // cache, so the resolver's `StyleFontFamily::Ref(font)` is invisible to it:
+    // measured, zero FontRefs are collected, nothing is registered as an
+    // embedded font, and the shaper falls back to a system face with no glyph
+    // at the icon's private-use codepoint.
+    //
+    // Putting the family in before the cascade makes it visible to collection,
+    // registration and shaping alike. Resolution still supplies the GLYPH.
+    if let Some(font) = font_of_spec(spec, provider) {
+        props.push(CssPropertyWithConditions::simple(CssProperty::FontFamily(
+            CssPropertyValue::Exact(azul_css::props::basic::StyleFontFamilyVec::from_vec(
+                alloc::vec![azul_css::props::basic::StyleFontFamily::Ref(font)],
+            )),
+        )));
+    }
+
     if let Some(c) = tint {
         props.push(CssPropertyWithConditions::simple(CssProperty::TextColor(
             CssPropertyValue::Exact(StyleTextColor { inner: c }),
         )));
     }
 
-    let mut dom = Dom::create_icon(String::from(spec))
+    let dom = Dom::create_icon(String::from(spec))
         .with_css_props(CssPropertyWithConditionsVec::from_vec(props));
 
-    let mut styled = StyledDom::create(&mut dom, Css::empty());
+    // `create_from_dom`, NOT `create(&mut dom, Css::empty())`: the former also
+    // runs `fixup_children_estimated` + `scope_inline_css` and collects the
+    // tree's inline CSS, which is what the engine's own layout path
+    // (`regenerate_layout`) uses. Building the StyledDom the other way produces
+    // a subtly different property cache and the icon does not resolve the same.
+    let mut styled = StyledDom::create_from_dom(dom);
     resolve_icons_in_styled_dom(&mut styled, provider, system_style);
 
     // The caller's FontManager, NOT a fresh one.
@@ -172,6 +200,28 @@ pub fn render_icon_to_rgba(
         height: result.pixel_height,
         rgba: result.rgba,
     })
+}
+
+/// The `FontRef` behind a font-backed icon spec, if it is one.
+///
+/// An image-backed icon (`ImageIconData`) has no font and returns `None`; it
+/// needs no seeding because it resolves to an image node, not to text.
+fn font_of_spec(
+    spec: &str,
+    provider: &SharedIconProvider,
+) -> Option<azul_css::props::basic::FontRef> {
+    for alt in spec.split(',') {
+        let alt = alt.trim();
+        if alt.is_empty() {
+            continue;
+        }
+        if let Some(mut data) = provider.lookup(alt) {
+            if let Some(f) = data.downcast_ref::<crate::icon::FontIconData>() {
+                return Some(f.font.clone());
+            }
+        }
+    }
+    None
 }
 
 /// Does any pack hold this spec? Mirrors the registry's own lookup, including

--- a/layout/src/tray_icon.rs
+++ b/layout/src/tray_icon.rs
@@ -106,29 +106,6 @@ pub fn render_icon_to_rgba(
             StyleFontSize::px(size)
         ))),
     ];
-    // Seed the icon's own font into the cascade, BEFORE the StyledDom is built.
-    //
-    // This is the difference between a visible icon and a `.notdef` tofu box.
-    // `resolve_icons_in_styled_dom` writes the resolved font family into the
-    // node's INLINE style (`apply_cached_resolution` -> `node.set_style`) and
-    // its `styled_nodes` entry, but it does NOT touch the CSS property cache -
-    // which was cascaded when the StyledDom was built and still describes the
-    // original `<icon>` node. `collect_font_stacks_from_styled_dom` reads that
-    // cache, so the resolver's `StyleFontFamily::Ref(font)` is invisible to it:
-    // measured, zero FontRefs are collected, nothing is registered as an
-    // embedded font, and the shaper falls back to a system face with no glyph
-    // at the icon's private-use codepoint.
-    //
-    // Putting the family in before the cascade makes it visible to collection,
-    // registration and shaping alike. Resolution still supplies the GLYPH.
-    if let Some(font) = font_of_spec(spec, provider) {
-        props.push(CssPropertyWithConditions::simple(CssProperty::FontFamily(
-            CssPropertyValue::Exact(azul_css::props::basic::StyleFontFamilyVec::from_vec(
-                alloc::vec![azul_css::props::basic::StyleFontFamily::Ref(font)],
-            )),
-        )));
-    }
-
     if let Some(c) = tint {
         props.push(CssPropertyWithConditions::simple(CssProperty::TextColor(
             CssPropertyValue::Exact(StyleTextColor { inner: c }),
@@ -202,28 +179,6 @@ pub fn render_icon_to_rgba(
     })
 }
 
-/// The `FontRef` behind a font-backed icon spec, if it is one.
-///
-/// An image-backed icon (`ImageIconData`) has no font and returns `None`; it
-/// needs no seeding because it resolves to an image node, not to text.
-fn font_of_spec(
-    spec: &str,
-    provider: &SharedIconProvider,
-) -> Option<azul_css::props::basic::FontRef> {
-    for alt in spec.split(',') {
-        let alt = alt.trim();
-        if alt.is_empty() {
-            continue;
-        }
-        if let Some(mut data) = provider.lookup(alt) {
-            if let Some(f) = data.downcast_ref::<crate::icon::FontIconData>() {
-                return Some(f.font.clone());
-            }
-        }
-    }
-    None
-}
-
 /// Does any pack hold this spec? Mirrors the registry's own lookup, including
 /// the comma-separated fallback list, so a spec that `<icon>` would resolve is
 /// never rejected here.
@@ -261,6 +216,68 @@ mod tests {
         assert!(!spec_resolves("missing:x", &p));
         assert!(!spec_resolves("", &p));
         assert!(!spec_resolves(" , ", &p));
+    }
+
+    /// REGRESSION (tray icons rendered as `.notdef` tofu boxes).
+    ///
+    /// `resolve_icons_in_styled_dom` rewrites a font icon's inline style to
+    /// carry `font-family: StyleFontFamily::Ref(face)` — the only place that
+    /// face is ever named. But the compact CSS cache is precomputed at cascade
+    /// time, so before the fix it still described the pre-resolution `<icon>`
+    /// node. `collect_font_stacks_from_styled_dom` reads that cache, so it
+    /// never saw the `Ref`, never registered the face as an embedded font, and
+    /// shaping silently fell back to a system face with no glyph at the icon's
+    /// private-use codepoint.
+    ///
+    /// The invariant this pins: **after resolving a font-backed icon, the face
+    /// is visible to font-stack collection.** Everything downstream — embedded
+    /// registration, shaping, rasterisation — depends on it, and every one of
+    /// those steps reported success while producing a tofu box, so this is the
+    /// only place the failure is cheap to catch.
+    #[test]
+    fn resolving_a_font_icon_leaves_its_face_visible_to_font_collection() {
+        use azul_core::{
+            dom::Dom, icon::IconProviderHandle, refany::RefAny, styled_dom::StyledDom,
+        };
+        use azul_css::{css::Css, props::basic::FontRef};
+
+        // A FontRef needs no real font data here: collection only reports which
+        // faces are referenced, it does not parse them.
+        static DUMMY: u8 = 0;
+        extern "C" fn noop(_: *mut core::ffi::c_void) {}
+        let face = FontRef::new(
+            core::ptr::addr_of!(DUMMY).cast::<core::ffi::c_void>(),
+            noop,
+        );
+
+        let mut handle = IconProviderHandle::with_resolver(crate::icon::default_icon_resolver);
+        handle.register_icon(
+            "testpack",
+            "gear",
+            RefAny::new(crate::icon::FontIconData {
+                font: face.clone(),
+                icon_char: "\u{e8b8}".into(),
+            }),
+        );
+        let provider = SharedIconProvider::from_handle(handle);
+
+        let dom = Dom::create_icon(String::from("gear"));
+        let mut styled = StyledDom::create_from_dom(dom);
+        azul_core::icon::resolve_icons_in_styled_dom(
+            &mut styled,
+            &provider,
+            &SystemStyle::default(),
+        );
+
+        let collected = crate::solver3::getters::collect_font_stacks_from_styled_dom(
+            &styled,
+            &SystemStyle::default().platform,
+        );
+        assert!(
+            !collected.font_refs.is_empty(),
+            "the resolved icon's FontRef must reach font-stack collection; \
+             an empty set is the tofu-box bug (stale compact cache)"
+        );
     }
 
     #[test]

--- a/layout/src/tray_icon.rs
+++ b/layout/src/tray_icon.rs
@@ -74,12 +74,9 @@ pub fn render_icon_to_rgba(
     provider: &SharedIconProvider,
     system_style: &SystemStyle,
     tint: Option<ColorU>,
+    font_manager: &crate::font_traits::FontManager<azul_css::props::basic::FontRef>,
 ) -> Option<RenderedIcon> {
-    use crate::{
-        cpurender::{render_component_preview, ComponentPreviewOptions},
-        font::loading::build_font_cache,
-        font_traits::FontManager,
-    };
+    use crate::cpurender::{render_component_preview, ComponentPreviewOptions};
 
     if size_px == 0 || spec.is_empty() {
         return None;
@@ -121,8 +118,27 @@ pub fn render_icon_to_rgba(
     let mut styled = StyledDom::create(&mut dom, Css::empty());
     resolve_icons_in_styled_dom(&mut styled, provider, system_style);
 
-    let fc_cache = build_font_cache();
-    let font_manager = FontManager::new(fc_cache).ok()?;
+    // The caller's FontManager, NOT a fresh one.
+    //
+    // Building one here (`FontManager::new(build_font_cache())`) creates a
+    // second, disconnected font universe: a `FontManager` shapes from TWO pools
+    // — `parsed_fonts` (resolved by family NAME out of the system font cache)
+    // and `embedded_fonts` (handed over directly as `StyleFontFamily::Ref`) —
+    // and Material Icons live in the SECOND, because
+    // `create_font_icon_from_original` styles the glyph with
+    // `StyleFontFamily::Ref(font)` rather than a family name. A fresh manager
+    // has that pool empty, so every icon shaped to `.notdef` and the tray got a
+    // tofu box, with every intermediate step reporting success. Same shape as
+    // the 0.2.0 CPU-renderer failure documented on
+    // `FontManager::resolve_font_by_hash`.
+    //
+    // Registering the DOM's embedded fonts is still needed for a manager that
+    // has not seen this particular icon font yet; it is idempotent.
+    crate::solver3::getters::register_embedded_fonts_from_styled_dom(
+        &styled,
+        font_manager,
+        &system_style.platform,
+    );
 
     let result = render_component_preview(
         &styled,
@@ -138,6 +154,14 @@ pub fn render_icon_to_rgba(
         None,
     )
     .ok()?;
+
+    // A wrong-looking tray icon is otherwise almost impossible to diagnose: it
+    // is a 36px image inside the menu bar, and every intermediate step reports
+    // success. `AZ_TRAY_ICON_DUMP=<dir>` writes the exact bitmap we hand the OS.
+    if let Ok(dir) = std::env::var("AZ_TRAY_ICON_DUMP") {
+        let path = format!("{dir}/tray-icon-{size_px}.png");
+        let _ = std::fs::write(&path, &result.png_data);
+    }
 
     if result.rgba.is_empty() || result.pixel_width == 0 || result.pixel_height == 0 {
         return None;
@@ -165,27 +189,13 @@ mod tests {
     use super::*;
     use azul_core::icon::{IconProviderHandle, SharedIconProvider};
 
-    fn empty_provider() -> SharedIconProvider {
-        SharedIconProvider::from_handle(IconProviderHandle::new())
-    }
-
-    #[test]
-    fn degenerate_inputs_are_rejected_before_any_layout_work() {
-        let p = empty_provider();
-        let s = SystemStyle::default();
-        assert!(render_icon_to_rgba("settings", 0, &p, &s, None).is_none());
-        assert!(render_icon_to_rgba("", 16, &p, &s, None).is_none());
-    }
-
-    #[test]
-    fn an_unregistered_spec_is_none_not_a_blank_square() {
-        // The distinction matters: resolution turns an unknown icon into an
-        // empty div, which renders as a fully transparent square. Returning
-        // that as Some() would put an invisible icon in the tray and look
-        // exactly like a working one.
-        let p = empty_provider();
-        assert!(render_icon_to_rgba("definitely_not_registered", 16, &p, &SystemStyle::default(), None).is_none());
-    }
+    // `render_icon_to_rgba` itself is not unit-tested: it needs a real
+    // `FontManager`, and building one scans the system font directories, which
+    // makes the test slow and machine-dependent. Its pure precondition —
+    // "does this spec resolve at all" — is what actually decides whether the
+    // caller gets an icon or a silently-blank square, so that is what is
+    // pinned here. The rendering itself is exercised by the `tray` example
+    // plus `AZ_TRAY_ICON_DUMP`.
 
     #[test]
     fn spec_resolution_honours_the_fallback_list() {
@@ -196,10 +206,20 @@ mod tests {
 
         assert!(spec_resolves("logo", &p));
         assert!(spec_resolves("testpack:logo", &p));
-        // First alternative missing, second present — must still resolve.
+        // First alternative missing, second present - must still resolve.
         assert!(spec_resolves("missing:x, logo", &p));
         assert!(!spec_resolves("missing:x", &p));
         assert!(!spec_resolves("", &p));
         assert!(!spec_resolves(" , ", &p));
+    }
+
+    #[test]
+    fn an_unregistered_spec_does_not_resolve() {
+        // This is what stops a blank bitmap reaching the tray: resolution turns
+        // an unknown icon into an empty div, which renders as a fully
+        // TRANSPARENT square - indistinguishable from a working icon once it is
+        // 18pt in a menu bar.
+        let p = SharedIconProvider::from_handle(IconProviderHandle::new());
+        assert!(!spec_resolves("definitely_not_registered", &p));
     }
 }

--- a/layout/src/xml/mod.rs
+++ b/layout/src/xml/mod.rs
@@ -188,6 +188,31 @@ pub fn parse_xml_to_fast_dom(xml: &str) -> Result<azul_core::dom::FastDom, XmlEr
     Ok(fast_dom)
 }
 
+/// `parse_xml_to_styled_dom`, but resolving `<icon>` nodes on the way.
+///
+/// Routes through `Dom` (a real tree) rather than `FastDom`, and that is not an
+/// oversight: an icon resolves to a SUBTREE, and `FastDom` - like `StyledDom` -
+/// is a flat arena in DFS order, so a subtree cannot be spliced into it without
+/// inserting mid-arena and shifting every index after it. Resolving on the tree
+/// and cascading once is what makes an arbitrary `Dom` usable as an icon.
+///
+/// Use this whenever an icon provider is available. `parse_xml_to_styled_dom`
+/// exists for callers that have none, and differs only in that.
+///
+/// # Errors
+///
+/// Returns an `XmlError` if the XML cannot be parsed.
+pub fn parse_xml_to_styled_dom_resolving_icons(
+    xml: &str,
+    provider: &azul_core::icon::SharedIconProvider,
+    system_style: &azul_css::system::SystemStyle,
+) -> Result<StyledDom, XmlError> {
+    let parsed = parse_xml(xml)?;
+    let mut dom = dom_from_parsed_xml(parsed);
+    azul_core::icon::resolve_icons_in_dom(&mut dom, provider, system_style);
+    Ok(StyledDom::create_from_dom(dom))
+}
+
 /// Parse XML directly into `FastDom` + extracted CSS, ready for `StyledDom`.
 #[allow(clippy::cast_precision_loss)] // bounded layout/render numeric cast
 /// # Errors
@@ -2240,7 +2265,7 @@ mod autotest_generated {
     fn icon_resolution_consumes_the_spec_text_like_a_ligature_font() {
         use azul_core::{
             dom::NodeType,
-            icon::{resolve_icons_in_styled_dom, IconProviderHandle, SharedIconProvider},
+            icon::{IconProviderHandle, SharedIconProvider},
             refany::{OptionRefAny, RefAny},
             styled_dom::StyledDom,
         };
@@ -2251,16 +2276,17 @@ mod autotest_generated {
         // the spec-derived LOOKUP and the replacement without a real font.
         extern "C" fn marker_resolver(
             data: OptionRefAny,
-            original: &StyledDom,
+            original: &azul_core::dom::NodeData,
             _: &SystemStyle,
-        ) -> StyledDom {
-            let mut replacement = original.clone();
+        ) -> Dom {
             let marker = if data.is_some() { "RESOLVED" } else { "MISSING" };
-            if let Some(node) = replacement.node_data.as_mut().get_mut(0) {
-                node.set_node_type(NodeType::Text(azul_css::css::BoxOrStatic::heap(
+            let mut replacement = Dom::create_div();
+            replacement.root = original.clone();
+            replacement
+                .root
+                .set_node_type(NodeType::Text(azul_css::css::BoxOrStatic::heap(
                     marker.into(),
                 )));
-            }
             replacement
         }
 
@@ -2270,16 +2296,16 @@ mod autotest_generated {
 
         // Both the bare-name spec and the pack-qualified fallback-list spec
         // (`missing:x` first — must fall through to `testpack:content_copy`).
-        let mut styled = parse_xml_to_styled_dom(
+        let styled = parse_xml_to_styled_dom_resolving_icons(
             "<html><body>\
              <icon> content_copy </icon>\
              <icon>missing:x, testpack:CONTENT_COPY</icon>\
              <icon>unknown_icon</icon>\
              </body></html>",
+            &provider,
+            &SystemStyle::default(),
         )
         .expect("icon markup must cascade");
-
-        resolve_icons_in_styled_dom(&mut styled, &provider, &SystemStyle::default());
 
         let texts: Vec<String> = styled
             .node_data

--- a/layout/tests/flex_intrinsic_text.rs
+++ b/layout/tests/flex_intrinsic_text.rs
@@ -548,7 +548,7 @@ fn two_text_children_in_a_flex_row_stay_on_one_line() {
 #[test]
 #[cfg(all(feature = "text_layout", feature = "font_loading"))]
 fn label_beside_a_resolved_fontref_icon_stays_on_one_line() {
-    use azul_core::icon::{resolve_icons_in_styled_dom, IconProviderHandle, SharedIconProvider};
+    use azul_core::icon::{resolve_icons_in_dom, IconProviderHandle, SharedIconProvider};
     use azul_css::system::SystemStyle;
 
     const KOHO_LIGHT: &[u8] = include_bytes!("../../examples/assets/fonts/KoHo-Light.ttf");
@@ -576,9 +576,11 @@ fn label_beside_a_resolved_fontref_icon_stays_on_one_line() {
         .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Format Painter").with_ids_and_classes(class("lbl")));
     let mut dom = Dom::create_body().with_child(btn);
 
+    // Icons resolve on the Dom, BEFORE the cascade.
+    resolve_icons_in_dom(&mut dom, &provider, &SystemStyle::default());
+
     let (css, _) = azul_css::parser2::new_from_str(PROBE_CSS);
-    let mut styled = StyledDom::create(&mut dom, css);
-    resolve_icons_in_styled_dom(&mut styled, &provider, &SystemStyle::default());
+    let styled = StyledDom::create(&mut dom, css);
 
     let mut layout_window = LayoutWindow::new(FcFontCache::build()).unwrap();
     let mut window_state = FullWindowState::default();

--- a/scripts/APP_AND_WINDOW_ICON_RESEARCH_2026_08_24.md
+++ b/scripts/APP_AND_WINDOW_ICON_RESEARCH_2026_08_24.md
@@ -1,0 +1,187 @@
+# Setting window / taskbar / dock / app icons at runtime, from RGBA
+
+**Date:** 2026-08-24. Companion to `MULTIMONITOR_AND_TRAY_RESEARCH_2026_08_24.md`.
+**Why:** azul can now render any icon-registry entry to RGBA at any size
+(`azul_layout::tray_icon::render_icon_to_rgba`). This is what to feed that into.
+
+## 0. The one table that matters
+
+Four slots, four different pixel conventions. Getting one wrong is the whole
+bug class (black boxes, dark fringes, garbled rows).
+
+| Slot | Byte order in memory | Alpha | Rows |
+|---|---|---|---|
+| Win32 `HICON` (`CreateIconIndirect`, V5 header, `BI_BITFIELDS`, A=`0xFF000000`) | B,G,R,A | **straight** | top-down iff `bV5Height = -h` |
+| Win32 tray `hIcon` | B,G,R,A | **straight** | as above |
+| Win32 `AlphaBlend` / `UpdateLayeredWindow` / GDI+ PARGB | B,G,R,A | **premultiplied** | — |
+| macOS `NSBitmapImageRep` + `AlphaNonpremultiplied` | R,G,B,A | **straight** | top-down |
+| X11 `_NET_WM_ICON` | `0xAARRGGBB` packed into **`c_ulong`** | straight (spec silent, de-facto) | top-down |
+| Wayland `wl_shm` `ARGB8888` | B,G,R,A | **premultiplied** | top-down |
+
+From one straight-RGBA8 master: swizzle→BGRA (Windows); keep as-is + tag
+NonPremultiplied (macOS); pack to `0xAARRGGBB` in `u64` slots (X11); swizzle
+→BGRA **and multiply** (Wayland). Only Wayland premultiplies.
+
+## 1. Corrections to assumptions we would otherwise have made
+
+1. **`CreateIconIndirect` wants STRAIGHT alpha**, not premultiplied. The
+   "GDI always wants premultiplied" folklore is true for `AlphaBlend`,
+   `UpdateLayeredWindow` and GDI+ PARGB — *not* for icons. GLFW, SDL and
+   wxWidgets all copy straight. Premultiplying gives dark fringes on AA edges.
+2. **The AND mask is REQUIRED even for 32bpp alpha icons, and must be
+   computed.** `bit = (alpha < 128)`, 1bpp, MSB-first, rows DWORD-aligned, and
+   note the inversion: **1 = transparent**. All-zero (GLFW's `CreateBitmap`
+   leaves it undefined; SDL uses all-`0xFF`) survives the common `DI_NORMAL`
+   path and is "hideously ugly" wherever `DI_MASK` is consumed — drop shadows,
+   some Alt-Tab paths, image lists.
+3. **`ICON_SMALL2` is NOT settable.** `WM_SETICON` accepts only `ICON_BIG` and
+   `ICON_SMALL`; `ICON_SMALL2` is a `WM_GETICON` query value. The DPI-correct
+   mechanism is instead to **handle `WM_GETICON` yourself** — its `lParam`
+   carries the DPI being requested — and answer from a `(slot, dpi)` cache.
+4. **The EXE icon cannot be changed at runtime.** `BeginUpdateResourceW`
+   documents that the target "cannot be currently executing", and rewriting
+   resources invalidates Authenticode anyway.
+5. **macOS windows have no icon**, only the document proxy icon
+   (`representedURL` + `standardWindowButton(.documentIconButton)`). A
+   cross-platform `set_window_icon` should no-op on macOS, not fake it.
+6. **`NSWorkspace.setIcon:forFile:` on your own bundle breaks the code
+   signature** ("app is damaged" on Ventura+), fails under the sandbox. Do not
+   expose it. `applicationIconImage` is the answer; it is process-local and
+   resets on relaunch, and persisting requires an `NSDockTilePlugIn` (banned
+   from the App Store).
+7. **`xdg-toplevel-icon-v1` did NOT solve Wayland window icons.** Shipped in
+   wayland-protocols 1.37 (2024-08-31), still **staging** in 2026, and
+   **Mutter/GNOME does not implement it** (GNOME/mutter#4100 open). KWin
+   (Plasma 6.3+), wlroots 0.19+, sway 1.11+, labwc do. Plan for the fallback
+   being the common case.
+
+## 2. Windows
+
+Precedence, per the `WM_GETICON` remarks: **per-window (`WM_SETICON`) >
+per-class (`GCLP_HICON`/`GCLP_HICONSM`) > `LoadIcon` default.**
+
+Set BOTH: the class slots at registration (or between `CreateWindowExW` and
+`ShowWindow`), because a slow startup lets the shell snapshot the default icon
+for the taskbar button before `WM_SETICON` ever runs (dotnet/wpf#11308); and
+the window slots per window.
+
+Sizes: `GetSystemMetricsForDpi(SM_CXSMICON, dpi)` = 16/20/24/32 at
+96/120/144/192; `SM_CXICON` = 32/40/48/64. Supply at the EXACT metric size —
+`WM_SETICON` will accept an oversized icon and downscale it, which is why so
+many apps have a mushy title-bar icon.
+
+**Ownership:** `WM_SETICON` does not take ownership and returns the previous
+handle. `DestroyIcon` it (unless it came from `LoadIcon`/`LR_SHARED`). Not
+doing this on every `WM_DPICHANGED` burns toward the ~10 000 USER-object cap,
+after which icon creation silently fails.
+
+**Badges:** `ITaskbarList3::SetOverlayIcon` (16x16 @96dpi, `NULL` clears,
+description required for a11y) — and note it is the one API that copies the
+icon, so you may `DestroyIcon` immediately after.
+
+**Taskbar icon selection:** pinned-not-running → the `.lnk`'s icon; running
+without an explicit AUMID → the window icon; running WITH an AUMID matching a
+shortcut → grouped under it, and `System.AppUserModel.RelaunchIconResource`
+governs the pinned representation (ignored unless the window has an explicit
+AUMID).
+
+## 3. macOS
+
+`NSApp.applicationIconImage = NSImage` — Dock tile, Cmd-Tab, About panel.
+Apple's own wording: "**temporarily** change the app icon"; `nil` restores.
+Process-local, resets on relaunch.
+
+`NSApp.dockTile.badgeLabel` is the badge slot. **`NSDockTile` never redraws
+itself — you must call `display()`.** That is the #1 "my dock icon doesn't
+update" cause. Also: installing `dockTile.contentView` SUPERSEDES
+`applicationIconImage`; they do not compose.
+
+RGBA → `NSImage`: `NSBitmapImageRep` with `bitsPerSample:8 samplesPerPixel:4
+hasAlpha:YES isPlanar:NO colorSpaceName:NSDeviceRGBColorSpace
+bitmapFormat:NSBitmapFormatAlphaNonpremultiplied bytesPerRow:w*4
+bitsPerPixel:32`. **Pass `planes:NULL` and `memcpy` into `[rep bitmapData]`** —
+it does NOT copy a buffer you supply, so handing it a Rust `Vec`'s pointer is a
+use-after-free. Avoid `NSCalibratedRGBColorSpace` (colour shift).
+
+`NSImage.size` is POINTS, `pixelsWide` is PIXELS; the ratio is the scale. One
+1024x1024 rep is sufficient and never upscales.
+
+macOS 26 "Tahoe" enforces a squircle for bundle icons, but a runtime
+`applicationIconImage` is drawn as supplied — if you want it to look native you
+must draw the rounded-square yourself.
+
+## 4. X11
+
+`_NET_WM_ICON`, type `XA_CARDINAL`, format 32: `[w1,h1, w1*h1 px..., w2,h2,
+...]`, pixels `0xAARRGGBB`, multiple sizes concatenated into ONE property.
+
+**The 64-bit trap — this is the #1 bug here.** With `format == 32`, Xlib
+requires `data` to be an array of `long`, which is **8 bytes on LP64**. Passing
+`*const u32` gives garbage or crashes inside `_XData32`. From Rust build
+`Vec<c_ulong>` and zero-extend each pixel. **XCB is exempt** (raw bytes,
+`format=32` really means 32-bit) — so if we dlopen both, the buffer layout
+differs per path. Only reproduces on 64-bit, i.e. everywhere real.
+
+Set it BEFORE the first `XMapWindow` — a few WMs only read at `MapNotify`. Re-set
+after any window recreation.
+
+Ship a stable `WM_CLASS` + a `.desktop` file whose `StartupWMClass` matches it
+exactly (case-sensitive): panels generally prefer the desktop file's `Icon=`
+over `_NET_WM_ICON`.
+
+Skip the ICCCM `WM_HINTS.icon_pixmap` path — no alpha, needs a server-side
+Pixmap, nothing has preferred it in fifteen years.
+
+## 5. Wayland
+
+`xdg-toplevel-icon-v1` is the only pixel path. Bind
+`xdg_toplevel_icon_manager_v1`; it sends `icon_size` events then `done`.
+
+    create_icon -> icon
+    set_name("org.example.App")        // optional, but set BOTH name and buffers:
+    add_buffer(buf, scale)             // compositor policy chooses which to use
+    set_icon(toplevel, icon)           // icon is now IMMUTABLE
+    // keep every buffer + the shm pool ALIVE and unmodified
+
+Four rules, each violation a **fatal protocol error that kills the connection**:
+buffers must be **square** and `wl_shm`-backed (Wine shipped a fix purely to pad
+non-square icons); buffers must outlive the icon and not be rewritten;
+`add_buffer`/`set_name` after `set_icon` raises `immutable`; destroying a buffer
+early raises `no_buffer`. To change the icon, build a NEW icon object.
+
+Destroying the icon object does NOT clear it from the toplevel.
+
+Fallback when the global is absent: `xdg_toplevel.set_app_id` + a matching
+`.desktop` file (app_id == desktop file ID minus `.desktop`). No match → the
+generic/"image-missing" icon. The classic failure is a CASE mismatch between
+`WM_CLASS` and app_id (the Electron/Slack/Discord generic-icon bug).
+
+There is no other way to set pixels — no KDE- or GNOME-private extension.
+Under XWayland, `_NET_WM_ICON` works.
+
+## 6. Sizes to render
+
+* Windows: `SM_CXSMICON` and `SM_CXICON` per DPI (16/20/24/32 and 32/40/48/64);
+  tray at `SM_CXSMICON`; overlay 16.
+* macOS: one 1024 px rep; menu-bar `NSStatusItem` 18 pt (36 px @2x), TEMPLATE
+  image (black + alpha) so AppKit tints it.
+* X11: 16, 24, 32, 48, 64, 128, 256 in one property.
+* Wayland: honour `icon_size`; else 16/24/32/48/64/128/256 at scale 1 plus 2x
+  buffers. Square only.
+
+## 7. Proposed API
+
+    set_app_icon(&[IconImage])          // process-wide
+    set_window_icon(window, &[IconImage])
+    set_badge(Option<Badge>)
+
+|  | app icon | window icon | badge |
+|---|---|---|---|
+| Windows | class `GCLP_HICON`+`GCLP_HICONSM` + `WM_SETICON` on all windows | `WM_SETICON` both slots, answer `WM_GETICON` per-DPI | `ITaskbarList3::SetOverlayIcon` |
+| macOS | `NSApp.applicationIconImage` | **no-op** | `dockTile.badgeLabel` (+ `display()`) |
+| X11 | `_NET_WM_ICON` on every toplevel + `WM_CLASS` + `.desktop` | `_NET_WM_ICON` | none standard |
+| Wayland | `set_app_id` + `.desktop` | `xdg-toplevel-icon-v1` if bound, else nothing | none standard |
+
+Cache by `(slot, size, scale)`. Probe capability at startup (bind the Wayland
+global; `GetProcAddress("GetSystemMetricsForDpi")`) and degrade **loudly** —
+silently doing nothing is how the Wayland generic-icon bug survives.

--- a/scripts/az-crosscheck.sh
+++ b/scripts/az-crosscheck.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# scripts/az-crosscheck.sh — cargo check azul-dll for every target we ship.
+#
+# WHY: the platform shells in dll/src/desktop/shell2/ are `#[cfg(target_os)]`
+# gated, so a host-only `cargo check` compiles roughly a quarter of them. Any
+# change to the windows/, linux/ or macos/ backends is UNVERIFIED until this
+# script is green. Blind implementation makes that the only gate we have.
+#
+# Usage:  ./scripts/az-crosscheck.sh [extra cargo args...]
+set -uo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+# shellcheck disable=SC1091
+. ./.envrc.az
+
+TARGETS=(
+  aarch64-apple-darwin
+  x86_64-unknown-linux-gnu
+  x86_64-pc-windows-gnu
+)
+
+rc=0
+declare -a RESULTS=()
+for t in "${TARGETS[@]}"; do
+  echo "══════════════════════════════════════════════════════════"
+  echo "  cargo check -p azul-dll --target $t"
+  echo "══════════════════════════════════════════════════════════"
+  if cargo check --release -p azul-dll --target "$t" "$@" 2>&1; then
+    RESULTS+=("PASS  $t")
+  else
+    RESULTS+=("FAIL  $t")
+    rc=1
+  fi
+done
+
+echo
+echo "───────────────── cross-check summary ─────────────────"
+for r in "${RESULTS[@]}"; do echo "  $r"; done
+exit $rc


### PR DESCRIPTION
Stacked on `transient-window`. Implements the plan in
`scripts/MULTIMONITOR_AND_TRAY_RESEARCH_2026_08_24.md`, which is also in this PR.

## Framing

The two "missing desktop features" turned out not to be the same kind of gap.

**Multi-monitor is not missing — it is unwired and unit-confused.** The `Monitor`
type, the FFI export, per-platform enumeration and the event kinds all existed.
Parts are genuinely good: the macOS primary-screen-flip convention (MWA-B9), the
Windows `WM_DPICHANGED` handler, and Wayland's fractional-scale + `xdg_positioner`
support. What was missing was the plumbing between the layers.

**The tray is genuinely absent** — zero lines on all three platforms, no commit
in history. This PR lands the foundation, not the backends.

## Multi-monitor — 8 fixes

Each of these is the same shape: code that compiles, runs, and is wrong only on a
second monitor, so none would ever show up on the machine it was written on.

- `windows/dpi.rs` — `GetDpiForMonitor` and `SetProcessDpiAwareness` were looked
  up in **user32**; both live in **shcore**, so both were permanently `None`. On
  8.1 / pre-1607 Win10 the process silently degraded to system-DPI-aware. The
  other five symbols in that block genuinely are user32, which is what let the
  mistake survive; there is now a table saying which dll each lives in.
- `macos/mod.rs` — the explicit-position arm's own comment said *"macOS y-axis is
  flipped (0 at bottom)"* and then didn't flip. A window asked to open at `(0,0)`
  opened at the **bottom** of the screen. It was also the one site in that backend
  breaking its own MWA-B9 convention.
- `macos/mod.rs` — `detect_current_monitor` stored a raw `CGDirectDisplayID` in
  `MonitorId.index`, which every consumer reads as an index into the `0..n` list.
  So `get_current_monitor()` returned `None` on macOS in practice.
- `x11/mod.rs` — `let monitor_id = 0; // TODO`: the requested monitor was ignored
  and `ws.monitor_id` stayed `None` for the window's life, so
  `WindowMonitorChanged` could never fire (the rule needs both sides `Some`).
  Now seeded at creation and tracked from `ConfigureNotify`.
- `windows/mod.rs` — creation passed `Monitor::default().monitor_id` (== PRIMARY),
  throwing away `WindowCreateOptions.monitor_id`.
- `display.rs` — `get_displays()` is now memoised (250ms).
  `get_display_at_point` is called from the X11 `ConfigureNotify` arm, which fires
  once per **pixel** of pointer travel during a drag; each uncached call was
  `XOpenDisplay` + `XRRGetScreenResourcesCurrent` + N×`XRRGetCrtcInfo` +
  `XCloseDisplay`. Display-change handlers use `refresh_monitors()`, which
  invalidates first, so a refresh can never read through a stale entry.
- `wayland/events.rs` — `registry_global_remove` was an empty stub, leaking three
  ways on monitor unplug: `known_outputs` grew monotonically (shifting every
  index, which matters because `get_current_monitor` correlates two lists *by
  index*), the proxy was never destroyed, and the rebind entry kept pointing at it.
- `display.rs` — macOS `get_displays()` was `.expect("Must be called on main
  thread")`, making the public `App::get_monitors()` a hard panic one thread-hop
  away. Degrades to an empty list, which every caller already handles.

## Tray foundation

`azul_core::tray` — the platform-agnostic model. Two API decisions are forced by
Linux and expensive to walk back, so they are made up front:

- **The menu is state, not a call.** SNI's `Menu` property points at a
  `com.canonical.dbusmenu` object and the *panel* draws the menu, calling back
  with `GetLayout`/`AboutToShow`. An API shaped as `show_context_menu_at(x, y)`
  cannot be implemented on Linux.
- **`ContextMenu` is a request, not a command** — on Linux the panel may have
  already opened the menu itself.

`azul_layout::tray_icon::render_icon_to_rgba` — icons are an **icon-registry
spec**, exactly the string an `<icon>` node takes. Resolution runs the same
`resolve_icons_in_styled_dom` pass and renders the resulting `StyledDom` through
the CPU renderer, so every icon kind works with no tray-specific path — and
anything a future resolver expresses as a DOM (SVG, emoji) works for free. A tray
icon and an in-DOM `<icon>` of the same spec cannot disagree: same code path up to
rasterization.

`ComponentPreviewResult` gains raw `rgba` alongside `png_data`, since every
consumer here wants pixels and a PNG round-trip is pure waste.

## Also in here

`scripts/APP_AND_WINDOW_ICON_RESEARCH_2026_08_24.md` — research for the follow-up.
Seven findings contradict what one would write blind; the most useful is §0: four
icon slots, four pixel conventions, and **only Wayland premultiplies**.

## Testing

**Behaviour is untested — this is deliberate and worth being explicit about.**
There is no monitor coverage to test against: 0 of 54 e2e scenarios model a
monitor, and the headless shell has no monitor concept at all. Building that is
tracked in the plan as Phase 0 and is a prerequisite for verifying any of the
above.

What *is* verified: `scripts/az-crosscheck.sh` (new) checks `azul-dll` for
macOS + linux-gnu + windows-gnu, green on every commit. The shells are
`#[cfg(target_os)]`-gated, so a host-only `cargo check` compiles roughly a quarter
of them — this is the only gate available while implementing blind. Plus 5 unit
tests in `azul-core` and 3 in `azul-layout`.

## Not in this PR

The three tray backends (~1650 LOC, Linux SNI over half) and the app/window icon
plumbing. Both are unblocked now that the pixel-format questions are settled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BxYsEXV1WjJC6yyaP7ggLa