### PR TITLE
security: gate build-time code execution, environment access, and dependency versions

### DIFF
--- a/.github/actions/supply-chain-preflight/action.yml
+++ b/.github/actions/supply-chain-preflight/action.yml
@@ -1,0 +1,83 @@
+name: Supply chain preflight
+description: >-
+  Vendor the dependency tree and gate what may run at build time, what it may
+  read from the environment, and which versions may be in the lockfile — all
+  before anything compiles.
+
+# Lives in a composite action rather than inline in rust.yml because that file
+# is within a few KB of GitHub's 512,000-byte workflow-file limit, above which
+# runs are silently not started (no error, no startup_failure — the symptom is
+# simply that nothing happens). Splitting shared logic into a composite action
+# is the documented remedy.
+
+runs:
+  using: composite
+  steps:
+    # Keyed on Cargo.lock alone: the vendored bytes are a pure function of the
+    # lockfile, so a hit is always correct and a lockfile change always misses.
+    - name: Cache the crate registry
+      uses: actions/cache@v6
+      with:
+        path: |
+          ~/.cargo/registry/index
+          ~/.cargo/registry/cache
+        key: supply-chain-registry-v1-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+        restore-keys: |
+          supply-chain-registry-v1-${{ runner.os }}-
+
+    # A syntax error in a gate is a gate that does not run. Fail on it here,
+    # with a clear message, rather than inside a scan step. The scripts target
+    # Python 3.8+ deliberately (no tomllib): ubuntu-22.04 ships 3.10 and stock
+    # macOS ships 3.9, and an import a runner cannot satisfy is a dead gate.
+    - name: Gates must be syntactically valid
+      shell: bash
+      run: python3 -m py_compile scripts/supply-chain/*.py
+
+    # `cargo vendor` RESOLVES and DOWNLOADS. It does not build, and it does not
+    # run build scripts — which is the entire reason this gate can precede the
+    # build. --locked audits the committed lockfile, not today's resolution.
+    - name: Vendor the dependency tree (downloads sources, executes nothing)
+      shell: bash
+      run: |
+        set -euo pipefail
+        cargo vendor --locked --versioned-dirs vendor > /dev/null
+        echo "vendored $(ls vendor | wc -l) crates"
+
+    - name: cargo metadata (for the build-dependency closure)
+      shell: bash
+      run: cargo metadata --format-version=1 --locked --all-features > sc-metadata.json
+
+    - name: Lockfile integrity (registry checksums, yanked versions)
+      shell: bash
+      run: |
+        mkdir -p sc-reports
+        python3 scripts/supply-chain/lockfile_guard.py \
+          --check vendor --check yanked --check cksum \
+          --vendor vendor --no-cache --json sc-reports/lockfile.json
+
+    # THE ENV GATE. Runs before any build, so a credential cannot already have
+    # been read. It needs no secrets itself: the forbidden-name set is parsed
+    # out of the workflow files, so every secret this repository can inject is
+    # checked for even in a job that holds none of them.
+    - name: Environment access from build-time code
+      shell: bash
+      run: |
+        python3 scripts/supply-chain/env_guard.py \
+          --vendor vendor --metadata sc-metadata.json \
+          --json sc-reports/env.json
+
+    - name: Build-time code execution policy (build.rs / proc-macro)
+      shell: bash
+      run: |
+        python3 scripts/supply-chain/scan_build_scripts.py \
+          --vendor vendor --metadata sc-metadata.json \
+          --json sc-reports/build-scripts.json
+
+    - name: Upload supply-chain reports
+      if: always()
+      uses: actions/upload-artifact@v7
+      with:
+        name: supply-chain-preflight
+        path: sc-reports/
+        if-no-files-found: warn
+        retention-days: 30

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -238,8 +238,13 @@ jobs:
   # executing, which is what makes a before-the-build gate possible at all.
   #
   # Rationale, threat model and per-gate detail: scripts/supply-chain/README.md
-  # Cost, measured (855 crates, warm registry): vendor 40s + three scans ~106s.
-  # The preflight wall moves from 2.1 to ~5 min and everything inherits it.
+  #
+  # COST, measured on the runner (run 32889628218, 855 crates): the whole job is
+  # 1 min 38 s including checkout and toolchain — vendoring is network-bound and
+  # CI's network beats a laptop's, so it comes in under the 2.5 min a local
+  # measurement predicted. The preflight wall goes 2.1 -> ~3.7 min and everything
+  # downstream inherits that. content_state_lint started 4 s after this job
+  # finished, which is the gate doing its job: nothing compiled before it.
   #
   # cargo-vet, the publish-age cooldown and cargo-audit live in
   # .github/workflows/supply-chain.yml — they gate nothing here, and this file is

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -228,38 +228,22 @@ jobs:
   # macOS leg or relaxing the cheap-OS-first serialisation, both of which are
   # deliberate trade-offs documented on those jobs, not accidents.
 
-  # ===========================================================================
   # TIER 0 — SUPPLY CHAIN PREFLIGHT. Nothing in this file compiles before it.
-  # ===========================================================================
   #
-  # WHY THIS IS TIER 0 AND NOT "ANOTHER QUALITY JOB". `build.rs` and proc macros
-  # execute during `cargo build` with the full authority of the runner —
-  # filesystem, network, and the entire environment — and they run whether or
-  # not any of the crate's own code is ever called. That is the mechanism behind
-  # every significant crates.io compromise to date: `rustdecimal` (2022) keyed on
-  # GITLAB_CI before detonating; `mysten-metrics` 9.0.3 (2026) exfiltrated the
-  # environment plus ~/.cargo/credentials and SSH keys from a build script; the
-  # August 2026 `arrayref`/`internment`/`append-only-vec` compromise added one
-  # Cargo.toml line pulling in `proc-macro1`, whose build.rs fetched and ran a
-  # remote payload — nobody had to call anything.
+  # build.rs and proc macros execute during `cargo build` with the runner's full
+  # authority, whether or not the crate's own code is ever called — the mechanism
+  # behind every significant crates.io compromise to date. A check that runs after
+  # the build has already lost, and `cargo check` runs build scripts too, so this
+  # precedes even clippy and check_crates. `cargo vendor` downloads without
+  # executing, which is what makes a before-the-build gate possible at all.
   #
-  # A check that runs after the build has already lost. `cargo check` runs build
-  # scripts too, so this must precede even clippy and check_crates, which is why
-  # those four preflight jobs now carry `needs: [supply_chain_preflight]` and
-  # this job carries no `needs:` at all.
+  # Rationale, threat model and per-gate detail: scripts/supply-chain/README.md
+  # Cost, measured (855 crates, warm registry): vendor 40s + three scans ~106s.
+  # The preflight wall moves from 2.1 to ~5 min and everything inherits it.
   #
-  # WHAT IT COSTS. `cargo vendor` downloads sources and executes nothing, which
-  # is the whole reason the gate is possible. MEASURED (macOS laptop, warm
-  # registry, 855 crates): vendor 40s, lockfile+vendor checksum verify 42s,
-  # env scan 36s, build-script scan 28s — ~2.5 min wall, and the three scans are
-  # sequential rather than parallel only because they are cheap enough not to
-  # bother. Budget ~2-3 min in CI with the registry cache below; the preflight
-  # wall moves from 2.1 to roughly 5 min and everything downstream inherits it.
-  #
-  # That is a real cost and it is taken deliberately. The alternative on offer is
-  # not "a faster pipeline" — it is running 141 build scripts and 50 proc macros
-  # from a 855-crate tree before anything has established they are allowed to
-  # run. It is paid once per run, not once per build job.
+  # cargo-vet, the publish-age cooldown and cargo-audit live in
+  # .github/workflows/supply-chain.yml — they gate nothing here, and this file is
+  # 9 KB from GitHub's 512,000-byte workflow limit (see the note at `jobs:`).
   supply_chain_preflight:
     name: Supply chain preflight (build-time code + env)
     # DELIBERATELY NO `needs:`. See the header above — this gates the gates.
@@ -270,155 +254,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: 1.88.0
-
-      # Keyed on Cargo.lock alone: the vendored bytes are a pure function of the
-      # lockfile, so a hit is always correct and a lockfile change always misses.
-      - name: Cache the crate registry
-        uses: actions/cache@v6
-        with:
-          path: |
-            ~/.cargo/registry/index
-            ~/.cargo/registry/cache
-          key: supply-chain-registry-v1-${{ env.CACHE_BUST }}-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
-          restore-keys: |
-            supply-chain-registry-v1-${{ env.CACHE_BUST }}-${{ runner.os }}-
-
-      # A syntax error in a gate is a gate that does not run. Fail on it here,
-      # with a clear message, rather than inside a scan step.
-      - name: Gates must be syntactically valid
-        run: python3 -m py_compile scripts/supply-chain/*.py
-
-      # `cargo vendor` RESOLVES and DOWNLOADS. It does not build, and it does not
-      # run build scripts. --locked means the committed Cargo.lock is what gets
-      # audited, not whatever the resolver would pick today.
-      - name: Vendor the dependency tree (downloads sources, executes nothing)
-        run: |
-          set -euo pipefail
-          cargo vendor --locked --versioned-dirs vendor > /dev/null
-          echo "vendored $(ls vendor | wc -l) crates"
-
-      - name: cargo metadata (for the build-dependency closure)
-        run: cargo metadata --format-version=1 --locked --all-features > sc-metadata.json
-
-      - name: Lockfile integrity (registry checksums, yanked versions)
-        run: |
-          mkdir -p sc-reports
-          python3 scripts/supply-chain/lockfile_guard.py \
-            --check vendor --check yanked --check cksum \
-            --vendor vendor --no-cache --json sc-reports/lockfile.json
-
-      # THE ENV GATE. Runs before any build so a credential cannot already have
-      # been read. Note it needs no secrets itself — the forbidden-name set is
-      # parsed out of the workflow files, so every secret this repository can
-      # inject is checked for even in a job that has none of them.
-      - name: Environment access from build-time code
-        run: |
-          python3 scripts/supply-chain/env_guard.py \
-            --vendor vendor --metadata sc-metadata.json \
-            --json sc-reports/env.json
-
-      - name: Build-time code execution policy (build.rs / proc-macro)
-        run: |
-          python3 scripts/supply-chain/scan_build_scripts.py \
-            --vendor vendor --metadata sc-metadata.json \
-            --json sc-reports/build-scripts.json
-
-      - name: Upload supply-chain reports
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: supply-chain-preflight
-          path: sc-reports/
-          if-no-files-found: warn
-          retention-days: 30
-
-  # ---------------------------------------------------------------------------
-  # Version-level supply chain: cargo-vet and the publish-age cooldown.
-  #
-  # These answer the question `dependency-justifications.toml` structurally
-  # cannot. That file is keyed by crate NAME, so a crate already justified stays
-  # justified when a compromised maintainer account publishes a new version of
-  # it — which is exactly what happened to arrayref, internment and
-  # append-only-vec on 2026-08-20, all three already in thousands of trees.
-  #
-  # cargo-vet pins per VERSION: a bump lands as an unaudited version and fails
-  # until someone reviews the delta or exempts it deliberately. The cooldown
-  # refuses versions younger than 14 days, which turns that attack's 86-107
-  # minute exposure window into a non-event — the malicious release is yanked
-  # long before any build here is allowed to resolve it. It is RFC 3923
-  # `min-publish-age`, implemented locally because the client half had not
-  # shipped when arrayref happened.
-  #
-  # NOT GATED and not on the critical path: cheap, and useful as early signal.
-  supply_chain_versions:
-    name: Supply chain (cargo-vet + publish-age cooldown)
-    if: github.event_name != 'workflow_dispatch' || github.event.inputs.run_mode == 'ci' || github.event.inputs.run_mode == 'deploy' || github.event.inputs.run_mode == 'website'
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          # The cooldown check diffs Cargo.lock against the base branch, so it
-          # needs history. Without this the diff is empty and every version
-          # looks unchanged — a gate that passes by knowing nothing.
-          fetch-depth: 0
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: 1.88.0
-
-      - name: Install cargo-vet
-        run: cargo install cargo-vet --locked || cargo install cargo-vet
-
-      # --locked: the audit set and imports.lock as committed. Without it, vet
-      # would refresh imports from the network and a failing run could be turned
-      # green by an upstream publishing an audit, which is not a decision this
-      # repository should delegate.
-      - name: cargo vet
-        shell: bash
-        run: |
-          set -o pipefail
-          if ! cargo vet --locked 2>&1 | tee vet.txt; then
-            {
-              echo '## 🔎 cargo-vet'
-              echo ''
-              echo '```'
-              tail -80 vet.txt
-              echo '```'
-              echo ''
-              echo 'A new or bumped dependency is neither audited nor exempted.'
-              echo 'Review the delta and record it:'
-              echo ''
-              echo '```'
-              echo 'cargo vet diff <crate> <old-version> <new-version>'
-              echo 'cargo vet certify <crate> <old-version> <new-version>'
-              echo '# or, if you are accepting it without review:'
-              echo 'cargo vet add-exemption <crate> <version>'
-              echo '```'
-            } >> "$GITHUB_STEP_SUMMARY"
-            echo "::error::cargo-vet: an unaudited dependency version entered the tree."
-            exit 1
-          fi
-          {
-            echo '## 🔎 cargo-vet'
-            echo ''
-            echo '```'
-            tail -20 vet.txt
-            echo '```'
-          } >> "$GITHUB_STEP_SUMMARY"
-
-      # Only versions that CHANGED against the base are age-checked: crates.io's
-      # API is rate limited, and the lockfile diff is where a poisoned release
-      # enters anyway. On master the base is the previous commit.
-      - name: Publish-age cooldown (changed dependencies only)
-        shell: bash
-        run: |
-          BASE="${{ github.event.pull_request.base.sha || github.event.before }}"
-          if [ -z "$BASE" ] || [ "$BASE" = "0000000000000000000000000000000000000000" ]; then
-            BASE="$(git rev-parse HEAD~1 2>/dev/null || git rev-parse HEAD)"
-          fi
-          echo "comparing Cargo.lock against $BASE"
-          python3 scripts/supply-chain/lockfile_guard.py \
-            --check cooldown --min-age-days 14 \
-            --changed-only --base-ref "$BASE" --no-cache
+      - uses: ./.github/actions/supply-chain-preflight
 
   content_state_lint:
     # The cheap preflight lane: checkout + grep + python, no compilation, and a
@@ -8210,36 +8046,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: 1.88.0
-      - name: Install cargo-deny + cargo-audit
-        run: |
-          cargo install cargo-deny --locked || cargo install cargo-deny
-          cargo install cargo-audit --locked || cargo install cargo-audit
+      - name: Install cargo-deny
+        run: cargo install cargo-deny --locked || cargo install cargo-deny
 
-      # cargo-audit reads the SAME RustSec database as `cargo deny check
-      # advisories`, so this is a second opinion, not a second source. It earns
-      # its place for two reasons: it fetches a fresh advisory-db clone on every
-      # run (cargo-deny's is subject to its own caching), and its `--deny
-      # warnings` covers unmaintained/unsound advisories that the deny.toml
-      # `ignore` list deliberately silences — so a crate going unmaintained
-      # shows up here as a warning even while it stays ignored over there.
-      # Non-blocking on purpose: `advisories` in the deny step below is the
-      # gate, and two gates on one database means one of them is noise.
-      - name: cargo-audit (second opinion, non-blocking)
-        continue-on-error: true
-        shell: bash
-        run: |
-          mkdir -p stats
-          cargo audit --color never 2>&1 | tee stats/cargo-audit.txt || true
-          {
-            echo '## 🛡️ cargo-audit (RustSec)'
-            echo ''
-            echo '<details><summary>full report</summary>'
-            echo ''
-            echo '```'
-            tail -120 stats/cargo-audit.txt
-            echo '```'
-            echo '</details>'
-          } >> "$GITHUB_STEP_SUMMARY"
       - name: cargo-deny + summary
         shell: bash
         run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -194,10 +194,15 @@ jobs:
   #     at all rather than existing in order to skip (~60 billed macOS minutes
   #     per feature-branch push). See the note on that job.
   #
-  # DELIBERATELY NOT GATED (cheap, and useful as independent early signal):
-  # icu_parity (1.0 min), supply_chain (2.8), publish_safety (1.6), docs_pdf
-  # (0.3). Gating them would save single-digit machine-minutes and cost them
-  # their head start. dep_tree used to be in this list and still is not gated on
+  # DELIBERATELY NOT GATED ON THE QUALITY TIER (cheap, and useful as an
+  # independent early signal): icu_parity (1.0 min), supply_chain (2.8),
+  # publish_safety (1.6), docs_pdf (0.3). Gating them on clippy/test_lib would
+  # save single-digit machine-minutes and cost them their head start.
+  #
+  # They ARE gated on supply_chain_preflight (2026-08-25), because three of
+  # the four compile the dependency tree and therefore run its build scripts.
+  # That is a different question from "is the code good": it is "is this code
+  # allowed to run at all", and nothing gets a head start on it. dep_tree used to be in this list and still is not gated on
   # a quality tier — it just has a data dependency on the bindings now.
   #
   # THE CRITICAL PATH, before and after. Measured, run 32358047254:
@@ -223,11 +228,207 @@ jobs:
   # macOS leg or relaxing the cheap-OS-first serialisation, both of which are
   # deliberate trade-offs documented on those jobs, not accidents.
 
+  # ===========================================================================
+  # TIER 0 — SUPPLY CHAIN PREFLIGHT. Nothing in this file compiles before it.
+  # ===========================================================================
+  #
+  # WHY THIS IS TIER 0 AND NOT "ANOTHER QUALITY JOB". `build.rs` and proc macros
+  # execute during `cargo build` with the full authority of the runner —
+  # filesystem, network, and the entire environment — and they run whether or
+  # not any of the crate's own code is ever called. That is the mechanism behind
+  # every significant crates.io compromise to date: `rustdecimal` (2022) keyed on
+  # GITLAB_CI before detonating; `mysten-metrics` 9.0.3 (2026) exfiltrated the
+  # environment plus ~/.cargo/credentials and SSH keys from a build script; the
+  # August 2026 `arrayref`/`internment`/`append-only-vec` compromise added one
+  # Cargo.toml line pulling in `proc-macro1`, whose build.rs fetched and ran a
+  # remote payload — nobody had to call anything.
+  #
+  # A check that runs after the build has already lost. `cargo check` runs build
+  # scripts too, so this must precede even clippy and check_crates, which is why
+  # those four preflight jobs now carry `needs: [supply_chain_preflight]` and
+  # this job carries no `needs:` at all.
+  #
+  # WHAT IT COSTS. `cargo vendor` downloads sources and executes nothing, which
+  # is the whole reason the gate is possible. MEASURED (macOS laptop, warm
+  # registry, 855 crates): vendor 40s, lockfile+vendor checksum verify 42s,
+  # env scan 36s, build-script scan 28s — ~2.5 min wall, and the three scans are
+  # sequential rather than parallel only because they are cheap enough not to
+  # bother. Budget ~2-3 min in CI with the registry cache below; the preflight
+  # wall moves from 2.1 to roughly 5 min and everything downstream inherits it.
+  #
+  # That is a real cost and it is taken deliberately. The alternative on offer is
+  # not "a faster pipeline" — it is running 141 build scripts and 50 proc macros
+  # from a 855-crate tree before anything has established they are allowed to
+  # run. It is paid once per run, not once per build job.
+  supply_chain_preflight:
+    name: Supply chain preflight (build-time code + env)
+    # DELIBERATELY NO `needs:`. See the header above — this gates the gates.
+    if: github.event_name != 'workflow_dispatch' || github.event.inputs.run_mode == 'ci' || github.event.inputs.run_mode == 'deploy' || github.event.inputs.run_mode == 'website'
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.88.0
+
+      # Keyed on Cargo.lock alone: the vendored bytes are a pure function of the
+      # lockfile, so a hit is always correct and a lockfile change always misses.
+      - name: Cache the crate registry
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+          key: supply-chain-registry-v1-${{ env.CACHE_BUST }}-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            supply-chain-registry-v1-${{ env.CACHE_BUST }}-${{ runner.os }}-
+
+      # A syntax error in a gate is a gate that does not run. Fail on it here,
+      # with a clear message, rather than inside a scan step.
+      - name: Gates must be syntactically valid
+        run: python3 -m py_compile scripts/supply-chain/*.py
+
+      # `cargo vendor` RESOLVES and DOWNLOADS. It does not build, and it does not
+      # run build scripts. --locked means the committed Cargo.lock is what gets
+      # audited, not whatever the resolver would pick today.
+      - name: Vendor the dependency tree (downloads sources, executes nothing)
+        run: |
+          set -euo pipefail
+          cargo vendor --locked --versioned-dirs vendor > /dev/null
+          echo "vendored $(ls vendor | wc -l) crates"
+
+      - name: cargo metadata (for the build-dependency closure)
+        run: cargo metadata --format-version=1 --locked --all-features > sc-metadata.json
+
+      - name: Lockfile integrity (registry checksums, yanked versions)
+        run: |
+          mkdir -p sc-reports
+          python3 scripts/supply-chain/lockfile_guard.py \
+            --check vendor --check yanked --check cksum \
+            --vendor vendor --no-cache --json sc-reports/lockfile.json
+
+      # THE ENV GATE. Runs before any build so a credential cannot already have
+      # been read. Note it needs no secrets itself — the forbidden-name set is
+      # parsed out of the workflow files, so every secret this repository can
+      # inject is checked for even in a job that has none of them.
+      - name: Environment access from build-time code
+        run: |
+          python3 scripts/supply-chain/env_guard.py \
+            --vendor vendor --metadata sc-metadata.json \
+            --json sc-reports/env.json
+
+      - name: Build-time code execution policy (build.rs / proc-macro)
+        run: |
+          python3 scripts/supply-chain/scan_build_scripts.py \
+            --vendor vendor --metadata sc-metadata.json \
+            --json sc-reports/build-scripts.json
+
+      - name: Upload supply-chain reports
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: supply-chain-preflight
+          path: sc-reports/
+          if-no-files-found: warn
+          retention-days: 30
+
+  # ---------------------------------------------------------------------------
+  # Version-level supply chain: cargo-vet and the publish-age cooldown.
+  #
+  # These answer the question `dependency-justifications.toml` structurally
+  # cannot. That file is keyed by crate NAME, so a crate already justified stays
+  # justified when a compromised maintainer account publishes a new version of
+  # it — which is exactly what happened to arrayref, internment and
+  # append-only-vec on 2026-08-20, all three already in thousands of trees.
+  #
+  # cargo-vet pins per VERSION: a bump lands as an unaudited version and fails
+  # until someone reviews the delta or exempts it deliberately. The cooldown
+  # refuses versions younger than 14 days, which turns that attack's 86-107
+  # minute exposure window into a non-event — the malicious release is yanked
+  # long before any build here is allowed to resolve it. It is RFC 3923
+  # `min-publish-age`, implemented locally because the client half had not
+  # shipped when arrayref happened.
+  #
+  # NOT GATED and not on the critical path: cheap, and useful as early signal.
+  supply_chain_versions:
+    name: Supply chain (cargo-vet + publish-age cooldown)
+    if: github.event_name != 'workflow_dispatch' || github.event.inputs.run_mode == 'ci' || github.event.inputs.run_mode == 'deploy' || github.event.inputs.run_mode == 'website'
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # The cooldown check diffs Cargo.lock against the base branch, so it
+          # needs history. Without this the diff is empty and every version
+          # looks unchanged — a gate that passes by knowing nothing.
+          fetch-depth: 0
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.88.0
+
+      - name: Install cargo-vet
+        run: cargo install cargo-vet --locked || cargo install cargo-vet
+
+      # --locked: the audit set and imports.lock as committed. Without it, vet
+      # would refresh imports from the network and a failing run could be turned
+      # green by an upstream publishing an audit, which is not a decision this
+      # repository should delegate.
+      - name: cargo vet
+        shell: bash
+        run: |
+          set -o pipefail
+          if ! cargo vet --locked 2>&1 | tee vet.txt; then
+            {
+              echo '## 🔎 cargo-vet'
+              echo ''
+              echo '```'
+              tail -80 vet.txt
+              echo '```'
+              echo ''
+              echo 'A new or bumped dependency is neither audited nor exempted.'
+              echo 'Review the delta and record it:'
+              echo ''
+              echo '```'
+              echo 'cargo vet diff <crate> <old-version> <new-version>'
+              echo 'cargo vet certify <crate> <old-version> <new-version>'
+              echo '# or, if you are accepting it without review:'
+              echo 'cargo vet add-exemption <crate> <version>'
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "::error::cargo-vet: an unaudited dependency version entered the tree."
+            exit 1
+          fi
+          {
+            echo '## 🔎 cargo-vet'
+            echo ''
+            echo '```'
+            tail -20 vet.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # Only versions that CHANGED against the base are age-checked: crates.io's
+      # API is rate limited, and the lockfile diff is where a poisoned release
+      # enters anyway. On master the base is the previous commit.
+      - name: Publish-age cooldown (changed dependencies only)
+        shell: bash
+        run: |
+          BASE="${{ github.event.pull_request.base.sha || github.event.before }}"
+          if [ -z "$BASE" ] || [ "$BASE" = "0000000000000000000000000000000000000000" ]; then
+            BASE="$(git rev-parse HEAD~1 2>/dev/null || git rev-parse HEAD)"
+          fi
+          echo "comparing Cargo.lock against $BASE"
+          python3 scripts/supply-chain/lockfile_guard.py \
+            --check cooldown --min-age-days 14 \
+            --changed-only --base-ref "$BASE" --no-cache
+
   content_state_lint:
     # The cheap preflight lane: checkout + grep + python, no compilation, and a
     # gate for most of the run. It is the right home for CLASS checks — the ones
     # that cost a full hour of CI, or a whole release, to discover otherwise.
     # (The job KEY stays content_state_lint because ~34 `needs:` entries name it.)
+    # Tier 0: the supply-chain preflight gates even this. `cargo check`
+    # runs dependency build scripts, so a lint that compiles anything is
+    # downstream of "is that code allowed to run". See supply_chain_preflight.
+    needs: [supply_chain_preflight]
     name: Architecture + release contracts (preflight)
     if: github.event_name != 'workflow_dispatch' || github.event.inputs.run_mode == 'ci' || github.event.inputs.run_mode == 'deploy' || github.event.inputs.run_mode == 'website'
     runs-on: ubuntu-22.04
@@ -322,6 +523,10 @@ jobs:
           echo "shell2 backends keep blocking waits off the UI thread"
 
   documentation_paths:
+    # Tier 0: the supply-chain preflight gates even this. `cargo check`
+    # runs dependency build scripts, so a lint that compiles anything is
+    # downstream of "is that code allowed to run". See supply_chain_preflight.
+    needs: [supply_chain_preflight]
     name: Documentation paths (docproof)
     if: github.event_name != 'workflow_dispatch' || github.event.inputs.run_mode == 'ci' || github.event.inputs.run_mode == 'deploy' || github.event.inputs.run_mode == 'website'
     runs-on: ubuntu-22.04
@@ -750,6 +955,10 @@ jobs:
   # feature check that used to share the "Check crates" step moved to dll_tests,
   # which has the bindings.
   check_crates:
+    # Tier 0: the supply-chain preflight gates even this. `cargo check`
+    # runs dependency build scripts, so a lint that compiles anything is
+    # downstream of "is that code allowed to run". See supply_chain_preflight.
+    needs: [supply_chain_preflight]
     name: Check crates (engine)
     if: github.event_name != 'workflow_dispatch' || github.event.inputs.run_mode == 'ci' || github.event.inputs.run_mode == 'deploy' || github.event.inputs.run_mode == 'website'
     runs-on: ubuntu-22.04
@@ -2281,6 +2490,11 @@ jobs:
   # verifiable off-Windows, so that leg only compiles the backend + test; flip
   # its `run:` to true to execute on a real Windows host once values are pinned.
   icu_parity:
+    # Tier 0 (2026-08-25): this job compiles the dependency tree, so it is
+    # downstream of the supply-chain preflight like everything else that
+    # does. It keeps its head start over the rest of the pipeline — it
+    # still does not wait on the quality tier.
+    needs: [supply_chain_preflight]
     name: ICU Parity (${{ matrix.backend.feature }})
     # THE ONE azul-layout TEST THAT LEGITIMATELY RUNS OFF-LINUX, and the reason
     # it was not folded into test_lib's ubuntu-only rule on 2026-08-20. The three
@@ -5566,11 +5780,24 @@ jobs:
     # release on them.
     continue-on-error: true
     runs-on: macos-14
-    # Hoist the signing secrets to job env so the optional cert-import step can
-    # gate on `env.` (the `secrets.` context is not allowed in a step `if:`).
+    # Hoist a PRESENCE FLAG, never the material. The optional cert-import step
+    # needs to gate on something visible to a step `if:`, and the `secrets.`
+    # context is not allowed there — but the thing it needs is "is a cert
+    # configured", which is a boolean, not a certificate.
+    #
+    # This used to hoist APPLE_CERT_P12 and APPLE_CERT_PASSWORD themselves. Job
+    # env is the environment of EVERY step, and this job's build step runs
+    # scripts/build-ios.sh ten times, each of which runs `cargo build` — so the
+    # base64 signing certificate and its password sat in the environment of
+    # every build script and proc macro in a 700-crate dependency tree, for the
+    # whole build. Reading an environment variable is the single most common
+    # payload in a compromised crate (mysten-metrics 9.0.3 did exactly this),
+    # and a code-signing identity is close to the most valuable thing to take
+    # from a mobile CI job. The secrets are now scoped to the one step that
+    # imports them into the keychain, which is where they were always needed
+    # and nowhere else.
     env:
-      APPLE_CERT_P12: ${{ secrets.APPLE_CERT_P12 }}
-      APPLE_CERT_PASSWORD: ${{ secrets.APPLE_CERT_PASSWORD }}
+      HAVE_APPLE_CERT: ${{ secrets.APPLE_CERT_P12 != '' }}
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
@@ -5599,7 +5826,11 @@ jobs:
       # the Simulator .app never needs signing. (No Mac? the guide documents
       # rcodesign for signing off-host.)
       - name: Import Apple signing cert (optional)
-        if: ${{ env.APPLE_CERT_P12 != '' }}
+        if: ${{ env.HAVE_APPLE_CERT == 'true' }}
+        # The ONLY step in this job that sees the signing material.
+        env:
+          APPLE_CERT_P12: ${{ secrets.APPLE_CERT_P12 }}
+          APPLE_CERT_PASSWORD: ${{ secrets.APPLE_CERT_PASSWORD }}
         run: |
           KCHAIN="$RUNNER_TEMP/azul.keychain-db"
           security create-keychain -p actions "$KCHAIN"
@@ -7979,8 +8210,36 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: 1.88.0
-      - name: Install cargo-deny
-        run: cargo install cargo-deny --locked || cargo install cargo-deny
+      - name: Install cargo-deny + cargo-audit
+        run: |
+          cargo install cargo-deny --locked || cargo install cargo-deny
+          cargo install cargo-audit --locked || cargo install cargo-audit
+
+      # cargo-audit reads the SAME RustSec database as `cargo deny check
+      # advisories`, so this is a second opinion, not a second source. It earns
+      # its place for two reasons: it fetches a fresh advisory-db clone on every
+      # run (cargo-deny's is subject to its own caching), and its `--deny
+      # warnings` covers unmaintained/unsound advisories that the deny.toml
+      # `ignore` list deliberately silences — so a crate going unmaintained
+      # shows up here as a warning even while it stays ignored over there.
+      # Non-blocking on purpose: `advisories` in the deny step below is the
+      # gate, and two gates on one database means one of them is noise.
+      - name: cargo-audit (second opinion, non-blocking)
+        continue-on-error: true
+        shell: bash
+        run: |
+          mkdir -p stats
+          cargo audit --color never 2>&1 | tee stats/cargo-audit.txt || true
+          {
+            echo '## 🛡️ cargo-audit (RustSec)'
+            echo ''
+            echo '<details><summary>full report</summary>'
+            echo ''
+            echo '```'
+            tail -120 stats/cargo-audit.txt
+            echo '```'
+            echo '</details>'
+          } >> "$GITHUB_STEP_SUMMARY"
       - name: cargo-deny + summary
         shell: bash
         run: |
@@ -8138,6 +8397,10 @@ jobs:
           retention-days: 30
 
   clippy:
+    # Tier 0: the supply-chain preflight gates even this. `cargo check`
+    # runs dependency build scripts, so a lint that compiles anything is
+    # downstream of "is that code allowed to run". See supply_chain_preflight.
+    needs: [supply_chain_preflight]
     name: Clippy
     if: github.event_name != 'workflow_dispatch' || github.event.inputs.run_mode == 'ci' || github.event.inputs.run_mode == 'deploy' || github.event.inputs.run_mode == 'website'
     runs-on: ubuntu-22.04
@@ -8511,6 +8774,11 @@ jobs:
   # fail the pipeline. The @media print CSS (docgen/guide.rs) gives light code
   # blocks in the PDF while the web keeps the dark theme.
   docs_pdf:
+    # Tier 0 (2026-08-25): this job compiles the dependency tree, so it is
+    # downstream of the supply-chain preflight like everything else that
+    # does. It keeps its head start over the rest of the pipeline — it
+    # still does not wait on the quality tier.
+    needs: [supply_chain_preflight]
     name: Docs PDF (artifact)
     if: github.event_name != 'workflow_dispatch' || github.event.inputs.run_mode == 'ci' || github.event.inputs.run_mode == 'deploy' || github.event.inputs.run_mode == 'website'
     runs-on: ubuntu-22.04
@@ -8592,6 +8860,11 @@ jobs:
   # downgraded every failure to a warning.
   # ---------------------------------------------------------------------------
   publish_safety:
+    # Tier 0 (2026-08-25): this job compiles the dependency tree, so it is
+    # downstream of the supply-chain preflight like everything else that
+    # does. It keeps its head start over the rest of the pipeline — it
+    # still does not wait on the quality tier.
+    needs: [supply_chain_preflight]
     name: Publish safety (no [patch] on published deps)
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -108,6 +108,15 @@ jobs:
         run: |
           set -o pipefail
           if ! cargo vet --locked 2>&1 | tee vet.txt; then
+            # Distinguish "the store is broken" from "a dependency is
+            # unaudited". Reporting the first as the second sent the last
+            # failure looking for a bad crate when the real cause was
+            # supply-chain/imports.lock never having been committed (.gitignore
+            # has a blanket *.lock rule, and `git add` skipped it silently).
+            if grep -qiE "couldn't acquire the store|no such file or directory" vet.txt; then
+              echo "::error::cargo-vet could not read supply-chain/. Is the whole store committed? (imports.lock is matched by the blanket *.lock rule in .gitignore and needs the negation that keeps it tracked.)"
+              exit 1
+            fi
             {
               echo '## 🔎 cargo-vet'; echo ''
               echo '```'; tail -80 vet.txt; echo '```'; echo ''

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -1,0 +1,177 @@
+# Supply-chain checks that gate nothing inside rust.yml.
+#
+# WHY A SEPARATE FILE. `.github/workflows/rust.yml` is ~5 KB below GitHub's
+# 512,000-byte workflow-file limit. Above that limit GitHub does not start runs
+# and does not report an error: no run, no `startup_failure`, no annotation —
+# CI simply stops existing, and the PR sits with "no checks reported". Adding
+# these jobs inline pushed rust.yml to 516,759 bytes and did exactly that.
+#
+# Only `supply_chain_preflight` has to live in rust.yml, because seven jobs
+# there `needs:` it and `needs:` cannot cross workflow files. Everything else
+# belongs here, and its steps are a composite action for the same reason.
+
+name: Supply chain
+
+on:
+  push:
+    branches: ['**']
+    tags: ['[0-9]+.[0-9]+.[0-9]+*']
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: >-
+    ${{ github.workflow }}-${{
+      (github.event.pull_request.head.repo.full_name == github.repository
+        && github.event.pull_request.head.ref) || github.ref_name }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: never
+  NO_COLOR: "1"
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # The guard that would have caught the outage that created this file.
+  #
+  # A workflow file over 512,000 bytes is silently inert. This check CANNOT live
+  # in rust.yml — an oversized workflow does not run, so a size check inside it
+  # can never fire. It lives here, in a file small enough that it always runs.
+  workflow_size_guard:
+    name: Workflow files must stay under GitHub's size limit
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v7
+      - name: Check every workflow file against the 512,000-byte limit
+        shell: bash
+        run: |
+          python3 - <<'PY'
+          import os, pathlib, sys
+          LIMIT = 512_000          # GitHub: "500 KB or smaller to trigger a run"
+          WARN  = int(LIMIT * 0.95)
+          bad, warn = [], []
+          for p in sorted(pathlib.Path(".github/workflows").glob("*.y*ml")):
+              n = p.stat().st_size
+              (bad if n > LIMIT else warn if n > WARN else []).append((p, n))
+              print(f"{n:>9,}  {'OVER' if n > LIMIT else 'near' if n > WARN else 'ok':>4}  {p}")
+          summary = os.environ.get("GITHUB_STEP_SUMMARY")
+          for p, n in warn:
+              print(f"::warning file={p}::{p} is {n:,} bytes — within 5% of the "
+                    f"{LIMIT:,}-byte limit. Over it, GitHub silently stops running "
+                    f"this workflow: no run, no startup_failure, no annotation. "
+                    f"Split shared logic into a composite action or reusable workflow.")
+          for p, n in bad:
+              print(f"::error file={p}::{p} is {n:,} bytes, over GitHub's {LIMIT:,}-byte "
+                    f"workflow limit. Runs for it are silently not started.")
+          sys.exit(1 if bad else 0)
+          PY
+
+  # ---------------------------------------------------------------------------
+  # Version-level supply chain: cargo-vet and the publish-age cooldown.
+  #
+  # These answer what `dependency-justifications.toml` structurally cannot. That
+  # file is keyed by crate NAME, so a crate already justified stays justified
+  # when a compromised maintainer account publishes a new version of it — which
+  # is what happened to arrayref, internment and append-only-vec on 2026-08-20,
+  # all three already in thousands of trees.
+  #
+  # cargo-vet pins per VERSION: a bump lands unaudited and fails until someone
+  # reviews the delta or exempts it deliberately. The cooldown refuses versions
+  # younger than 14 days, turning that attack's 86-107 minute exposure window
+  # into a non-event. It is RFC 3923 min-publish-age, implemented locally
+  # because the client half had not shipped when arrayref happened.
+  supply_chain_versions:
+    name: cargo-vet + publish-age cooldown
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # The cooldown diffs Cargo.lock against the base ref, so it needs
+          # history. Without this the diff is empty and every version looks
+          # unchanged — a gate that passes by knowing nothing.
+          fetch-depth: 0
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.88.0
+
+      - name: Install cargo-vet
+        run: cargo install cargo-vet --locked || cargo install cargo-vet
+
+      # --locked: the audit set and imports.lock as committed. Without it vet
+      # refreshes imports from the network, so a failing run could be turned
+      # green by an upstream publishing an audit — not a decision to delegate.
+      - name: cargo vet
+        shell: bash
+        run: |
+          set -o pipefail
+          if ! cargo vet --locked 2>&1 | tee vet.txt; then
+            {
+              echo '## 🔎 cargo-vet'; echo ''
+              echo '```'; tail -80 vet.txt; echo '```'; echo ''
+              echo 'A new or bumped dependency is neither audited nor exempted:'
+              echo ''
+              echo '```'
+              echo 'cargo vet diff <crate> <old-version> <new-version>'
+              echo 'cargo vet certify <crate> <old-version> <new-version>'
+              echo '# or, if accepting it without review:'
+              echo 'cargo vet add-exemption <crate> <version>'
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "::error::cargo-vet: an unaudited dependency version entered the tree."
+            exit 1
+          fi
+          { echo '## 🔎 cargo-vet'; echo ''; echo '```'; tail -20 vet.txt; echo '```'; } \
+            >> "$GITHUB_STEP_SUMMARY"
+
+      # Only CHANGED versions are age-checked: crates.io's API is rate limited,
+      # and the lockfile diff is where a poisoned release enters anyway.
+      - name: Publish-age cooldown (changed dependencies only)
+        shell: bash
+        run: |
+          BASE="${{ github.event.pull_request.base.sha || github.event.before }}"
+          if [ -z "$BASE" ] || [ "$BASE" = "0000000000000000000000000000000000000000" ]; then
+            BASE="$(git rev-parse HEAD~1 2>/dev/null || git rev-parse HEAD)"
+          fi
+          echo "comparing Cargo.lock against $BASE"
+          python3 scripts/supply-chain/lockfile_guard.py \
+            --check cooldown --min-age-days 14 \
+            --changed-only --base-ref "$BASE" --no-cache
+
+  # ---------------------------------------------------------------------------
+  # cargo-audit reads the SAME RustSec database as `cargo deny check advisories`
+  # (which gates in rust.yml), so this is a second opinion, not a second source.
+  # It earns its place by fetching a fresh advisory-db on every run and by
+  # surfacing the unmaintained/unsound advisories that deny.toml's `ignore` list
+  # deliberately silences. Non-blocking: two gates on one database means one of
+  # them is noise.
+  advisories:
+    name: cargo-audit (second opinion)
+    runs-on: ubuntu-22.04
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.88.0
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked || cargo install cargo-audit
+      - name: cargo audit
+        shell: bash
+        run: |
+          mkdir -p stats
+          cargo audit --color never 2>&1 | tee stats/cargo-audit.txt || true
+          {
+            echo '## 🛡️ cargo-audit (RustSec)'; echo ''
+            echo '<details><summary>full report</summary>'; echo ''
+            echo '```'; tail -120 stats/cargo-audit.txt; echo '```'
+            echo '</details>'
+          } >> "$GITHUB_STEP_SUMMARY"
+      - uses: actions/upload-artifact@v7
+        with:
+          name: stats-cargo-audit
+          path: stats/cargo-audit.txt
+          if-no-files-found: warn
+          retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,12 @@ LICENSE-WINDOWS.txt
 LICENSE-LINUX.txt
 LICENSE-MAC.txt
 *.lock
+
+# ...except cargo-vet's import lock. The blanket *.lock rule above silently
+# excluded it, `git add supply-chain/` skipped it without a word, and CI failed
+# with "Couldn't acquire the store" — which reads like an audit problem and is
+# not. It pins the exact imported audit revisions and MUST be committed.
+!supply-chain/imports.lock
 # Track the root workspace lockfile: reproducible CI builds + a stable
 # Swatinem/rust-cache key. Nested/vendored locks stay ignored via *.lock above;
 # the excluded experiment keeps its own ignore rule lower in this file.

--- a/.gitignore
+++ b/.gitignore
@@ -208,3 +208,6 @@ examples/node/package-lock.json
 /azul.pdb
 examples/c/*.pdb
 examples/c/*.ilk
+
+# lockfile_guard.py publish-date cache (regenerable, per-machine)
+.supply-chain-cache.json

--- a/scripts/SUPPLY_CHAIN_AUDIT_2026_08_25.md
+++ b/scripts/SUPPLY_CHAIN_AUDIT_2026_08_25.md
@@ -1,0 +1,217 @@
+# Supply-chain audit + hardening — 2026-08-25
+
+Branch `security/supply-chain-hardening`, from `origin/master` @ cf5099e17.
+
+## What was done
+
+1. Four new gates, wired into CI **before anything compiles** (`scripts/supply-chain/`).
+2. cargo-vet adopted, with the shared audit pool imported.
+3. Every crate in azul's tree that executes code at build time was read and
+   classified by a reviewer — **192 crate-versions, 13 parallel reviewers**.
+4. One live credential exposure in CI found and fixed.
+
+## Headline results
+
+**Zero suspicious crates.** 192 crate-versions audited; none did anything
+unexplained by its stated purpose. Independent per-batch verification also
+re-hashed the vendored files against `.cargo-checksum.json`: **855 crates, every
+file matching what crates.io published**, no additions, no modifications.
+
+**Zero build scripts use network primitives.** No sockets, no HTTP clients, no
+`curl`/`wget` shell-outs, no DNS anywhere in the 141 build scripts as configured.
+Three crates carry latent, feature-gated network paths (below), all currently
+inert.
+
+**Nothing yanked, no checksum drift, nothing suspiciously new.** All 779
+crates.io versions in `Cargo.lock` are ≥14 days old once first-party crates are
+excluded; every lockfile checksum matches the sparse index.
+
+## Composition
+
+| | count |
+|---|---|
+| crates in `Cargo.lock` | 773 |
+| crates vendored | 855 |
+| **with a build script** | **141** |
+| proc-macro crates | 50 |
+| transitive `[build-dependencies]` closure | 247 |
+| **total crates executing code at build time** | **416** |
+
+The 141 build scripts break down as: 38 declare cfg names, 26 emit link
+directives, 21 emit cfg flags, 19 generate tables into `OUT_DIR`, 17 compile
+C/C++, 14 probe the rustc version, 1 probes pkg-config, 5 other. That ratio —
+~16% of crates having a build script — is normal for a tree with this much
+native integration; the number is not inflated. It was cross-checked against
+`cargo metadata --all-features`, which reports 143 `custom-build` targets, the
+extra two being azul's own path crates that `cargo vendor` does not vendor.
+
+## Findings — things a human should decide on
+
+### 1. Build-time execution of binaries chosen by the environment
+
+Six crates execute a binary whose identity comes from `PATH` or an environment
+variable, during `cargo build`:
+
+| crate | executes | chosen by |
+|---|---|---|
+| `pyo3` / `pyo3-ffi` / `pyo3-build-config` | a Python interpreter, script piped to stdin | `PYO3_PYTHON`, `VIRTUAL_ENV`, `CONDA_PREFIX`, `PATH` |
+| `mozjpeg-sys` (via `nasm-rs`) | **every `PATH` entry joined with `nasm`**, each run with `-v` until one is new enough | `PATH`, incl. relative entries |
+| `find-msvc-tools` | the first `cl.exe` on `PATH`; `vswhere.exe` under `%ProgramFiles(x86)%` | `PATH`, `ProgramFiles(x86)` |
+| `clang-sys` (via `bindgen`, in 8 crates' build scripts) | `dlopen`s a `libclang` found on the host | `LIBCLANG_PATH`, `LD_LIBRARY_PATH`, system globs |
+| `turso_sqlite3_parser` | compiles vendored `lemon.c` (5,881 lines) to a host binary, then runs it | — (sources in-crate) |
+| `tikv-jemalloc-sys` | `sh <bundled autoconf configure>` then `make` | — (script in-crate, Autoconf 2.69, checksummed) |
+
+The last two are self-contained and were verified. The first four are
+environment-steerable. **Recommended**: pin `PYO3_PYTHON` and `NASM` to absolute
+paths in CI, and set `LIBCLANG_PATH` explicitly.
+
+`nasm-rs` deserves the specific note: it builds its candidate list as `nasm`
+chained with each `PATH` entry joined with `nasm`, then *executes* each candidate.
+A relative `PATH` entry therefore yields a CWD-relative binary that gets run.
+
+### 2. Latent network fetches (all currently inert)
+
+| crate | what | gate |
+|---|---|---|
+| `ext-php-rs` | GETs `php-devel-pack-*.zip` from `windows.php.net`/`downloads.php.net`, unzips into `OUT_DIR`, links `php8*.lib` from it — **no checksum, no signature, no version pin**; URL derived from the local `php -i` | `cfg(windows)` + `php-extension` feature |
+| `oboe-sys` | downloads a prebuilt tarball from GitHub releases | `fetch-prebuilt` feature (not enabled; `fetch_unroll` not vendored) |
+| `libgit2-sys` | `git submodule update --init libgit2` when `libgit2/src` is absent | inert — sources are vendored |
+
+The `ext-php-rs` one is the real decision: it is a build-time download of an
+unverified third-party archive that gets linked into the output. It is off on
+macOS/Linux and behind an optional feature, but if PHP bindings are ever built
+on Windows CI, that path runs. Also note `ureq`'s `Config::default()` calls
+`Proxy::try_from_env()`, so `HTTPS_PROXY` in the build environment silently
+redirects that download.
+
+### 3. `built` bakes this repository's identity into a shipped binary
+
+`turso_core` uses `built` 0.7.7 in its build script. `built` calls
+`git2::Repository::discover(CARGO_MANIFEST_DIR)`, which walks **upward** — for a
+vendored crate that finds the *enclosing* azul checkout. Five facts about it
+become `pub static`s inside the compiled `turso_core`:
+
+- `GIT_HEAD_REF` — the full branch ref, e.g. `refs/heads/transient-window`
+- `GIT_COMMIT_HASH`, `GIT_COMMIT_HASH_SHORT`, `GIT_VERSION`, `GIT_DIRTY`
+
+It also stamps a wall-clock timestamp, so this crate alone makes azul's builds
+non-reproducible, and it calls `env::vars_os()` over the whole environment
+(verified: only a fixed allowlist is emitted — no arbitrary value reaches the
+generated file, but the whole environment is in hand should that ever change).
+
+**Recommended**: drop `built`'s `git2` and `chrono` features on the `turso_core`
+dependency unless the git stamp is wanted in shipped binaries.
+
+### 4. Whole-environment enumeration
+
+Four crates call `env::vars()`/`vars_os()` in build-time code. All were read:
+
+- `openssl-sys` — name-only, filtered to `DEP_AWS_LC_*`, values discarded; dead
+  unless the `aws-lc` features are on. **But** its `env_inner` helper *echoes the
+  name and value* of every variable it queries to build-script stdout, which cargo
+  persists to `target/<profile>/build/openssl-sys-*/output`. It also does
+  `env::set_var("PKG_CONFIG_ALLOW_CROSS", "1")`, mutating the environment of
+  every sibling build script.
+- `built` — see above.
+- `libm` — names only, filtered to `CARGO_FEATURE_*`.
+- `wasi` — generated bindings.
+
+`tikv-jemalloc-sys` reads `CI` (to decide whether to dump `config.log` on
+failure) — the only CI-provider detection in the tree, and benign.
+
+### 5. Writes outside `OUT_DIR`
+
+All feature-gated and inert as configured, but worth a lint if the policy is
+"OUT_DIR only": `io-uring` (`bindgen`+`overwrite`), `ring`
+(`RING_PREGENERATE_ASM`), `mvt-reader` (`protoc-generated`), `pulldown-cmark`
+(`gen-tests`), `vk-mem` (`generate_bindings`).
+
+### 6. `ICU4X_DATA_DIR` redirects a compile-time `include!`
+
+Eleven `icu_*_data` crates set `cfg(icu4x_custom_data)` from the presence of
+`ICU4X_DATA_DIR`; their `src/lib.rs` then does
+`include!(concat!(env!("ICU4X_DATA_DIR"), "/mod.rs"))`. Anyone who can set that
+variable in the build environment compiles arbitrary Rust into azul. It should
+be pinned unset in CI.
+
+### 7. Unreviewable prebuilt binaries
+
+Shipped in-crate and linked without rebuild. All verified structurally (import
+tables, no oversized code members, clean `strings` sweeps) and all checksum-clean,
+but none is auditable by reading:
+
+- `winapi-x86_64-pc-windows-gnu` — 1,416 `.a` files, 53 MB
+- `winapi-i686-pc-windows-gnu` — 1,387 `.a` files, 51 MB
+- `windows_{aarch64,x86_64,i686}_{msvc,gnu,gnullvm}` — 3–13 MB import libs each
+- `aegis` — `wasm-libs/libaegis*.a` (~320 KB), linked on wasm32 **without a
+  source rebuild** (native targets compile from source)
+- `wit-bindgen` — 858-byte wasm archive, matches its shipped C
+- `hyphenation` — 82 `.bincode` dictionaries (data, not code)
+- `libloading` — two ~3 KB PE test fixtures, `cfg(test)` only
+
+### 8. Why `openssl-sys` is in the tree
+
+It is not reachable from `cargo tree` on macOS, but it is in the lockfile via two
+paths:
+
+```
+openssl-sys <- native-tls <- ureq 3.3.0     <- azul-layout, azul-doc
+openssl-sys <- native-tls <- ext-php-rs     <- azul-dll
+```
+
+`ureq` pulls `native-tls` by default, which is at odds with `deny.toml`'s stated
+reason for using `rustls-rustcrypto` — a pure-Rust provider so `libazul`
+cross-compiles to targets where `ring`/`aws-lc-rs` need platform asm. **Worth
+checking whether `ureq`'s default features should be off.** It also means the one
+crate in the tree that enumerates the entire environment compiles on Linux CI.
+
+## Gap found in the existing justification gate
+
+`dependency-justifications.toml` has 548 justified crates. `Cargo.lock` has 773.
+The `dep_tree` job runs `cargo tree` for **azul-css / azul-core / azul-layout /
+azul-dll `--features build-dll`** across three OSes. That is *one feature
+combination*, and it does not include `azul-doc` at all.
+
+Reproducing it on macOS: the gate sees 415 crates and **all 415 are justified** —
+it is doing real work and is genuinely green. But 235 lockfile crates are outside
+its view, including `openssl-sys`, `ring`, `native-tls`, `pyo3`, `ext-php-rs`,
+`jni`, `tikv-jemalloc-sys`, `mimalloc`, `v4l2-sys-mit`, `zstd-sys`, `alsa`,
+`comrak`, `clap` — all of which CI compiles under other feature sets
+(`build_pyext`, `php-extension`, `allocator_jemalloc`, azul-doc).
+
+**Recommended follow-up**: widen `dep_tree` to `--workspace --all-features`, or to
+the union of the feature sets CI actually builds. That will surface ~235 crates
+needing a justification line — real work, but it is the honest scope, and the new
+build-script policy already covers the dangerous subset of them.
+
+## Fixed here
+
+**`build_mobile_apps` handed the Apple signing certificate to every build script
+in the tree.** The job hoisted `APPLE_CERT_P12` (base64 cert) and
+`APPLE_CERT_PASSWORD` to **job-level `env:`**, so the optional cert-import step
+could gate on `env.` — `secrets.` is not allowed in a step `if:`. Job env is the
+environment of every step, and the build step runs `build-ios.sh` ten times, each
+invoking `cargo build`. So a code-signing identity and its password sat in the
+environment of ~700 crates' build scripts and proc macros for the whole build.
+
+Reading an environment variable is the single most common payload in a
+compromised crate. The `if:` needs a boolean, not a certificate: it now hoists
+`HAVE_APPLE_CERT: ${{ secrets.APPLE_CERT_P12 != '' }}` and the material is scoped
+to the one step that imports it into the keychain. (The secret is currently empty
+in this repo, so nothing has leaked — the exposure was structural.)
+
+## Open follow-ups
+
+1. Widen `dep_tree` to the feature sets CI actually builds (~235 crates to justify).
+2. Pin `PYO3_PYTHON`, `NASM`, `LIBCLANG_PATH` to absolute paths in CI; assert
+   `ICU4X_DATA_DIR` is unset.
+3. Decide on `ext-php-rs`'s Windows devel-pack download (pre-stage, or accept).
+4. Check whether `ureq` should be `default-features = false` — it is what pulls
+   `native-tls` → `openssl-sys`.
+5. Drop `built`'s `git2`/`chrono` features on `turso_core` if branch names and a
+   wall-clock timestamp are not wanted in shipped binaries.
+6. Enable **Trusted Publishing** on crates.io for azul-css/core/layout — it
+   replaces the long-lived `CARGO_REGISTRY_TOKEN` with short-lived OIDC and kills
+   the stolen-token vector outright. Same for PyPI.
+7. `cargo vet`: 693 exemptions remain. `cargo vet suggest` shows which are worth
+   auditing next.

--- a/scripts/supply-chain/README.md
+++ b/scripts/supply-chain/README.md
@@ -1,0 +1,147 @@
+# Supply-chain gates
+
+Four gates, three questions. Each answers something the others structurally cannot.
+
+| gate | question | keyed by |
+|---|---|---|
+| `scripts/dependency-justifications.toml` (pre-existing) | why is this crate here at all? | crate **name** |
+| `scan_build_scripts.py` + `build-script-policy.toml` | may this crate run code at build time, and is it the same code we read? | **content digest** |
+| `env_guard.py` | which environment variables may build-time code read? | variable **name** |
+| `lockfile_guard.py` | may this **version** enter the tree? | name + **version** |
+| `cargo vet` (`supply-chain/`) | has this exact version been audited? | name + **version** |
+
+## Why the name-keyed gate is not enough
+
+`dependency-justifications.toml` requires a written reason for every crate in the
+tree, which stops a dependency being added quietly. It is keyed by crate *name*,
+so a crate that is already justified stays justified when a compromised
+maintainer account publishes a new version of it.
+
+That is not hypothetical. On 2026-08-20 `arrayref`, `internment` and
+`append-only-vec` — all long-established, all already in thousands of dependency
+trees — had malicious releases published from a compromised account inside a
+23-minute window. The only change was one line of `Cargo.toml` adding
+`proc-macro1`, a typosquat of `proc-macro2`, whose `build.rs` downloaded and ran
+a remote payload. No code in the compromised crates had to be called. Exposure
+was 86–107 minutes, and the attacker yanked the good releases to force the
+resolver onto the bad ones.
+
+A name-keyed allowlist says yes to every one of those releases. The three gates
+here are the ones that say no.
+
+## The gates
+
+### `scan_build_scripts.py` — build-time code execution
+
+`build.rs` runs during `cargo build` with the full authority of whoever typed
+the command; proc macros run inside rustc with the same authority and less
+visibility. This gate finds every crate that executes code at build time and
+requires a policy entry carrying `allow`, an acknowledged `risk`, a written
+`reason`, and `reviewed` — a list of `<version>:<sha256>` pins over the actual
+build-time files.
+
+The digest is the part the justifications file cannot do. It covers the build
+script, a sibling `build/` directory, and the transitive closure of everything
+pulled in with `mod` / `#[path]` / `include!` — 16 of azul's 141 build scripts
+span more than one file, so hashing `build.rs` alone would let a payload move one
+file sideways and keep the pin green. A version bump changes the digest, fails
+the build, and forces someone to read the diff.
+
+It also scans build-time code against a table of behaviours that separate a real
+build script from an exfiltration stub (`--print-rules`). The table is applied at
+full strength to build scripts and proc macros, and reduced to the exfiltration
+subset for build *dependencies* — ordinary libraries linked into build scripts,
+where rules written for a 200-line `build.rs` produce nothing but noise against
+50k lines of FFI declarations.
+
+### `env_guard.py` — environment access
+
+Credential theft through the build is the most productive thing a poisoned
+dependency can do, because cargo hands every build script the runner's full
+environment. This gate scans build-time code for `env!`, `option_env!`,
+`env::var`, `env::var_os`, `env::vars` (whole-environment enumeration), `getenv`
+in C sources, and `GetEnvironmentVariable`.
+
+The forbidden-name set does not come from `os.environ` — a secret only exists in
+the environment of the job it is wired into, and this gate deliberately runs in a
+job that has none. It is parsed out of `.github/workflows/*.yml`: every
+`secrets.NAME` the repository can inject, checked for whether or not this run has
+it.
+
+### `lockfile_guard.py` — version integrity
+
+Four checks: every vendored file matches the registry checksum cargo recorded
+(offline); no locked version is yanked; lockfile checksums match the index; and
+no version is younger than `--min-age-days` (default 14).
+
+The cooldown is RFC 3923 `min-publish-age`, implemented here because the
+client-side half had not shipped when the arrayref attack happened — two days
+after the stabilisation PR entered its final comment period. A 14-day floor turns
+a 107-minute exposure window into a non-event. First-party crates are exempt; see
+`cooldown-exempt.txt` for why that exemption is necessary rather than convenient.
+
+### `cargo vet` — per-version audits
+
+`supply-chain/config.toml` records an audit or an exemption for every version in
+the tree, and imports the shared audit sets published by Mozilla, Google, the
+Bytecode Alliance, Embark, ISRG and Zcash. A dependency bump lands as an
+unaudited version and fails until someone reviews the delta.
+
+## Running them
+
+```sh
+scripts/supply-chain/run_all.sh                  # everything CI blocks on
+scripts/supply-chain/run_all.sh --with-cooldown  # + publish-age (slow: one API call per crate)
+scripts/supply-chain/run_all.sh --keep-vendor    # leave vendor/ for inspection
+```
+
+Individually — each takes `--vendor DIR` and most take `--report-only`:
+
+```sh
+cargo vendor --locked --versioned-dirs vendor
+python3 scripts/supply-chain/scan_build_scripts.py --vendor vendor
+python3 scripts/supply-chain/env_guard.py          --vendor vendor
+python3 scripts/supply-chain/lockfile_guard.py     --vendor vendor --check all
+python3 scripts/supply-chain/scan_build_scripts.py --print-rules   # the risk table
+python3 scripts/supply-chain/env_guard.py          --print-classes # the name classes
+```
+
+## When a gate fails
+
+**"UNREVIEWED — no entry in build-script-policy.toml"** — a new crate runs code
+at build time. Read its build script, then `--update` to write the skeleton and
+fill in the `reason` by hand.
+
+**"DIGEST — version X is not reviewed"** — a crate you already allow shipped new
+build-time code. **Read the diff before re-pinning.** This is the account-takeover
+signal; `--update` makes re-pinning cheap precisely so that the review, not the
+mechanics, is the work.
+
+**"forbidden read"** — build-time code reads a credential-shaped variable or one
+of this repository's secrets. There is no correct way to allow this; the crate is
+either compromised or must be dropped.
+
+**cargo-vet failure** — `cargo vet diff <crate> <old> <new>`, then
+`cargo vet certify` if it is clean, or `cargo vet add-exemption` to accept it
+without review.
+
+**COOLDOWN** — a dependency is younger than the floor. Wait, or, if it is genuinely
+urgent, pass `--min-age-days` on that one run and say why in the commit message
+so the exception is visible instead of permanent.
+
+## In CI
+
+`supply_chain_preflight` (in `.github/workflows/rust.yml`) has no `needs:` and
+every job that compiles anything is downstream of it — including `clippy` and
+`check_crates`, because `cargo check` runs build scripts too. `cargo vendor`
+downloads sources and executes nothing, which is what makes a gate that runs
+*before* the build possible at all. `supply_chain_versions` runs cargo-vet and
+the cooldown; `supply_chain` runs cargo-deny and cargo-audit.
+
+## Notes
+
+The policy files are written in a small TOML subset parsed by `sc_common.py`
+rather than `tomllib`, which is Python 3.11+ — the ubuntu-22.04 runner ships 3.10
+and stock macOS ships 3.9, so a `tomllib` import in a CI gate is a gate that does
+not run. The files are still valid TOML; the subset constrains what these scripts
+*write*, not what is legal.

--- a/scripts/supply-chain/build-script-policy.toml
+++ b/scripts/supply-chain/build-script-policy.toml
@@ -1,0 +1,1150 @@
+# build-script-policy.toml — which dependencies may execute code at BUILD time.
+#
+# GENERATED SKELETON, HUMAN-OWNED CONTENT. `scan_build_scripts.py --update`
+# refreshes `reviewed` digests and adds skeletons for new crates; it never
+# invents a `reason` and never flips an `allow`. A crate whose reason is still
+# the TODO placeholder has not been reviewed by anybody.
+#
+# Fields:
+#   allow    — may this crate run code at build time at all
+#   risk     — behaviour level a human ACKNOWLEDGED: low | medium | high
+#   reason   — one line: why does this crate need to run code at build time
+#   reviewed — ["<version>:<sha256-of-build-time-files>"] — the exact bytes read
+#
+# Re-pinning after a version bump is DELIBERATELY manual: the digest changing
+# is the signal that somebody has to read the diff. `--update` writes the new
+# digest so the mechanics are cheap, but the review is the point.
+
+[crate."aegis"]  # build-script
+allow = true
+risk = "low"
+reason = "compiles bundled libaegis C with cc; on wasm32 links a prebuilt static lib shipped in the crate"
+reviewed = ["0.9.15:dc8628ecad50deff381612634ab72829846cff83cfe7aef47aa0712b0034b44b"]
+
+[crate."alsa-sys"]  # build-script
+allow = true
+risk = "low"
+reason = "pkg-config probe for system libasound to emit link flags; bindings are pre-generated, no cc"
+reviewed = ["0.3.1:e1d3e61fa491d8be98b61259e33363d73e9fa81b0e3cfd18bc5c15b4f3e7d3e1"]
+
+[crate."android-activity"]  # build-script
+allow = true
+risk = "low"
+reason = "compiles the GameActivity C/C++ glue with cc when the game-activity feature is enabled"
+reviewed = ["0.6.1:dc18f6384bb392dcb9f6c76ed4754ebf0dc7aec0241996b5245eb2d6bfca0763"]
+
+[crate."android_system_properties"]  # build-dependency
+allow = true
+risk = "medium"
+reason = "no build-time code; dlopen(libc, RTLD_NOLOAD) is Android-only and not compiled on build hosts"
+reviewed = ["0.1.5:ccedb15b31dba594c73d004b9229e7e9f48ac7922a48ff2d2ecc268b4ed6fef3"]
+
+[crate."anyhow"]  # build-script
+allow = true
+risk = "low"
+reason = "probes rustc version and trial-compiles src/nightly.rs in OUT_DIR to detect unstable Error APIs"
+reviewed = ["1.0.103:f9c1c73d31cfb9e0cde53cbd412e382191a6f789cf609a9f1226ced0ce466903"]
+
+[crate."ash"]  # build-script
+allow = true
+risk = "low"
+reason = "emits the vulkan link directive and a VULKAN_SDK link-search path under the linked feature"
+reviewed = ["0.38.0+1.3.281:d91b89e509757381ff8dba3559f2361d29807c61f79f77775f5f65f195ab5054"]
+
+[crate."async-io"]  # build-script
+allow = true
+risk = "low"
+reason = "probes rustc version via autocfg to emit one cfg for std::pipe availability"
+reviewed = ["2.6.0:c3ebe3052baee2119db95a87368526d4e0cf1470a40b7b068181e6d954e527dc"]
+
+[crate."async-recursion"]  # proc-macro
+allow = true
+risk = "low"
+reason = "proc macro rewriting async fns to box the recursive future"
+reviewed = ["1.1.1:de0745e78869c1c39d5a4c2c3208f3ebe32c41d09ffa38fe3538227580c6b46c"]
+
+[crate."async-trait"]  # proc-macro
+allow = true
+risk = "low"
+reason = "proc macro desugaring async fn in traits to boxed futures"
+reviewed = ["0.1.89:5080f691ea79356df5fcb954f5972504698c61de9128ec15e4e261c34b674803"]
+
+[crate."atomic-polyfill"]  # build-script
+allow = true
+risk = "low"
+reason = "reads TARGET and emits polyfill_* cfgs; no deps, no fs, no process"
+reviewed = ["1.0.3:36aee49e066fe78c35a0284b0b780a77f0aba90c009301a984a40de82994474b"]
+
+[crate."bincode_derive"]  # proc-macro
+allow = true
+risk = "low"
+reason = "derives Encode/Decode/BorrowDecode for bincode via virtue; pure token transformation"
+reviewed = ["2.0.1:2862c5d69969aef564501b3685207ef6164f997cb08d11c538b1e11fceb9ec50"]
+
+[crate."bindgen"]  # build-script
+allow = true
+risk = "low"
+reason = "records the host TARGET triple in OUT_DIR and declares libclang env rerun triggers"
+reviewed = ["0.65.1:b043a44dbfb69a2342e419b39c38ce164f7b602f67562bbb9e38a924dfbd6485", "0.72.1:5775fc2cca7725ba0929839d1d097a14f89c891f7288e418f16b555972003d32"]
+
+[crate."built"]  # build-dependency
+allow = true
+risk = "high"
+reason = "generates OUT_DIR/built.rs from cargo metadata, rustc -V, and the ENCLOSING git repo's HEAD/branch/dirty"
+reviewed = ["0.7.7:a155acc3e3ecb1466782540593577082d0c912415582eb30b30cca3c93700e94"]
+
+[crate."bumpalo"]  # build-dependency
+allow = true
+risk = "medium"
+reason = "arena allocator library; no build-time code of its own, linked into wasm-bindgen's proc macro"
+reviewed = ["3.20.3:c9dfe51f2e5dc99772e5eba8a933070b0ae6f011fc14a85e3789fd2856296486"]
+
+[crate."bytemuck_derive"]  # proc-macro
+allow = true
+risk = "low"
+reason = "proc macro deriving Pod/Zeroable/NoUninit with compile-time layout checks"
+reviewed = ["1.11.0:9273c1acd9f61470729c7d19c92f30ad95e2b814d61009932bc480acf16642bc"]
+
+[crate."camino"]  # build-script
+allow = true
+risk = "low"
+reason = "probes rustc --version/channel to cfg-gate std Path APIs by stabilisation version"
+reviewed = ["1.2.4:19ff4656f02373eac69b34dee9e0f24a7e4a53992e98d7b78740c158c1aea01c"]
+
+[crate."clang-sys"]  # build-script
+allow = true
+risk = "low"
+reason = "finds libclang: globs system lib dirs, runs llvm-config/xcode-select, emits link flags"
+reviewed = ["1.8.1:b7af1fdd468aa9f699b921124de95feef374ea309c7fbfd3bc221d2e0c96e390"]
+
+[crate."clap_derive"]  # proc-macro
+allow = true
+risk = "low"
+reason = "derive macro building clap Command from types + doc comments; reads CARGO_PKG_* only"
+reviewed = ["4.6.1:34440937571121e88cac80f71a2e3be5b7a4e910c793c3609c79f021741dd346"]
+
+[crate."comrak"]  # build-script
+allow = true
+risk = "low"
+reason = "sorts the HTML entity table from the entities crate into an OUT_DIR binary-search table"
+reviewed = ["0.48.0:524448bc2fe7e02f416983e7339f3a279672d60d86ab470ec67830abea3ce203"]
+
+[crate."cookie"]  # build-script
+allow = true
+risk = "low"
+reason = "probes rustc channel via version_check to gate nightly doc_cfg; emits one cfg"
+reviewed = ["0.18.1:d4176ce04b0194104075b50384a9d19c3142b0bf00a9f0bb641137c3ebe3729e"]
+
+[crate."core-foundation-sys"]  # build-dependency/build-script
+allow = true
+risk = "low"
+reason = "emits the CoreFoundation framework link directive on Apple targets (0.8 has no build script)"
+reviewed = ["0.7.0:ad20851b8b681ed764e4e09ee67e0742c34de3f006332ec4acf63bb4141d2ac8", "0.8.7:8732decad0b926a3374481c781b6242dd4a1a80bced424ef3a93ff8c2311a6f7"]
+
+[crate."coreaudio-sys"]  # build-script
+allow = true
+risk = "low"
+reason = "runs xcrun for the Apple SDK path and bindgen over framework headers into OUT_DIR"
+reviewed = ["0.2.18:5ca4c100cdfbb00e272b8af0b9c8aeae39628599d1639e16375357814b39e663"]
+
+[crate."cpal"]  # build-script
+allow = true
+risk = "low"
+reason = "sets the asio cfg when CPAL_ASIO_DIR is present; no file or process access"
+reviewed = ["0.15.3:3baa3b904cf524fe6f2c148449f2b77db1fdc367f6c9e8beef120d7b60f84e8d"]
+
+[crate."crc32fast"]  # build-script
+allow = true
+risk = "low"
+reason = "runs rustc --version to enable stable ARM CRC32 intrinsics cfg on 1.80+"
+reviewed = ["1.5.0:547564906abafc17e705df59aa16e9a7ad2b21b895c9d6071e0620d6ce1a16b2"]
+
+[crate."crossbeam-deque"]  # build-script
+allow = true
+risk = "low"
+reason = "build.rs reads CARGO_CFG_SANITIZE and emits one rustc-cfg"
+reviewed = ["0.8.7:412521f2bced5099782c95f4a42c1d8b3229b8dae4977021901a8d38cb2d4df1"]
+
+[crate."crossbeam-epoch"]  # build-script
+allow = true
+risk = "low"
+reason = "reads CARGO_CFG_SANITIZE to emit one cfg, since cfg(sanitize) is unstable"
+reviewed = ["0.9.20:412521f2bced5099782c95f4a42c1d8b3229b8dae4977021901a8d38cb2d4df1"]
+
+[crate."crossbeam-utils"]  # build-script
+allow = true
+risk = "low"
+reason = "build script classifying TARGET against a checked-in no-atomics list; emits cfg only"
+reviewed = ["0.8.22:2cb723dc144a4d4108838aad931101cac73dc24394835f8cc483ffb65a369390"]
+
+[crate."crunchy"]  # build-script
+allow = true
+risk = "low"
+reason = "text-generates the unroll! macro arms (one per loop count up to the feature limit) into OUT_DIR/lib.rs"
+reviewed = ["0.2.4:1ad5bca1dfd4d750d0870d44947e0a3ab3f9a6fab102d9f851b967f02bcd4e29"]
+
+[crate."ctor"]  # proc-macro
+allow = true
+risk = "low"
+reason = "proc macro emitting .init_array/__mod_init_func/.CRT$XCU glue for pre-main constructors"
+reviewed = ["0.2.9:083faed807b7a040b974fdbb966ef805db199e77d387ff9e0e72880ac62fa93a"]
+
+[crate."curve25519-dalek"]  # build-script
+allow = true
+risk = "low"
+reason = "selects 32/64-bit limbs + serial/simd backend from CARGO_CFG_*; probes rustc version"
+reviewed = ["4.1.3:c9b37d3dd0d36957eec457733ef5190b7bf18d43bd9c5ee83bcbdacf3a2cdb5d"]
+
+[crate."curve25519-dalek-derive"]  # proc-macro
+allow = true
+risk = "low"
+reason = "attribute macro that adds #[target_feature] and unsafe-wraps fn bodies for SIMD"
+reviewed = ["0.1.1:0e322f57df58ff7c52152cff41986c34da28d76e571b9a8e6a0e6ca53424a784"]
+
+[crate."darling_macro"]  # proc-macro
+allow = true
+risk = "low"
+reason = "proc-macro forwarding derive input to darling_core; pure syn/quote expansion"
+reviewed = ["0.23.0:5f76b2f053a8d1d12afccc5e0618eee499af848295ad935aaadf1ce27442a55a"]
+
+[crate."derivative"]  # proc-macro
+allow = true
+risk = "low"
+reason = "derive macro for Clone/Debug/Default/Hash/Eq/Ord with per-field options; pure syn/quote codegen"
+reviewed = ["2.2.0:614a5969250e364456e6135d9a8196e4f89cecaf2cff2631d3616121c9dec45a"]
+
+[crate."derive_arbitrary"]  # proc-macro
+allow = true
+risk = "low"
+reason = "proc macro deriving Arbitrary for fuzzing"
+reviewed = ["1.4.2:c234445616a7cf85eeb782fd943e14858a24290f270697bbb0e6390bf5c223f7"]
+
+[crate."derive_more-impl"]  # proc-macro
+allow = true
+risk = "low"
+reason = "derive macro backend expanding Display/From/Deref/arithmetic impls via syn+quote"
+reviewed = ["2.1.1:534b243d12940aa7cc9f4a2690bd1ad290cdb397671afd791d747f6a25155422"]
+
+[crate."displaydoc"]  # proc-macro
+allow = true
+risk = "low"
+reason = "derive macro building Display impls from doc comments; syn/quote only"
+reviewed = ["0.2.6:a2ffd15bff28132217cbd4103d5c9ab54a44fcd4750067a36f9d21be757b9372"]
+
+[crate."document-features"]  # proc-macro
+allow = true
+risk = "low"
+reason = "reads the consuming crate's own Cargo.toml to turn feature comments into rustdoc; read-only"
+reviewed = ["0.2.12:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"]
+
+[crate."enumflags2_derive"]  # proc-macro
+allow = true
+risk = "low"
+reason = "proc-macro expanding #[bitflags] into flag trait impls; pure syn/quote"
+reviewed = ["0.7.12:ec37ab107099b8cba6072b1e5772b475bbccd8e30573243f48819b1b57a5094d"]
+
+[crate."erased-serde"]  # build-script
+allow = true
+risk = "low"
+reason = "probes rustc version to cfg out the #[diagnostic] namespace on pre-1.78 compilers"
+reviewed = ["0.4.10:292c3342e28cabc995bd2690497d66d24e2232ed5ce440ff41315f67f8d2e59e"]
+
+[crate."error-chain"]  # build-script
+allow = true
+risk = "low"
+reason = "version_check probe of rustc to emit has_error_source cfgs; reads PROFILE for a test cfg"
+reviewed = ["0.12.4:6edc7c45432027ae663cad5b5f56a2752304c66a06b7599fcbbe1fa7498e0612"]
+
+[crate."ext-php-rs"]  # build-script
+allow = true
+risk = "low"
+reason = "runs php/php-config to find Zend headers, compiles wrapper.c, bindgens; downloads PHP devel pack on Windows"
+reviewed = ["0.15.15:023c2ec3129a33c687d686287cf3c628c5270fb52c5fb36168cd94dda41259b6"]
+
+[crate."ext-php-rs-bindgen"]  # build-script
+allow = true
+risk = "low"
+reason = "writes the host target triple to OUT_DIR and declares libclang/bindgen rerun-if-env-changed"
+reviewed = ["0.72.1-extphprs.2:5775fc2cca7725ba0929839d1d097a14f89c891f7288e418f16b555972003d32"]
+
+[crate."ext-php-rs-derive"]  # proc-macro
+allow = true
+risk = "low"
+reason = "proc macro expanding #[php_class]/#[php_function] into PHP extension glue"
+reviewed = ["0.11.14:d3963faf480a138a81e67af71997d959f1daf28ffe41171cbbb237321c12ddf9"]
+
+[crate."find-msvc-tools"]  # build-dependency
+allow = true
+risk = "high"
+reason = "locates MSVC/SDK via vcvars env, HKLM (read-only), VS COM/vswhere; runs cl.exe to probe arch"
+reviewed = ["0.1.9:bc57728deb8fa5e085b2dbb27c58563fa1a900d76e6b20e034036b92bc62d9d5"]
+
+[crate."foreign-types-macros"]  # proc-macro
+allow = true
+risk = "low"
+reason = "expands foreign_type! into FFI wrapper types; syn/quote only"
+reviewed = ["0.2.3:bd94ca33dc4c24a92622b263fe2a664b30299019cc21be3f6b8e282deee7e065"]
+
+[crate."fst"]  # build-script
+allow = true
+risk = "low"
+reason = "generates CRC32 (and an unused snappy tag) lookup tables as Rust source into OUT_DIR"
+reviewed = ["0.4.7:66382bcdb53f0e10d213774b421a4cd15cb22d0e06891fd306752118466e4f47"]
+
+[crate."futures-macro"]  # proc-macro
+allow = true
+risk = "low"
+reason = "expands futures' join!/select!/stream_select! and #[test]; pure syn/quote rewriting"
+reviewed = ["0.3.33:60e34402b1ca4f5b2cd79319209c246179acdcc7fb512e7109e88c9cbb105b0d"]
+
+[crate."generic-array"]  # build-script
+allow = true
+risk = "low"
+reason = "0.14 probes rustc >= 1.41 via version_check for cfg(relaxed_coherence); 0.12/0.13 have no build code"
+reviewed = ["0.14.7:420bf749af19079a86c6261d5133f305fd4b935a8ce6188e0de2050df20c9087"]
+
+[crate."getrandom"]  # build-dependency/build-script
+allow = true
+risk = "medium"
+reason = "detects cfg(sanitize=memory) and pre-1.78 rustc to pick the legacy Windows RNG backend"
+reviewed = ["0.2.17:c512e046c289f7974ab75d17226b9d0e9a73aabe5bab0795ce802c8c8c9489ed", "0.3.4:e36395cd6efe5a932a346dd888f8cb9b0b384974729c5936cc5b946583f9b88f", "0.4.3:7f34d75edfac24afb8207c85830c3cd7df93ce6270a6f3a591ca522670cc0922"]
+
+[crate."gilrs-azul"]  # build-script
+allow = true
+risk = "low"
+reason = "filters the bundled SDL gamecontrollerdb.txt down to the target platform's mappings into OUT_DIR"
+reviewed = ["0.11.2:6c79f8dd2ccb1ef103c69c5062dc4636085377866faee811f4cdc76242a8f105"]
+
+[crate."git2"]  # build-dependency
+allow = true
+risk = "high"
+reason = "libgit2 bindings; built calls Repository::discover/head to stamp git rev into generated source"
+reviewed = ["0.20.4:ac6a98217207b38eee901fc64c89c3fc4dad0d8f923acbca49319e1d9073c724"]
+
+[crate."gpu-video-azul"]  # build-script
+allow = true
+risk = "low"
+reason = "sets the vulkan cfg alias; optional naga WGSL->SPIR-V shader compile into OUT_DIR"
+reviewed = ["0.4.0:1ff5b3a30ec5b19273d7bbcbb4fe378a6c17aeeeca58e7fb7686063700e73bab"]
+
+[crate."heapless"]  # build-script
+allow = true
+risk = "low"
+reason = "compiles a rustc probe in OUT_DIR to detect Arm LL/SC (clrex) support and emit cfgs"
+reviewed = ["0.6.1:19fc89748e383c1a9aee699db89aad63de4fb50552fe017a3f9e4d2ce7e1426a", "0.7.17:ccec70fcead425a4254f5132d4bc66edfd51986ea2f9aba3706e1e9d96ca12bc", "0.8.0:d55ee39c13f36dcab7c7aec8ad44944cf1e1b97de0f539c64356cf78a8cd05d7"]
+
+[crate."httparse"]  # build-script
+allow = true
+risk = "low"
+reason = "probes rustc version and CARGO_CFG_TARGET_FEATURE to emit SIMD/NEON cfg flags; writes nothing"
+reviewed = ["1.10.1:4fff40cac8de2e90a516e9647aa914cacd01ede6a354e6fb1637700e96b283d3"]
+
+[crate."hyphenation"]  # build-script
+allow = true
+risk = "low"
+reason = "bakes the shipped TeX hyphenation patterns/dictionaries into OUT_DIR; no network, no subprocesses"
+reviewed = ["0.8.4:8c7f467d4bdc8df9c29e6ddcc4cdba8b8cd1eb3eb82f0f2250a7936956933792"]
+
+[crate."iana-time-zone"]  # build-dependency
+allow = true
+risk = "medium"
+reason = "plain library reachable from build scripts via chrono; reads host tz files when called"
+reviewed = ["0.1.65:1f98c4b241771263b3854695f15df0f803109c03d99f1c99f3f598abf224432b"]
+
+[crate."iana-time-zone-haiku"]  # build-script
+allow = true
+risk = "low"
+reason = "cc-compiles a 67-line C++ shim for Haiku BTimeZone; stub returning 0 elsewhere"
+reviewed = ["0.1.2:3e778f990373f395bb1e452c4f703070c923a4ce32e59c00898ed17422fd82dc"]
+
+[crate."icu_calendar_data"]  # build-script
+allow = true
+risk = "low"
+reason = "sets cfg(icu4x_custom_data) when ICU4X_DATA_DIR is set so lib.rs includes external instead of bundled data"
+reviewed = ["2.2.0:bf68e21004d0826bbee3562716b3649908ad284314dbfa16468c0d9902f8ff75"]
+
+[crate."icu_casemap_data"]  # build-script
+allow = true
+risk = "low"
+reason = "sets the icu4x_custom_data cfg when ICU4X_DATA_DIR points at a replacement data tree"
+reviewed = ["2.2.0:bf68e21004d0826bbee3562716b3649908ad284314dbfa16468c0d9902f8ff75"]
+
+[crate."icu_collator_data"]  # build-script
+allow = true
+risk = "low"
+reason = "turns ICU4X_DATA_DIR presence into the icu4x_custom_data cfg; no file or process I/O"
+reviewed = ["2.2.0:bf68e21004d0826bbee3562716b3649908ad284314dbfa16468c0d9902f8ff75"]
+
+[crate."icu_collections"]  # build-dependency
+allow = true
+risk = "medium"
+reason = "codepoint-trie/inversion-list containers baked into data by ICU4X build scripts; no IO"
+reviewed = ["2.2.0:dd2ef680ea0fef354ef057ff8949156415ea7e3585dfd30cd32183e0752c0b0f"]
+
+[crate."icu_datetime_data"]  # build-script
+allow = true
+risk = "low"
+reason = "sets the icu4x_custom_data cfg when ICU4X_DATA_DIR points at a custom baked-data directory"
+reviewed = ["2.2.0:bf68e21004d0826bbee3562716b3649908ad284314dbfa16468c0d9902f8ff75"]
+
+[crate."icu_decimal_data"]  # build-script
+allow = true
+risk = "low"
+reason = "sets cfg(icu4x_custom_data) when ICU4X_DATA_DIR points at a custom baked data dir"
+reviewed = ["2.2.0:bf68e21004d0826bbee3562716b3649908ad284314dbfa16468c0d9902f8ff75"]
+
+[crate."icu_experimental_data"]  # build-script
+allow = true
+risk = "low"
+reason = "sets icu4x_custom_data cfg when ICU4X_DATA_DIR overrides the bundled CLDR data"
+reviewed = ["0.5.0:bf68e21004d0826bbee3562716b3649908ad284314dbfa16468c0d9902f8ff75"]
+
+[crate."icu_list_data"]  # build-script
+allow = true
+risk = "low"
+reason = "sets icu4x_custom_data cfg from ICU4X_DATA_DIR, which redirects the include! of the data module"
+reviewed = ["2.2.0:bf68e21004d0826bbee3562716b3649908ad284314dbfa16468c0d9902f8ff75"]
+
+[crate."icu_locale_data"]  # build-script
+allow = true
+risk = "low"
+reason = "sets cfg(icu4x_custom_data) when ICU4X_DATA_DIR is set so lib.rs includes external instead of bundled data"
+reviewed = ["2.2.0:bf68e21004d0826bbee3562716b3649908ad284314dbfa16468c0d9902f8ff75"]
+
+[crate."icu_normalizer_data"]  # build-script
+allow = true
+risk = "low"
+reason = "sets the icu4x_custom_data cfg when ICU4X_DATA_DIR points at a replacement data tree"
+reviewed = ["2.2.0:bf68e21004d0826bbee3562716b3649908ad284314dbfa16468c0d9902f8ff75"]
+
+[crate."icu_plurals_data"]  # build-script
+allow = true
+risk = "low"
+reason = "turns ICU4X_DATA_DIR presence into the icu4x_custom_data cfg; no file or process I/O"
+reviewed = ["2.2.0:bf68e21004d0826bbee3562716b3649908ad284314dbfa16468c0d9902f8ff75"]
+
+[crate."icu_properties_data"]  # build-script
+allow = true
+risk = "low"
+reason = "sets the icu4x_custom_data cfg when ICU4X_DATA_DIR points at a custom baked-data directory"
+reviewed = ["2.2.0:bf68e21004d0826bbee3562716b3649908ad284314dbfa16468c0d9902f8ff75"]
+
+[crate."icu_segmenter_data"]  # build-script
+allow = true
+risk = "low"
+reason = "sets cfg(icu4x_custom_data) when ICU4X_DATA_DIR points at a custom baked data dir"
+reviewed = ["2.2.0:bf68e21004d0826bbee3562716b3649908ad284314dbfa16468c0d9902f8ff75"]
+
+[crate."icu_time_data"]  # build-script
+allow = true
+risk = "low"
+reason = "sets icu4x_custom_data cfg when ICU4X_DATA_DIR overrides the bundled tz data"
+reviewed = ["2.2.1:bf68e21004d0826bbee3562716b3649908ad284314dbfa16468c0d9902f8ff75"]
+
+[crate."indoc"]  # proc-macro
+allow = true
+risk = "low"
+reason = "unindents multi-line string literals at macro expansion; no build script (build = false)"
+reviewed = ["2.0.7:43bacfdb470d5cc4921a2b86ca3967aae8773c7b61ff064a27bdd111cfe4f0eb"]
+
+[crate."inotify-sys"]  # build-script
+allow = true
+risk = "low"
+reason = "emits libinotify link flags on NetBSD/OpenBSD, locating libdir via pkg-config"
+reviewed = ["0.1.8:741c8cca420c2f1cd6fb299ef28e948f68bcd2fa6e5afe27d98ddd82e529f455"]
+
+[crate."io-uring"]  # build-script
+allow = true
+risk = "low"
+reason = "optionally runs bindgen over linux/io_uring.h; by default only emits rustc-check-cfg lines"
+reviewed = ["0.7.13:afa1c9a2a184b1dde37eed5bbeda03003b6ef0d3388ca487d1bd7258380cd315"]
+
+[crate."jetscii"]  # build-script
+allow = true
+risk = "low"
+reason = "generates 1..16-arity macro arms into OUT_DIR and emits an SSE4.2 availability cfg"
+reviewed = ["0.5.3:b694c18e68c9393734dcf636f6cf16886dbb940260b1e8d2abda8468ad43caa9"]
+
+[crate."jni"]  # build-script
+allow = true
+risk = "low"
+reason = "emits a target-OS cfg selecting the TLS vs FLS thread-attach guard"
+reviewed = ["0.22.4:016600fae53cbb1ec79fe844b6829c213c02ea8c9f7b5d41c480e49a2f62dd53"]
+
+[crate."jni-macros"]  # build-script+proc-macro
+allow = true
+risk = "low"
+reason = "proc-macro generating JNI glue; build.rs probes rustc >= 1.82 to gate unsafe-attribute syntax"
+reviewed = ["0.22.4:b290149fe6988cb16b26b4f1685f64e4a26220b014188862c31656e191c84021"]
+
+[crate."jni-sys"]  # build-script
+allow = true
+risk = "low"
+reason = "emits libjvm link-search/link-lib directives from JAVA_HOME for its own test builds"
+reviewed = ["0.3.1:301010e7920913efc952154c2c6537132cb1246e284ec5d2d22ab76b097217f1"]
+
+[crate."jni-sys-macros"]  # proc-macro
+allow = true
+risk = "low"
+reason = "attribute macro turning a versioned JNI fn-pointer struct into the ABI union"
+reviewed = ["0.4.1:e5dd270de4af378d22fa6105956dde1ad559e0b32869075949e341c855485c28"]
+
+[crate."libc"]  # build-script
+allow = true
+risk = "low"
+reason = "probes rustc/emcc/freebsd versions and target env to emit platform cfg flags"
+reviewed = ["0.2.186:805e8c8943da7785796ae72bb4667754e1ecd2639c72294ea7553e206cf26819"]
+
+[crate."libgit2-sys"]  # build-script
+allow = true
+risk = "low"
+reason = "probes system libgit2 via pkg-config, else compiles the vendored libgit2 C sources with cc"
+reviewed = ["0.18.5+1.9.4:5e164a25854a808ce3bafe01be6a78d4e4f5d2a88c1d1906f10953eb55118796"]
+
+[crate."libloading"]  # build-dependency
+allow = true
+risk = "medium"
+reason = "dlopen/LoadLibraryExW wrapper; clang-sys uses it in build scripts to load libclang"
+reviewed = ["0.8.9:e9f6d9ee89d25a0d101fbde4238c5fa504d56afa12e3c8d3cff610aa5568cbe8"]
+
+[crate."libm"]  # build-script
+allow = true
+risk = "high"
+reason = "derives feature/opt-level/f16-f128 cfgs from target env; enumerates env var names for CARGO_FEATURE_*"
+reviewed = ["0.2.16:f8327dc3fc4214e010062a921bda0e8cd97e92d67d6fdaaa430ac4dc257f4741"]
+
+[crate."libmimalloc-sys"]  # build-script
+allow = true
+risk = "low"
+reason = "compiles the crate-vendored mimalloc C amalgamation with cc and emits platform link libs"
+reviewed = ["0.1.49:b55de46737251b9b31e56a54b8159e4332a17d3ffc808434ed8a8b9beb41cd87"]
+
+[crate."libz-sys"]  # build-script
+allow = true
+risk = "low"
+reason = "locates system zlib via pkg-config/vcpkg or compiles the crate-vendored zlib/zlib-ng C into OUT_DIR"
+reviewed = ["1.1.29:aaba25f49994cc6eab5baa90b1546c67633306f60d8e8fdbcee25096ceb4fe92"]
+
+[crate."linux-raw-sys"]  # build-dependency
+allow = true
+risk = "high"
+reason = "no build code; bindgen-generated Linux type/constant declarations only"
+reviewed = ["0.12.1:79731c69c98f6e91a2c42375ee123e6f250bb33e7ab7025d6967904a57991efd", "0.4.15:e28b695a8d8508667bf0c407d0cf9fa31dcce9cd3a02e8285dc2fe9aeb78f5f8"]
+
+[crate."memoffset"]  # build-script
+allow = true
+risk = "low"
+reason = "autocfg probes rustc version (1.20-1.77) to pick the offset_of impl; emits cfgs only"
+reviewed = ["0.9.1:2a25f9e674e665b7fd27b6c2877f7d9b543a354d3133c6694d00860fac7bc078"]
+
+[crate."miette-derive"]  # proc-macro
+allow = true
+risk = "low"
+reason = "derives miette's Diagnostic impl (code/severity/help/url/labels) from attributes via syn"
+reviewed = ["7.6.0:1d69f9f17b34d331698a074c041abe2064229430df3bc18f25a3c06cba0e4c37"]
+
+[crate."mozjpeg-sys"]  # build-script
+allow = true
+risk = "low"
+reason = "builds bundled libjpeg-turbo C and assembles x86 SIMD .asm via NASM found on PATH, into OUT_DIR"
+reviewed = ["2.2.3:bce116251588265d8db2e9a0198a30cca945492b06ee8e25784dba801f7f3d93"]
+
+[crate."mvt-reader"]  # build-script
+allow = true
+risk = "low"
+reason = "build.rs compiles vector_tile.proto via prost-build, only under the protoc features (off here)"
+reviewed = ["2.4.0:111196b0bdb7935ce33c996f1d0bf4701783c98e145676d5421b8133c9d21159"]
+
+[crate."native-tls"]  # build-script
+allow = true
+risk = "low"
+reason = "reads DEP_OPENSSL_* version to cfg-gate min/max protocol-version API; no build-time I/O"
+reviewed = ["0.2.18:1c93fddc1130f66ce60f4cf17fd7a7b785c58512bcf89a60896ed76499b8a3b3"]
+
+[crate."nix"]  # build-script
+allow = true
+risk = "low"
+reason = "build script declaring cfg aliases (bsd, apple_targets, ...) via cfg_aliases; emits cfg only"
+reviewed = ["0.31.3:9f9debe95cce58beef3537972c14fdef017522dc3a1f4d38cc905c0340f68e7a"]
+
+[crate."nokhwa-bindings-macos"]  # build-script
+allow = true
+risk = "low"
+reason = "build.rs emits framework link flags (AVFoundation/CoreMedia/CoreVideo) on Apple targets"
+reviewed = ["0.2.4:59e3864f6a684a0adc2bd7bdaa16d4b3650aca8ebefdb8894434644d9e0bc585"]
+
+[crate."num-bigint-dig"]  # build-script
+allow = true
+risk = "low"
+reason = "3-line build.rs unconditionally emitting cfg has_i128; no deps, no IO"
+reviewed = ["0.8.6:d616ca59ee325bb56bb19cd9b1925ed8032827182c7d4adcc7bdaf5cb05ebf9a"]
+
+[crate."num-derive"]  # proc-macro
+allow = true
+risk = "low"
+reason = "derives num-traits impls (FromPrimitive/ToPrimitive/Num/Float) via syn/quote"
+reviewed = ["0.4.2:a54509b2c5ab0b960906f647e9e03408501a86a74051956170588426c3114d81"]
+
+[crate."num-traits"]  # build-script
+allow = true
+risk = "low"
+reason = "build.rs uses autocfg to probe f64::total_cmp and emit cfg(has_total_cmp)"
+reviewed = ["0.2.19:339783bc220bd9836bf28c7100b15c81b9c6bd7ab3310bc1fa95b7ca1950d5fe"]
+
+[crate."num_enum_derive"]  # proc-macro
+allow = true
+risk = "low"
+reason = "derives integer<->enum conversions; proc-macro-crate reads Cargo.toml for the crate alias"
+reviewed = ["0.7.6:250b5c7186b275dad4a9927ef8d54abee581d4694cc48c236008becfd6fa0d0d"]
+
+[crate."objc-sys"]  # build-script
+allow = true
+risk = "low"
+reason = "selects the ObjC runtime, emits link/DEP_ cc args, cc-compiles a 21-line @catch shim"
+reviewed = ["0.3.5:aa557d74e54a9f09121e285dda419db5cd819b6a73fac3d12f0039b738e14f4e"]
+
+[crate."objc2"]  # build-script
+allow = true
+risk = "low"
+reason = "0.6 build.rs emits target_abi_macabi/target_simulator cfgs because MSRV lacks cfg(target_abi); 0.5 has none"
+reviewed = ["0.6.4:46be90f0f35eb1ed8c457d2020e0157169facd5e4d3e52820a7cada5e3cb1000"]
+
+[crate."objc_exception"]  # build-script
+allow = true
+risk = "low"
+reason = "cc compiles the in-crate 21-line extern/exception.m ObjC @throw/@catch shim"
+reviewed = ["0.1.2:c2ed8fbac5714364f63f00c8b3015fca5d00eef10afa4ca5d830a30111cd11d8"]
+
+[crate."object"]  # build-script
+allow = true
+risk = "low"
+reason = "probes rustc version to emit cfg(core_error) for the pre-1.81 MSRV shim"
+reviewed = ["0.37.3:be83a61f70adf9a2d2d935d053f511460dbe5087c5b5746415fb82e1cdfb5136"]
+
+[crate."oboe-sys"]  # build-script
+allow = true
+risk = "low"
+reason = "cc-builds vendored Oboe C++; optional fetch-prebuilt feature downloads a tarball over HTTPS"
+reviewed = ["0.6.1:80ee00e425cd5cbcfc822170d2c87dd24daa215b1a814961ca8cc736a98350ac"]
+
+[crate."openssl"]  # build-script
+allow = true
+risk = "low"
+reason = "translates openssl-sys DEP_OPENSSL_* metadata into version cfgs; no fs, net or subprocess"
+reviewed = ["0.10.81:557cf702326255f1688e0c7edf3a8e13d0abe45fd9c9cb0d46e494864ef922c6"]
+
+[crate."openssl-macros"]  # proc-macro
+allow = true
+risk = "low"
+reason = "proc-macro appending an openssl.org doc link to a function signature; pure quote, no fetch"
+reviewed = ["0.1.1:35d7f5de82095381eb49e9a2e459a58d8829671ab29b68cde7bed79a8321eef3"]
+
+[crate."openssl-sys"]  # build-script
+allow = true
+risk = "high"
+reason = "probes system OpenSSL via pkg-config/vcpkg/brew and cc header expansion to emit version cfgs + link flags"
+reviewed = ["0.9.117:d5fc4f8a9deef3c1e23b925a0b4d71b11419f89b63e4b7a95ec34145558f94c0"]
+
+[crate."ouroboros_macro"]  # proc-macro
+allow = true
+risk = "low"
+reason = "expands #[self_referencing] into the builder, accessors and Drop for a self-referential struct"
+reviewed = ["0.18.5:46e051bf2bbff4369d1f5be582eac74526bc572ef37cb6f39d3e66022904acfb"]
+
+[crate."parking_lot_core"]  # build-script
+allow = true
+risk = "low"
+reason = "build script emitting cfg(tsan_enabled) from CARGO_CFG_SANITIZE"
+reviewed = ["0.9.12:2d64bd445513370ab0721f2aa3b82badc45b06fda14f4aa25c2aa20d69a59cda"]
+
+[crate."paste"]  # build-script+proc-macro
+allow = true
+risk = "low"
+reason = "probes rustc --version to emit the no_literal_fromstr cfg used by its proc macro"
+reviewed = ["1.0.15:363c68f73f1d17fb48370ef1c21b1f93f5fc1d7e87a01cadb78b02cb33fb55a2"]
+
+[crate."pathfinder_simd"]  # build-script
+allow = true
+risk = "low"
+reason = "probes rustc channel via rustc_version to gate nightly-only SIMD intrinsics"
+reviewed = ["0.5.6:bf85f91f87a5d6efff7aebcc92e052a85508093dc882b0507ef058a291484989"]
+
+[crate."phf_macros"]  # proc-macro
+allow = true
+risk = "low"
+reason = "computes a perfect hash over literal keys at expansion; emits a static phf::Map, no IO"
+reviewed = ["0.13.1:8d8c1484b2d859638f756fc48b036194686066893468853e9f46280efc5e67a2"]
+
+[crate."portable-atomic"]  # build-script
+allow = true
+risk = "low"
+reason = "probes rustc/LLVM version and RUSTFLAGS target-feature to emit atomic backend cfgs; no file writes"
+reviewed = ["1.14.0:ed82f8ca5775e35fff4885ffbe4d4ddd9887518f6d7e3c5564bc67f77589c671"]
+
+[crate."prettyplease"]  # build-script
+allow = true
+risk = "low"
+reason = "emits check-cfg lines and exports its version as links metadata; no file or process I/O"
+reviewed = ["0.2.37:860bcda83de3b2b1bdefed962fa2438a5ed94a89b658448edd5b7dc19a3d3018"]
+
+[crate."proc-macro2"]  # build-script
+allow = true
+risk = "low"
+reason = "probes rustc version and trial-compiles in-crate probe files to pick proc_macro cfgs"
+reviewed = ["1.0.106:5396bb864a858291c92945de720160a2b22e5c6039707f0f16caea4055e5a3c8"]
+
+[crate."proc-macro2-diagnostics"]  # build-script
+allow = true
+risk = "low"
+reason = "probes rustc channel via version_check to cfg-gate the nightly Diagnostic API"
+reviewed = ["0.10.1:8e96e3d2fc4d607a28e3958e0c1bc43a6dc2c468d595289f784b6931d82bbabc"]
+
+[crate."prost-derive"]  # proc-macro
+allow = true
+risk = "low"
+reason = "proc-macro deriving Message/Enumeration/Oneof encode-decode bodies; pure syn/quote"
+reviewed = ["0.13.5:f7a38aedc1617799f2a6485e7e4bba97f9e1d111d752fb5c6e52e3a1f78af3ac"]
+
+[crate."pulldown-cmark"]  # build-script
+allow = true
+risk = "low"
+reason = "no-op unless the off-by-default gen-tests feature regenerates the CommonMark spec test suite"
+reviewed = ["0.9.6:ebed3a7d88e5f89548f541a51b4354f0caf3fc8665d2615e71d74e656a596432"]
+
+[crate."pyo3"]  # build-script
+allow = true
+risk = "low"
+reason = "runs a Python interpreter (PYO3_PYTHON/VIRTUAL_ENV/CONDA_PREFIX/PATH) to probe ABI and emit link cfgs"
+reviewed = ["0.27.2:dee465b672f4ddf2f75eb55d9310db46ffe4ee6b7a7a14422ab54bb8526b6f1f"]
+
+[crate."pyo3-build-config"]  # build-script
+allow = true
+risk = "low"
+reason = "spawns the host Python interpreter to introspect ABI/lib config, writes it to OUT_DIR"
+reviewed = ["0.27.2:b0a9b02ad688f5ff15793ffd16314a282e7155e6c352f217d51d4529faa3e9ed"]
+
+[crate."pyo3-ffi"]  # build-script
+allow = true
+risk = "low"
+reason = "runs the target Python interpreter to read its sysconfig, then emits libpython link + version cfgs"
+reviewed = ["0.27.2:1d3000cc8a6a4cfff56ac046977c00fa5948b624450f4fb7581e0fdec79861bb"]
+
+[crate."pyo3-macros"]  # proc-macro
+allow = true
+risk = "low"
+reason = "proc macro expanding #[pyclass]/#[pymethods]; backend reads the PyO3 config inside rustc"
+reviewed = ["0.27.2:c3544bbb636ce3444ebab862fcb76349111cb97c546b244c21addb11abb451ea"]
+
+[crate."pyo3-macros-backend"]  # build-script
+allow = true
+risk = "low"
+reason = "build.rs prints check-cfg + rustc-version feature cfgs; src expands #[pyclass]/#[pymethods]"
+reviewed = ["0.27.2:d37d275e8d0e49f0c1dc5810a116decf1b613a1199f6a304b9d2ee379af5c424"]
+
+[crate."quote"]  # build-script
+allow = true
+risk = "low"
+reason = "runs rustc --version to gate the #[diagnostic] namespace cfg"
+reviewed = ["1.0.46:3f0c039e1283f2dc09cd59efc748c7f5c8666dc8b1db8e3a02c221fa2d983ccd"]
+
+[crate."rayon-core"]  # build-script
+allow = true
+risk = "low"
+reason = "empty build.rs required so links=\"rayon-core\" can enforce a single version"
+reviewed = ["1.13.0:fc12a8025da2e5dc5fe159b3de08fbbecbd3d275987beb04e7e164932d8ec38b"]
+
+[crate."ring"]  # build-script
+allow = true
+risk = "low"
+reason = "compiles in-crate C and per-arch assembly with cc, generates symbol-prefix headers into OUT_DIR"
+reviewed = ["0.17.14:937a3690c0454a0746e74e2d4373ea0118c25d146114e92939e26923f888cb15"]
+
+[crate."rustix"]  # build-script
+allow = true
+risk = "low"
+reason = "probes rustc for feature/asm support and maps target cfgs to backend selection cfgs"
+reviewed = ["0.38.44:1de00dd64f9463fbb7fe65f3fb5a3436fd911573abb779cd948a2c05b0782b36", "1.1.4:5d1c498232b38e5311f3274a77814cab9080a42489383df9d87324e795d4b205"]
+
+[crate."rustls"]  # build-script
+allow = true
+risk = "low"
+reason = "one-line build script cfg-gating the nightly read_buf feature; sans-I/O library, no build-time I/O"
+reviewed = ["0.23.42:253b9987f6beaf9c80f7cc7f237ee5e0ce83cceec26350f9fb4dcae235e4cb39"]
+
+[crate."rustversion"]  # build-script+proc-macro
+allow = true
+risk = "low"
+reason = "runs $RUSTC --version and writes OUT_DIR/version.expr for its version-gating proc macros"
+reviewed = ["1.0.23:e0676d433d40bf221d0906e05e169a15ee9d1c4b2bd4d4493582a820bf93521d"]
+
+[crate."schannel"]  # build-dependency
+allow = true
+risk = "high"
+reason = "no build-time code; #![cfg(windows)] TLS lib - the CI env reads live only in cfg(test) fixtures"
+reviewed = ["0.1.29:ada8ac6b72bbe367f25aa003d94d1cfcc9a37a9eb24ea2c6d7dfeabe395e79c7"]
+
+[crate."scroll_derive"]  # proc-macro
+allow = true
+risk = "low"
+reason = "derives Pread/Pwrite/SizeWith/IOread/IOwrite endian-aware binary (de)serialisation impls"
+reviewed = ["0.13.1:e7c74f3991c77a8633038a36c3385dd79efc1504cbf07039d8d813e24fcb735f"]
+
+[crate."serde"]  # build-script
+allow = true
+risk = "low"
+reason = "probes rustc version for cfgs and writes a version-suffixed __private module into OUT_DIR"
+reviewed = ["1.0.228:1e9bd8c600c35acad25f25efcc67da81f9359efcad0c05ea5861d385663f9857"]
+
+[crate."serde_core"]  # build-script
+allow = true
+risk = "low"
+reason = "probes rustc version for cfgs and writes a version-suffixed private.rs into OUT_DIR"
+reviewed = ["1.0.228:832a69942dd42410d5e0cfb7776d76c57cac090409093c9539ca27eb682917e2"]
+
+[crate."serde_derive"]  # proc-macro
+allow = true
+risk = "low"
+reason = "proc macro deriving Serialize/Deserialize; pure source, no precompiled binary in this version"
+reviewed = ["1.0.228:ecbc1eff129d431cb54b9b120d0bd7cbf675283ea4236f5c7c4a4cf543585aec"]
+
+[crate."serde_json"]  # build-script
+allow = true
+risk = "low"
+reason = "build.rs selects 32/64-bit limb width cfg for the float parser from target arch"
+reviewed = ["1.0.150:299064d15d127affcd8d2452afe1fa77462ed8183207b6b6fbe4c390be305066"]
+
+[crate."serde_repr"]  # proc-macro
+allow = true
+risk = "low"
+reason = "derive emitting Serde impls over an enum's repr discriminant; syn/quote only"
+reviewed = ["0.1.20:0437fd79314aba11b7dcd5df1d08cd0376a791a94bda92f2103b8011590c5911"]
+
+[crate."slotmap"]  # build-script
+allow = true
+risk = "low"
+reason = "probes rustc version/channel via version_check to emit the nightly cfg and an MSRV warning"
+reviewed = ["1.1.1:7810b69d0e06900ecb54547d5d5e1d6214044f5d89a5ddf5e364483a9482c71d"]
+
+[crate."strum_macros"]  # proc-macro
+allow = true
+risk = "low"
+reason = "proc-macro deriving enum<->string traits; reads STRUM_DEBUG only to print its own expansion"
+reviewed = ["0.26.4:c00303f46d3b09b74880ec4ca4154d4e2de2c1d5a21ce220b303c73a902804b6"]
+
+[crate."syn"]  # build-dependency/build-script
+allow = true
+risk = "low"
+reason = "runs rustc --version to emit back-compat cfgs for older compilers"
+reviewed = ["1.0.109:b46c8b60b3087ce87dcf923fd0f282690b868740eb20e5a11663581bdc1ea550", "2.0.119:9b3c41ebfc9c758a8bc04e96fc927980d0aaa5940722189a62201ab7ea9ebb9e"]
+
+[crate."target-lexicon"]  # build-script
+allow = true
+risk = "low"
+reason = "writes OUT_DIR/host.rs from TARGET and probes rustc --version for a feature cfg"
+reviewed = ["0.13.5:2a332ba3bc3b2753cc66270eac89cecc343f9b1406c88b0efe5f7a01a86be52c"]
+
+[crate."tempfile"]  # build-dependency
+allow = true
+risk = "high"
+reason = "temp file/dir library used by build scripts for scratch space; O_TMPFILE/mkstemp, 0o600 default"
+reviewed = ["3.27.0:ad3ec9e7f8a8b9394e240443e886e621185d31e2b1a7535ad39333ca0564a485"]
+
+[crate."thiserror"]  # build-script
+allow = true
+risk = "low"
+reason = "trial-compiles build/probe.rs for error_generic_member_access and writes private.rs into OUT_DIR"
+reviewed = ["1.0.69:b98e56a3134b92e0e7142ff26899b12a8fbe2bb1569a8bc5922eed6caccaaf7b", "2.0.18:dbbaf177d59359ff78df7a52bf3247aa374411e8ed52b79d0855b7a4f9dbc0bd"]
+
+[crate."thiserror-impl"]  # proc-macro
+allow = true
+risk = "low"
+reason = "proc macro deriving std::error::Error impls from #[error(...)] attributes"
+reviewed = ["1.0.69:12f0d2137a3f01246dcf5f2e59d0a00446e086abc55aa966d274e2ee3880060d", "2.0.18:ec21b5c601b17cccff906b16669f44c82159d4a981aeb076164bb589be250464"]
+
+[crate."tikv-jemalloc-sys"]  # build-script
+allow = true
+risk = "high"
+reason = "runs the bundled jemalloc autoconf configure via sh + make to build the static C allocator into OUT_DIR"
+reviewed = ["0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7:7e0c4b37ac2adb1928030c6d3c48d294bdc856c4cb537fba29daf5c575f4c584"]
+
+[crate."time-macros"]  # proc-macro
+allow = true
+risk = "low"
+reason = "proc macros parsing date/time/format-description literals at compile time"
+reviewed = ["0.2.31:b58c39e6942c86f879592a2002f964eaef2769a9dbb8a84cbb9e9d1449b69de9"]
+
+[crate."tracing-attributes"]  # proc-macro
+allow = true
+risk = "low"
+reason = "#[instrument] rewrites fn bodies to open tracing spans; syn/quote only"
+reviewed = ["0.1.31:9db0393d52624760ac8a29f35e261a949c3da0cb6e8c7431357696ca18e6cbc0"]
+
+[crate."turso_core"]  # build-script
+allow = true
+risk = "low"
+reason = "generates build metadata (cargo env, rustc -V, git HEAD, timestamp) into OUT_DIR/built.rs via built"
+reviewed = ["0.1.5:78f6c37081317e59a9d22155d116f5e61aed7e393b4f0461f071c301b755aaef"]
+
+[crate."turso_ext"]  # build-script
+allow = true
+risk = "low"
+reason = "emits the advapi32 link directive on Windows; library is FFI type declarations only"
+reviewed = ["0.1.5:0a977dc7bcc03afb2f373a668ae6397712e72b729c7243e3d6784c7862ff18d0"]
+
+[crate."turso_macros"]  # proc-macro
+allow = true
+risk = "low"
+reason = "proc-macro deriving turso extension/vtab/vfs FFI glue; pure syn/quote"
+reviewed = ["0.1.5:dd06e784ac9e89ae37c97fcafe26c261b337632d2bb80b93c2a029b6c6620f20"]
+
+[crate."turso_sqlite3_parser"]  # build-script
+allow = true
+risk = "low"
+reason = "compiles vendored lemon.c to a host binary in OUT_DIR and runs it to generate the SQL parser"
+reviewed = ["0.1.5:9e58c4b55031cb292e103eb1c0de2372e6b1b42cfbb5a7f03f5675b661d831e6"]
+
+[crate."typeid"]  # build-script
+allow = true
+risk = "low"
+reason = "probes rustc --version to gate the const TypeId path on Rust >= 1.61"
+reviewed = ["1.0.3:b2ca2e0a8b4a94883d372b9e3d69c01b0b0a7dac1569f4e7bde1cb415c0257c8"]
+
+[crate."uncased"]  # build-script
+allow = true
+risk = "low"
+reason = "version_check probe of rustc to emit nightly and const_fn_transmute cfgs"
+reviewed = ["0.9.10:4682c0d5fe27e84e1d2d4119eb7201720f5073ae31e775be868ad10d489b738b"]
+
+[crate."unicode-canonical-combining-class"]  # build-script
+allow = true
+risk = "low"
+reason = "expands the compiled-in UCD range table into a block lookup in OUT_DIR"
+reviewed = ["1.0.0:cb52fec2ac56a47ef57844a23c2e88f3f901db6dc35deb3ed06d676780466e83"]
+
+[crate."unicode-general-category"]  # build-script
+allow = true
+risk = "low"
+reason = "compresses the in-crate UCD category table into a block lookup written to OUT_DIR"
+reviewed = ["1.1.0:7ad1643db8b98edfe24bf67faa6cfa1cd840e433fd34aa3bd4b4916ff10cf891"]
+
+[crate."unicode-joining-type"]  # build-script
+allow = true
+risk = "low"
+reason = "compresses the Unicode joining-type/group tables into generated lookup arrays in OUT_DIR"
+reviewed = ["1.0.0:6e732a24edeeb60397374d9e6cb5afcb36f91ccab5bf4cbed09eb701ca75dd94"]
+
+[crate."ureq"]  # build-dependency
+allow = true
+risk = "high"
+reason = "HTTP/TLS client; ext-php-rs build-deps it on Windows to download the PHP devel pack"
+reviewed = ["3.3.0:1f2ad4f12997ad572acc22abe4d440557c67c619578f755e4e35de7dc3239dd7"]
+
+[crate."url"]  # build-dependency
+allow = true
+risk = "high"
+reason = "no build code; WHATWG URL parser. socket_addrs() is opt-in DNS, never called internally"
+reviewed = ["2.5.8:0eb80aad344a2a41324533f0da4d8d054f16a8a911b9e978f966aca87f3d7fb4"]
+
+[crate."v4l2-sys-mit"]  # build-script
+allow = true
+risk = "low"
+reason = "bindgen+libclang generate videodev2.h FFI into OUT_DIR; trusts host headers and clang env"
+reviewed = ["0.3.0:f68f323de4f9bb40c2cb10f62652131e8ff38bdddbc27a2c46db507436d3975d"]
+
+[crate."vk-mem"]  # build-script
+allow = true
+risk = "low"
+reason = "compiles the in-crate vendored VMA C++ header via cc; sources ship in the crate, nothing fetched"
+reviewed = ["0.4.0:b935a7fdb955400de27647f727cc0b191091ad428415c79750d565e479bf8bed"]
+
+[crate."wasm-bindgen"]  # build-script
+allow = true
+risk = "low"
+reason = "build.rs probes rustc version + CARGO_CFG_TARGET_* to emit cfgs and one emscripten link arg"
+reviewed = ["0.2.126:ba6f6a198a62faca1676036674d8c374c8dd4bcbc12b6f4e0d380c4d5a37052d"]
+
+[crate."wasm-bindgen-macro"]  # proc-macro
+allow = true
+risk = "low"
+reason = "encodes the Rust<->JS binding descriptor into a custom section; reads JS files named by the user"
+reviewed = ["0.2.126:2c7039ca9acbe77d9f91adc80af0d062c77d23a3535b525edbc792a2686953e0"]
+
+[crate."wasm-bindgen-shared"]  # build-script
+allow = true
+risk = "low"
+reason = "hashes src/lib.rs for a schema version and records git rev-parse HEAD as WBG_VERSION"
+reviewed = ["0.2.126:9c15199b20ae3c1f9ec80dbe9e33cd879b1c83c43577c3804d7297141a4fd2a9"]
+
+[crate."webpki-root-certs"]  # build-dependency
+allow = true
+risk = "medium"
+reason = "no build-time code; a generated const of 121 Mozilla root certificates as DER bytes"
+reviewed = ["1.0.9:91634c47dfb208195ef065b721d8d10437087cecc49eff1bd4a635e2abac14d4"]
+
+[crate."winapi"]  # build-script
+allow = true
+risk = "low"
+reason = "build.rs resolves the header feature graph and emits feature cfgs + rustc-link-lib for Windows targets"
+reviewed = ["0.3.9:e7c41ef0cb0d21f0769924ac9d5508617353eeb4785f0683a939f0438e1a89ba"]
+
+[crate."winapi-i686-pc-windows-gnu"]  # build-script
+allow = true
+risk = "low"
+reason = "emits link-search for its 1387 bundled MinGW import libs on i686-windows-gnu"
+reviewed = ["0.4.0:649ed8d3e7cb4200380e683309d6775a27d52bea65f4356df8c2f4c1e4910563"]
+
+[crate."winapi-x86_64-pc-windows-gnu"]  # build-script
+allow = true
+risk = "low"
+reason = "adds its bundled MinGW import-lib dir to the link search path; ships 53MB of .a"
+reviewed = ["0.4.0:fa3742e0b1f07afe82fa6c9317f62d5a5969ef97bac27c1dbb7d9cc344eac8f1"]
+
+[crate."windows-implement"]  # proc-macro
+allow = true
+risk = "low"
+reason = "proc-macro generating COM vtable/IUnknown impls; the rustfmt spawn is cfg(test) only"
+reviewed = ["0.60.2:24e77dbdebc3b9a04d21bc93d6ddbc34c993e64790ffa2b2288fe3fb67f71c6c"]
+
+[crate."windows-interface"]  # proc-macro
+allow = true
+risk = "low"
+reason = "expands #[interface(GUID)] into the COM vtable, IUnknown impl and method wrappers"
+reviewed = ["0.59.3:b6132b5fad5db85a14925344201bc1487ceb80ae67558fd12092fd5c5c7746f6"]
+
+[crate."windows-sys"]  # build-dependency
+allow = true
+risk = "high"
+reason = "no build-time code; extern fn/struct/const declarations only, no call sites"
+reviewed = ["0.45.0:19fe52ab7ed3b640e070cd7cd494c5a34563ec598d544797902510dd1de78791", "0.52.0:5609e644746dea161a49250ff7db316b069e3cd755323337b8ae08e32efdf146", "0.59.0:abefe9f04b42d1dc9982f4f2983b5b4b6e3a66f8fe3d8f2a704e5ab1377db218", "0.61.2:a15dc306533053e9069513f761f532a8d21e2c35c0b04e08368904a087587239"]
+
+[crate."windows_aarch64_gnullvm"]  # build-script
+allow = true
+risk = "low"
+reason = "build.rs adds the crate's bundled Windows import library (link thunks only) to the search path"
+reviewed = ["0.42.2:5d8c544b694ccd2d005f03f8affa91885bba42c06031ea6822d2adf8449803e8", "0.52.6:ede6125cf9720739f7dcfecef56faa11245ba61787c472cf7057efa8ca85b32c"]
+
+[crate."windows_aarch64_msvc"]  # build-script
+allow = true
+risk = "low"
+reason = "emits link-search for the bundled windows.lib import library on aarch64-msvc"
+reviewed = ["0.42.2:1b4ac78c12f8eea56fbbc37fd4ec900972b30568b0a5eb207d01d70f9bb71e1f", "0.52.6:ede6125cf9720739f7dcfecef56faa11245ba61787c472cf7057efa8ca85b32c"]
+
+[crate."windows_i686_gnu"]  # build-script
+allow = true
+risk = "low"
+reason = "adds its bundled Windows import-lib dir to the link search path (0.52 does so unconditionally)"
+reviewed = ["0.42.2:80a139fff6b02eea682401de17a62af620e721a2740baf5a2575b5802985edf8", "0.52.6:ede6125cf9720739f7dcfecef56faa11245ba61787c472cf7057efa8ca85b32c"]
+
+[crate."windows_i686_gnullvm"]  # build-script
+allow = true
+risk = "low"
+reason = "build.rs emits a link-search path for the shipped Windows import library (verified import-only .a)"
+reviewed = ["0.52.6:ede6125cf9720739f7dcfecef56faa11245ba61787c472cf7057efa8ca85b32c"]
+
+[crate."windows_i686_msvc"]  # build-script
+allow = true
+risk = "low"
+reason = "adds the shipped Windows import lib to the linker search path for i686-msvc"
+reviewed = ["0.42.2:34d5889b819715eb0d55306e77d3394440ee47eed4bc89d2b75b50120b1fee9e", "0.52.6:ede6125cf9720739f7dcfecef56faa11245ba61787c472cf7057efa8ca85b32c"]
+
+[crate."windows_x86_64_gnu"]  # build-script
+allow = true
+risk = "low"
+reason = "build script adding lib/ to the link search path for the shipped import archive"
+reviewed = ["0.42.2:96e355c8f6819b697a52be83263fc940b2906e7a4bec3e4b2b05939642e7b18f", "0.52.6:ede6125cf9720739f7dcfecef56faa11245ba61787c472cf7057efa8ca85b32c"]
+
+[crate."windows_x86_64_gnullvm"]  # build-script
+allow = true
+risk = "low"
+reason = "build.rs adds the crate's bundled Windows import library (link thunks only) to the search path"
+reviewed = ["0.42.2:4d1418115fb5ff002aeb381f7938dbab30e8ec4a389f164853af4df63614bacd", "0.52.6:ede6125cf9720739f7dcfecef56faa11245ba61787c472cf7057efa8ca85b32c"]
+
+[crate."windows_x86_64_msvc"]  # build-script
+allow = true
+risk = "low"
+reason = "emits link-search for the bundled windows.lib import library on x86_64-msvc"
+reviewed = ["0.42.2:648a2c85ad55de6c6478ce22ec7fd492bfd5760c4e61928b2f66937dab94f889", "0.52.6:ede6125cf9720739f7dcfecef56faa11245ba61787c472cf7057efa8ca85b32c"]
+
+[crate."wit-bindgen"]  # build-script
+allow = true
+risk = "low"
+reason = "copies the bundled cabi_realloc wasm static archive into OUT_DIR and emits link flags (wasm targets only)"
+reviewed = ["0.57.1:441b6d71c1a175273667ed15926b4e381dcf6a7f8034017647d1afa7c19f6557"]
+
+[crate."yoke-derive"]  # proc-macro
+allow = true
+risk = "low"
+reason = "derives ICU4X's Yokeable impl by lifetime-folding the type with syn; pure token rewriting"
+reviewed = ["0.8.2:c6441bd36a14d4aba58d7aa45c1deafcb9bce56e50a9a0a5f717e4e766b442d9"]
+
+[crate."zbus-lockstep-macros"]  # proc-macro
+allow = true
+risk = "low"
+reason = "proc-macro reading D-Bus XML from disk at expansion to emit a signature-validation test"
+reviewed = ["0.5.2:631c5f86d23722e61dab43b0c7732d9931935a5f142ea784fc0eb309f712a815"]
+
+[crate."zbus_macros"]  # proc-macro
+allow = true
+risk = "low"
+reason = "generates D-Bus proxy/interface/error code from annotated traits; no bus access at expansion"
+reviewed = ["5.18.0:db733d28091a2dba932e5eb4974cf2fed7ad0fcc915a7ae779051bb42749649a"]
+
+[crate."zerocopy"]  # build-script
+allow = true
+risk = "low"
+reason = "reads own Cargo.toml MSRV table and rustc --version to emit version-gate cfgs"
+reviewed = ["0.8.54:a7990e58562a334ca5b8f49ccc269e03eaf95c8c133a02033342921d3f6e707b"]
+
+[crate."zerocopy-derive"]  # proc-macro
+allow = true
+risk = "low"
+reason = "proc macro deriving FromBytes/IntoBytes etc. with layout soundness checks"
+reviewed = ["0.8.54:fd8bc0d459099ee607f9f44bcdc5895343e49da0143dd2735ad5529a844658b9"]
+
+[crate."zerofrom-derive"]  # proc-macro
+allow = true
+risk = "low"
+reason = "derive macro generating zero-copy ZeroFrom impls with lifetime substitution"
+reviewed = ["0.1.7:c1c3bf62be293a5c18cfbd18277b0b1fe07f496d26252da4a608cf11ebfd5fd4"]
+
+[crate."zeroize_derive"]  # proc-macro
+allow = true
+risk = "low"
+reason = "derive emitting per-field zeroize() + Drop impls; syn/quote only, no IO"
+reviewed = ["1.5.0:76c60c8bcb178e3075869fcfbb8aac0299490e47148e0336157cfcf28422b3af"]
+
+[crate."zerovec-derive"]  # proc-macro
+allow = true
+risk = "low"
+reason = "derives ICU4X ULE/VarULE zero-copy layout impls and companion packed types via syn"
+reviewed = ["0.11.3:cd2f5ab0cdd621f1a37f2b9ad6656532ccd36edce2833686eb1c8b8a409e44d6"]
+
+[crate."zip"]  # build-dependency/build-script
+allow = true
+risk = "high"
+reason = "build.rs only warns on the deflate-miniz feature; extraction is zip-slip guarded (used by ext-php-rs on Windows)"
+reviewed = ["2.4.2:8af6cb53df7b829c83dee16d0d63dd604e0303529e4ea00eb935d2788beabb8f", "6.0.0:62c2e567fee69d11eee10ffef513f910b2c5fd84944ee906ca6ca579cb016acc", "8.6.0:701aa86c6f603494759a69f6df7a5c9e03987d61665addf9b926282387b8a3b8"]
+
+[crate."zmij"]  # build-script
+allow = true
+risk = "low"
+reason = "probes rustc version and OPT_LEVEL to emit select_unpredictable / size-profile cfg flags"
+reviewed = ["1.0.23:3609ee996f9b3c6e7f39fdb2a8d534b77bf806bf6379353b847cc8452a7ee505"]
+
+[crate."zstd-safe"]  # build-script
+allow = true
+risk = "low"
+reason = "reads CARGO_CFG_TARGET_ARCH/OS to force the std feature on wasm32 and hermit"
+reviewed = ["7.2.4:6abc9c177d23c3895fe14e4d9bdbd9c43c84faa52eac5185353e2795d3d79331"]
+
+[crate."zstd-sys"]  # build-script
+allow = true
+risk = "low"
+reason = "compiles the vendored zstd C/asm sources with cc; optional pkg-config probe and bindgen"
+reviewed = ["2.0.16+zstd.1.5.7:fab53176ea922925d985673b86c0b4717da96636ef355122faa95dd1c43e16d9"]
+
+[crate."zvariant_derive"]  # proc-macro
+allow = true
+risk = "low"
+reason = "proc macro deriving D-Bus Type/Value; resolves the zvariant crate name via proc-macro-crate"
+reviewed = ["5.13.1:7d478055e02a133bf9d843d0324d0ca06489e846845f56919584f4195b1b06c1"]

--- a/scripts/supply-chain/cooldown-exempt.txt
+++ b/scripts/supply-chain/cooldown-exempt.txt
@@ -1,0 +1,40 @@
+# cooldown-exempt.txt — crates exempt from the publish-age floor.
+#
+# The cooldown exists to defend against a COMPROMISED MAINTAINER ACCOUNT: a
+# malicious version published from a stolen credential is typically yanked
+# within hours, so refusing anything younger than 14 days makes that window
+# irrelevant. (arrayref/internment/append-only-vec, 2026-08-20: 86-107 minutes
+# from publish to yank.)
+#
+# That threat model does not describe azul's own releases. When this repository
+# bumps a crate it publishes itself, the publish and the lockfile bump are the
+# same change, made by the same person, in the open — waiting two weeks to
+# consume it adds no safety and would make the release process impossible. Left
+# unexempted, the gate fires on every release, and a gate that fires on every
+# release is a gate somebody deletes.
+#
+# So: first-party crates only. Everything here must be published from an account
+# this project controls. A third-party crate does NOT belong in this file — if a
+# third-party bump is urgent enough to skip the floor, pass --min-age-days on
+# that one run and say why in the commit message, so the exception is visible
+# rather than permanent.
+#
+# Verified 2026-08-25: each of these was <14 days old in the tree at the time
+# this gate was written, i.e. every one of them would have failed the build.
+
+# azul's own crates, published from this repository.
+azul-css
+azul-core
+azul-layout
+azul-simplecss
+
+# First-party crates maintained by the same owner, consumed from crates.io.
+printpdf
+rust-fontconfig
+agg-rust-azul
+allsorts-azul
+micromail
+gilrs-azul
+gilrs-core-azul
+libudev-sys-azul
+gpu-video-azul

--- a/scripts/supply-chain/env_guard.py
+++ b/scripts/supply-chain/env_guard.py
@@ -1,0 +1,366 @@
+#!/usr/bin/env python3
+"""
+env_guard.py — which environment variables build-time code is allowed to read.
+
+THE THREAT. Credential theft through the build is the most productive move an
+attacker gets from a poisoned dependency, because CI hands the build a fully
+populated environment and `cargo` passes that environment, unfiltered, to every
+`build.rs` and every proc macro in the tree. `rustdecimal` (2022) branched on
+`GITLAB_CI` before detonating. `mysten-metrics` 9.0.3 (2026) exfiltrated the
+environment plus `~/.cargo/credentials` and SSH keys from a build script. The
+code doing this does not need to be in a crate you chose — it needs to be in
+anything, anywhere in the tree, at any depth.
+
+WHAT THIS GATE DOES. It builds the set of variable names that exist in (or can
+be injected into) azul's CI, classifies each one, then scans every build script
+and proc-macro source in a `cargo vendor` tree for reads of them:
+
+    env!("X")  option_env!("X")  env::var("X")  env::var_os("X")
+    env::vars()  env::vars_os()                 <- whole-environment sweep
+    getenv("X")  GetEnvironmentVariable         <- C sources compiled by cc
+
+The interesting half of the name set does NOT come from `os.environ`: a secret
+only appears in the environment of the job it is wired into, and a scan running
+in a different job would never see it. So the names are also parsed straight out
+of `.github/workflows/*.yml` — every `secrets.NAME` the repository can inject,
+whether or not this job has it. A dependency reading `CARGO_REGISTRY_TOKEN`
+fails here even on a run where that secret was never set.
+
+IT MUST RUN BEFORE ANY BUILD. `cargo vendor` downloads sources without
+executing anything; that is the whole reason this gate is possible. Once a
+build has started, the build scripts have already run and the credentials have
+already been read. This is a preflight, not a post-check.
+
+Usage:
+    env_guard.py --vendor vendor/ [--workflows .github/workflows]
+                 [--scope compile-time|all] [--strict] [--json OUT]
+    env_guard.py --emit-env-allowlist      # `env -i` prefix for a hardened build
+    env_guard.py --print-classes           # the classification table
+
+Exit 0 when no build-time code reads a forbidden variable; exit 1 otherwise.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import sc_common as sc  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# CLASSIFICATION
+# ---------------------------------------------------------------------------
+#
+# ALLOWED is cargo's documented build-script contract plus the toolchain and
+# platform variables a native build legitimately needs. It is an ALLOWLIST: a
+# name that is not matched here is not automatically fatal, but it is reported,
+# because "why does this crate want that" is the question worth asking.
+
+ALLOWED = [
+    # cargo's build-script contract
+    r'^CARGO$', r'^CARGO_(MANIFEST_DIR|MANIFEST_LINKS|MANIFEST_PATH|MAKEFLAGS)$',
+    r'^CARGO_PKG_', r'^CARGO_FEATURE_', r'^CARGO_CFG_', r'^CARGO_BIN_', r'^CARGO_CRATE_NAME$',
+    r'^CARGO_PRIMARY_PACKAGE$', r'^CARGO_ENCODED_RUSTFLAGS$', r'^CARGO_TARGET_',
+    r'^OUT_DIR$', r'^TARGET$', r'^HOST$', r'^NUM_JOBS$', r'^OPT_LEVEL$',
+    r'^DEBUG$', r'^PROFILE$', r'^DEP_', r'^RUSTC$', r'^RUSTC_WRAPPER$',
+    r'^RUSTC_WORKSPACE_WRAPPER$', r'^RUSTC_LINKER$', r'^RUSTDOC$', r'^RUSTFLAGS$',
+    r'^RUSTDOCFLAGS$', r'^CARGO_HOME$', r'^RUSTUP_HOME$', r'^RUSTUP_TOOLCHAIN$',
+    # native toolchain
+    r'^(CC|CXX|AR|AS|LD|NM|RANLIB|STRIP|OBJCOPY|OBJDUMP|WINDRES|DLLTOOL)(_.*)?$',
+    r'^(CFLAGS|CXXFLAGS|LDFLAGS|CPPFLAGS|ASMFLAGS|ARFLAGS)(_.*)?$',
+    r'^PKG_CONFIG', r'^SYSROOT$', r'^SDKROOT$', r'^MACOSX_DEPLOYMENT_TARGET$',
+    r'^IPHONEOS_DEPLOYMENT_TARGET$', r'^DEVELOPER_DIR$', r'^XCODE',
+    r'^ANDROID_(NDK|SDK|HOME|API)', r'^NDK_HOME$', r'^EMSDK', r'^EMCC',
+    r'^LIBCLANG_PATH$', r'^CLANG_PATH$', r'^BINDGEN_', r'^LLVM_CONFIG',
+    r'^VCPKG', r'^VCINSTALLDIR$', r'^VSINSTALLDIR$', r'^WINDOWSSDK', r'^WINSDK',
+    r'^(LIB|INCLUDE|LIBPATH)$', r'^MSYSTEM$', r'^MSVC',
+    # benign platform / locale / paths
+    r'^PATH$', r'^HOME$', r'^USERPROFILE$', r'^TMPDIR$', r'^TEMP$', r'^TMP$',
+    r'^LANG$', r'^LC_', r'^TZ$', r'^TERM$', r'^SHELL$', r'^PWD$', r'^OSTYPE$',
+    r'^SYSTEMROOT$', r'^WINDIR$', r'^PROGRAMFILES', r'^PROCESSOR_',
+    r'^NUMBER_OF_PROCESSORS$', r'^COMSPEC$', r'^PATHEXT$', r'^HOSTTYPE$',
+    # reproducible-builds / docs.rs conventions
+    r'^SOURCE_DATE_EPOCH$', r'^DOCS_RS$',
+]
+
+# CI_DETECT — reading these is how a payload decides it is on a build server
+# worth robbing rather than a developer laptop. rustdecimal keyed on GITLAB_CI.
+# There is no legitimate reason for a *library's* build script to care.
+CI_DETECT = [
+    r'^CI$', r'^CONTINUOUS_INTEGRATION$', r'^BUILD_(ID|NUMBER|URL)$',
+    r'^GITHUB_(ACTIONS|WORKFLOW|RUN_ID|RUN_NUMBER|JOB|ACTOR|REPOSITORY|EVENT_NAME|SHA|REF)$',
+    r'^GITLAB_CI$', r'^TRAVIS', r'^CIRCLECI$', r'^JENKINS', r'^HUDSON',
+    r'^BUILDKITE', r'^TF_BUILD$', r'^TEAMCITY_', r'^APPVEYOR', r'^DRONE',
+    r'^SEMAPHORE', r'^CODEBUILD_', r'^BITBUCKET_', r'^WOODPECKER_',
+]
+
+# FORBIDDEN — a read of any of these from build-time code fails the build,
+# unconditionally. There is no configuration in which a dependency's build
+# script has business reading a credential.
+FORBIDDEN = [
+    r'TOKEN', r'SECRET', r'PASSWORD', r'PASSWD', r'CREDENTIAL', r'API_?KEY',
+    r'PRIVATE_?KEY', r'ACCESS_?KEY', r'AUTH', r'SESSION', r'COOKIE', r'BEARER',
+    r'^AWS_', r'^AZURE_', r'^GCP_', r'^GOOGLE_APPLICATION_CREDENTIALS$',
+    r'^SSH_', r'^GPG_', r'^GNUPG', r'^NPM_', r'^PYPI_', r'^TWINE_',
+    r'^DOCKER_(AUTH|PASSWORD)', r'^KUBECONFIG$', r'^VAULT_',
+    r'^ACTIONS_RUNTIME_TOKEN$', r'^ACTIONS_ID_TOKEN_REQUEST_',
+    r'^CARGO_REGISTRY_TOKEN$', r'^CARGO_REGISTRIES_.*_TOKEN$',
+    r'^GH_TOKEN$', r'^GITHUB_TOKEN$',
+    # azul's own signing/publishing material, by name
+    r'^APPLE_(CERT|ID|TEAM_ID|APP_PASSWORD)', r'^OSSRH_', r'^MAVEN_GPG_',
+    r'^AUR_', r'^RUBYGEMS_', r'^NUGET_', r'^LUAROCKS_', r'^AZUL_APT_GPG',
+]
+
+_ALLOWED_RE = re.compile("|".join(ALLOWED))
+_CI_RE = re.compile("|".join(CI_DETECT))
+_FORBIDDEN_RE = re.compile("|".join(FORBIDDEN), re.IGNORECASE)
+
+
+def classify(name: str) -> str:
+    """forbidden > ci-detect > allowed > unknown. Order matters: a name can
+    match several patterns and the most dangerous reading must win —
+    GITHUB_TOKEN is both a GITHUB_* name and a credential."""
+    if _FORBIDDEN_RE.search(name):
+        return "forbidden"
+    if _CI_RE.match(name):
+        return "ci-detect"
+    if _ALLOWED_RE.match(name):
+        return "allowed"
+    return "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Where the names come from
+# ---------------------------------------------------------------------------
+
+def workflow_secret_names(workflow_dir: Path) -> set[str]:
+    """Every `secrets.NAME` any workflow can inject.
+
+    This is the half of the name set `os.environ` cannot provide. A secret is
+    only in the environment of the job it is wired into, so a preflight job —
+    which deliberately has no secrets — would otherwise scan against an empty
+    list and pass everything.
+    """
+    names: set[str] = set()
+    if not workflow_dir.is_dir():
+        return names
+    for wf in sorted(workflow_dir.rglob("*.y*ml")):
+        text = wf.read_text(encoding="utf-8", errors="replace")
+        # Every `secrets.NAME` reference, plus the env-var NAME each one is
+        # bound to — `CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}`
+        # contributes both, and they are not always spelled the same.
+        #
+        # The binding pattern REQUIRES `secrets.` inside the expression. It used
+        # to match any `NAME: ${{ ... }}` line, which swept up
+        # `LD_LIBRARY_PATH: ${{ github.workspace }}/target/debug` and made
+        # clang-sys — which legitimately reads LD_LIBRARY_PATH to find libclang —
+        # a hard build failure. An over-broad secret list does not fail safe: it
+        # trains people to add exemptions to a security gate.
+        names |= set(re.findall(r'secrets\.([A-Za-z_][A-Za-z0-9_]*)', text))
+        names |= set(re.findall(
+            r'(?m)^\s{2,}([A-Za-z_][A-Za-z0-9_]*)\s*:\s*\$\{\{[^}]*\bsecrets\.', text))
+    names.discard("GITHUB_TOKEN")   # re-added below; it is always available
+    names.add("GITHUB_TOKEN")
+    return names
+
+
+# ---------------------------------------------------------------------------
+# Reading the sources
+# ---------------------------------------------------------------------------
+
+READ_PATTERNS = [
+    ("env!", re.compile(r'\benv!\s*\(\s*"([A-Za-z_][A-Za-z0-9_]*)"')),
+    ("option_env!", re.compile(r'\boption_env!\s*\(\s*"([A-Za-z_][A-Za-z0-9_]*)"')),
+    ("env::var", re.compile(r'\benv::var(?:_os)?\s*\(\s*"([A-Za-z_][A-Za-z0-9_]*)"')),
+    ("var()", re.compile(r'(?<![:\w])var(?:_os)?\s*\(\s*"([A-Za-z_][A-Za-z0-9_]*)"')),
+    ("getenv", re.compile(r'\bgetenv\s*\(\s*"([A-Za-z_][A-Za-z0-9_]*)"')),
+    ("GetEnvironmentVariable", re.compile(
+        r'\bGetEnvironmentVariable[AW]?\s*\(\s*"?([A-Za-z_][A-Za-z0-9_]*)"?')),
+]
+ENUMERATE_RE = re.compile(r'\b(?:std::)?env::vars(?:_os)?\s*\(|\benviron\b')
+DYNAMIC_RE = re.compile(r'\benv::var(?:_os)?\s*\(\s*(?!")')
+
+SCANNABLE = {".rs", ".c", ".h", ".cc", ".cpp", ".cxx", ".hpp", ".m", ".mm"}
+
+
+def strip_comments(text: str) -> str:
+    """Comments and `#[test]`/`#[cfg(test)]` items are not build-time code."""
+    return sc.normalise_source(text)
+
+
+def scan_crate(crate: sc.VendoredCrate, scope: str,
+               build_deps: set[str] | None = None) -> dict | None:
+    """Every environment read in this crate's build-time code.
+
+    `build_deps` is the transitive `[build-dependencies]` closure. Those crates
+    are ordinary libraries — no build script, not proc macros — but they are
+    linked INTO build scripts and run with the same authority. Scoping to
+    "build scripts and proc macros" alone reports `turso_core` as reading
+    nothing unusual while `built`, its build dependency, calls `env::vars_os()`
+    over the entire environment on its behalf.
+    """
+    build_deps = build_deps or set()
+    paths = sc.build_script_paths(crate)
+    kind = "build-script"
+    if not paths and sc.manifest_facts(crate)["proc_macro"]:
+        paths, kind = sc.proc_macro_paths(crate), "proc-macro"
+    if not paths and crate.name in build_deps:
+        paths, kind = sc.proc_macro_paths(crate), "build-dependency"
+    if scope == "all" and not paths:
+        src = crate.path / "src"
+        paths, kind = (sorted(src.rglob("*.rs")) if src.is_dir() else []), "library"
+    if not paths:
+        return None
+
+    reads: dict[str, set[str]] = {}
+    enumerates: list[str] = []
+    dynamic: list[str] = []
+    for p in paths:
+        if p.suffix not in SCANNABLE:
+            continue
+        try:
+            text = strip_comments(p.read_text(encoding="utf-8", errors="replace"))
+        except OSError:
+            continue
+        rel = str(p.relative_to(crate.path)).replace(os.sep, "/")
+        for label, pat in READ_PATTERNS:
+            for name in pat.findall(text):
+                reads.setdefault(name, set()).add(f"{rel} ({label})")
+        if ENUMERATE_RE.search(text):
+            enumerates.append(rel)
+        if DYNAMIC_RE.search(text):
+            dynamic.append(rel)
+    if not reads and not enumerates and not dynamic:
+        return None
+    return {
+        "name": crate.name, "version": crate.version, "kind": kind,
+        "reads": {k: sorted(v) for k, v in sorted(reads.items())},
+        "enumerates": sorted(set(enumerates)),
+        "dynamic": sorted(set(dynamic)),
+    }
+
+
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--vendor", type=Path, default=Path("vendor"))
+    ap.add_argument("--workflows", type=Path, default=Path(".github/workflows"))
+    ap.add_argument("--scope", choices=("compile-time", "all"), default="compile-time",
+                    help="compile-time = build scripts + proc macros (default)")
+    ap.add_argument("--strict", action="store_true",
+                    help="also fail on CI-provider detection and whole-env enumeration")
+    ap.add_argument("--allow-enumerate", action="append", default=[], metavar="CRATE",
+                    help="crate permitted to call env::vars() (repeatable)")
+    ap.add_argument("--json", type=Path)
+    ap.add_argument("--report-only", action="store_true")
+    ap.add_argument("--emit-env-allowlist", action="store_true",
+                    help="print an `env -i ...` prefix that passes only allowed vars")
+    ap.add_argument("--print-classes", action="store_true")
+    ap.add_argument("--metadata", type=Path,
+                    help="cargo metadata JSON; without it the build-dependency "
+                         "closure is computed by invoking cargo")
+    ap.add_argument("--no-build-deps", action="store_true")
+    args = ap.parse_args()
+
+    if args.print_classes:
+        for label, pats in (("ALLOWED", ALLOWED), ("CI_DETECT", CI_DETECT),
+                            ("FORBIDDEN", FORBIDDEN)):
+            print(f"=== {label} ({len(pats)} patterns) ===")
+            for p in pats:
+                print(f"  {p}")
+            print()
+        return 0
+
+    if args.emit_env_allowlist:
+        keep = [f'{k}={v}' for k, v in sorted(os.environ.items())
+                if classify(k) == "allowed"]
+        print("env -i \\\n  " + " \\\n  ".join(
+            f"'{kv}'" for kv in keep) + " \\\n  cargo build --locked")
+        return 0
+
+    secret_names = workflow_secret_names(args.workflows)
+    live_names = set(os.environ)
+
+    build_deps: set[str] = set()
+    if not args.no_build_deps:
+        build_deps = sc.build_dependency_closure(sc.load_metadata(args.metadata))
+
+    findings = []
+    for crate in sc.walk_vendor(args.vendor):
+        f = scan_crate(crate, args.scope, build_deps)
+        if f:
+            findings.append(f)
+
+    violations, notices = [], []
+    for f in findings:
+        for name, sites in f["reads"].items():
+            cls = classify(name)
+            # A name literally wired into this repository's workflows is
+            # forbidden regardless of shape: AUR_USERNAME is not "secret-shaped"
+            # but it is still ours and no dependency should be reading it.
+            if name in secret_names:
+                cls = "forbidden"
+            rec = {**{k: f[k] for k in ("name", "version", "kind")},
+                   "var": name, "class": cls, "sites": sites,
+                   "live_in_this_env": name in live_names}
+            if cls == "forbidden":
+                violations.append(rec)
+            elif cls in ("ci-detect", "unknown"):
+                (violations if (args.strict and cls == "ci-detect") else notices).append(rec)
+        if f["enumerates"]:
+            rec = {**{k: f[k] for k in ("name", "version", "kind")},
+                   "var": "*", "class": "enumerate", "sites": f["enumerates"],
+                   "live_in_this_env": True}
+            if f["name"] in args.allow_enumerate:
+                notices.append({**rec, "class": "enumerate (allowlisted)"})
+            elif args.strict:
+                violations.append(rec)
+            else:
+                notices.append(rec)
+
+    if args.json:
+        args.json.parent.mkdir(parents=True, exist_ok=True)
+        args.json.write_text(json.dumps(
+            {"findings": findings, "violations": violations, "notices": notices,
+             "secret_names": sorted(secret_names)}, indent=2), encoding="utf-8")
+
+    # ---- report ----
+    md = ["## 🔑 Environment access from build-time code", "",
+          f"Scanned `{len(findings)}` crates that read the environment at build time, "
+          f"against `{len(secret_names)}` secret names this repository's workflows can "
+          f"inject and `{len(live_names)}` variables live in this job.", ""]
+    if violations:
+        md += ["### ❌ Forbidden reads", "", "| crate | kind | variable | class | where |",
+               "|---|---|---|---|---|"]
+        for v in violations:
+            md.append(f'| `{v["name"]} {v["version"]}` | {v["kind"]} | `{v["var"]}` '
+                      f'| {v["class"]} | {", ".join(v["sites"][:3])} |')
+        md.append("")
+    if notices:
+        md += [f"<details><summary><b>Notices ({len(notices)}) — "
+               f"non-standard or CI-shaped names</b></summary>", "",
+               "| crate | variable | class |", "|---|---|---|"]
+        for n_ in notices:
+            md.append(f'| `{n_["name"]}` | `{n_["var"]}` | {n_["class"]} |')
+        md += ["", "</details>", ""]
+    sc.summary("\n".join(md))
+
+    print(f"crates reading the environment at build time: {len(findings)}")
+    print(f"  forbidden reads : {len(violations)}")
+    print(f"  notices         : {len(notices)}")
+    for v in violations:
+        sc.annotate("error", f'{v["name"]} {v["version"]} ({v["kind"]}) reads '
+                             f'{v["var"]} [{v["class"]}] at {v["sites"][0]}')
+    if not violations:
+        print("no build-time code reads a credential-shaped or repository-secret variable")
+    return 0 if (not violations or args.report_only) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/supply-chain/lockfile_guard.py
+++ b/scripts/supply-chain/lockfile_guard.py
@@ -1,0 +1,377 @@
+#!/usr/bin/env python3
+"""
+lockfile_guard.py — which crate VERSIONS are allowed into the tree.
+
+THE THREAT THIS COVERS AND `dependency-justifications.toml` DOES NOT. That file
+answers "why is this crate here", keyed by crate NAME. It is the right question
+and it stops a dependency being added quietly. It is also, by construction,
+blind to the attack that actually happened on 2026-08-20: `arrayref`,
+`internment` and `append-only-vec` were already in thousands of trees, already
+justified by anyone who justifies dependencies, when a compromised maintainer
+account published new versions of all three inside a 23-minute window. The only
+change was one line of Cargo.toml pulling in `proc-macro1`. Exposure was 86–107
+minutes. A name-keyed allowlist says yes to every one of those releases.
+
+Four checks, in increasing cost:
+
+  --check vendor    every vendored file matches the registry's published
+                    checksum (offline, seconds). Catches a tampered vendor tree
+                    and a lockfile checksum that disagrees with the crate.
+  --check yanked    no locked version is yanked. The arrayref attacker YANKED
+                    the good releases to force resolution onto the malicious
+                    one, so "is anything in my lockfile yanked" is a live
+                    question, not hygiene.
+  --check cksum     lockfile checksums match the registry index.
+  --check cooldown  no locked version is younger than --min-age-days. This is
+                    RFC 3923 `min-publish-age`, which is merged but whose
+                    client-side half had not shipped when arrayref happened —
+                    two days after the stabilisation PR entered final comment
+                    period. A 14-day floor turns a 107-minute exposure window
+                    into a non-event, because the malicious version is yanked
+                    long before any build is allowed to resolve it.
+
+Cooldown needs one crates.io API request per crate and that API is rate-limited,
+so by default it runs only over versions that CHANGED against a base ref
+(`--changed-only`), which is both the fast path and the interesting one: a
+lockfile diff is exactly where a poisoned release enters.
+
+Usage:
+    lockfile_guard.py --check vendor --vendor vendor/
+    lockfile_guard.py --check yanked --check cksum
+    lockfile_guard.py --check cooldown --changed-only --base-ref origin/master
+    lockfile_guard.py --check all --vendor vendor/ --min-age-days 14
+
+Exit 0 when every locked version passes the selected checks; 1 otherwise.
+"""
+from __future__ import annotations
+
+import argparse
+import concurrent.futures as cf
+import hashlib
+import json
+import re
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import sc_common as sc  # noqa: E402
+
+CRATES_IO = "registry+https://github.com/rust-lang/crates.io-index"
+SPARSE = "https://index.crates.io"
+API = "https://crates.io/api/v1/crates"
+UA = "azul-supply-chain-gate (+https://github.com/fschutt/azul)"
+
+
+# ---------------------------------------------------------------------------
+
+def parse_lock(path: Path) -> list[dict]:
+    """[[package]] blocks. Regex, not a TOML library — same portability reason
+    as everywhere else in this directory, and the shape is fixed by cargo."""
+    if not path.is_file():
+        raise SystemExit(f"error: {path} not found")
+    out = []
+    for blk in path.read_text(encoding="utf-8").split("[[package]]")[1:]:
+        name = re.search(r'(?m)^name = "(.+)"$', blk)
+        ver = re.search(r'(?m)^version = "(.+)"$', blk)
+        src = re.search(r'(?m)^source = "(.+)"$', blk)
+        cks = re.search(r'(?m)^checksum = "(.+)"$', blk)
+        if name and ver:
+            out.append({"name": name.group(1), "version": ver.group(1),
+                        "source": src.group(1) if src else None,
+                        "checksum": cks.group(1) if cks else None})
+    return out
+
+
+def index_path(name: str) -> str:
+    n = name.lower()
+    if len(n) == 1:
+        return f"1/{n}"
+    if len(n) == 2:
+        return f"2/{n}"
+    if len(n) == 3:
+        return f"3/{n[0]}/{n}"
+    return f"{n[:2]}/{n[2:4]}/{n}"
+
+
+def _get(url: str, timeout: int = 20) -> bytes:
+    req = urllib.request.Request(url, headers={"User-Agent": UA})
+    with urllib.request.urlopen(req, timeout=timeout) as r:
+        return r.read()
+
+
+class Cache:
+    """Disk cache. The index is immutable per (crate, version) except for the
+    yank flag, so a cache makes repeat runs cheap without hiding a fresh yank:
+    `--check yanked` passes --no-cache in CI's scheduled run."""
+
+    def __init__(self, path: Path | None):
+        self.path = path
+        self.data: dict = {}
+        if path and path.is_file():
+            try:
+                self.data = json.loads(path.read_text(encoding="utf-8"))
+            except (OSError, ValueError):
+                self.data = {}
+
+    def get(self, key: str):
+        return self.data.get(key)
+
+    def put(self, key: str, value) -> None:
+        self.data[key] = value
+
+    def flush(self) -> None:
+        if self.path:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            self.path.write_text(json.dumps(self.data), encoding="utf-8")
+
+
+def fetch_index(names: list[str], cache: Cache, workers: int = 12) -> dict:
+    """{name: {version: {"cksum":..., "yanked":...}}} from the sparse index."""
+    todo = [n for n in names if cache.get(f"idx:{n}") is None]
+    if todo:
+        def one(n):
+            try:
+                body = _get(f"{SPARSE}/{index_path(n)}")
+            except urllib.error.HTTPError as e:
+                return n, ({} if e.code == 404 else None)
+            except Exception:
+                return n, None
+            vers = {}
+            for line in body.decode("utf-8", "replace").splitlines():
+                if not line.strip():
+                    continue
+                try:
+                    d = json.loads(line)
+                except ValueError:
+                    continue
+                vers[d["vers"]] = {"cksum": d.get("cksum"), "yanked": bool(d.get("yanked"))}
+            return n, vers
+        with cf.ThreadPoolExecutor(max_workers=workers) as ex:
+            for n, vers in ex.map(one, todo):
+                if vers is not None:
+                    cache.put(f"idx:{n}", vers)
+    return {n: cache.get(f"idx:{n}") or {} for n in names}
+
+
+def fetch_published(pkgs: list[dict], cache: Cache, delay: float = 0.6) -> dict:
+    """{(name, version): iso8601}. Serialised — the crates.io API is rate
+    limited and a gate that gets itself 429'd is a gate that fails open."""
+    out = {}
+    for p in pkgs:
+        key = f"pub:{p['name']}:{p['version']}"
+        hit = cache.get(key)
+        if hit is None:
+            try:
+                body = _get(f"{API}/{p['name']}/{p['version']}")
+                hit = json.loads(body)["version"]["created_at"]
+            except Exception:
+                hit = ""
+            cache.put(key, hit)
+            time.sleep(delay)
+        if hit:
+            out[(p["name"], p["version"])] = hit
+    return out
+
+
+def changed_versions(base_ref: str, lock: Path) -> set[tuple[str, str]] | None:
+    """(name, version) pairs present now and not at `base_ref`."""
+    try:
+        old = subprocess.run(["git", "show", f"{base_ref}:{lock}"],
+                             capture_output=True, text=True, check=True).stdout
+    except subprocess.CalledProcessError:
+        return None
+    prev = set()
+    for blk in old.split("[[package]]")[1:]:
+        n = re.search(r'(?m)^name = "(.+)"$', blk)
+        v = re.search(r'(?m)^version = "(.+)"$', blk)
+        if n and v:
+            prev.add((n.group(1), v.group(1)))
+    now = {(p["name"], p["version"]) for p in parse_lock(lock)}
+    return now - prev
+
+
+def verify_vendor(vendor: Path, lock: list[dict]) -> list[dict]:
+    """Every vendored file against the registry checksums cargo recorded.
+
+    `.cargo-checksum.json` is written by cargo from what the registry served, so
+    this is an offline integrity check of the whole vendor tree against what
+    crates.io published — including the package-level checksum, which must also
+    agree with Cargo.lock.
+    """
+    by_id = {(p["name"], p["version"]): p for p in lock}
+    problems = []
+    for crate in sc.walk_vendor(vendor):
+        manifest = crate.path / ".cargo-checksum.json"
+        if not manifest.is_file():
+            # Path/git sources legitimately have none; a registry crate without
+            # one cannot be verified and must be said out loud, not skipped.
+            if (crate.name, crate.version) in by_id and \
+                    by_id[(crate.name, crate.version)]["source"] == CRATES_IO:
+                problems.append({"crate": crate.id, "kind": "NO-CHECKSUM-FILE",
+                                 "detail": ".cargo-checksum.json missing"})
+            continue
+        try:
+            doc = json.loads(manifest.read_text(encoding="utf-8"))
+        except (OSError, ValueError) as e:
+            problems.append({"crate": crate.id, "kind": "UNREADABLE", "detail": str(e)})
+            continue
+
+        locked = by_id.get((crate.name, crate.version))
+        pkg_sum = doc.get("package")
+        if locked and locked["checksum"] and pkg_sum and locked["checksum"] != pkg_sum:
+            problems.append({"crate": crate.id, "kind": "LOCK-MISMATCH", "detail":
+                             f"Cargo.lock {locked['checksum'][:16]}… vs vendor {pkg_sum[:16]}…"})
+
+        files = doc.get("files", {})
+        on_disk = {str(p.relative_to(crate.path)).replace("\\", "/")
+                   for p in crate.path.rglob("*") if p.is_file()
+                   and p.name != ".cargo-checksum.json"}
+        for rel, want in files.items():
+            p = crate.path / rel
+            if not p.is_file():
+                problems.append({"crate": crate.id, "kind": "MISSING",
+                                 "detail": rel})
+                continue
+            got = hashlib.sha256(p.read_bytes()).hexdigest()
+            if got != want:
+                problems.append({"crate": crate.id, "kind": "MODIFIED",
+                                 "detail": f"{rel}: {got[:16]}… != {want[:16]}…"})
+        for extra in sorted(on_disk - set(files)):
+            problems.append({"crate": crate.id, "kind": "EXTRA-FILE", "detail": extra})
+    return problems
+
+
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--lock", type=Path, default=Path("Cargo.lock"))
+    ap.add_argument("--vendor", type=Path, default=Path("vendor"))
+    ap.add_argument("--check", action="append", default=[],
+                    choices=("vendor", "yanked", "cksum", "cooldown", "all"))
+    ap.add_argument("--min-age-days", type=int, default=14)
+    ap.add_argument("--exempt", action="append", default=[], metavar="CRATE",
+                    help="crate exempt from the cooldown floor (repeatable)")
+    ap.add_argument("--exempt-file", type=Path,
+                    default=Path(__file__).resolve().parent / "cooldown-exempt.txt",
+                    help="file of cooldown-exempt crate names, one per line")
+    ap.add_argument("--changed-only", action="store_true")
+    ap.add_argument("--base-ref", default="origin/master")
+    ap.add_argument("--cache", type=Path, default=Path(".supply-chain-cache.json"))
+    ap.add_argument("--no-cache", action="store_true")
+    ap.add_argument("--json", type=Path)
+    ap.add_argument("--report-only", action="store_true")
+    args = ap.parse_args()
+
+    checks = set(args.check) or {"vendor", "yanked", "cksum"}
+    if "all" in checks:
+        checks = {"vendor", "yanked", "cksum", "cooldown"}
+
+    lock = parse_lock(args.lock)
+    registry = [p for p in lock if p["source"] == CRATES_IO]
+    cache = Cache(None if args.no_cache else args.cache)
+    violations: list[dict] = []
+    md = [f"## 📌 Lockfile integrity — {len(lock)} packages "
+          f"({len(registry)} from crates.io)", ""]
+
+    if "vendor" in checks:
+        problems = verify_vendor(args.vendor, lock)
+        violations += [{"kind": p["kind"], "crate": p["crate"], "detail": p["detail"]}
+                       for p in problems]
+        md.append(f"- **vendor integrity**: {'❌ ' + str(len(problems)) + ' problem(s)' if problems else '✅ every vendored file matches its registry checksum'}")
+
+    scope = registry
+    if args.changed_only:
+        changed = changed_versions(args.base_ref, args.lock)
+        if changed is None:
+            print(f"::warning::could not read {args.base_ref}:{args.lock} — checking everything")
+        else:
+            scope = [p for p in registry if (p["name"], p["version"]) in changed]
+            md.append(f"- **scope**: {len(scope)} version(s) changed against `{args.base_ref}`")
+
+    if checks & {"yanked", "cksum"}:
+        idx = fetch_index(sorted({p["name"] for p in scope}), cache)
+        yanked = cks_bad = unknown = 0
+        for p in scope:
+            entry = idx.get(p["name"], {}).get(p["version"])
+            if entry is None:
+                unknown += 1
+                continue
+            if "yanked" in checks and entry["yanked"]:
+                yanked += 1
+                violations.append({"kind": "YANKED", "crate": f'{p["name"]} {p["version"]}',
+                                   "detail": "this version is yanked on crates.io"})
+            if "cksum" in checks and p["checksum"] and entry["cksum"] \
+                    and p["checksum"] != entry["cksum"]:
+                cks_bad += 1
+                violations.append({"kind": "CKSUM", "crate": f'{p["name"]} {p["version"]}',
+                                   "detail": f'lockfile {p["checksum"][:16]}… != index {entry["cksum"][:16]}…'})
+        if "yanked" in checks:
+            md.append(f"- **yanked**: {'❌ ' + str(yanked) if yanked else '✅ none'}"
+                      + (f" ({unknown} not found in the index)" if unknown else ""))
+        if "cksum" in checks:
+            md.append(f"- **checksums**: {'❌ ' + str(cks_bad) + ' mismatched' if cks_bad else '✅ all match the registry index'}")
+
+    if "cooldown" in checks:
+        # First-party crates are exempt. The floor defends against a stolen
+        # publishing credential; azul publishing its own crate and bumping the
+        # lockfile in the same change is not that, and blocking it would make
+        # every release red. See cooldown-exempt.txt for the full reasoning.
+        exempt = set(args.exempt)
+        if args.exempt_file and args.exempt_file.is_file():
+            for line in args.exempt_file.read_text(encoding="utf-8").splitlines():
+                line = line.split("#", 1)[0].strip()
+                if line:
+                    exempt.add(line)
+        pub = fetch_published([p for p in scope if p["name"] not in exempt], cache)
+        now = datetime.now(timezone.utc)
+        young = []
+        skipped = sum(1 for p in scope if p["name"] in exempt)
+        for p in scope:
+            if p["name"] in exempt:
+                continue
+            iso = pub.get((p["name"], p["version"]))
+            if not iso:
+                continue
+            when = datetime.fromisoformat(iso.replace("Z", "+00:00"))
+            age = (now - when).days
+            if age < args.min_age_days:
+                young.append((p, age))
+                violations.append({"kind": "COOLDOWN",
+                                   "crate": f'{p["name"]} {p["version"]}',
+                                   "detail": f"published {age}d ago, minimum is {args.min_age_days}d"})
+        md.append(f"- **cooldown ({args.min_age_days}d)**: "
+                  + (f"❌ {len(young)} version(s) too new" if young
+                     else f"✅ all {len(pub)} checked versions are at least {args.min_age_days} days old")
+                  + (f" ({skipped} first-party crate(s) exempt)" if skipped else ""))
+
+    cache.flush()
+
+    if violations:
+        md += ["", "| kind | crate | detail |", "|---|---|---|"]
+        md += [f'| **{v["kind"]}** | `{v["crate"]}` | {v["detail"]} |' for v in violations[:60]]
+        if len(violations) > 60:
+            md.append(f'| … | | {len(violations) - 60} more |')
+    sc.summary("\n".join(md))
+
+    if args.json:
+        args.json.parent.mkdir(parents=True, exist_ok=True)
+        args.json.write_text(json.dumps({"violations": violations}, indent=2), encoding="utf-8")
+
+    for line in md:
+        if line.startswith("- "):
+            print(line[2:].replace("**", ""))
+    for v in violations[:40]:
+        sc.annotate("error", f'{v["kind"]}: {v["crate"]} — {v["detail"]}')
+    print(f"\n{len(violations)} violation(s)")
+    return 0 if (not violations or args.report_only) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/supply-chain/run_all.sh
+++ b/scripts/supply-chain/run_all.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# run_all.sh — run every supply-chain gate locally, exactly as CI runs them.
+#
+# CI runs these in two jobs (supply_chain_preflight and supply_chain_versions in
+# .github/workflows/rust.yml). This script is the single local entry point, so
+# "it passed on my machine" and "it passed in CI" mean the same thing.
+#
+#   scripts/supply-chain/run_all.sh                  # the blocking gates
+#   scripts/supply-chain/run_all.sh --with-cooldown  # + publish-age (slow: one
+#                                                    #   crates.io request per crate)
+#   scripts/supply-chain/run_all.sh --keep-vendor    # leave vendor/ in place
+#
+# The vendor tree is ~1.1 GB and is removed on exit unless --keep-vendor.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+VENDOR="${AZ_SC_VENDOR:-vendor}"
+META="${AZ_SC_META:-target/sc-metadata.json}"
+KEEP=0
+COOLDOWN=0
+for arg in "$@"; do
+  case "$arg" in
+    --keep-vendor) KEEP=1 ;;
+    --with-cooldown) COOLDOWN=1 ;;
+    -h|--help) sed -n '2,14p' "$0"; exit 0 ;;
+    *) echo "unknown option: $arg" >&2; exit 2 ;;
+  esac
+done
+
+created_vendor=0
+cleanup() {
+  if [ "$KEEP" = "0" ] && [ "$created_vendor" = "1" ]; then
+    rm -rf "$VENDOR"
+  fi
+}
+trap cleanup EXIT
+
+step() { printf '\n\033[1m== %s\033[0m\n' "$1"; }
+
+if [ ! -d "$VENDOR" ]; then
+  step "cargo vendor (downloads sources; runs nothing)"
+  created_vendor=1
+  cargo vendor --locked --versioned-dirs "$VENDOR" > /dev/null
+  echo "vendored $(find "$VENDOR" -maxdepth 1 -mindepth 1 -type d | wc -l | tr -d ' ') crates"
+else
+  echo "reusing existing $VENDOR"
+fi
+
+mkdir -p "$(dirname "$META")"
+cargo metadata --format-version=1 --locked --all-features > "$META"
+
+rc=0
+step "1/4  Lockfile integrity (vendor checksums, yanked versions, index checksums)"
+python3 scripts/supply-chain/lockfile_guard.py \
+  --check vendor --check yanked --check cksum --vendor "$VENDOR" || rc=1
+
+step "2/4  Environment access from build-time code"
+python3 scripts/supply-chain/env_guard.py \
+  --vendor "$VENDOR" --metadata "$META" || rc=1
+
+step "3/4  Build-time code execution policy (build.rs / proc-macro)"
+python3 scripts/supply-chain/scan_build_scripts.py \
+  --vendor "$VENDOR" --metadata "$META" || rc=1
+
+step "4/4  cargo-vet (per-version audit state)"
+if command -v cargo-vet > /dev/null; then
+  cargo vet --locked || rc=1
+else
+  echo "cargo-vet not installed — skipping (cargo install cargo-vet --locked)"
+fi
+
+if [ "$COOLDOWN" = "1" ]; then
+  step "extra  Publish-age cooldown (one crates.io request per crate — slow)"
+  python3 scripts/supply-chain/lockfile_guard.py --check cooldown --min-age-days 14 || rc=1
+fi
+
+printf '\n'
+if [ "$rc" = "0" ]; then
+  echo "all supply-chain gates passed"
+else
+  echo "one or more supply-chain gates FAILED (see above)"
+fi
+exit "$rc"

--- a/scripts/supply-chain/sc_common.py
+++ b/scripts/supply-chain/sc_common.py
@@ -1,0 +1,530 @@
+"""
+sc_common.py — shared plumbing for azul's supply-chain gates.
+
+Three scripts sit on top of this module:
+
+    scan_build_scripts.py   which crates may run code at BUILD time, pinned by digest
+    env_guard.py            which environment variables that code may READ
+    lockfile_guard.py       which crate VERSIONS may enter the tree at all
+
+They all need the same four things, so they live here rather than being
+copy-pasted three ways: a vendor-directory walker, a content digest, a
+GitHub-Actions summary/annotation emitter, and a TOML *subset* reader.
+
+WHY A HAND-WRITTEN TOML READER. `tomllib` is Python 3.11+. The GitHub runner
+image for ubuntu-22.04 ships Python 3.10, and stock macOS ships 3.9 — so a
+`import tomllib` at the top of a CI gate is a gate that does not run. The
+existing `scripts/check_dep_justifications.py` made the same call for the same
+reason. The policy files in this directory are therefore written in a
+deliberately small, fully-documented TOML subset (see `read_toml_subset`), which
+is still real TOML — `taplo`, editors and `tomllib` all parse these files
+correctly. The subset is a constraint on what we WRITE, not on what is valid.
+"""
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+import sys
+from pathlib import Path
+
+# --------------------------------------------------------------------------
+# TOML subset reader
+# --------------------------------------------------------------------------
+#
+# Supported, and nothing else:
+#
+#     # comment
+#     [table]  |  [table."quoted.key"]  |  [a.b.c]
+#     key = "string"          (with \" and \\ escapes)
+#     key = true | false
+#     key = 123
+#     key = ["one", "two"]    (single-line array of strings)
+#
+# Anything else raises, loudly, naming the file and line — a policy file that
+# silently half-parses is worse than one that fails to parse, because the half
+# that vanished is the half that was gating something.
+
+_TBL_RE = re.compile(r'^\[([^\]]+)\]\s*(?:#.*)?$')
+_KV_RE = re.compile(r'^([A-Za-z0-9_.-]+)\s*=\s*(.+?)\s*$')
+_STR_RE = re.compile(r'^"((?:[^"\\]|\\.)*)"\s*(?:#.*)?$')
+_ARR_RE = re.compile(r'^\[\s*(.*?)\s*,?\s*\]\s*(?:#.*)?$')
+_ARR_ITEM_RE = re.compile(r'"((?:[^"\\]|\\.)*)"')
+_INT_RE = re.compile(r'^(-?\d+)\s*(?:#.*)?$')
+_BOOL_RE = re.compile(r'^(true|false)\s*(?:#.*)?$')
+
+
+def _unescape(s: str) -> str:
+    return s.replace('\\"', '"').replace("\\\\", "\\").replace("\\n", "\n")
+
+
+def _split_table_path(raw: str) -> list[str]:
+    """`crate."serde_derive"` -> ['crate', 'serde_derive']; `a.b` -> ['a','b']."""
+    parts, buf, in_q = [], "", False
+    for ch in raw:
+        if ch == '"':
+            in_q = not in_q
+        elif ch == "." and not in_q:
+            parts.append(buf.strip())
+            buf = ""
+        else:
+            buf += ch
+    parts.append(buf.strip())
+    return [p.strip('"') for p in parts if p.strip()]
+
+
+def read_toml_subset(path: Path) -> dict:
+    """Parse the documented TOML subset into nested dicts. Raises on anything
+    outside the subset, naming file:line."""
+    if not path.is_file():
+        raise SystemExit(f"error: policy file not found: {path}")
+    root: dict = {}
+    cur = root
+    for lineno, raw in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        m = _TBL_RE.match(line)
+        if m:
+            cur = root
+            for part in _split_table_path(m.group(1)):
+                cur = cur.setdefault(part, {})
+            continue
+        m = _KV_RE.match(line)
+        if not m:
+            raise SystemExit(f"{path}:{lineno}: not a key/value or table header: {raw!r}")
+        key, val = m.group(1), m.group(2)
+        if (sm := _STR_RE.match(val)):
+            cur[key] = _unescape(sm.group(1))
+        elif (bm := _BOOL_RE.match(val)):
+            cur[key] = bm.group(1) == "true"
+        elif (im := _INT_RE.match(val)):
+            cur[key] = int(im.group(1))
+        elif (am := _ARR_RE.match(val)):
+            cur[key] = [_unescape(x) for x in _ARR_ITEM_RE.findall(am.group(1))]
+        else:
+            raise SystemExit(
+                f"{path}:{lineno}: value outside the supported TOML subset "
+                f"(string / bool / int / single-line string array): {val!r}"
+            )
+    return root
+
+
+# --------------------------------------------------------------------------
+# Vendor directory
+# --------------------------------------------------------------------------
+
+_VERSIONED_DIR_RE = re.compile(r'^(?P<name>.+)-(?P<version>\d+\.\d+\.\d+(?:[-+].*)?)$')
+
+
+class VendoredCrate:
+    """One `name-version/` directory produced by `cargo vendor --versioned-dirs`."""
+
+    __slots__ = ("name", "version", "path")
+
+    def __init__(self, name: str, version: str, path: Path):
+        self.name, self.version, self.path = name, version, path
+
+    @property
+    def id(self) -> str:
+        return f"{self.name} {self.version}"
+
+    def __repr__(self) -> str:
+        return f"<VendoredCrate {self.id}>"
+
+
+def walk_vendor(vendor_dir: Path) -> list[VendoredCrate]:
+    """Every crate in the vendor directory, sorted by name then version.
+
+    The vendor directory — not `cargo metadata` — is the source of truth for
+    these gates on purpose. `cargo metadata` resolves FEATURES, so a crate that
+    only compiles under a feature nobody enabled today is absent from it; the
+    lockfile (and therefore `cargo vendor`) contains it anyway, and a feature
+    flip in a later commit is enough to start compiling its build script. The
+    strictly larger set is the correct one to review.
+    """
+    if not vendor_dir.is_dir():
+        raise SystemExit(
+            f"error: vendor directory not found: {vendor_dir}\n"
+            f"       run: cargo vendor --locked --versioned-dirs {vendor_dir}"
+        )
+    out = []
+    for entry in sorted(vendor_dir.iterdir()):
+        if not entry.is_dir() or entry.name.startswith("."):
+            continue
+        m = _VERSIONED_DIR_RE.match(entry.name)
+        if m:
+            out.append(VendoredCrate(m.group("name"), m.group("version"), entry))
+        else:
+            # Not `--versioned-dirs`, or a crate whose version isn't semver-ish.
+            # Recover the version from the manifest rather than dropping it: a
+            # crate silently skipped by a security scan is a hole in the scan.
+            ver = "0.0.0-unknown"
+            mani = entry / "Cargo.toml"
+            if mani.is_file():
+                vm = re.search(r'(?m)^\s*version\s*=\s*"([^"]+)"', mani.read_text(
+                    encoding="utf-8", errors="replace"))
+                if vm:
+                    ver = vm.group(1)
+            out.append(VendoredCrate(entry.name, ver, entry))
+    return out
+
+
+def manifest_facts(crate: VendoredCrate) -> dict:
+    """`build` / `links` / `proc-macro` straight out of the vendored Cargo.toml.
+
+    Regex rather than a TOML parse: vendored manifests are cargo-normalised
+    output, and we only need four scalars out of them. `build` is the subtle
+    one — `build = false` means "no build script EVEN IF build.rs exists on
+    disk", and `build = "custom.rs"` means the script is not called build.rs.
+    Both shapes appear in the wild, and both are ways to make a naive
+    `ls build.rs` scan report the wrong answer.
+    """
+    text = (crate.path / "Cargo.toml").read_text(encoding="utf-8", errors="replace") \
+        if (crate.path / "Cargo.toml").is_file() else ""
+    facts = {"build": None, "build_disabled": False, "links": None, "proc_macro": False}
+
+    if (bm := re.search(r'(?m)^\s*build\s*=\s*(?:"([^"]+)"|(false)|(true))', text)):
+        if bm.group(2):
+            facts["build_disabled"] = True
+        elif bm.group(1):
+            facts["build"] = bm.group(1)
+    if (lm := re.search(r'(?m)^\s*links\s*=\s*"([^"]+)"', text)):
+        facts["links"] = lm.group(1)
+    if re.search(r'(?m)^\s*proc-macro\s*=\s*true', text):
+        facts["proc_macro"] = True
+    return facts
+
+
+# `mod name;`, optionally preceded by `#[path = "..."]`, and `include!("...")`.
+_MOD_RE = re.compile(
+    r'(?:#\s*\[\s*path\s*=\s*"([^"]+)"\s*\]\s*)?'
+    r'(?:pub(?:\s*\([^)]*\))?\s+)?mod\s+([A-Za-z_][A-Za-z0-9_]*)\s*;')
+_INCLUDE_RE = re.compile(r'include(?:_str|_bytes)?!\s*\(\s*"([^"]+)"\s*\)')
+
+
+def _module_candidates(from_file: Path, path_attr: str | None, name: str) -> list[Path]:
+    """Where rustc would look for `mod name;` declared inside `from_file`.
+
+    Deliberately over-inclusive: every plausible resolution is offered and the
+    caller keeps the ones that exist. Missing a file here means hashing less
+    than what executes, which is the failure that matters; hashing one extra
+    file that happens to exist costs nothing.
+    """
+    base = from_file.parent
+    stem_dir = base if from_file.name in ("build.rs", "mod.rs", "main.rs", "lib.rs") \
+        else base / from_file.stem
+    if path_attr:
+        return [base / path_attr, stem_dir / path_attr]
+    return [base / f"{name}.rs", base / name / "mod.rs",
+            stem_dir / f"{name}.rs", stem_dir / name / "mod.rs"]
+
+
+def _follow_includes(crate_root: Path, seeds: list[Path]) -> tuple[list[Path], list[str]]:
+    """Transitive closure of `mod`/`#[path]`/`include!` from the seed files.
+
+    A build script that is one file today can become two in the next release —
+    `libm` keeps `env::vars()` in a root-level `configure.rs`, `portable-atomic`
+    pulls in `src/gen/build.rs` and `version.rs`. Without following the graph,
+    a digest over `build.rs` alone pins the door and leaves the window open, and
+    a capability scan reports "no environment access" for a crate that sweeps
+    the whole environment one `mod` declaration away.
+
+    Returns (files, escapes) where `escapes` names any reference resolving
+    OUTSIDE the crate directory — which a vendored crate has no legitimate
+    reason to do, and which the caller should surface rather than silently drop.
+    """
+    seen: set[Path] = set()
+    escapes: list[str] = []
+    stack = list(seeds)
+    while stack:
+        f = stack.pop()
+        try:
+            f = f.resolve()
+        except OSError:
+            continue
+        if f in seen or not f.is_file():
+            continue
+        seen.add(f)
+        if f.suffix != ".rs":
+            continue
+        try:
+            text = f.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        refs: list[Path] = []
+        for path_attr, name in _MOD_RE.findall(text):
+            refs.extend(_module_candidates(f, path_attr or None, name))
+        for inc in _INCLUDE_RE.findall(text):
+            if "$" in inc or "concat!" in inc:   # OUT_DIR-relative, generated
+                continue
+            refs.append(f.parent / inc)
+        for r in refs:
+            try:
+                rr = r.resolve()
+            except OSError:
+                continue
+            if not rr.is_file():
+                continue
+            try:
+                rr.relative_to(crate_root.resolve())
+            except ValueError:
+                escapes.append(str(r))
+                continue
+            stack.append(rr)
+    return sorted(seen), sorted(set(escapes))
+
+
+def build_script_paths(crate: VendoredCrate) -> list[Path]:
+    """Every file that runs at BUILD time for this crate, relative-sorted.
+
+    That is the declared build script, a sibling `build/` module directory
+    (clang-sys, openssl-sys, thiserror and rustversion all split their build
+    script across one), AND the transitive closure of everything the script
+    pulls in with `mod` / `#[path]` / `include!`. Hashing only `build.rs` would
+    let a compromised release move the payload one file sideways and keep the
+    pin green — which is not hypothetical: 16 of the 141 build scripts in
+    azul's tree already span more than one file.
+    """
+    facts = manifest_facts(crate)
+    if facts["build_disabled"]:
+        return []
+    paths: list[Path] = []
+    declared = facts["build"]
+    if declared:
+        p = crate.path / declared
+        if p.is_file():
+            paths.append(p)
+    elif (crate.path / "build.rs").is_file():
+        paths.append(crate.path / "build.rs")
+    if not paths:
+        return []
+    build_dir = crate.path / "build"
+    if build_dir.is_dir():
+        paths.extend(sorted(q for q in build_dir.rglob("*") if q.is_file()))
+    followed, _escapes = _follow_includes(crate.path, paths)
+    return sorted(set(paths) | set(followed))
+
+
+def build_script_escapes(crate: VendoredCrate) -> list[str]:
+    """References from build-time code that resolve outside the crate directory."""
+    facts = manifest_facts(crate)
+    if facts["build_disabled"]:
+        return []
+    seeds = []
+    if facts["build"] and (crate.path / facts["build"]).is_file():
+        seeds.append(crate.path / facts["build"])
+    elif (crate.path / "build.rs").is_file():
+        seeds.append(crate.path / "build.rs")
+    if not seeds:
+        return []
+    return _follow_includes(crate.path, seeds)[1]
+
+
+def proc_macro_paths(crate: VendoredCrate) -> list[Path]:
+    """Sources of a proc-macro crate — these run INSIDE rustc, with the same
+    ambient authority a build script has and none of the visibility."""
+    src = crate.path / "src"
+    return sorted(p for p in src.rglob("*.rs")) if src.is_dir() else []
+
+
+def digest_files(root: Path, paths: list[Path]) -> str:
+    """sha256 over (relative path, content) pairs — order-independent, and
+    sensitive to a file being ADDED or RENAMED, not just edited.
+
+    Line endings are normalised to \\n so a crate that ships CRLF in one release
+    and LF in the next does not read as a payload change. Nothing else is
+    normalised: whitespace and comments are part of what was reviewed.
+    """
+    h = hashlib.sha256()
+    for p in sorted(paths, key=lambda q: str(q.relative_to(root)).replace(os.sep, "/")):
+        rel = str(p.relative_to(root)).replace(os.sep, "/")
+        data = p.read_bytes().replace(b"\r\n", b"\n")
+        h.update(rel.encode("utf-8"))
+        h.update(b"\0")
+        h.update(hashlib.sha256(data).digest())
+    return h.hexdigest()
+
+
+# --------------------------------------------------------------------------
+# GitHub Actions output
+# --------------------------------------------------------------------------
+
+def summary(text: str) -> None:
+    """Append markdown to the run Summary, when running under Actions."""
+    dest = os.environ.get("GITHUB_STEP_SUMMARY")
+    if dest:
+        with open(dest, "a", encoding="utf-8") as fh:
+            fh.write(text.rstrip("\n") + "\n")
+
+
+def annotate(level: str, message: str) -> None:
+    """`::error::`/`::warning::`/`::notice::` — surfaced on the run page.
+
+    Newlines are encoded (%0A) because a raw newline TERMINATES a workflow
+    command: a multi-line annotation printed naively loses everything after the
+    first line, which on a security gate is the part naming the offender.
+    """
+    if os.environ.get("GITHUB_ACTIONS"):
+        print(f"::{level}::" + message.replace("%", "%25")
+              .replace("\r", "%0D").replace("\n", "%0A"))
+    else:
+        print(f"[{level.upper()}] {message}", file=sys.stderr)
+
+
+def rel_to_repo(p: Path) -> str:
+    try:
+        return str(p.relative_to(Path.cwd()))
+    except ValueError:
+        return str(p)
+
+
+# --------------------------------------------------------------------------
+# Build-dependency closure
+# --------------------------------------------------------------------------
+
+def build_dependency_closure(metadata: dict) -> set[str]:
+    """Names of every crate that is, transitively, a `[build-dependencies]` entry.
+
+    These crates have no `build.rs` and are not proc macros, so a scan scoped to
+    "build scripts and proc macros" never looks at them — yet their library code
+    executes at build time with exactly the same authority, because a build
+    script is a program and these are the libraries it links.
+
+    This is not a theoretical hole. `built` 0.7.7 reaches azul as a build
+    dependency of `turso_core`; it calls `env::vars_os()` over the whole
+    environment and uses `git2::Repository::discover` to walk UPWARD out of the
+    crate directory, baking the enclosing repository's branch, commit hash and
+    dirty flag into the compiled artifact. `turso_core`'s own build.rs is twenty
+    lines and does none of that.
+
+    Takes parsed `cargo metadata --format-version=1` output. Walks the resolve
+    graph from every edge whose `dep_kinds` contains `build`, then takes the
+    full normal-dependency closure of each — a build dependency's own
+    dependencies also run at build time.
+    """
+    resolve = metadata.get("resolve") or {}
+    nodes = {n["id"]: n for n in resolve.get("nodes", [])}
+    id_to_name = {p["id"]: p["name"] for p in metadata.get("packages", [])}
+
+    seeds: set[str] = set()
+    for node in nodes.values():
+        for dep in node.get("deps", []):
+            kinds = {k.get("kind") for k in dep.get("dep_kinds", [])}
+            if "build" in kinds:
+                seeds.add(dep["pkg"])
+
+    closure: set[str] = set()
+    stack = list(seeds)
+    while stack:
+        pid = stack.pop()
+        if pid in closure:
+            continue
+        closure.add(pid)
+        for dep in nodes.get(pid, {}).get("deps", []):
+            if dep["pkg"] not in closure:
+                stack.append(dep["pkg"])
+    return {id_to_name[p] for p in closure if p in id_to_name}
+
+
+def load_metadata(path: Path | None = None) -> dict:
+    """`cargo metadata` output, from a file if given else by invoking cargo."""
+    import json
+    import subprocess
+    if path and path.is_file():
+        return json.loads(path.read_text(encoding="utf-8"))
+    out = subprocess.run(
+        ["cargo", "metadata", "--format-version=1", "--locked", "--all-features"],
+        capture_output=True, text=True)
+    if out.returncode != 0:
+        raise SystemExit(f"error: cargo metadata failed:\n{out.stderr[-2000:]}")
+    return json.loads(out.stdout)
+
+
+# --------------------------------------------------------------------------
+# Source normalisation
+# --------------------------------------------------------------------------
+
+_COMMENT_LINE_RE = re.compile(r'//[^\n]*')
+_COMMENT_BLOCK_RE = re.compile(r'/\*.*?\*/', re.S)
+_TEST_ATTR_RE = re.compile(
+    r'#\s*\[\s*(?:'
+    r'test'
+    r'|cfg\s*\(\s*test\s*\)'
+    r'|cfg\s*\([^)]*\btest\b[^)]*\)'
+    r'|cfg_attr\s*\(\s*test\s*,[^)]*\)'
+    r'|(?:tokio|async_std|rstest|proptest|quickcheck)\s*::\s*\w+'
+    r'|bench'
+    r')\s*\]')
+
+
+def _skip_to_item_body(text: str, start: int) -> int:
+    """From just past an attribute, find the `{` opening the item it applies to,
+    or the `;` ending it. Returns the index one past the item."""
+    i = start
+    n = len(text)
+    while i < n:
+        c = text[i]
+        if c == "#":                       # another attribute — keep scanning
+            i += 1
+            continue
+        if c == ";":                       # `#[test] fn f();` — item has no body
+            return i + 1
+        if c == "{":
+            break
+        i += 1
+    if i >= n:
+        return n
+    depth, in_str, in_chr, esc = 0, False, False, False
+    while i < n:
+        c = text[i]
+        if esc:
+            esc = False
+        elif c == "\\" and (in_str or in_chr):
+            esc = True
+        elif in_str:
+            if c == '"':
+                in_str = False
+        elif in_chr:
+            if c == "'":
+                in_chr = False
+        elif c == '"':
+            in_str = True
+        elif c == "{":
+            depth += 1
+        elif c == "}":
+            depth -= 1
+            if depth == 0:
+                return i + 1
+        i += 1
+    return n
+
+
+def strip_test_items(text: str) -> str:
+    """Remove `#[test]` / `#[cfg(test)]` items.
+
+    Test code is not build-time code: rustc only compiles these items under
+    `--test`, so a `cargo build` never runs them. Leaving them in makes the
+    scanners report reads that cannot happen — `security-framework`'s
+    `authorization.rs` reads `PASSWORD` and `USER` in three `#[test]` functions
+    and one test helper, which is a hard failure on a credential-shaped name
+    for code that is never compiled into anything azul builds.
+
+    Skipping them is safe in the other direction too: a payload hidden behind
+    `#[cfg(test)]` genuinely does not execute during a dependency's build.
+    """
+    out, last = [], 0
+    for m in _TEST_ATTR_RE.finditer(text):
+        if m.start() < last:
+            continue
+        end = _skip_to_item_body(text, m.end())
+        out.append(text[last:m.start()])
+        last = end
+    out.append(text[last:])
+    return "".join(out)
+
+
+def normalise_source(text: str) -> str:
+    """Comments out, test items out — what is left is what runs at build time."""
+    text = _COMMENT_BLOCK_RE.sub("", _COMMENT_LINE_RE.sub("", text))
+    return strip_test_items(text)

--- a/scripts/supply-chain/sc_common.py
+++ b/scripts/supply-chain/sc_common.py
@@ -148,6 +148,15 @@ def walk_vendor(vendor_dir: Path) -> list[VendoredCrate]:
             f"error: vendor directory not found: {vendor_dir}\n"
             f"       run: cargo vendor --locked --versioned-dirs {vendor_dir}"
         )
+    # Resolve ONCE, here, so every crate path downstream is absolute.
+    # `_follow_includes` resolves the files it discovers, so with a relative
+    # --vendor the two halves disagree and `p.relative_to(crate.path)` raises
+    # `'/abs/vendor/x/build.rs' is not in the subpath of 'vendor/x'`. Local runs
+    # passed an absolute path and never hit it; CI passes `--vendor vendor` and
+    # died on the first crate. Resolving here fixes the digest, the capability
+    # scan and the checksum verifier at once, and does not change any digest:
+    # those hash paths RELATIVE to the crate root, which is unaffected.
+    vendor_dir = vendor_dir.resolve()
     out = []
     for entry in sorted(vendor_dir.iterdir()):
         if not entry.is_dir() or entry.name.startswith("."):

--- a/scripts/supply-chain/scan_build_scripts.py
+++ b/scripts/supply-chain/scan_build_scripts.py
@@ -1,0 +1,438 @@
+#!/usr/bin/env python3
+"""
+scan_build_scripts.py — which dependencies may execute code at BUILD time.
+
+THE THREAT. `build.rs` is the kill chain in every significant crates.io supply
+chain attack to date. It runs during `cargo build` with the full authority of
+whoever typed the command — filesystem, network, environment — and it runs
+whether or not any of the crate's actual code is ever called. Proc macros are
+the same authority with less visibility: they run inside rustc. The August 2026
+`arrayref` / `internment` / `append-only-vec` compromise did not put a single
+byte of payload in those crates; it added one line to Cargo.toml pulling in
+`proc-macro1` (a typosquat of proc-macro2), whose build.rs downloaded and ran a
+remote payload. Nobody had to call anything.
+
+WHAT THIS GATE DOES. It reads a `cargo vendor` tree, finds every crate that
+executes code at build time, and requires each one to have an entry in
+`build-script-policy.toml` that carries:
+
+    allow     — may this crate run code at build time at all
+    risk      — the risk level a human ACKNOWLEDGED when they read it
+    reason    — why this crate needs a build script, in one line
+    reviewed  — ["<version>:<sha256>", ...] the exact bytes that were read
+
+`reviewed` is the part that `dependency-justifications.toml` cannot do. That
+file answers "why is this crate in the tree", keyed by NAME — so a crate that is
+already justified stays justified when a compromised account publishes a new
+version of it. The digest here is over the build script's actual content, so a
+new version, a new payload, or a payload moved sideways into `build/probe.rs`
+all read as a mismatch and fail the build until a human looks at the diff.
+
+It also classifies each build script against a table of behaviours that
+distinguish a legitimate build script from an exfiltration stub (see RULES
+below), so review has somewhere to start and a NEW dangerous behaviour in an
+already-pinned crate is called out by name.
+
+Usage:
+    scan_build_scripts.py --vendor vendor/ [--policy FILE] [--report-only]
+    scan_build_scripts.py --vendor vendor/ --update      # refresh digests/skeletons
+    scan_build_scripts.py --print-rules                  # the rule table
+
+Exit 0 when every build-time crate is allowed, pinned and unchanged; exit 1
+naming the offenders otherwise.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import sc_common as sc  # noqa: E402
+
+DEFAULT_POLICY = Path(__file__).resolve().parent / "build-script-policy.toml"
+
+# ---------------------------------------------------------------------------
+# RULES — behaviours that separate a real build script from a payload.
+#
+# Each rule is (id, weight, description, compiled regex). Weights add up into a
+# score; the score picks a level. The weights are deliberately lopsided: a build
+# script spawning a C compiler is completely ordinary (`cc`, `bindgen` and every
+# -sys crate do it), while a build script opening a socket has, essentially, no
+# legitimate reason to exist — cargo has already downloaded everything the crate
+# is allowed to have by the time build.rs runs.
+#
+# False positives are expected and fine. This table does not decide anything on
+# its own; it decides where a human looks first, and it turns "this crate's
+# build script started doing something new" into a build failure rather than a
+# thing nobody noticed.
+# ---------------------------------------------------------------------------
+
+RULES: list[tuple[str, int, str, re.Pattern]] = [
+    # ---- network: the exfiltration/download primitive itself -------------
+    ("net.std", 45, "std::net socket use in a build script", re.compile(
+        r'\b(?:std::)?net::(?:TcpStream|TcpListener|UdpSocket|ToSocketAddrs)\b'
+        r'|\bTcpStream::connect\b|\bUdpSocket::bind\b|\bto_socket_addrs\s*\(')),
+    ("net.http_client", 50, "HTTP client crate used at build time", re.compile(
+        r'\b(?:reqwest|ureq|isahc|attohttpc|minreq|hyper|surf|curl|awc)\s*::')),
+    ("net.download_tool", 55, "build script shells out to a downloader", re.compile(
+        r'Command::new\s*\(\s*"(?:curl|wget|Invoke-WebRequest|powershell|pwsh|nc|ncat)"')),
+    ("net.url_literal", 15, "http(s) URL literal in build-time code", re.compile(
+        r'"https?://[^"\s]{6,}"')),
+    # `resolv` + \w* used to be in this alternation. It matched `resolve` and
+    # `resolved_at` — so every proc-macro crate in the tree that resolves a
+    # path or a span scored 35 for "DNS", and thiserror-impl and clap_derive
+    # came out HIGH on a rule neither of them trips. Match real APIs only.
+    ("net.dns", 35, "DNS resolution / tunneling primitive", re.compile(
+        r'\b(?:trust_dns|hickory_dns)\w*\s*::|\bres_query\s*\(|\bDnsQuery\w*\s*\('
+        r'|\bgetaddrinfo\s*\(|\bresolv\.conf\b')),
+
+    # ---- environment: the credential-theft primitive ---------------------
+    ("env.enumerate", 55, "enumerates the ENTIRE environment (vars/vars_os)", re.compile(
+        r'\b(?:std::)?env::vars(?:_os)?\s*\(')),
+    ("env.ci_detect", 45, "branches on a CI-provider variable (rustdecimal tell)", re.compile(
+        r'"(?:GITLAB_CI|GITHUB_ACTIONS|GITHUB_TOKEN|TRAVIS|CIRCLECI|JENKINS_URL'
+        r'|BUILDKITE|TF_BUILD|TEAMCITY_VERSION|APPVEYOR|DRONE|CODEBUILD_BUILD_ID)"')),
+    ("env.secretish", 60, "reads a token/secret/credential-shaped variable", re.compile(
+        r'(?:env!|option_env!|env::var(?:_os)?)\s*\(\s*"[^"]*'
+        r'(?:TOKEN|SECRET|PASSWORD|PASSWD|CREDENTIAL|API_KEY|APIKEY|PRIVATE_KEY)[^"]*"',
+        re.IGNORECASE)),
+
+    # ---- process execution ----------------------------------------------
+    ("proc.shell", 50, "build script spawns a SHELL", re.compile(
+        r'Command::new\s*\(\s*"(?:sh|bash|zsh|dash|cmd|cmd\.exe)"'
+        r'|\.args?\s*\(\s*&?\[\s*"-c"')),
+    ("proc.spawn", 8, "spawns a subprocess (normal for -sys/cc/bindgen crates)", re.compile(
+        r'\bCommand::new\s*\(')),
+
+    # ---- filesystem outside the sandbox ----------------------------------
+    ("fs.credentials", 70, "touches a credential store path", re.compile(
+        r'"[^"]*(?:\.ssh|\.cargo/credentials|\.aws/credentials|\.npmrc|\.netrc'
+        r'|id_rsa|id_ed25519|\.gnupg|Keychains)[^"]*"')),
+    ("fs.home", 30, "resolves the user's HOME/profile directory", re.compile(
+        r'\b(?:home_dir|home::home_dir|dirs::(?:home|config|data)_dir)\s*\('
+        r'|env::var(?:_os)?\s*\(\s*"(?:HOME|USERPROFILE|APPDATA)"')),
+    ("fs.write_abs", 20, "writes to an absolute/system path", re.compile(
+        r'(?:File::create|fs::write|OpenOptions::new)[^\n]{0,80}"(?:/etc/|/usr/|/bin/'
+        r'|/var/|C:\\\\Windows|/Library/LaunchAgents)')),
+
+    # ---- code loading / obfuscation --------------------------------------
+    ("load.dynamic", 35, "loads a shared object at build time", re.compile(
+        r'\blibloading\s*::|\bdlopen\s*\(|\bLoadLibrary[AW]?\s*\(|\bdlsym\s*\(')),
+    ("obf.long_b64", 45, "long base64-shaped literal (packed payload)", re.compile(
+        r'"[A-Za-z0-9+/]{220,}={0,2}"')),
+    ("obf.hex_escape", 40, "long run of \\x byte escapes", re.compile(
+        r'(?:\\x[0-9a-fA-F]{2}){48,}')),
+    ("obf.decode", 30, "decodes an embedded blob at build time", re.compile(
+        r'\b(?:base64|hex)\s*::\s*decode\b|\bfrom_base64\b|\bBASE64[A-Z_]*\.decode\b')),
+    ("obf.xor", 35, "XOR/reverse deobfuscation loop", re.compile(
+        r'\.iter\(\)[^\n]{0,60}\|\s*\w+\s*\|\s*\w+\s*\^|\bchars\(\)\s*\.\s*rev\s*\(\)')),
+    ("obf.exec_written", 60, "makes a file executable at build time", re.compile(
+        r'set_permissions|PermissionsExt|from_mode\s*\(\s*0o7|chmod')),
+]
+
+LEVELS = ("low", "medium", "high")
+THRESHOLD_HIGH = 45
+THRESHOLD_MEDIUM = 15
+
+# Rules that describe *ordinary* build-script work. They still count toward the
+# score (a shell-out is how you'd invoke a downloader), but they must never be
+# the sole reason a crate is called out — otherwise every -sys crate is "high"
+# and the signal is gone.
+BENIGN_ONLY = {"proc.spawn", "net.url_literal", "fs.home"}
+
+# Rules that still mean something when applied to a whole LIBRARY rather than a
+# build script. The rest of the table assumes it is reading a two-hundred-line
+# build.rs where every line is purposeful; run against fifty thousand lines of
+# FFI declarations it produces noise and nothing else. Measured, before this
+# split: `windows-sys` scored "high" on net.dns because it DECLARES DnsQuery and
+# on load.dynamic because it declares LoadLibraryA; `linux-raw-sys` scored 1200
+# on obf.exec_written because it is a crate of syscall constants;
+# `webpki-root-certs` tripped obf.hex_escape because it is, by design, a file of
+# hex-encoded root certificates. Fifteen "high" findings, none of them real.
+#
+# What survives the move to library scope is the exfiltration set — reading the
+# environment, detecting CI, shelling out to a downloader — because those are
+# behaviours, not vocabulary, and a library has no more business doing them than
+# a build script does. `built` 0.7.7 is still caught here.
+LIBRARY_RULES = {
+    "env.enumerate", "env.ci_detect", "env.secretish",
+    "net.download_tool", "net.http_client", "proc.shell", "obf.long_b64",
+}
+
+
+def classify(paths: list[Path], scope: str = "build-script") -> tuple[str, int, list[dict]]:
+    """Score a set of build-time files. Returns (level, score, hits).
+
+    `scope` is "build-script" for a real build script or proc macro, and
+    "library" for a build-dependency whose ordinary library code happens to run
+    at build time; see LIBRARY_RULES.
+    """
+    active = RULES if scope != "library" else [r for r in RULES if r[0] in LIBRARY_RULES]
+    hits: list[dict] = []
+    score = 0
+    for path in paths:
+        if path.suffix not in (".rs", ".c", ".h", ".cc", ".cpp", ".py", ".sh"):
+            continue
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        # Comments are not behaviour, and neither are `#[test]` items — rustc
+        # only compiles those under `--test`. Stripping both removes the two
+        # biggest sources of noise here: every other -sys crate documents a URL
+        # in a comment, and test helpers routinely read credential-shaped
+        # variables that no build ever touches.
+        stripped = sc.normalise_source(text)
+        for rule_id, weight, desc, pat in active:
+            found = pat.findall(stripped)
+            if not found:
+                continue
+            score += weight
+            sample = found[0] if isinstance(found[0], str) else str(found[0])
+            hits.append({
+                "rule": rule_id, "weight": weight, "desc": desc,
+                "file": path.name, "count": len(found), "sample": sample[:120],
+            })
+    substantive = [h for h in hits if h["rule"] not in BENIGN_ONLY]
+    if not substantive:
+        return "low", score, hits
+    if score >= THRESHOLD_HIGH:
+        return "high", score, hits
+    if score >= THRESHOLD_MEDIUM:
+        return "medium", score, hits
+    return "low", score, hits
+
+
+def rank(level: str) -> int:
+    return LEVELS.index(level)
+
+
+# ---------------------------------------------------------------------------
+
+def collect(vendor: Path, build_deps: set[str] | None = None) -> list[dict]:
+    """Every crate that runs code at build time, with digest and risk.
+
+    `build_deps` is the transitive `[build-dependencies]` closure. Those crates
+    have no build script and are not proc macros, but their library code is
+    linked into build scripts and therefore executes with the same authority —
+    `built` 0.7.7 reaches azul that way and sweeps the whole environment. They
+    are scanned, but (see `evaluate`) only need a policy entry if they actually
+    exhibit non-trivial behaviour; requiring a hand-written line for all 178 of
+    them would bury the ~170 that matter under boilerplate.
+    """
+    build_deps = build_deps or set()
+    out = []
+    for crate in sc.walk_vendor(vendor):
+        facts = sc.manifest_facts(crate)
+        bpaths = sc.build_script_paths(crate)
+        is_pm = facts["proc_macro"]
+        is_bd = crate.name in build_deps
+        if not bpaths and not is_pm and not is_bd:
+            continue
+        # A proc-macro crate's *sources* are build-time code, but hashing all of
+        # src/ would repin on every cosmetic release. Digest the build script
+        # when there is one; for a pure proc-macro crate, digest src/ — its
+        # sources ARE the executed code and there is nothing else to pin.
+        paths = bpaths if bpaths else sc.proc_macro_paths(crate)
+        scope = "library" if (not bpaths and not is_pm) else "build-script"
+        level, score, hits = classify(paths, scope)
+        out.append({
+            "name": crate.name,
+            "version": crate.version,
+            "kind": ("build-script+proc-macro" if bpaths and is_pm
+                     else "build-script" if bpaths
+                     else "proc-macro" if is_pm else "build-dependency"),
+            "escapes": sc.build_script_escapes(crate),
+            "links": facts["links"],
+            "files": [str(p.relative_to(crate.path)).replace("\\", "/") for p in paths],
+            "digest": sc.digest_files(crate.path, paths),
+            "risk": level,
+            "score": score,
+            "hits": hits,
+        })
+    return sorted(out, key=lambda d: (d["name"], d["version"]))
+
+
+def load_policy(path: Path) -> dict:
+    doc = sc.read_toml_subset(path)
+    return doc.get("crate", {})
+
+
+def evaluate(found: list[dict], policy: dict) -> tuple[list[dict], list[dict]]:
+    """Returns (violations, ok_entries)."""
+    violations, ok = [], []
+    for entry in found:
+        rule = policy.get(entry["name"])
+        pin = f'{entry["version"]}:{entry["digest"]}'
+        # A reference escaping the crate directory is always a violation: a
+        # vendored crate has no legitimate reason to compile a file it does not
+        # ship, and it is how a pin over "this crate's files" gets bypassed.
+        if entry.get("escapes"):
+            violations.append({**entry, "why": "ESCAPES", "detail":
+                               "build-time code references files outside the crate: "
+                               + ", ".join(entry["escapes"][:3])})
+            continue
+        if rule is None and entry["kind"] == "build-dependency" and entry["risk"] == "low":
+            continue        # linked into build scripts, but behaves trivially
+        if rule is None:
+            violations.append({**entry, "why": "UNREVIEWED", "detail":
+                               "no entry in build-script-policy.toml"})
+            continue
+        if not rule.get("allow", False):
+            violations.append({**entry, "why": "DENIED", "detail":
+                               rule.get("reason", "allow = false")})
+            continue
+        reviewed = rule.get("reviewed", [])
+        if pin not in reviewed:
+            known = [r.split(":", 1)[0] for r in reviewed]
+            if entry["version"] in known:
+                detail = (f'build-time code CHANGED for {entry["name"]} '
+                          f'{entry["version"]} without a version bump — '
+                          f'expected {[r for r in reviewed if r.startswith(entry["version"] + ":")][0][:24]}…, '
+                          f'got {entry["digest"][:16]}…')
+            else:
+                detail = (f'version {entry["version"]} is not reviewed '
+                          f'(reviewed: {", ".join(known) or "none"})')
+            violations.append({**entry, "why": "DIGEST", "detail": detail})
+            continue
+        ack = rule.get("risk", "low")
+        if rank(entry["risk"]) > rank(ack):
+            violations.append({**entry, "why": "RISK", "detail":
+                               f'behaviour scores {entry["risk"]} but policy acknowledges '
+                               f'{ack}: ' + "; ".join(sorted({h["desc"] for h in entry["hits"]
+                                                              if h["rule"] not in BENIGN_ONLY}))})
+            continue
+        ok.append({**entry, "reason": rule.get("reason", "")})
+    return violations, ok
+
+
+def render_policy(found: list[dict], policy: dict) -> str:
+    """Regenerate the policy file, preserving human-written reasons."""
+    lines = [
+        "# build-script-policy.toml — which dependencies may execute code at BUILD time.",
+        "#",
+        "# GENERATED SKELETON, HUMAN-OWNED CONTENT. `scan_build_scripts.py --update`",
+        "# refreshes `reviewed` digests and adds skeletons for new crates; it never",
+        "# invents a `reason` and never flips an `allow`. A crate whose reason is still",
+        "# the TODO placeholder has not been reviewed by anybody.",
+        "#",
+        "# Fields:",
+        "#   allow    — may this crate run code at build time at all",
+        "#   risk     — behaviour level a human ACKNOWLEDGED: low | medium | high",
+        "#   reason   — one line: why does this crate need to run code at build time",
+        "#   reviewed — [\"<version>:<sha256-of-build-time-files>\"] — the exact bytes read",
+        "#",
+        "# Re-pinning after a version bump is DELIBERATELY manual: the digest changing",
+        "# is the signal that somebody has to read the diff. `--update` writes the new",
+        "# digest so the mechanics are cheap, but the review is the point.",
+        "",
+    ]
+    by_name: dict[str, list[dict]] = {}
+    for e in found:
+        by_name.setdefault(e["name"], []).append(e)
+    for name in sorted(by_name):
+        entries = by_name[name]
+        old = policy.get(name, {})
+        reason = old.get("reason") or "TODO: why does this crate run code at build time?"
+        ack = old.get("risk") or max((e["risk"] for e in entries), key=rank)
+        allow = old.get("allow", True)
+        pins = sorted(f'{e["version"]}:{e["digest"]}' for e in entries)
+        kinds = "/".join(sorted({e["kind"] for e in entries}))
+        lines.append(f'[crate."{name}"]  # {kinds}')
+        lines.append(f'allow = {"true" if allow else "false"}')
+        lines.append(f'risk = "{ack}"')
+        lines.append(f'reason = "{reason.replace(chr(92), chr(92)*2).replace(chr(34), chr(92) + chr(34))}"')
+        lines.append("reviewed = [" + ", ".join(f'"{p}"' for p in pins) + "]")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--vendor", type=Path, default=Path("vendor"))
+    ap.add_argument("--policy", type=Path, default=DEFAULT_POLICY)
+    ap.add_argument("--json", type=Path, help="write the full finding set here")
+    ap.add_argument("--update", action="store_true",
+                    help="rewrite the policy file: refresh digests, add skeletons")
+    ap.add_argument("--report-only", action="store_true", help="never exit non-zero")
+    ap.add_argument("--print-rules", action="store_true")
+    ap.add_argument("--metadata", type=Path,
+                    help="cargo metadata JSON; without it the build-dependency "
+                         "closure is computed by invoking cargo")
+    ap.add_argument("--no-build-deps", action="store_true",
+                    help="scan only build scripts and proc macros")
+    args = ap.parse_args()
+
+    if args.print_rules:
+        print(f"{'rule':22s} {'wt':>3s}  description")
+        for rid, w, desc, _ in RULES:
+            print(f"{rid:22s} {w:3d}  {desc}"
+                  + ("   [benign-only]" if rid in BENIGN_ONLY else ""))
+        print(f"\nhigh >= {THRESHOLD_HIGH}, medium >= {THRESHOLD_MEDIUM}, "
+              f"and at least one non-benign hit is required for either.")
+        return 0
+
+    build_deps: set[str] = set()
+    if not args.no_build_deps:
+        build_deps = sc.build_dependency_closure(sc.load_metadata(args.metadata))
+    found = collect(args.vendor, build_deps)
+    policy = load_policy(args.policy) if args.policy.is_file() else {}
+
+    if args.update:
+        # Only crates that must carry a policy line are written out; a
+        # trivially-behaved build dependency is scanned every run but does not
+        # need a hand-written justification.
+        needed = [e for e in found if e["kind"] != "build-dependency"
+                  or e["risk"] != "low" or e["name"] in policy]
+        args.policy.write_text(render_policy(needed, policy), encoding="utf-8")
+        todo = sum(1 for n, r in load_policy(args.policy).items()
+                   if str(r.get("reason", "")).startswith("TODO"))
+        print(f"wrote {args.policy} — {len(found)} build-time crates, {todo} awaiting a written reason")
+        return 0
+
+    violations, ok = evaluate(found, policy)
+    if args.json:
+        args.json.parent.mkdir(parents=True, exist_ok=True)
+        args.json.write_text(json.dumps(
+            {"found": found, "violations": violations}, indent=2), encoding="utf-8")
+
+    # ---- report ----
+    by_risk = {lvl: [e for e in found if e["risk"] == lvl] for lvl in LEVELS}
+    md = ["## 🔧 Build-time code execution (build.rs / proc-macro)", "",
+          f"`{len(found)}` of `{len(sc.walk_vendor(args.vendor))}` vendored crates run code at build time — "
+          f"**{len(by_risk['high'])} high**, {len(by_risk['medium'])} medium, {len(by_risk['low'])} low risk.", ""]
+    if violations:
+        md += ["### ❌ Violations", "",
+               "| crate | version | why | detail |", "|---|---|---|---|"]
+        for v in violations:
+            md.append(f'| `{v["name"]}` | {v["version"]} | **{v["why"]}** | {v["detail"]} |')
+        md.append("")
+    for lvl in ("high", "medium"):
+        if not by_risk[lvl]:
+            continue
+        md += [f"<details><summary><b>{lvl} risk ({len(by_risk[lvl])})</b></summary>", "",
+               "| crate | score | behaviours |", "|---|---|---|"]
+        for e in by_risk[lvl]:
+            beh = ", ".join(sorted({h["desc"] for h in e["hits"] if h["rule"] not in BENIGN_ONLY}))
+            md.append(f'| `{e["name"]} {e["version"]}` | {e["score"]} | {beh} |')
+        md += ["", "</details>", ""]
+    sc.summary("\n".join(md))
+
+    print(f"build-time crates: {len(found)}  "
+          f"(high={len(by_risk['high'])} medium={len(by_risk['medium'])} low={len(by_risk['low'])})")
+    if not violations:
+        print(f"all {len(ok)} allowed, pinned by digest, and unchanged since review")
+        return 0
+    for v in violations:
+        sc.annotate("error", f'{v["name"]} {v["version"]}: {v["why"]} — {v["detail"]}')
+    print(f"\n{len(violations)} violation(s). Review the build script, then re-pin with:\n"
+          f"    python3 {sc.rel_to_repo(Path(__file__))} --vendor {args.vendor} --update")
+    return 0 if args.report_only else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -1,0 +1,4 @@
+
+# cargo-vet audits file
+
+[audits]

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -1,0 +1,2834 @@
+
+# cargo-vet config file
+
+[cargo-vet]
+version = "0.10"
+
+[imports.bytecode-alliance]
+url = "https://raw.githubusercontent.com/bytecodealliance/wasmtime/main/supply-chain/audits.toml"
+
+[imports.embark-studios]
+url = "https://raw.githubusercontent.com/EmbarkStudios/rust-ecosystem/main/audits.toml"
+
+[imports.google]
+url = "https://raw.githubusercontent.com/google/rust-crate-audits/main/audits.toml"
+
+[imports.isrg]
+url = "https://raw.githubusercontent.com/divviup/libprio-rs/main/supply-chain/audits.toml"
+
+[imports.mozilla]
+url = "https://raw.githubusercontent.com/mozilla/supply-chain/main/audits.toml"
+
+[imports.zcash]
+url = "https://raw.githubusercontent.com/zcash/rust-ecosystem/main/supply-chain/audits.toml"
+
+[policy.azul-core]
+audit-as-crates-io = false
+
+[policy.azul-css]
+audit-as-crates-io = false
+
+[policy.azul-dll]
+audit-as-crates-io = false
+
+[policy.azul-layout]
+audit-as-crates-io = false
+
+[policy.turso]
+audit-as-crates-io = true
+
+[policy.turso_core]
+audit-as-crates-io = true
+
+[policy.turso_ext]
+audit-as-crates-io = true
+
+[policy.turso_macros]
+audit-as-crates-io = true
+
+[policy.turso_parser]
+audit-as-crates-io = true
+
+[policy.turso_sqlite3_parser]
+audit-as-crates-io = true
+
+[policy.webrender]
+audit-as-crates-io = true
+
+[policy.webrender_api]
+audit-as-crates-io = true
+
+[policy.webrender_build]
+audit-as-crates-io = true
+
+[[exemptions.accesskit]]
+version = "0.24.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.accesskit_atspi_common]]
+version = "0.18.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.accesskit_consumer]]
+version = "0.35.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.accesskit_consumer]]
+version = "0.36.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.accesskit_consumer]]
+version = "0.38.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.accesskit_macos]]
+version = "0.26.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.accesskit_unix]]
+version = "0.21.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.accesskit_windows]]
+version = "0.32.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.addr2line]]
+version = "0.25.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.aead]]
+version = "0.5.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.aegis]]
+version = "0.9.15"
+criteria = "safe-to-deploy"
+
+[[exemptions.aes]]
+version = "0.8.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.aes]]
+version = "0.9.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.aes-gcm]]
+version = "0.10.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.agg-rust-azul]]
+version = "1.1.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.aho-corasick]]
+version = "1.1.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.aliasable]]
+version = "0.1.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.alloc-no-stdlib]]
+version = "2.0.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.alloc-stdlib]]
+version = "0.2.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.allocator-api2]]
+version = "0.3.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.allsorts-azul]]
+version = "0.17.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.alsa]]
+version = "0.9.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.alsa-sys]]
+version = "0.3.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.android-activity]]
+version = "0.6.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.android-properties]]
+version = "0.2.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.android_log-sys]]
+version = "0.3.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.android_logger]]
+version = "0.14.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.anstream]]
+version = "1.0.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.anstyle]]
+version = "1.0.14"
+criteria = "safe-to-deploy"
+
+[[exemptions.anstyle-parse]]
+version = "1.0.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.anstyle-query]]
+version = "1.1.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.anstyle-wincon]]
+version = "3.0.11"
+criteria = "safe-to-deploy"
+
+[[exemptions.approx]]
+version = "0.5.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.arc-swap]]
+version = "1.9.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.arrayvec]]
+version = "0.7.8"
+criteria = "safe-to-deploy"
+
+[[exemptions.as-slice]]
+version = "0.1.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.async-broadcast]]
+version = "0.7.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.async-channel]]
+version = "2.5.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.async-executor]]
+version = "1.14.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.async-io]]
+version = "2.6.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.async-lock]]
+version = "3.4.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.async-process]]
+version = "2.5.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.async-recursion]]
+version = "1.1.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.async-signal]]
+version = "0.2.14"
+criteria = "safe-to-deploy"
+
+[[exemptions.async-trait]]
+version = "0.1.89"
+criteria = "safe-to-deploy"
+
+[[exemptions.atomic-polyfill]]
+version = "1.0.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.atspi]]
+version = "0.29.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.atspi-common]]
+version = "0.13.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.atspi-proxies]]
+version = "0.13.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.autocfg]]
+version = "1.5.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.azul-simplecss]]
+version = "0.2.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.backtrace]]
+version = "0.3.76"
+criteria = "safe-to-deploy"
+
+[[exemptions.base16ct]]
+version = "0.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.base64ct]]
+version = "1.8.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.bincode]]
+version = "1.3.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.bincode]]
+version = "2.0.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.bincode_derive]]
+version = "2.0.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.bindgen]]
+version = "0.65.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.bitflags]]
+version = "2.13.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.bitstream-io]]
+version = "2.6.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.block]]
+version = "0.1.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.block-buffer]]
+version = "0.12.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.block-padding]]
+version = "0.4.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.block2]]
+version = "0.5.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.blocking]]
+version = "1.6.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.brotli]]
+version = "8.0.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.brotli-decompressor]]
+version = "5.0.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.bstr]]
+version = "1.13.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.built]]
+version = "0.7.7"
+criteria = "safe-to-deploy"
+
+[[exemptions.bytecount]]
+version = "0.6.9"
+criteria = "safe-to-deploy"
+
+[[exemptions.bytemuck]]
+version = "1.25.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.bytemuck_derive]]
+version = "1.11.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.byteorder-lite]]
+version = "0.1.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.bytes]]
+version = "1.12.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.bzip2]]
+version = "0.6.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.calendrical_calculations]]
+version = "0.2.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.camino]]
+version = "1.2.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.cargo-license]]
+version = "0.7.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.cargo-platform]]
+version = "0.1.9"
+criteria = "safe-to-deploy"
+
+[[exemptions.cargo-platform]]
+version = "0.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.cargo-util-schemas]]
+version = "0.8.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.cargo_metadata]]
+version = "0.14.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.cargo_metadata]]
+version = "0.21.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.cargo_toml]]
+version = "0.22.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.caseless]]
+version = "0.2.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.cbc]]
+version = "0.2.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.cc]]
+version = "1.3.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.cesu8]]
+version = "1.1.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.cfg-if]]
+version = "0.1.10"
+criteria = "safe-to-deploy"
+
+[[exemptions.cfg_block]]
+version = "0.1.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.chacha20]]
+version = "0.9.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.chacha20]]
+version = "0.10.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.chacha20poly1305]]
+version = "0.10.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.chrono]]
+version = "0.4.45"
+criteria = "safe-to-deploy"
+
+[[exemptions.cipher]]
+version = "0.5.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.clang-sys]]
+version = "1.8.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.clap]]
+version = "4.6.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.clap_builder]]
+version = "4.6.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.clap_derive]]
+version = "4.6.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.clap_lex]]
+version = "1.1.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.clipboard-win]]
+version = "5.4.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.cmov]]
+version = "0.5.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.cocoa-foundation]]
+version = "0.2.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.colorchoice]]
+version = "1.0.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.colored]]
+version = "2.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.combine]]
+version = "4.6.7"
+criteria = "safe-to-deploy"
+
+[[exemptions.comrak]]
+version = "0.48.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.concurrent-queue]]
+version = "2.5.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.console_log]]
+version = "1.1.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.const-oid]]
+version = "0.9.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.const-oid]]
+version = "0.10.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.constant_time_eq]]
+version = "0.4.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.convert_case]]
+version = "0.11.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.cookie]]
+version = "0.18.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.cookie_store]]
+version = "0.22.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.core-foundation]]
+version = "0.10.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.core-graphics]]
+version = "0.23.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.core-media-sys]]
+version = "0.1.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.core-video-sys]]
+version = "0.1.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.coreaudio-rs]]
+version = "0.11.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.coreaudio-sys]]
+version = "0.2.18"
+criteria = "safe-to-deploy"
+
+[[exemptions.cpal]]
+version = "0.15.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.cpubits]]
+version = "0.1.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.cpufeatures]]
+version = "0.2.17"
+criteria = "safe-to-deploy"
+
+[[exemptions.crc]]
+version = "3.4.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.crc-catalog]]
+version = "2.5.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.crc32fast]]
+version = "1.5.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.critical-section]]
+version = "1.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.crossbeam-channel]]
+version = "0.5.16"
+criteria = "safe-to-deploy"
+
+[[exemptions.crossbeam-deque]]
+version = "0.8.7"
+criteria = "safe-to-deploy"
+
+[[exemptions.crossbeam-epoch]]
+version = "0.9.20"
+criteria = "safe-to-deploy"
+
+[[exemptions.crossbeam-skiplist]]
+version = "0.1.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.crossbeam-utils]]
+version = "0.8.22"
+criteria = "safe-to-deploy"
+
+[[exemptions.crypto-bigint]]
+version = "0.5.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.crypto-common]]
+version = "0.1.7"
+criteria = "safe-to-deploy"
+
+[[exemptions.crypto-common]]
+version = "0.2.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.csv]]
+version = "1.4.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.csv-core]]
+version = "0.1.13"
+criteria = "safe-to-deploy"
+
+[[exemptions.ct-codecs]]
+version = "1.1.7"
+criteria = "safe-to-run"
+
+[[exemptions.ctor]]
+version = "0.2.9"
+criteria = "safe-to-deploy"
+
+[[exemptions.ctr]]
+version = "0.9.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.ctutils]]
+version = "0.4.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.curve25519-dalek]]
+version = "4.1.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.curve25519-dalek-derive]]
+version = "0.1.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.darling]]
+version = "0.23.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.darling_core]]
+version = "0.23.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.darling_macro]]
+version = "0.23.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.dasp_sample]]
+version = "0.11.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.data-encoding]]
+version = "2.11.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.deflate64]]
+version = "0.1.12"
+criteria = "safe-to-deploy"
+
+[[exemptions.der]]
+version = "0.8.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.derivative]]
+version = "2.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.derive_more]]
+version = "2.1.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.derive_more-impl]]
+version = "2.1.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.digest]]
+version = "0.10.7"
+criteria = "safe-to-deploy"
+
+[[exemptions.digest]]
+version = "0.11.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.dirs]]
+version = "6.0.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.dirs-sys]]
+version = "0.5.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.dispatch2]]
+version = "0.3.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.displaydoc]]
+version = "0.2.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.ecb]]
+version = "0.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.ecdsa]]
+version = "0.16.9"
+criteria = "safe-to-deploy"
+
+[[exemptions.ed25519]]
+version = "2.2.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.ed25519-dalek]]
+version = "2.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.elliptic-curve]]
+version = "0.13.8"
+criteria = "safe-to-deploy"
+
+[[exemptions.endi]]
+version = "1.1.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.entities]]
+version = "1.0.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.enumflags2]]
+version = "0.7.12"
+criteria = "safe-to-deploy"
+
+[[exemptions.enumflags2_derive]]
+version = "0.7.12"
+criteria = "safe-to-deploy"
+
+[[exemptions.env_filter]]
+version = "0.1.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.env_filter]]
+version = "2.0.0"
+criteria = "safe-to-run"
+
+[[exemptions.env_logger]]
+version = "0.11.11"
+criteria = "safe-to-run"
+
+[[exemptions.erased-serde]]
+version = "0.4.10"
+criteria = "safe-to-deploy"
+
+[[exemptions.error-chain]]
+version = "0.12.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.error-code]]
+version = "3.3.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.event-listener]]
+version = "5.4.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.event-listener-strategy]]
+version = "0.5.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.ext-php-rs]]
+version = "0.15.15"
+criteria = "safe-to-deploy"
+
+[[exemptions.ext-php-rs-bindgen]]
+version = "0.72.1-extphprs.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.ext-php-rs-build]]
+version = "0.1.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.ext-php-rs-derive]]
+version = "0.11.14"
+criteria = "safe-to-deploy"
+
+[[exemptions.fancy-regex]]
+version = "0.13.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.fastrand]]
+version = "2.4.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.fax]]
+version = "0.2.7"
+criteria = "safe-to-deploy"
+
+[[exemptions.fern]]
+version = "0.7.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.ff]]
+version = "0.13.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.find-msvc-tools]]
+version = "0.1.9"
+criteria = "safe-to-deploy"
+
+[[exemptions.fixed_decimal]]
+version = "0.7.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.flate2]]
+version = "1.1.9"
+criteria = "safe-to-deploy"
+
+[[exemptions.float_next_after]]
+version = "1.0.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.flume]]
+version = "0.11.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.four-cc]]
+version = "0.4.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.fst]]
+version = "0.4.7"
+criteria = "safe-to-deploy"
+
+[[exemptions.futures-core]]
+version = "0.3.33"
+criteria = "safe-to-deploy"
+
+[[exemptions.futures-io]]
+version = "0.3.33"
+criteria = "safe-to-deploy"
+
+[[exemptions.futures-lite]]
+version = "2.6.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.futures-macro]]
+version = "0.3.33"
+criteria = "safe-to-deploy"
+
+[[exemptions.futures-sink]]
+version = "0.3.33"
+criteria = "safe-to-deploy"
+
+[[exemptions.futures-task]]
+version = "0.3.33"
+criteria = "safe-to-deploy"
+
+[[exemptions.futures-util]]
+version = "0.3.33"
+criteria = "safe-to-deploy"
+
+[[exemptions.generic-array]]
+version = "0.12.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.generic-array]]
+version = "0.13.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.generic-array]]
+version = "0.14.7"
+criteria = "safe-to-deploy"
+
+[[exemptions.geo-types]]
+version = "0.7.19"
+criteria = "safe-to-deploy"
+
+[[exemptions.geojson]]
+version = "0.24.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.gethostname]]
+version = "1.1.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.getopts]]
+version = "0.2.24"
+criteria = "safe-to-deploy"
+
+[[exemptions.getrandom]]
+version = "0.2.17"
+criteria = "safe-to-deploy"
+
+[[exemptions.getrandom]]
+version = "0.3.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.getrandom]]
+version = "0.4.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.ghash]]
+version = "0.5.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.gif]]
+version = "0.14.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.gilrs-azul]]
+version = "0.11.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.gilrs-core-azul]]
+version = "0.6.8"
+criteria = "safe-to-deploy"
+
+[[exemptions.git2]]
+version = "0.20.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.gl-context-loader]]
+version = "0.1.10"
+criteria = "safe-to-deploy"
+
+[[exemptions.globset]]
+version = "0.4.19"
+criteria = "safe-to-deploy"
+
+[[exemptions.glyph-names]]
+version = "0.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.goblin]]
+version = "0.10.7"
+criteria = "safe-to-deploy"
+
+[[exemptions.gpu-video-azul]]
+version = "0.4.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.grid]]
+version = "1.0.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.group]]
+version = "0.13.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.h264-reader]]
+version = "0.8.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.half]]
+version = "2.7.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.hash32]]
+version = "0.1.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.hash32]]
+version = "0.2.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.hash32]]
+version = "0.3.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.hashbrown]]
+version = "0.16.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.heapless]]
+version = "0.6.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.heapless]]
+version = "0.7.17"
+criteria = "safe-to-deploy"
+
+[[exemptions.heapless]]
+version = "0.8.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.hermit-abi]]
+version = "0.5.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.hex-slice]]
+version = "0.1.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.hkdf]]
+version = "0.12.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.hmac]]
+version = "0.13.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.home]]
+version = "0.5.12"
+criteria = "safe-to-deploy"
+
+[[exemptions.http]]
+version = "1.4.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.httparse]]
+version = "1.10.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.hybrid-array]]
+version = "0.4.13"
+criteria = "safe-to-deploy"
+
+[[exemptions.hyphenation]]
+version = "0.8.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.hyphenation_commons]]
+version = "0.8.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.iana-time-zone]]
+version = "0.1.65"
+criteria = "safe-to-deploy"
+
+[[exemptions.iced-x86]]
+version = "1.21.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.icu]]
+version = "2.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.icu_calendar]]
+version = "2.2.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.icu_calendar_data]]
+version = "2.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.icu_casemap]]
+version = "2.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.icu_casemap_data]]
+version = "2.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.icu_collator]]
+version = "2.2.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.icu_collator_data]]
+version = "2.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.icu_collections]]
+version = "2.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.icu_datetime]]
+version = "2.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.icu_datetime_data]]
+version = "2.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.icu_decimal]]
+version = "2.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.icu_decimal_data]]
+version = "2.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.icu_experimental]]
+version = "0.5.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.icu_experimental_data]]
+version = "0.5.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.icu_list]]
+version = "2.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.icu_list_data]]
+version = "2.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.icu_locale]]
+version = "2.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.icu_locale_core]]
+version = "2.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.icu_locale_data]]
+version = "2.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.icu_normalizer]]
+version = "2.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.icu_normalizer_data]]
+version = "2.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.icu_pattern]]
+version = "0.4.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.icu_plurals]]
+version = "2.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.icu_plurals_data]]
+version = "2.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.icu_properties]]
+version = "2.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.icu_properties_data]]
+version = "2.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.icu_provider]]
+version = "2.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.icu_provider_blob]]
+version = "2.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.icu_segmenter]]
+version = "2.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.icu_segmenter_data]]
+version = "2.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.icu_time]]
+version = "2.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.icu_time_data]]
+version = "2.2.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.idna_adapter]]
+version = "1.2.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.ignore]]
+version = "0.4.30"
+criteria = "safe-to-deploy"
+
+[[exemptions.image]]
+version = "0.25.10"
+criteria = "safe-to-deploy"
+
+[[exemptions.image-webp]]
+version = "0.2.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.indoc]]
+version = "2.0.7"
+criteria = "safe-to-deploy"
+
+[[exemptions.inotify]]
+version = "0.11.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.inotify-sys]]
+version = "0.1.8"
+criteria = "safe-to-deploy"
+
+[[exemptions.inventory]]
+version = "0.3.24"
+criteria = "safe-to-deploy"
+
+[[exemptions.io-uring]]
+version = "0.7.13"
+criteria = "safe-to-deploy"
+
+[[exemptions.is_terminal_polyfill]]
+version = "1.70.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.itertools]]
+version = "0.13.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.itertools]]
+version = "0.14.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.itoa]]
+version = "1.0.18"
+criteria = "safe-to-deploy"
+
+[[exemptions.ixdtf]]
+version = "0.6.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.jetscii]]
+version = "0.5.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.jni]]
+version = "0.22.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.jni-macros]]
+version = "0.22.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.jni-sys]]
+version = "0.3.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.jni-sys]]
+version = "0.4.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.jni-sys-macros]]
+version = "0.4.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.jobserver]]
+version = "0.1.35"
+criteria = "safe-to-deploy"
+
+[[exemptions.js-sys]]
+version = "0.3.103"
+criteria = "safe-to-deploy"
+
+[[exemptions.lazycell]]
+version = "1.3.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.libbz2-rs-sys]]
+version = "0.2.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.libc]]
+version = "0.2.186"
+criteria = "safe-to-deploy"
+
+[[exemptions.libgit2-sys]]
+version = "0.18.5+1.9.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.libloading]]
+version = "0.8.9"
+criteria = "safe-to-deploy"
+
+[[exemptions.libm]]
+version = "0.2.16"
+criteria = "safe-to-deploy"
+
+[[exemptions.libmimalloc-sys]]
+version = "0.1.49"
+criteria = "safe-to-deploy"
+
+[[exemptions.libredox]]
+version = "0.1.18"
+criteria = "safe-to-deploy"
+
+[[exemptions.libudev-sys-azul]]
+version = "0.1.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.libz-sys]]
+version = "1.1.29"
+criteria = "safe-to-deploy"
+
+[[exemptions.linux-raw-sys]]
+version = "0.4.15"
+criteria = "safe-to-deploy"
+
+[[exemptions.linux-raw-sys]]
+version = "0.12.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.litemap]]
+version = "0.8.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.litrs]]
+version = "1.0.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.lock_api]]
+version = "0.4.14"
+criteria = "safe-to-deploy"
+
+[[exemptions.log]]
+version = "0.4.33"
+criteria = "safe-to-deploy"
+
+[[exemptions.lopdf]]
+version = "0.44.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.lru]]
+version = "0.18.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.lyon]]
+version = "1.0.19"
+criteria = "safe-to-deploy"
+
+[[exemptions.lyon_algorithms]]
+version = "1.0.20"
+criteria = "safe-to-deploy"
+
+[[exemptions.lyon_geom]]
+version = "1.0.19"
+criteria = "safe-to-deploy"
+
+[[exemptions.lyon_path]]
+version = "1.0.19"
+criteria = "safe-to-deploy"
+
+[[exemptions.lyon_tessellation]]
+version = "1.0.20"
+criteria = "safe-to-deploy"
+
+[[exemptions.lzma-rust2]]
+version = "0.13.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.lzma-rust2]]
+version = "0.16.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.mach2]]
+version = "0.4.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.material-icons]]
+version = "0.3.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.md-5]]
+version = "0.11.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.memchr]]
+version = "2.8.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.memoffset]]
+version = "0.9.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.metal]]
+version = "0.18.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.microdns]]
+version = "0.1.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.micromail]]
+version = "0.1.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.miette]]
+version = "7.6.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.miette-derive]]
+version = "7.6.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.mimalloc]]
+version = "0.1.52"
+criteria = "safe-to-deploy"
+
+[[exemptions.minimal-lexical]]
+version = "0.2.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.minisign]]
+version = "0.9.1"
+criteria = "safe-to-run"
+
+[[exemptions.minisign-verify]]
+version = "0.2.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.mmapio]]
+version = "0.9.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.moxcms]]
+version = "0.8.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.mozjpeg]]
+version = "0.10.13"
+criteria = "safe-to-deploy"
+
+[[exemptions.mozjpeg-sys]]
+version = "2.2.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.mp4]]
+version = "0.14.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.mp4ra-rust]]
+version = "0.3.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.mpeg4-audio-const]]
+version = "0.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.mvt-reader]]
+version = "2.4.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.nanorand]]
+version = "0.7.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.nanospinner]]
+version = "0.3.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.nasm-rs]]
+version = "0.3.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.native-tls]]
+version = "0.2.18"
+criteria = "safe-to-deploy"
+
+[[exemptions.ndk]]
+version = "0.8.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.ndk]]
+version = "0.9.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.ndk-sys]]
+version = "0.5.0+25.2.9519653"
+criteria = "safe-to-deploy"
+
+[[exemptions.ndk-sys]]
+version = "0.6.0+11769913"
+criteria = "safe-to-deploy"
+
+[[exemptions.nix]]
+version = "0.31.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.nokhwa]]
+version = "0.10.11"
+criteria = "safe-to-deploy"
+
+[[exemptions.nokhwa-bindings-linux]]
+version = "0.1.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.nokhwa-bindings-macos]]
+version = "0.2.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.nokhwa-bindings-windows]]
+version = "0.4.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.nokhwa-core]]
+version = "0.1.9"
+criteria = "safe-to-deploy"
+
+[[exemptions.nom]]
+version = "8.0.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.num-bigint]]
+version = "0.4.8"
+criteria = "safe-to-deploy"
+
+[[exemptions.num-bigint-dig]]
+version = "0.8.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.num-iter]]
+version = "0.1.46"
+criteria = "safe-to-deploy"
+
+[[exemptions.num_enum]]
+version = "0.7.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.num_enum_derive]]
+version = "0.7.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.objc]]
+version = "0.2.7"
+criteria = "safe-to-deploy"
+
+[[exemptions.objc-foundation]]
+version = "0.1.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.objc-sys]]
+version = "0.3.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.objc2]]
+version = "0.5.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.objc2]]
+version = "0.6.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.objc2-app-kit]]
+version = "0.2.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.objc2-app-kit]]
+version = "0.3.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.objc2-av-foundation]]
+version = "0.3.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.objc2-avf-audio]]
+version = "0.3.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.objc2-cloud-kit]]
+version = "0.3.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.objc2-core-audio]]
+version = "0.3.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.objc2-core-audio-types]]
+version = "0.3.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.objc2-core-data]]
+version = "0.2.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.objc2-core-data]]
+version = "0.3.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.objc2-core-image]]
+version = "0.2.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.objc2-core-image]]
+version = "0.3.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.objc2-core-location]]
+version = "0.3.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.objc2-core-media]]
+version = "0.3.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.objc2-core-motion]]
+version = "0.3.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.objc2-core-text]]
+version = "0.3.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.objc2-core-video]]
+version = "0.3.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.objc2-foundation]]
+version = "0.2.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.objc2-io-kit]]
+version = "0.3.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.objc2-local-authentication]]
+version = "0.3.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.objc2-metal]]
+version = "0.2.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.objc2-quartz-core]]
+version = "0.2.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.objc2-security]]
+version = "0.3.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.objc_exception]]
+version = "0.1.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.objc_id]]
+version = "0.1.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.object]]
+version = "0.37.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.oboe]]
+version = "0.6.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.oboe-sys]]
+version = "0.6.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.once_cell]]
+version = "1.21.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.once_cell_polyfill]]
+version = "1.70.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.open]]
+version = "5.4.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.openssl]]
+version = "0.10.81"
+criteria = "safe-to-deploy"
+
+[[exemptions.openssl-probe]]
+version = "0.2.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.openssl-sys]]
+version = "0.9.117"
+criteria = "safe-to-deploy"
+
+[[exemptions.ordered-float]]
+version = "2.10.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.ordered-stream]]
+version = "0.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.ouroboros]]
+version = "0.18.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.ouroboros_macro]]
+version = "0.18.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.p256]]
+version = "0.13.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.p384]]
+version = "0.13.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.pack1]]
+version = "1.1.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.parking_lot]]
+version = "0.12.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.parking_lot_core]]
+version = "0.9.12"
+criteria = "safe-to-deploy"
+
+[[exemptions.paste]]
+version = "1.0.15"
+criteria = "safe-to-deploy"
+
+[[exemptions.pathfinder_geometry]]
+version = "0.5.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.pathfinder_simd]]
+version = "0.5.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.pbkdf2]]
+version = "0.12.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.pbkdf2]]
+version = "0.13.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.pdb]]
+version = "0.8.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.pdqselect]]
+version = "0.1.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.pem-rfc7468]]
+version = "1.0.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.phf]]
+version = "0.13.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.phf_generator]]
+version = "0.13.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.phf_macros]]
+version = "0.13.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.phf_shared]]
+version = "0.13.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.pin-project-lite]]
+version = "0.2.17"
+criteria = "safe-to-deploy"
+
+[[exemptions.piper]]
+version = "0.2.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.pkcs1]]
+version = "0.7.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.pkcs5]]
+version = "0.7.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.pkcs8]]
+version = "0.10.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.pkg-config]]
+version = "0.3.33"
+criteria = "safe-to-deploy"
+
+[[exemptions.plain]]
+version = "0.2.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.png]]
+version = "0.18.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.pocket-resources]]
+version = "0.3.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.polling]]
+version = "3.11.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.pollster]]
+version = "0.4.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.poly1305]]
+version = "0.8.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.polyval]]
+version = "0.6.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.portable-atomic]]
+version = "1.14.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.potential_utf]]
+version = "0.1.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.ppmd-rust]]
+version = "1.4.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.ppv-lite86]]
+version = "0.2.21"
+criteria = "safe-to-deploy"
+
+[[exemptions.prettyplease]]
+version = "0.2.37"
+criteria = "safe-to-deploy"
+
+[[exemptions.primeorder]]
+version = "0.13.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.printpdf]]
+version = "0.12.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.proc-macro-crate]]
+version = "3.5.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.proc-macro2-diagnostics]]
+version = "0.10.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.proj4rs]]
+version = "0.1.10"
+criteria = "safe-to-deploy"
+
+[[exemptions.prost]]
+version = "0.13.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.prost-derive]]
+version = "0.13.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.pulldown-cmark]]
+version = "0.9.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.pxfm]]
+version = "0.1.30"
+criteria = "safe-to-deploy"
+
+[[exemptions.pyo3]]
+version = "0.27.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.pyo3-build-config]]
+version = "0.27.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.pyo3-ffi]]
+version = "0.27.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.pyo3-log]]
+version = "0.13.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.pyo3-macros]]
+version = "0.27.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.pyo3-macros-backend]]
+version = "0.27.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.quick-error]]
+version = "2.0.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.quote]]
+version = "1.0.46"
+criteria = "safe-to-deploy"
+
+[[exemptions.r-efi]]
+version = "5.3.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.r-efi]]
+version = "6.0.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.rand]]
+version = "0.8.7"
+criteria = "safe-to-deploy"
+
+[[exemptions.rand]]
+version = "0.9.5"
+criteria = "safe-to-run"
+
+[[exemptions.rand]]
+version = "0.10.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.rand_core]]
+version = "0.10.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.rangemap]]
+version = "1.7.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.rayon]]
+version = "1.12.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.redox_syscall]]
+version = "0.5.18"
+criteria = "safe-to-deploy"
+
+[[exemptions.redox_users]]
+version = "0.5.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.regex]]
+version = "1.13.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.regex-automata]]
+version = "0.4.16"
+criteria = "safe-to-deploy"
+
+[[exemptions.regex-syntax]]
+version = "0.8.11"
+criteria = "safe-to-deploy"
+
+[[exemptions.rfc6381-codec]]
+version = "0.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.rfc6979]]
+version = "0.4.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.rgb]]
+version = "0.8.53"
+criteria = "safe-to-deploy"
+
+[[exemptions.ring]]
+version = "0.17.14"
+criteria = "safe-to-deploy"
+
+[[exemptions.roxmltree]]
+version = "0.21.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.rpassword]]
+version = "7.5.4"
+criteria = "safe-to-run"
+
+[[exemptions.rsa]]
+version = "0.9.10"
+criteria = "safe-to-deploy"
+
+[[exemptions.rstar]]
+version = "0.8.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.rstar]]
+version = "0.9.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.rstar]]
+version = "0.10.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.rstar]]
+version = "0.11.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.rstar]]
+version = "0.12.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.rtoolbox]]
+version = "0.0.5"
+criteria = "safe-to-run"
+
+[[exemptions.rust-fontconfig]]
+version = "4.4.11"
+criteria = "safe-to-deploy"
+
+[[exemptions.rustc-demangle]]
+version = "0.1.28"
+criteria = "safe-to-deploy"
+
+[[exemptions.rustc-hash]]
+version = "2.1.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.rustix]]
+version = "0.38.44"
+criteria = "safe-to-deploy"
+
+[[exemptions.rustix]]
+version = "1.1.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.rustls]]
+version = "0.23.42"
+criteria = "safe-to-deploy"
+
+[[exemptions.rustls-pki-types]]
+version = "1.15.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.rustls-rustcrypto]]
+version = "0.0.2-alpha"
+criteria = "safe-to-deploy"
+
+[[exemptions.rustls-webpki]]
+version = "0.102.8"
+criteria = "safe-to-deploy"
+
+[[exemptions.rustls-webpki]]
+version = "0.103.13"
+criteria = "safe-to-deploy"
+
+[[exemptions.rustversion]]
+version = "1.0.23"
+criteria = "safe-to-deploy"
+
+[[exemptions.ryu]]
+version = "1.0.23"
+criteria = "safe-to-deploy"
+
+[[exemptions.salsa20]]
+version = "0.10.2"
+criteria = "safe-to-run"
+
+[[exemptions.same-file]]
+version = "1.0.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.schannel]]
+version = "0.1.29"
+criteria = "safe-to-deploy"
+
+[[exemptions.scopeguard]]
+version = "1.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.scroll]]
+version = "0.11.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.scroll]]
+version = "0.13.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.scroll_derive]]
+version = "0.13.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.scrypt]]
+version = "0.11.0"
+criteria = "safe-to-run"
+
+[[exemptions.sec1]]
+version = "0.7.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.security-framework]]
+version = "3.7.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.security-framework-sys]]
+version = "2.17.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.self_cell]]
+version = "1.3.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.serde-untagged]]
+version = "0.1.9"
+criteria = "safe-to-deploy"
+
+[[exemptions.serde_bytes]]
+version = "0.11.19"
+criteria = "safe-to-deploy"
+
+[[exemptions.serde_json]]
+version = "1.0.150"
+criteria = "safe-to-deploy"
+
+[[exemptions.serde_repr]]
+version = "0.1.20"
+criteria = "safe-to-deploy"
+
+[[exemptions.serde_spanned]]
+version = "0.6.9"
+criteria = "safe-to-deploy"
+
+[[exemptions.serde_yaml]]
+version = "0.9.34+deprecated"
+criteria = "safe-to-deploy"
+
+[[exemptions.sha1]]
+version = "0.10.7"
+criteria = "safe-to-deploy"
+
+[[exemptions.sha1]]
+version = "0.11.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.sha2]]
+version = "0.11.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.shlex]]
+version = "2.0.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.signal-hook-registry]]
+version = "1.4.8"
+criteria = "safe-to-deploy"
+
+[[exemptions.simd-adler32]]
+version = "0.3.10"
+criteria = "safe-to-deploy"
+
+[[exemptions.simd_cesu8]]
+version = "1.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.simdutf8]]
+version = "0.1.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.siphasher]]
+version = "1.0.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.skeptic]]
+version = "0.13.7"
+criteria = "safe-to-deploy"
+
+[[exemptions.slab]]
+version = "0.4.12"
+criteria = "safe-to-deploy"
+
+[[exemptions.slotmap]]
+version = "1.1.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.softaes]]
+version = "0.1.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.spdx]]
+version = "0.10.9"
+criteria = "safe-to-deploy"
+
+[[exemptions.spin]]
+version = "0.9.9"
+criteria = "safe-to-deploy"
+
+[[exemptions.spki]]
+version = "0.7.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.spmc]]
+version = "0.3.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.stable_deref_trait]]
+version = "1.2.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.strfmt]]
+version = "0.2.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.stringprep]]
+version = "0.1.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.strum]]
+version = "0.28.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.svg_fmt]]
+version = "0.4.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.syn]]
+version = "1.0.109"
+criteria = "safe-to-deploy"
+
+[[exemptions.syn]]
+version = "2.0.119"
+criteria = "safe-to-deploy"
+
+[[exemptions.taffy]]
+version = "0.10.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.target-lexicon]]
+version = "0.13.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.tempfile]]
+version = "3.27.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.tfd]]
+version = "0.1.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.thiserror]]
+version = "2.0.18"
+criteria = "safe-to-deploy"
+
+[[exemptions.thiserror-impl]]
+version = "2.0.18"
+criteria = "safe-to-deploy"
+
+[[exemptions.tiff]]
+version = "0.11.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.tiktoken-rs]]
+version = "0.6.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.tikv-jemalloc-sys]]
+version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+criteria = "safe-to-deploy"
+
+[[exemptions.tikv-jemallocator]]
+version = "0.6.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.time]]
+version = "0.3.53"
+criteria = "safe-to-deploy"
+
+[[exemptions.time-macros]]
+version = "0.2.31"
+criteria = "safe-to-deploy"
+
+[[exemptions.tinystr]]
+version = "0.8.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.tinyvec]]
+version = "1.12.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.toml]]
+version = "0.8.23"
+criteria = "safe-to-deploy"
+
+[[exemptions.toml]]
+version = "0.9.12+spec-1.1.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.toml_datetime]]
+version = "0.6.11"
+criteria = "safe-to-deploy"
+
+[[exemptions.toml_edit]]
+version = "0.22.27"
+criteria = "safe-to-deploy"
+
+[[exemptions.toml_edit]]
+version = "0.25.13+spec-1.1.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.toml_parser]]
+version = "1.1.2+spec-1.1.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.toml_write]]
+version = "0.1.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.toml_writer]]
+version = "1.1.2+spec-1.1.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.tracing]]
+version = "0.1.44"
+criteria = "safe-to-deploy"
+
+[[exemptions.tracing-attributes]]
+version = "0.1.31"
+criteria = "safe-to-deploy"
+
+[[exemptions.tracing-core]]
+version = "0.1.36"
+criteria = "safe-to-deploy"
+
+[[exemptions.tungstenite]]
+version = "0.24.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.turso]]
+version = "0.1.5@git:c12a566ee9e199241b60a42847142198e63d44c1"
+criteria = "safe-to-deploy"
+
+[[exemptions.turso_core]]
+version = "0.1.5@git:c12a566ee9e199241b60a42847142198e63d44c1"
+criteria = "safe-to-deploy"
+
+[[exemptions.turso_ext]]
+version = "0.1.5@git:c12a566ee9e199241b60a42847142198e63d44c1"
+criteria = "safe-to-deploy"
+
+[[exemptions.turso_macros]]
+version = "0.1.5@git:c12a566ee9e199241b60a42847142198e63d44c1"
+criteria = "safe-to-deploy"
+
+[[exemptions.turso_parser]]
+version = "0.1.5@git:c12a566ee9e199241b60a42847142198e63d44c1"
+criteria = "safe-to-deploy"
+
+[[exemptions.turso_sqlite3_parser]]
+version = "0.1.5@git:c12a566ee9e199241b60a42847142198e63d44c1"
+criteria = "safe-to-deploy"
+
+[[exemptions.type-map]]
+version = "0.5.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.typed-arena]]
+version = "2.0.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.typed-path]]
+version = "0.12.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.typeid]]
+version = "1.0.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.typenum]]
+version = "1.20.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.ucd-trie]]
+version = "0.1.7"
+criteria = "safe-to-deploy"
+
+[[exemptions.uds_windows]]
+version = "1.2.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.uncased]]
+version = "0.9.10"
+criteria = "safe-to-deploy"
+
+[[exemptions.unicase]]
+version = "2.9.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.unicode-canonical-combining-class]]
+version = "1.0.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.unicode-general-category]]
+version = "1.1.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.unicode-ident]]
+version = "1.0.24"
+criteria = "safe-to-deploy"
+
+[[exemptions.unicode-joining-type]]
+version = "1.0.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.unicode-properties]]
+version = "0.1.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.unicode_categories]]
+version = "0.1.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.unindent]]
+version = "0.2.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.unsafe-libyaml]]
+version = "0.2.11"
+criteria = "safe-to-deploy"
+
+[[exemptions.untrusted]]
+version = "0.9.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.unty]]
+version = "0.0.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.ureq]]
+version = "3.3.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.ureq-proto]]
+version = "0.6.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.url]]
+version = "2.5.8"
+criteria = "safe-to-deploy"
+
+[[exemptions.utf8-zero]]
+version = "0.8.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.uuid]]
+version = "1.24.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.v4l]]
+version = "0.14.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.v4l2-sys-mit]]
+version = "0.3.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.version_check]]
+version = "0.9.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.virtue]]
+version = "0.0.18"
+criteria = "safe-to-deploy"
+
+[[exemptions.vk-mem]]
+version = "0.4.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.walkdir]]
+version = "2.5.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.wasi]]
+version = "0.11.1+wasi-snapshot-preview1"
+criteria = "safe-to-deploy"
+
+[[exemptions.wasm-bindgen]]
+version = "0.2.126"
+criteria = "safe-to-deploy"
+
+[[exemptions.wasm-bindgen-futures]]
+version = "0.4.76"
+criteria = "safe-to-deploy"
+
+[[exemptions.wasm-bindgen-macro]]
+version = "0.2.126"
+criteria = "safe-to-deploy"
+
+[[exemptions.wasm-bindgen-macro-support]]
+version = "0.2.126"
+criteria = "safe-to-deploy"
+
+[[exemptions.wasm-bindgen-shared]]
+version = "0.2.126"
+criteria = "safe-to-deploy"
+
+[[exemptions.web-sys]]
+version = "0.3.103"
+criteria = "safe-to-deploy"
+
+[[exemptions.webpki-root-certs]]
+version = "1.0.9"
+criteria = "safe-to-deploy"
+
+[[exemptions.webpki-roots]]
+version = "1.0.9"
+criteria = "safe-to-deploy"
+
+[[exemptions.webrender]]
+version = "0.62.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.webrender_api]]
+version = "0.62.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.webrender_build]]
+version = "0.0.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.weezl]]
+version = "0.1.12"
+criteria = "safe-to-deploy"
+
+[[exemptions.weezl]]
+version = "0.2.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.which]]
+version = "4.4.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.winapi]]
+version = "0.3.9"
+criteria = "safe-to-deploy"
+
+[[exemptions.winapi-i686-pc-windows-gnu]]
+version = "0.4.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.winapi-util]]
+version = "0.1.11"
+criteria = "safe-to-deploy"
+
+[[exemptions.winapi-x86_64-pc-windows-gnu]]
+version = "0.4.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows]]
+version = "0.54.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows]]
+version = "0.62.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows-collections]]
+version = "0.3.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows-core]]
+version = "0.54.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows-core]]
+version = "0.62.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows-future]]
+version = "0.3.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows-implement]]
+version = "0.60.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows-interface]]
+version = "0.59.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows-numerics]]
+version = "0.3.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows-result]]
+version = "0.1.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows-result]]
+version = "0.4.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows-strings]]
+version = "0.5.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows-sys]]
+version = "0.45.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows-sys]]
+version = "0.52.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows-sys]]
+version = "0.59.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows-sys]]
+version = "0.61.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows-targets]]
+version = "0.42.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows-targets]]
+version = "0.52.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows-threading]]
+version = "0.2.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows_aarch64_gnullvm]]
+version = "0.42.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows_aarch64_gnullvm]]
+version = "0.52.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows_aarch64_msvc]]
+version = "0.42.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows_aarch64_msvc]]
+version = "0.52.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows_i686_gnu]]
+version = "0.42.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows_i686_gnu]]
+version = "0.52.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows_i686_gnullvm]]
+version = "0.52.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows_i686_msvc]]
+version = "0.42.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows_i686_msvc]]
+version = "0.52.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows_x86_64_gnu]]
+version = "0.42.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows_x86_64_gnu]]
+version = "0.52.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows_x86_64_gnullvm]]
+version = "0.42.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows_x86_64_gnullvm]]
+version = "0.52.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows_x86_64_msvc]]
+version = "0.42.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows_x86_64_msvc]]
+version = "0.52.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.winnow]]
+version = "0.7.15"
+criteria = "safe-to-deploy"
+
+[[exemptions.winnow]]
+version = "1.0.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.writeable]]
+version = "0.6.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.x11-clipboard]]
+version = "0.9.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.x11rb]]
+version = "0.13.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.x11rb-protocol]]
+version = "0.13.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.x25519-dalek]]
+version = "2.0.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.xmlparser]]
+version = "0.13.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.xmlwriter]]
+version = "0.1.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.yansi]]
+version = "1.0.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.yoke]]
+version = "0.8.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.yoke-derive]]
+version = "0.8.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.zbus]]
+version = "5.18.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.zbus-lockstep]]
+version = "0.5.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.zbus-lockstep-macros]]
+version = "0.5.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.zbus_macros]]
+version = "5.18.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.zbus_names]]
+version = "4.3.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.zbus_xml]]
+version = "5.2.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.zerocopy]]
+version = "0.8.54"
+criteria = "safe-to-deploy"
+
+[[exemptions.zerocopy-derive]]
+version = "0.8.54"
+criteria = "safe-to-deploy"
+
+[[exemptions.zerofrom]]
+version = "0.1.8"
+criteria = "safe-to-deploy"
+
+[[exemptions.zerofrom-derive]]
+version = "0.1.7"
+criteria = "safe-to-deploy"
+
+[[exemptions.zeroize]]
+version = "1.9.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.zeroize_derive]]
+version = "1.5.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.zerotrie]]
+version = "0.2.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.zerovec]]
+version = "0.11.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.zerovec-derive]]
+version = "0.11.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.zip]]
+version = "6.0.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.zip]]
+version = "8.6.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.zlib-rs]]
+version = "0.6.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.zmij]]
+version = "1.0.23"
+criteria = "safe-to-deploy"
+
+[[exemptions.zopfli]]
+version = "0.8.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.zstd]]
+version = "0.13.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.zstd-safe]]
+version = "7.2.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.zstd-sys]]
+version = "2.0.16+zstd.1.5.7"
+criteria = "safe-to-deploy"
+
+[[exemptions.zune-core]]
+version = "0.5.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.zune-jpeg]]
+version = "0.5.15"
+criteria = "safe-to-deploy"
+
+[[exemptions.zvariant]]
+version = "5.13.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.zvariant_derive]]
+version = "5.13.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.zvariant_utils]]
+version = "3.5.0"
+criteria = "safe-to-deploy"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1,0 +1,2965 @@
+
+# cargo-vet imports lock
+
+[[publisher.arbitrary]]
+version = "1.4.2"
+when = "2025-08-14"
+user-id = 696
+user-login = "fitzgen"
+user-name = "Nick Fitzgerald"
+
+[[publisher.bumpalo]]
+version = "3.20.3"
+when = "2026-05-22"
+user-id = 696
+user-login = "fitzgen"
+user-name = "Nick Fitzgerald"
+
+[[publisher.cexpr]]
+version = "0.6.0"
+when = "2021-10-11"
+user-id = 3788
+user-login = "emilio"
+user-name = "Emilio Cobos Álvarez"
+
+[[publisher.cocoa]]
+version = "0.20.2"
+when = "2020-06-23"
+user-id = 2396
+user-login = "jdm"
+user-name = "Josh Matthews"
+
+[[publisher.core-foundation]]
+version = "0.7.0"
+when = "2019-11-12"
+user-id = 2396
+user-login = "jdm"
+user-name = "Josh Matthews"
+
+[[publisher.core-foundation]]
+version = "0.9.3"
+when = "2022-02-07"
+user-id = 5946
+user-login = "jrmuizel"
+user-name = "Jeff Muizelaar"
+
+[[publisher.core-foundation-sys]]
+version = "0.7.0"
+when = "2019-11-12"
+user-id = 2396
+user-login = "jdm"
+user-name = "Josh Matthews"
+
+[[publisher.core-graphics]]
+version = "0.19.2"
+when = "2020-06-27"
+user-id = 2396
+user-login = "jdm"
+user-name = "Josh Matthews"
+
+[[publisher.core-graphics-types]]
+version = "0.1.1"
+when = "2020-09-15"
+user-id = 2396
+user-login = "jdm"
+user-name = "Josh Matthews"
+
+[[publisher.core-text]]
+version = "19.2.0"
+when = "2021-02-14"
+user-id = 5946
+user-login = "jrmuizel"
+user-name = "Jeff Muizelaar"
+
+[[publisher.derive_arbitrary]]
+version = "1.4.2"
+when = "2025-08-14"
+user-id = 696
+user-login = "fitzgen"
+user-name = "Nick Fitzgerald"
+
+[[publisher.encoding_rs]]
+version = "0.8.35"
+when = "2024-10-24"
+user-id = 4484
+user-login = "hsivonen"
+user-name = "Henri Sivonen"
+
+[[publisher.etagere]]
+version = "0.2.15"
+when = "2025-01-21"
+user-id = 1281
+user-login = "nical"
+user-name = "Nicolas Silva"
+
+[[publisher.euclid]]
+version = "0.22.14"
+when = "2026-03-18"
+user-id = 1281
+user-login = "nical"
+user-name = "Nicolas Silva"
+
+[[publisher.unicode-normalization]]
+version = "0.1.25"
+when = "2025-10-30"
+user-id = 1139
+user-login = "Manishearth"
+user-name = "Manish Goregaokar"
+
+[[publisher.unicode-segmentation]]
+version = "1.13.3"
+when = "2026-06-01"
+user-id = 1139
+user-login = "Manishearth"
+user-name = "Manish Goregaokar"
+
+[[publisher.unicode-width]]
+version = "0.1.14"
+when = "2024-09-19"
+user-id = 1139
+user-login = "Manishearth"
+user-name = "Manish Goregaokar"
+
+[[publisher.unicode-width]]
+version = "0.2.2"
+when = "2025-10-06"
+user-id = 1139
+user-login = "Manishearth"
+user-name = "Manish Goregaokar"
+
+[[publisher.unicode-xid]]
+version = "0.2.6"
+when = "2024-09-19"
+user-id = 1139
+user-login = "Manishearth"
+user-name = "Manish Goregaokar"
+
+[[publisher.utf8_iter]]
+version = "1.0.4"
+when = "2023-12-01"
+user-id = 4484
+user-login = "hsivonen"
+user-name = "Henri Sivonen"
+
+[[publisher.wasip2]]
+version = "1.0.4+wasi-0.2.12"
+when = "2026-06-12"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
+
+[[publisher.wit-bindgen]]
+version = "0.57.1"
+when = "2026-04-17"
+trusted-publisher = "github:bytecodealliance/wit-bindgen"
+
+[[audits.bytecode-alliance.wildcard-audits.arbitrary]]
+who = "Nick Fitzgerald <fitzgen@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 696 # Nick Fitzgerald (fitzgen)
+start = "2020-01-14"
+end = "2026-08-21"
+notes = "I am an author of this crate."
+
+[[audits.bytecode-alliance.wildcard-audits.bumpalo]]
+who = "Nick Fitzgerald <fitzgen@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 696 # Nick Fitzgerald (fitzgen)
+start = "2019-03-16"
+end = "2026-08-21"
+
+[[audits.bytecode-alliance.wildcard-audits.derive_arbitrary]]
+who = "Nick Fitzgerald <fitzgen@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 696 # Nick Fitzgerald (fitzgen)
+start = "2020-01-14"
+end = "2026-08-21"
+notes = "I am an author of this crate"
+
+[[audits.bytecode-alliance.wildcard-audits.wasip2]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+user-id = 1 # Alex Crichton (alexcrichton)
+start = "2025-08-10"
+end = "2026-08-21"
+notes = """
+This is a Bytecode Alliance authored crate.
+"""
+
+[[audits.bytecode-alliance.wildcard-audits.wit-bindgen]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wit-bindgen"
+start = "2025-08-13"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
+
+[[audits.bytecode-alliance.audits.adler2]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+version = "2.0.0"
+notes = "Fork of the original `adler` crate, zero unsfae code, works in `no_std`, does what it says on th tin."
+
+[[audits.bytecode-alliance.audits.anyhow]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.69 -> 1.0.71"
+
+[[audits.bytecode-alliance.audits.async-task]]
+who = "Chris Fallin <chris@cfallin.org>"
+criteria = "safe-to-deploy"
+version = "4.7.1"
+notes = "Fairly significant chunk of unsafe code in the async executor core, but seems isolated to well-understood patterns, e.g. a manual vtable and some manual layout code."
+
+[[audits.bytecode-alliance.audits.atomic-waker]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+version = "1.1.2"
+notes = "Contains `unsafe` code but it's well-documented and scoped to what it's intended to be doing. Otherwise a well-focused and straightforward crate."
+
+[[audits.bytecode-alliance.audits.base64]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "0.21.0"
+notes = "This crate has no dependencies, no build.rs, and contains no unsafe code."
+
+[[audits.bytecode-alliance.audits.block-buffer]]
+who = "Benjamin Bouvier <public@benj.me>"
+criteria = "safe-to-deploy"
+delta = "0.9.0 -> 0.10.2"
+
+[[audits.bytecode-alliance.audits.cfg-if]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+version = "1.0.0"
+notes = "I am the author of this crate."
+
+[[audits.bytecode-alliance.audits.cipher]]
+who = "Andrew Brown <andrew.brown@intel.com>"
+criteria = "safe-to-deploy"
+version = "0.4.4"
+notes = "Most unsafe is hidden by `inout` dependency; only remaining unsafe is raw-splitting a slice and an unreachable hint. Older versions of this regularly reach ~150k daily downloads."
+
+[[audits.bytecode-alliance.audits.cobs]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+version = "0.2.3"
+notes = "No `unsafe` code in the crate and no usage of `std`"
+
+[[audits.bytecode-alliance.audits.cobs]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.2.3 -> 0.3.0"
+notes = "Nothing out of the ordinary, virtually no unsafe code."
+
+[[audits.bytecode-alliance.audits.constant_time_eq]]
+who = "Nick Fitzgerald <fitzgen@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.2.4"
+notes = "A few tiny blocks of `unsafe` but each of them is very obviously correct."
+
+[[audits.bytecode-alliance.audits.der]]
+who = "Chris Fallin <chris@cfallin.org>"
+criteria = "safe-to-deploy"
+version = "0.7.10"
+notes = "No unsafe code aside from transmutes for transparent newtypes."
+
+[[audits.bytecode-alliance.audits.embedded-io]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+version = "0.4.0"
+notes = "No `unsafe` code and only uses `std` in ways one would expect the crate to do so."
+
+[[audits.bytecode-alliance.audits.embedded-io]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.4.0 -> 0.6.1"
+notes = "Major updates, but almost all safe code. Lots of pruning/deletions, nothing out of the ordrinary."
+
+[[audits.bytecode-alliance.audits.errno]]
+who = "Dan Gohman <dev@sunfishcode.online>"
+criteria = "safe-to-deploy"
+version = "0.3.0"
+notes = "This crate uses libc and windows-sys APIs to get and set the raw OS error value."
+
+[[audits.bytecode-alliance.audits.errno]]
+who = "Dan Gohman <dev@sunfishcode.online>"
+criteria = "safe-to-deploy"
+delta = "0.3.0 -> 0.3.1"
+notes = "Just a dependency version bump and a bug fix for redox"
+
+[[audits.bytecode-alliance.audits.errno]]
+who = "Dan Gohman <dev@sunfishcode.online>"
+criteria = "safe-to-deploy"
+delta = "0.3.9 -> 0.3.10"
+
+[[audits.bytecode-alliance.audits.fallible-iterator]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.2.0 -> 0.3.0"
+notes = """
+This major version update has a few minor breaking changes but everything
+this crate has to do with iterators and `Result` and such. No `unsafe` or
+anything like that, all looks good.
+"""
+
+[[audits.bytecode-alliance.audits.foldhash]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+version = "0.1.3"
+notes = """
+Only a minor amount of `unsafe` code in this crate related to global per-process
+initialization which looks correct to me.
+"""
+
+[[audits.bytecode-alliance.audits.foreign-types]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "0.3.2"
+notes = "This crate defined a macro-rules which creates wrappers working with FFI types. The implementation of this crate appears to be safe, but each use of this macro would need to be vetted for correctness as well."
+
+[[audits.bytecode-alliance.audits.foreign-types-shared]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "0.1.1"
+
+[[audits.bytecode-alliance.audits.gimli]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.29.0 -> 0.31.0"
+notes = "Various updates here and there, nothing too major, what you'd expect from a DWARF parsing crate."
+
+[[audits.bytecode-alliance.audits.gimli]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.31.0 -> 0.31.1"
+notes = "No fundmanetally new `unsafe` code, some small refactoring of existing code. Lots of changes in tests, not as many changes in the rest of the crate. More dwarf!"
+
+[[audits.bytecode-alliance.audits.gimli]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.31.1 -> 0.32.0"
+notes = "Ever more DWARF to parse, but also no new `unsafe` and everything looks like gimli."
+
+[[audits.bytecode-alliance.audits.gimli]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.32.0 -> 0.32.3"
+notes = "Ever more dwarf, it never ends! (nothing out of the ordinary)"
+
+[[audits.bytecode-alliance.audits.heck]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.4.1 -> 0.5.0"
+notes = "Minor changes for a `no_std` upgrade but otherwise everything looks as expected."
+
+[[audits.bytecode-alliance.audits.iana-time-zone-haiku]]
+who = "Dan Gohman <dev@sunfishcode.online>"
+criteria = "safe-to-deploy"
+version = "0.1.2"
+
+[[audits.bytecode-alliance.audits.idna]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+version = "0.3.0"
+notes = """
+This is a crate without unsafe code or usage of the standard library. The large
+size of this crate comes from the large generated unicode tables file. This
+crate is broadly used throughout the ecosystem and does not contain anything
+suspicious.
+"""
+
+[[audits.bytecode-alliance.audits.inout]]
+who = "Andrew Brown <andrew.brown@intel.com>"
+criteria = "safe-to-deploy"
+version = "0.1.3"
+notes = "A part of RustCrypto/utils, this crate is designed to handle unsafe buffers and carefully documents the safety concerns throughout. Older versions of this tally up to ~130k daily downloads."
+
+[[audits.bytecode-alliance.audits.miniz_oxide]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+version = "0.7.1"
+notes = """
+This crate is a Rust implementation of zlib compression/decompression and has
+been used by default by the Rust standard library for quite some time. It's also
+a default dependency of the popular `backtrace` crate for decompressing debug
+information. This crate forbids unsafe code and does not otherwise access system
+resources. It's originally a port of the `miniz.c` library as well, and given
+its own longevity should be relatively hardened against some of the more common
+compression-related issues.
+"""
+
+[[audits.bytecode-alliance.audits.miniz_oxide]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.7.1 -> 0.8.0"
+notes = "Minor updates, using new Rust features like `const`, no major changes."
+
+[[audits.bytecode-alliance.audits.miniz_oxide]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.8.0 -> 0.8.5"
+notes = """
+Lots of small updates here and there, for example around modernizing Rust
+idioms. No new `unsafe` code and everything looks like what you'd expect a
+compression library to be doing.
+"""
+
+[[audits.bytecode-alliance.audits.miniz_oxide]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.8.5 -> 0.8.9"
+notes = "No new unsafe code, just refactorings."
+
+[[audits.bytecode-alliance.audits.num-conv]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.2.0 -> 0.2.1"
+notes = "Minor update, nothing major"
+
+[[audits.bytecode-alliance.audits.num-traits]]
+who = "Andrew Brown <andrew.brown@intel.com>"
+criteria = "safe-to-deploy"
+version = "0.2.19"
+notes = "As advertised: a numeric library. The only `unsafe` is from some float-to-int conversions, which seems expected."
+
+[[audits.bytecode-alliance.audits.openssl-macros]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "0.1.0"
+
+[[audits.bytecode-alliance.audits.parking]]
+who = "Chris Fallin <chris@cfallin.org>"
+criteria = "safe-to-deploy"
+version = "2.2.1"
+notes = "forbid-unsafe crate with straightforward imports."
+
+[[audits.bytecode-alliance.audits.peeking_take_while]]
+who = "Nick Fitzgerald <fitzgen@gmail.com>"
+criteria = "safe-to-deploy"
+version = "1.0.0"
+notes = "I am the author of this crate."
+
+[[audits.bytecode-alliance.audits.pem-rfc7468]]
+who = "Chris Fallin <chris@cfallin.org>"
+criteria = "safe-to-deploy"
+version = "0.7.0"
+notes = "Only `unsafe` around a `from_utf8_unchecked`, and no IO."
+
+[[audits.bytecode-alliance.audits.percent-encoding]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+version = "2.2.0"
+notes = """
+This crate is a single-file crate that does what it says on the tin. There are
+a few `unsafe` blocks related to utf-8 validation which are locally verifiable
+as correct and otherwise this crate is good to go.
+"""
+
+[[audits.bytecode-alliance.audits.postcard]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+version = "1.0.8"
+notes = """
+I've audited the unsafe code to do what it looks like it's doing. Otherwise the
+crate is a standard serializer/deserializer crate.
+"""
+
+[[audits.bytecode-alliance.audits.postcard]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.8 -> 1.1.3"
+notes = "Substantial updates, but nothing out of the ordinary one would expect from a serialization crate. Minor `unsafe` updates, but nothing major from what was already there."
+
+[[audits.bytecode-alliance.audits.semver]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "1.0.17"
+notes = "plenty of unsafe pointer and vec tricks, but in well-structured and commented code that appears to be correct"
+
+[[audits.bytecode-alliance.audits.shlex]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+version = "1.1.0"
+notes = "Only minor `unsafe` code blocks which look valid and otherwise does what it says on the tin."
+
+[[audits.bytecode-alliance.audits.smallvec]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "1.13.2 -> 1.14.0"
+notes = "Minor new feature, nothing out of the ordinary."
+
+[[audits.bytecode-alliance.audits.static_assertions]]
+who = "Andrew Brown <andrew.brown@intel.com>"
+criteria = "safe-to-deploy"
+version = "1.1.0"
+notes = "No dependencies and completely a compile-time crate as advertised. Uses `unsafe` in one module as a compile-time check only: `mem::transmute` and `ptr::write` are wrapped in an impossible-to-run closure."
+
+[[audits.bytecode-alliance.audits.tinyvec_macros]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+version = "0.1.0"
+notes = """
+This is a trivial crate which only contains a singular macro definition which is
+intended to multiplex across the internal representation of a tinyvec,
+presumably. This trivially doesn't contain anything bad.
+"""
+
+[[audits.bytecode-alliance.audits.topological-sort]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.1.0 -> 0.2.2"
+notes = """
+No major changes, mostly CI changes in this update. A new `Default` impl
+and a new test.
+"""
+
+[[audits.bytecode-alliance.audits.utf-8]]
+who = "Chris Fallin <chris@cfallin.org>"
+criteria = "safe-to-deploy"
+version = "0.7.6"
+notes = "Small library that uses `unsafe` only around `str::from_utf8_unchecked` after explicitly verifying UTF-8."
+
+[[audits.bytecode-alliance.audits.vcpkg]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "0.2.15"
+notes = "no build.rs, no macros, no unsafe. It reads the filesystem and makes copies of DLLs into OUT_DIR."
+
+[[audits.embark-studios.audits.anyhow]]
+who = "Johan Andersson <opensource@embark-studios.com>"
+criteria = "safe-to-deploy"
+version = "1.0.58"
+
+[[audits.embark-studios.audits.cfg_aliases]]
+who = "Johan Andersson <opensource@embark-studios.com>"
+criteria = "safe-to-deploy"
+version = "0.1.1"
+notes = "No unsafe usage or ambient capabilities"
+
+[[audits.embark-studios.audits.cty]]
+who = "Johan Andersson <opensource@embark-studios.com>"
+criteria = "safe-to-deploy"
+version = "0.2.2"
+notes = "Inspected it and is a tiny crate with just type definitions"
+
+[[audits.embark-studios.audits.ident_case]]
+who = "Johan Andersson <opensource@embark-studios.com>"
+criteria = "safe-to-deploy"
+version = "1.0.1"
+notes = "No unsafe usage or ambient capabilities"
+
+[[audits.embark-studios.audits.idna]]
+who = "Johan Andersson <opensource@embark-studios.com>"
+criteria = "safe-to-deploy"
+delta = "0.3.0 -> 0.4.0"
+notes = "No unsafe usage or ambient capabilities"
+
+[[audits.embark-studios.audits.jni]]
+who = "Robert Bragg <opensource@embark-studios.com>"
+criteria = "safe-to-deploy"
+version = "0.21.1"
+notes = """
+Aims to provide a safe JNI (Java Native Interface) API over the
+unsafe `jni_sys` crate.
+
+This is a very general FFI abstraction for Java VMs with a lot of unsafe code
+throughout the API. There are almost certainly some edge cases with its design
+that could lead to unsound behaviour but it should still be considerably safer
+than working with JNI directly.
+
+A lot of the unsafe usage relates to quite-simple use of `from_raw` APIs to
+construct or cast wrapper types (around JNI pointers) which are fairly
+straight-forward to verify/trust in context.
+
+Some unsafe code has good `// # Safety` documentation (this has been enforced for
+newer code) but a lot of unsafe code doesn't document invariants that are
+being relied on.
+
+The design depends on non-trivial named lifetimes across many APIs to associate
+Java local references with JNI stack frames.
+
+The crate is not very actively maintained and was practically unmaintained for
+over a year before the 0.20 release.
+
+Robert Bragg who now works at Embark Studios became the maintainer of this
+crate in October 2022.
+
+In the process of working on the `jni` crate since becoming maintainer it's
+worth noting that I came across multiple APIs that I found needed to be
+re-worked to address safety issues, including ensuring that APIs that are not
+implemented safely are correctly declared as `unsafe`.
+
+There has been a focus on improving safety in the last two release.
+
+The jni crate has been used in production with the Signal messaging application
+for over two years:
+https://github.com/signalapp/libsignal/blob/main/rust/bridge/jni/Cargo.toml
+
+# Some Notable Open Issues
+- https://github.com/jni-rs/jni-rs/issues/422 - questions soundness of linking
+  multiple versions of jni crate into an application, considering the use
+  of (separately scoped) thread-local-storage to track thread attachments
+- https://github.com/jni-rs/jni-rs/issues/405 - discusses the ease with which
+  code may expose the JVM to invalid booleans with undefined behaviour
+"""
+
+[[audits.embark-studios.audits.ndk-context]]
+who = "Johan Andersson <opensource@embark-studios.com>"
+criteria = "safe-to-deploy"
+version = "0.1.1"
+notes = "Tiny crate that initializes Android with FFI, looks sane. No other ambient capabilities"
+
+[[audits.embark-studios.audits.thiserror]]
+who = "Johan Andersson <opensource@embark-studios.com>"
+criteria = "safe-to-deploy"
+version = "1.0.40"
+notes = "Wrapper over implementation crate, found no unsafe or ambient capabilities used"
+
+[[audits.embark-studios.audits.thiserror-impl]]
+who = "Johan Andersson <opensource@embark-studios.com>"
+criteria = "safe-to-deploy"
+version = "1.0.40"
+notes = "Found no unsafe or ambient capabilities used"
+
+[[audits.embark-studios.audits.utf8parse]]
+who = "Johan Andersson <opensource@embark-studios.com>"
+criteria = "safe-to-deploy"
+version = "0.2.1"
+notes = "Single unsafe usage that looks sound, no ambient capabilities"
+
+[[audits.embark-studios.audits.vec_map]]
+who = "Johan Andersson <opensource@embark-studios.com>"
+criteria = "safe-to-deploy"
+version = "0.8.2"
+notes = "No unsafe usage or ambient capabilities"
+
+[[audits.google.audits.android_system_properties]]
+who = "Manish Goregaokar <manishearth@google.com>"
+criteria = "safe-to-deploy"
+version = "0.1.5"
+notes = "Android system API FFI"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.ash]]
+who = "David Koloski <dkoloski@google.com>"
+criteria = "safe-to-deploy"
+version = "0.37.0+1.3.209"
+notes = "Reviewed on https://fxrev.dev/694269"
+aggregated-from = "https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/third_party/rust_crates/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.base64]]
+who = "amarjotgill <amarjotgill@google.com>"
+criteria = "safe-to-deploy"
+version = "0.22.1"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.bitflags]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+version = "1.3.2"
+notes = """
+Security review of earlier versions of the crate can be found at
+(Google-internal, sorry): go/image-crate-chromium-security-review
+
+The crate exposes a function marked as `unsafe`, but doesn't use any
+`unsafe` blocks (except for tests of the single `unsafe` function).  I
+think this justifies marking this crate as `ub-risk-1`.
+
+Additional review comments can be found at https://crrev.com/c/4723145/31
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.byteorder]]
+who = "danakj <danakj@chromium.org>"
+criteria = "safe-to-deploy"
+version = "1.5.0"
+notes = "Unsafe review in https://crrev.com/c/5838022"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.color_quant]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-deploy"
+version = "1.1.0"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.core-foundation-sys]]
+who = "Manish Goregaokar <manishearth@google.com>"
+criteria = "safe-to-deploy"
+version = "0.8.7"
+notes = "OSX system APIs"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.core_maths]]
+who = "Manish Goregaokar <manishearth@google.com>"
+criteria = "safe-to-deploy"
+version = "0.1.1"
+notes = "Contains no unsafe"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.either]]
+who = "Manish Goregaokar <manishearth@google.com>"
+criteria = "safe-to-deploy"
+version = "1.13.0"
+notes = "Unsafe code pertaining to wrapping Pin APIs. Mostly passes invariants down."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.either]]
+who = "Daniel Cheng <dcheng@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.13.0 -> 1.14.0"
+notes = """
+Inheriting ub-risk-1 from the baseline review of 1.13.0. While the delta has some diffs in unsafe code, they are either:
+- migrating code to use helper macros
+- migrating match patterns to take advantage of default bindings mode from RFC 2005
+Either way, the result is code that does exactly the same thing and does not change the risk of UB.
+
+See https://crrev.com/c/6323164 for more audit details.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.either]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.14.0 -> 1.15.0"
+notes = 'The delta in `lib.rs` only tweaks doc comments and `#[cfg(feature = "std")]`.'
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.equivalent]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-deploy"
+version = "1.0.1"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.equivalent]]
+who = "Jonathan Hao <phao@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.1 -> 1.0.2"
+notes = "No changes to any .rs files or Rust code."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.fdeflate]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+version = "0.3.4"
+notes = '''
+Grepped for `-i cipher`, `-i crypto`, `'\bfs\b'`, `'\bnet\b'`, `'\bunsafe\b'`
+and there were no hits.
+
+Note that some additional, internal notes about an older version of this crate
+can be found at go/image-crate-chromium-security-review.
+'''
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.fdeflate]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "0.3.4 -> 0.3.5"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.fdeflate]]
+who = "Dustin J. Mitchell <djmitche@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "0.3.5 -> 0.3.6"
+notes = "No unsafe, no crypto, mysterious tables replaced with const expressions"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.fdeflate]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "0.3.6 -> 0.3.7"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.foldhash]]
+who = "Adrian Taylor <adetaylor@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "0.1.3 -> 0.1.4"
+notes = "No changes to safety-relevant code"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.foldhash]]
+who = "Chris Palmer <palmer@google.com>"
+criteria = "safe-to-deploy"
+delta = "0.1.4 -> 0.1.5"
+notes = "No new `unsafe`."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.glob]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-deploy"
+version = "0.3.1"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.heck]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+version = "0.4.1"
+notes = """
+Grepped for `-i cipher`, `-i crypto`, `'\bfs\b'``, `'\bnet\b'``, `'\bunsafe\b'``
+and there were no hits.
+
+`heck` (version `0.3.3`) has been added to Chromium in
+https://source.chromium.org/chromium/chromium/src/+/28841c33c77833cc30b286f9ae24c97e7a8f4057
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.indexmap]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+version = "2.7.1"
+notes = '''
+Grepped for `-i cipher`, `-i crypto`, `'\bfs\b'`, `'\bnet\b'`
+and there were no hits.
+
+There is a little bit of `unsafe` Rust code - the audit can be found at
+https://chromium-review.googlesource.com/c/chromium/src/+/6187726/2
+'''
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.indexmap]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "2.7.1 -> 2.8.0"
+notes = """
+No `unsafe` introduced or affected in:
+* `indexmap_with_default!` and `indexset_with_default!` macros
+* New `PartialEq` implementations
+* `fn slice_eq` in `util.rs`
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.lazy_static]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+version = "1.4.0"
+notes = '''
+I grepped for \"crypt\", \"cipher\", \"fs\", \"net\" - there were no hits.
+
+There are two places where `unsafe` is used.  Unsafe review notes can be found
+in https://crrev.com/c/5347418.
+
+This crate has been added to Chromium in https://crrev.com/c/3321895.
+'''
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.lazy_static]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.4.0 -> 1.5.0"
+notes = "Unsafe review notes: https://crrev.com/c/5650836"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.nom]]
+who = "danakj@chromium.org"
+criteria = "safe-to-deploy"
+version = "7.1.3"
+notes = """
+Reviewed in https://chromium-review.googlesource.com/c/chromium/src/+/5046153
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.num-integer]]
+who = "Manish Goregaokar <manishearth@google.com>"
+criteria = "safe-to-deploy"
+version = "0.1.46"
+notes = "Contains no unsafe"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.num-rational]]
+who = "Manish Goregaokar <manishearth@google.com>"
+criteria = "safe-to-deploy"
+version = "0.4.2"
+notes = "Contains no unsafe"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.openssl-macros]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-deploy"
+delta = "0.1.0 -> 0.1.1"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+version = "1.0.78"
+notes = """
+Grepped for "crypt", "cipher", "fs", "net" - there were no hits
+(except for a benign "fs" hit in a doc comment)
+
+Notes from the `unsafe` review can be found in https://crrev.com/c/5385745.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "Adrian Taylor <adetaylor@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.78 -> 1.0.79"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "Adrian Taylor <adetaylor@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.79 -> 1.0.80"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "Dustin J. Mitchell <djmitche@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.80 -> 1.0.81"
+notes = "Comment changes only"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "danakj <danakj@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.81 -> 1.0.82"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "Dustin J. Mitchell <djmitche@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.82 -> 1.0.83"
+notes = "Substantive change is replacing String with Box<str>, saving memory."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.83 -> 1.0.84"
+notes = "Only doc comment changes in `src/lib.rs`."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "danakj@chromium.org"
+criteria = "safe-to-deploy"
+delta = "1.0.84 -> 1.0.85"
+notes = "Test-only changes."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.85 -> 1.0.86"
+notes = """
+Comment-only changes in `build.rs`.
+Reordering of `Cargo.toml` entries.
+Just bumping up the version number in `lib.rs`.
+Config-related changes in `test_size.rs`.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "danakj <danakj@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.86 -> 1.0.87"
+notes = "No new unsafe interactions."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "Liza Burakova <liza@chromium.org"
+criteria = "safe-to-deploy"
+delta = "1.0.87 -> 1.0.89"
+notes = """
+Biggest change is adding error handling in build.rs.
+Some config related changes in wrapper.rs.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.89 -> 1.0.92"
+notes = """
+I looked at the delta and the previous discussion at
+https://chromium-review.googlesource.com/c/chromium/src/+/5385745/3#message-a8e2813129fa3779dab15acede408ee26d67b7f3
+and the changes look okay to me (including the `unsafe fn from_str_unchecked`
+changes in `wrapper.rs`).
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.92 -> 1.0.93"
+notes = "No `unsafe`-related changes."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "Daniel Cheng <dcheng@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.93 -> 1.0.94"
+notes = "Minor doc changes and clippy lint adjustments+fixes."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.rand_chacha]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+version = "0.3.1"
+notes = """
+For more detailed unsafe review notes please see https://crrev.com/c/6362797
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.rand_chacha]]
+who = "Android Legacy"
+criteria = "safe-to-run"
+version = "0.3.1"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.rand_core]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+version = "0.6.4"
+notes = """
+For more detailed unsafe review notes please see https://crrev.com/c/6362797
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.rand_core]]
+who = "Android Legacy"
+criteria = "safe-to-run"
+version = "0.6.4"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+version = "1.0.197"
+notes = """
+Grepped for `-i cipher`, `-i crypto`, `'\bfs\b'`, `'\bnet\b'`, `'\bunsafe\b'`.
+
+There were some hits for `net`, but they were related to serialization and
+not actually opening any connections or anything like that.
+
+There were 2 hits of `unsafe` when grepping:
+* In `fn as_str` in `impl Buf`
+* In `fn serialize` in `impl Serialize for net::Ipv4Addr`
+
+Unsafe review comments can be found in https://crrev.com/c/5350573/2 (this
+review also covered `serde_json_lenient`).
+
+Version 1.0.130 of the crate has been added to Chromium in
+https://crrev.com/c/3265545.  The CL description contains a link to a
+(Google-internal, sorry) document with a mini security review.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde]]
+who = "Dustin J. Mitchell <djmitche@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.197 -> 1.0.198"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde]]
+who = "danakj <danakj@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.198 -> 1.0.201"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde]]
+who = "Dustin J. Mitchell <djmitche@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.201 -> 1.0.202"
+notes = "Trivial changes"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.202 -> 1.0.203"
+notes = "s/doc_cfg/docsrs/ + tuple_impls/tuple_impl_body-related changes"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde]]
+who = "Adrian Taylor <adetaylor@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.203 -> 1.0.204"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.204 -> 1.0.207"
+notes = "The small change in `src/private/ser.rs` should have no impact on `ub-risk-2`."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.207 -> 1.0.209"
+notes = """
+The delta carries fairly small changes in `src/private/de.rs` and
+`src/private/ser.rs` (see https://crrev.com/c/5812194/2..5).  AFAICT the
+delta has no impact on the `unsafe`, `from_utf8_unchecked`-related parts
+of the crate (in `src/de/format.rs` and `src/ser/impls.rs`).
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde]]
+who = "Adrian Taylor <adetaylor@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.209 -> 1.0.210"
+notes = "Almost no new code - just feature rearrangement"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde]]
+who = "Liza Burakova <liza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.210 -> 1.0.213"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde]]
+who = "Dustin J. Mitchell <djmitche@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.213 -> 1.0.214"
+notes = "No unsafe, no crypto"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde]]
+who = "Adrian Taylor <adetaylor@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.214 -> 1.0.215"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.215 -> 1.0.216"
+notes = "The delta makes minor changes in `build.rs` - switching to the `?` syntax sugar."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde]]
+who = "Dustin J. Mitchell <djmitche@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.216 -> 1.0.217"
+notes = "Minimal changes, nothing unsafe"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde]]
+who = "Daniel Cheng <dcheng@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.217 -> 1.0.218"
+notes = "No changes outside comments and documentation."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.218 -> 1.0.219"
+notes = "Just allowing `clippy::elidable_lifetime_names`."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde_derive]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+version = "1.0.197"
+notes = 'Grepped for "unsafe", "crypt", "cipher", "fs", "net" - there were no hits'
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde_derive]]
+who = "danakj <danakj@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.197 -> 1.0.201"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde_derive]]
+who = "Dustin J. Mitchell <djmitche@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.201 -> 1.0.202"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde_derive]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.202 -> 1.0.203"
+notes = 'Grepped for "unsafe", "crypt", "cipher", "fs", "net" - there were no hits'
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde_derive]]
+who = "Adrian Taylor <adetaylor@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.203 -> 1.0.204"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde_derive]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.204 -> 1.0.207"
+notes = 'Grepped for \"unsafe\", \"crypt\", \"cipher\", \"fs\", \"net\" - there were no hits'
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde_derive]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.207 -> 1.0.209"
+notes = '''
+There are no code changes in this delta - see https://crrev.com/c/5812194/2..5
+
+I've neverthless also grepped for `-i cipher`, `-i crypto`, `\bfs\b`,
+`\bnet\b`, and `\bunsafe\b`.  There were no hits.
+'''
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde_derive]]
+who = "Adrian Taylor <adetaylor@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.209 -> 1.0.210"
+notes = "Almost no new code - just feature rearrangement"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde_derive]]
+who = "Liza Burakova <liza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.210 -> 1.0.213"
+notes = "Grepped for 'unsafe', 'crypt', 'cipher', 'fs', 'net' - there were no hits"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde_derive]]
+who = "Dustin J. Mitchell <djmitche@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.213 -> 1.0.214"
+notes = "No changes to unsafe, no crypto"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde_derive]]
+who = "Adrian Taylor <adetaylor@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.214 -> 1.0.215"
+notes = "Minor changes should not impact UB risk"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde_derive]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.215 -> 1.0.216"
+notes = "The delta adds `#[automatically_derived]` in a few places.  Still no `unsafe`."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde_derive]]
+who = "Dustin J. Mitchell <djmitche@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.216 -> 1.0.217"
+notes = "No changes"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde_derive]]
+who = "Daniel Cheng <dcheng@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.217 -> 1.0.218"
+notes = "No changes outside comments and documentation."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde_derive]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.218 -> 1.0.219"
+notes = "Minor changes (clippy tweaks, using `mem::take` instead of `mem::replace`)."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.smallvec]]
+who = "Manish Goregaokar <manishearth@google.com>"
+criteria = "safe-to-deploy"
+version = "1.13.2"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.strsim]]
+who = "danakj@chromium.org"
+criteria = "safe-to-deploy"
+version = "0.10.0"
+notes = """
+Reviewed in https://crrev.com/c/5171063
+
+Previously reviewed during security review and the audit is grandparented in.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.strum]]
+who = "danakj@chromium.org"
+criteria = "safe-to-deploy"
+version = "0.25.0"
+notes = """
+Reviewed in https://crrev.com/c/5171063
+
+Previously reviewed during security review and the audit is grandparented in.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.strum_macros]]
+who = "danakj@chromium.org"
+criteria = "safe-to-deploy"
+version = "0.25.3"
+notes = """
+Reviewed in https://crrev.com/c/5171063
+
+Previously reviewed during security review and the audit is grandparented in.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.synstructure]]
+who = "Manish Goregaokar <manishearth@google.com>"
+criteria = "safe-to-deploy"
+version = "0.13.1"
+notes = "Exposes unsafe codegen APIs but does not itself contain unsafe"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.unicode-bidi]]
+who = "Manish Goregaokar <manishearth@google.com>"
+criteria = "safe-to-deploy"
+version = "0.3.18"
+notes = "Contains one line of repr(transparent) unsafe"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.write16]]
+who = "Manish Goregaokar <manishearth@google.com>"
+criteria = "safe-to-deploy"
+version = "1.0.0"
+notes = "No unsafe code."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.isrg.audits.base64]]
+who = "Tim Geoghegan <timg@letsencrypt.org>"
+criteria = "safe-to-deploy"
+delta = "0.21.0 -> 0.21.1"
+
+[[audits.isrg.audits.base64]]
+who = "Brandon Pitman <bran@bran.land>"
+criteria = "safe-to-deploy"
+delta = "0.21.1 -> 0.21.2"
+
+[[audits.isrg.audits.base64]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "0.21.2 -> 0.21.3"
+
+[[audits.isrg.audits.block-buffer]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+version = "0.9.0"
+
+[[audits.isrg.audits.cfg-if]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.0 -> 1.0.1"
+
+[[audits.isrg.audits.cfg-if]]
+who = "J.C. Jones <jc@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.1 -> 1.0.3"
+
+[[audits.isrg.audits.cfg-if]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.3 -> 1.0.4"
+
+[[audits.isrg.audits.cpufeatures]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "0.2.17 -> 0.3.0"
+
+[[audits.isrg.audits.fiat-crypto]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+version = "0.1.17"
+notes = """
+This crate does not contain any unsafe code, and does not use any items from
+the standard library or other crates, aside from operations backed by
+`std::ops`. All paths with array indexing use integer literals for indexes, so
+there are no panics due to indexes out of bounds (as rustc would catch an
+out-of-bounds literal index). I did not check whether arithmetic overflows
+could cause a panic, and I am relying on the Coq code having satisfied the
+necessary preconditions to ensure panics due to overflows are unreachable.
+"""
+
+[[audits.isrg.audits.fiat-crypto]]
+who = "Brandon Pitman <bran@bran.land>"
+criteria = "safe-to-deploy"
+delta = "0.1.17 -> 0.1.18"
+
+[[audits.isrg.audits.fiat-crypto]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "0.1.18 -> 0.1.19"
+notes = """
+This release renames many items and adds a new module. The code in the new
+module is entirely composed of arithmetic and array accesses.
+"""
+
+[[audits.isrg.audits.fiat-crypto]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "0.1.19 -> 0.1.20"
+
+[[audits.isrg.audits.fiat-crypto]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "0.1.20 -> 0.2.0"
+
+[[audits.isrg.audits.fiat-crypto]]
+who = "Brandon Pitman <bran@bran.land>"
+criteria = "safe-to-deploy"
+delta = "0.2.0 -> 0.2.1"
+
+[[audits.isrg.audits.fiat-crypto]]
+who = "Tim Geoghegan <timg@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "0.2.1 -> 0.2.2"
+notes = "No changes to `unsafe` code, or any functional changes that I can detect at all."
+
+[[audits.isrg.audits.fiat-crypto]]
+who = "Brandon Pitman <bran@bran.land>"
+criteria = "safe-to-deploy"
+delta = "0.2.2 -> 0.2.4"
+
+[[audits.isrg.audits.fiat-crypto]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "0.2.4 -> 0.2.5"
+
+[[audits.isrg.audits.fiat-crypto]]
+who = "Brandon Pitman <bran@bran.land>"
+criteria = "safe-to-deploy"
+delta = "0.2.5 -> 0.2.6"
+
+[[audits.isrg.audits.fiat-crypto]]
+who = "Brandon Pitman <bran@bran.land>"
+criteria = "safe-to-deploy"
+delta = "0.2.6 -> 0.2.7"
+
+[[audits.isrg.audits.fiat-crypto]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "0.2.7 -> 0.2.8"
+
+[[audits.isrg.audits.fiat-crypto]]
+who = "Tim Geoghegan <timg@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "0.2.8 -> 0.2.9"
+notes = "No changes to Rust code between 0.2.8 and 0.2.9"
+
+[[audits.isrg.audits.hmac]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+version = "0.12.1"
+
+[[audits.isrg.audits.inout]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "0.1.4 -> 0.2.2"
+
+[[audits.isrg.audits.opaque-debug]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+version = "0.3.0"
+
+[[audits.isrg.audits.rand_chacha]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "0.3.1 -> 0.9.0"
+
+[[audits.isrg.audits.rand_core]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "0.6.4 -> 0.9.3"
+
+[[audits.isrg.audits.rand_core]]
+who = "J.C. Jones <jc@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "0.9.3 -> 0.9.5"
+
+[[audits.isrg.audits.rayon-core]]
+who = "Ameer Ghani <inahga@divviup.org>"
+criteria = "safe-to-deploy"
+version = "1.12.1"
+
+[[audits.isrg.audits.rayon-core]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "1.12.1 -> 1.13.0"
+
+[[audits.isrg.audits.serde]]
+who = "J.C. Jones <jc@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.219 -> 1.0.224"
+
+[[audits.isrg.audits.serde]]
+who = "J.C. Jones <jc@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.224 -> 1.0.225"
+
+[[audits.isrg.audits.serde]]
+who = "Tim Geoghegan <timg@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.225 -> 1.0.226"
+
+[[audits.isrg.audits.serde_core]]
+who = "J.C. Jones <jc@divviup.org>"
+criteria = "safe-to-deploy"
+version = "1.0.224"
+
+[[audits.isrg.audits.serde_core]]
+who = "J.C. Jones <jc@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.224 -> 1.0.225"
+
+[[audits.isrg.audits.serde_core]]
+who = "Tim Geoghegan <timg@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.225 -> 1.0.226"
+
+[[audits.isrg.audits.serde_derive]]
+who = "J.C. Jones <jc@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.219 -> 1.0.224"
+
+[[audits.isrg.audits.serde_derive]]
+who = "J.C. Jones <jc@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.224 -> 1.0.225"
+
+[[audits.isrg.audits.serde_derive]]
+who = "Tim Geoghegan <timg@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.225 -> 1.0.226"
+
+[[audits.isrg.audits.sha2]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+version = "0.10.2"
+
+[[audits.isrg.audits.sha2]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "0.10.8 -> 0.10.9"
+
+[[audits.isrg.audits.subtle]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "2.5.0 -> 2.6.1"
+
+[[audits.isrg.audits.thiserror]]
+who = "Brandon Pitman <bran@bran.land>"
+criteria = "safe-to-deploy"
+delta = "1.0.40 -> 1.0.43"
+
+[[audits.isrg.audits.thiserror-impl]]
+who = "Brandon Pitman <bran@bran.land>"
+criteria = "safe-to-deploy"
+delta = "1.0.40 -> 1.0.43"
+
+[[audits.isrg.audits.universal-hash]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+version = "0.4.1"
+
+[[audits.isrg.audits.universal-hash]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "0.5.0 -> 0.5.1"
+
+[[audits.mozilla.wildcard-audits.cexpr]]
+who = "Emilio Cobos Álvarez <emilio@crisal.io>"
+criteria = "safe-to-deploy"
+user-id = 3788 # Emilio Cobos Álvarez (emilio)
+start = "2021-06-21"
+end = "2024-04-21"
+notes = "No unsafe code, rather straight-forward parser."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.wildcard-audits.cocoa]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 2396 # Josh Matthews (jdm)
+start = "2019-07-23"
+end = "2023-05-04"
+renew = false
+notes = "I've reviewed every source contribution that was neither authored nor reviewed by Mozilla."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.wildcard-audits.core-foundation]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 2396 # Josh Matthews (jdm)
+start = "2019-11-12"
+end = "2023-05-04"
+renew = false
+notes = "I've reviewed every source contribution that was neither authored nor reviewed by Mozilla."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.wildcard-audits.core-foundation]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 5946 # Jeff Muizelaar (jrmuizel)
+start = "2019-03-29"
+end = "2023-05-04"
+renew = false
+notes = "I've reviewed every source contribution that was neither authored nor reviewed by Mozilla."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.wildcard-audits.core-foundation-sys]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 2396 # Josh Matthews (jdm)
+start = "2019-11-12"
+end = "2023-05-04"
+renew = false
+notes = "I've reviewed every source contribution that was neither authored nor reviewed by Mozilla."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.wildcard-audits.core-graphics]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 2396 # Josh Matthews (jdm)
+start = "2019-10-28"
+end = "2023-05-04"
+renew = false
+notes = "I've reviewed every source contribution that was neither authored nor reviewed by Mozilla."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.wildcard-audits.core-graphics-types]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 2396 # Josh Matthews (jdm)
+start = "2020-07-20"
+end = "2023-05-04"
+renew = false
+notes = "I've reviewed every source contribution that was neither authored nor reviewed by Mozilla."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.wildcard-audits.core-text]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 5946 # Jeff Muizelaar (jrmuizel)
+start = "2021-02-14"
+end = "2023-05-04"
+renew = false
+notes = "I've reviewed every source contribution that was neither authored nor reviewed by Mozilla."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.wildcard-audits.encoding_rs]]
+who = "Henri Sivonen <hsivonen@hsivonen.fi>"
+criteria = "safe-to-deploy"
+user-id = 4484 # Henri Sivonen (hsivonen)
+start = "2019-02-26"
+end = "2025-10-23"
+notes = "I, Henri Sivonen, wrote encoding_rs for Gecko and have reviewed contributions by others. There are two caveats to the certification: 1) The crate does things that are documented to be UB but that do not appear to actually be UB due to integer types differing from the general rule; https://github.com/hsivonen/encoding_rs/issues/79 . 2) It would be prudent to re-review the code that reinterprets buffers of integers as SIMD vectors; see https://github.com/hsivonen/encoding_rs/issues/87 ."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.wildcard-audits.etagere]]
+who = "Nicolas Silva <nical@fastmail.com>"
+criteria = "safe-to-deploy"
+user-id = 1281 # Nicolas Silva (nical)
+start = "2020-11-12"
+end = "2027-04-23"
+notes = "I am the author of this crate."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.wildcard-audits.euclid]]
+who = "Nicolas Silva <nical@fastmail.com>"
+criteria = "safe-to-deploy"
+user-id = 1281 # Nicolas Silva (nical)
+start = "2019-03-14"
+end = "2027-01-15"
+notes = "I wrote most of the commits in the euclid reprository and review every change that is not produced by me."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.wildcard-audits.unicode-normalization]]
+who = "Manish Goregaokar <manishsmail@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 1139 # Manish Goregaokar (Manishearth)
+start = "2019-11-06"
+end = "2027-04-23"
+notes = "All code written or reviewed by Manish"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.wildcard-audits.unicode-segmentation]]
+who = "Manish Goregaokar <manishsmail@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 1139 # Manish Goregaokar (Manishearth)
+start = "2019-05-15"
+end = "2027-04-23"
+notes = "All code written or reviewed by Manish"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.wildcard-audits.unicode-width]]
+who = "Manish Goregaokar <manishsmail@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 1139 # Manish Goregaokar (Manishearth)
+start = "2019-12-05"
+end = "2026-02-01"
+notes = "All code written or reviewed by Manish"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.wildcard-audits.unicode-xid]]
+who = "Manish Goregaokar <manishsmail@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 1139 # Manish Goregaokar (Manishearth)
+start = "2019-07-25"
+end = "2027-04-23"
+notes = "All code written or reviewed by Manish"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.wildcard-audits.utf8_iter]]
+who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
+criteria = "safe-to-deploy"
+user-id = 4484 # Henri Sivonen (hsivonen)
+start = "2022-04-19"
+end = "2024-06-16"
+notes = "Maintained by Henri Sivonen who works at Mozilla."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.adler2]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "2.0.0 -> 2.0.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.anyhow]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.57 -> 1.0.61"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.anyhow]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.58 -> 1.0.57"
+notes = "No functional differences, just CI config and docs."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.anyhow]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.61 -> 1.0.62"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.anyhow]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.62 -> 1.0.68"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.anyhow]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.68 -> 1.0.69"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.anyhow]]
+who = "Jan-Erik Rediger <jrediger@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.71 -> 1.0.95"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.anyhow]]
+who = "Jan-Erik Rediger <jrediger@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.95 -> 1.0.103"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.app_units]]
+who = "Nicolas Silva <nical@fastmail.com>"
+criteria = "safe-to-deploy"
+version = "0.7.3"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.app_units]]
+who = "Emilio Cobos Álvarez <emilio@crisal.io>"
+criteria = "safe-to-deploy"
+delta = "0.7.3 -> 0.7.8"
+notes = "Relatively minor changes, no unsafety, only minor rounding API additions, malloc-size-of integration, tests, and formatting."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.ash]]
+who = "Jim Blandy <jimb@red-bean.com>"
+criteria = "safe-to-deploy"
+delta = "0.37.0+1.3.209 -> 0.37.1+1.3.235"
+notes = """
+Nicolas Silva, Jim Blandy, and Teodor Tanasoaia audited ash master
+branch commits from e43e9c0c to 6bd82768 inclusive.
+"""
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.ash]]
+who = "Nicolas Silva <nical@fastmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.37.1+1.3.235 -> 0.37.2+1.3.238"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.ash]]
+who = "Teodor Tanasoaia <ttanasoaia@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.37.2+1.3.238 -> 0.37.3+1.3.251"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.ash]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.37.3+1.3.251 -> 0.38.0+1.3.281"
+notes = """
+There are many sweeping changes to code generation that make this review intimidating, at first.
+However, I have audited all hand-written code, and vetted changes to the code generator (with some
+auditing of generated output to ensure correspondence to my mental model). Vulkan is an inherently
+unsafe API, but this crate makes many of the preparatory steps for calling Vulkan APIs safer and
+easier to use.
+"""
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.bindgen]]
+who = "Emilio Cobos Álvarez <emilio@crisal.io>"
+criteria = "safe-to-deploy"
+version = "0.59.2"
+notes = "I'm the primary author and maintainer of the crate."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.bindgen]]
+who = "Emilio Cobos Álvarez <emilio@crisal.io>"
+criteria = "safe-to-deploy"
+delta = "0.59.2 -> 0.63.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.bindgen]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.63.0 -> 0.64.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.bindgen]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.64.0 -> 0.66.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.bindgen]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.66.1 -> 0.68.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.bindgen]]
+who = "Andreas Pehrson <apehrson@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.68.1 -> 0.69.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.bindgen]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.69.1 -> 0.69.2"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.bindgen]]
+who = "Emilio Cobos Álvarez <emilio@crisal.io>"
+criteria = "safe-to-deploy"
+delta = "0.69.2 -> 0.69.4"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.bindgen]]
+who = "Emilio Cobos Álvarez <emilio@crisal.io>"
+criteria = "safe-to-deploy"
+delta = "0.69.4 -> 0.72.0"
+notes = "I'm the primary maintainer of this crate."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.bit-set]]
+who = "Aria Beingessner <a.beingessner@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.5.2"
+notes = "Another crate I own via contain-rs that is ancient and maintenance mode, no known issues."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.bit-set]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.5.2 -> 0.5.3"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.bit-vec]]
+who = "Aria Beingessner <a.beingessner@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.6.3"
+notes = "Another crate I own via contain-rs that is ancient and in maintenance mode but otherwise perfectly fine."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.block-buffer]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.10.2 -> 0.10.3"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.block2]]
+who = "Andy Leiserson <aleiserson@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.6.2"
+notes = "Contains unsafe code to interoperate with the ObjC runtime."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.cfg_aliases]]
+who = "Alex Franchuk <afranchuk@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.1.1 -> 0.2.1"
+notes = "Very minor changes."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.cfg_aliases]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.2.1 -> 0.2.2"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.cgl]]
+who = "Sotaro Ikeda <sotaro.ikeda.g@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.3.2"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.core-foundation]]
+who = "Teodor Tanasoaia <ttanasoaia@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.9.3 -> 0.9.4"
+notes = "I've reviewed every source contribution that was neither authored nor reviewed by Mozilla."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.core-graphics-types]]
+who = "Teodor Tanasoaia <ttanasoaia@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.1.1 -> 0.1.2"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.core-graphics-types]]
+who = "Teodor Tanasoaia <ttanasoaia@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.1.2 -> 0.1.3"
+notes = "I've reviewed every source contribution that was neither authored nor reviewed by Mozilla."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.core-graphics-types]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.1.3 -> 0.2.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.core-text]]
+who = "Teodor Tanasoaia <ttanasoaia@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "19.2.0 -> 20.0.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.core-text]]
+who = "Jonathan Kew <jfkthame@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "20.0.0 -> 20.1.0"
+notes = """
+The bulk of the 20.0.0 -> 20.1.0 changes were purely cosmetic clippy and rustfmt changes.
+
+The only substantive change was the addition of wrappers to expose two additional Core Text APIs,
+the variants of CTFontCreateWithName and CTFontCreateWithFontDescriptor that accept a CTFontOptions
+parameter. These are directly parallel to the existing versions without CTFontOptions, and do not
+introduce any new forms of risk.
+"""
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.crunchy]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.2.3"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.deranged]]
+who = "Alex Franchuk <afranchuk@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.3.11"
+notes = """
+This crate contains a decent bit of `unsafe` code, however all internal
+unsafety is verified with copious assertions (many are compile-time), and
+otherwise the unsafety is documented and left to the caller to verify.
+"""
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.deranged]]
+who = "Lars Eggert <lars@eggert.org>"
+criteria = "safe-to-deploy"
+delta = "0.3.11 -> 0.4.0"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.deranged]]
+who = "Lars Eggert <lars@eggert.org>"
+criteria = "safe-to-deploy"
+delta = "0.4.0 -> 0.5.8"
+notes = "New unsafe code is properly guarded"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.document-features]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.2.8"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.document-features]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.2.8 -> 0.2.9"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.document-features]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.2.9 -> 0.2.10"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.document-features]]
+who = "Teodor Tanasoaia <ttanasoaia@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.2.10 -> 0.2.11"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.either]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "1.15.0 -> 1.16.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.errno]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.3.1 -> 0.3.3"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.fallible-iterator]]
+who = "Jan-Erik Rediger <jrediger@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.2.0"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.fluent]]
+who = "Zibi Braniecki <zibi@unicode.org>"
+criteria = "safe-to-deploy"
+version = "0.16.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.fluent]]
+who = "Nika Layzell <nika@thelayzells.com>"
+criteria = "safe-to-deploy"
+delta = "0.16.0 -> 0.17.0"
+notes = "Style and dependency changes"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.fluent-bundle]]
+who = "Zibi Braniecki <zibi@unicode.org>"
+criteria = "safe-to-deploy"
+version = "0.15.2"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.fluent-bundle]]
+who = "Nika Layzell <nika@thelayzells.com>"
+criteria = "safe-to-deploy"
+delta = "0.15.2 -> 0.16.0"
+notes = "Added support for NUMBER. Style and dependency changes."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.fluent-langneg]]
+who = "Zibi Braniecki <zibi@unicode.org>"
+criteria = "safe-to-deploy"
+version = "0.13.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.fluent-syntax]]
+who = "Zibi Braniecki <zibi@unicode.org>"
+criteria = "safe-to-deploy"
+version = "0.11.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.fluent-syntax]]
+who = "Nika Layzell <nika@thelayzells.com>"
+criteria = "safe-to-deploy"
+delta = "0.11.0 -> 0.12.0"
+notes = "New serializer module does not use unsafe"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.fnv]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+version = "1.0.7"
+notes = "Simple hasher implementation with no unsafe code."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.foldhash]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.1.5 -> 0.2.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.foreign-types]]
+who = "Teodor Tanasoaia <ttanasoaia@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.3.2 -> 0.5.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.foreign-types-macros]]
+who = "Teodor Tanasoaia <ttanasoaia@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.2.3"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.foreign-types-shared]]
+who = "Teodor Tanasoaia <ttanasoaia@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.1.1 -> 0.3.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.form_urlencoded]]
+who = "Valentin Gosu <valentin.gosu@gmail.com>"
+criteria = "safe-to-deploy"
+version = "1.2.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.form_urlencoded]]
+who = "Valentin Gosu <valentin.gosu@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "1.2.0 -> 1.2.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.form_urlencoded]]
+who = "edgul <ed.guloien@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "1.2.1 -> 1.2.2"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.fxhash]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.2.1"
+notes = "Straightforward crate with no unsafe code, does what it says on the tin."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.gimli]]
+who = "Alex Franchuk <afranchuk@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.30.0"
+notes = """
+Unsafe code blocks are sound. Minimal dependencies used. No use of
+side-effectful std functions.
+"""
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.gimli]]
+who = "Chris Martin <cmartin@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.30.0 -> 0.29.0"
+notes = "No unsafe code, mostly algorithms and parsing. Very unlikely to cause security issues."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.glob]]
+who = "Ben Dean-Kawamura <bdk@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.3.1 -> 0.3.3"
+notes = "Very few changes.  No new unsafe code."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.hashbrown]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.16.1 -> 0.17.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.hashbrown]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.17.0 -> 0.17.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.hex]]
+who = "Simon Friedberger <simon@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.4.3"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.idna]]
+who = "Valentin Gosu <valentin.gosu@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.4.0 -> 0.5.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.idna]]
+who = "Henri Sivonen <hsivonen@hsivonen.fi>"
+criteria = "safe-to-deploy"
+delta = "0.5.0 -> 1.0.2"
+notes = "In the 0.5.0 to 1.0.2 delta, I, Henri Sivonen, rewrote the non-Punycode internals of the crate and made the changes to the Punycode code."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.idna]]
+who = "Valentin Gosu <valentin.gosu@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.2 -> 1.0.3"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.idna]]
+who = "edgul <ed.guloien@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.3 -> 1.1.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.indexmap]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "2.8.0 -> 2.11.4"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.indexmap]]
+who = "Ben Dean-Kawamura <bdk@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "2.11.4 -> 2.14.0"
+notes = "Mostly internal refactorings.  No new unsafe code."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.intl-memoizer]]
+who = "Zibi Braniecki <zibi@unicode.org>"
+criteria = "safe-to-deploy"
+version = "0.5.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.intl-memoizer]]
+who = "Lars Eggert <lars@eggert.org>"
+criteria = "safe-to-deploy"
+delta = "0.5.1 -> 0.5.3"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.intl_pluralrules]]
+who = "Zibi Braniecki <zibi@unicode.org>"
+criteria = "safe-to-deploy"
+version = "7.0.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.intl_pluralrules]]
+who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
+criteria = "safe-to-deploy"
+delta = "7.0.1 -> 7.0.2"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.is-docker]]
+who = "Nika Layzell <nika@thelayzells.com>"
+criteria = "safe-to-deploy"
+version = "0.2.0"
+notes = "Fairly straightforward checking of /.dockerenv and /proc/self/cgroup"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/cargo-vet/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.is-wsl]]
+who = "Nika Layzell <nika@thelayzells.com>"
+criteria = "safe-to-deploy"
+version = "0.4.0"
+notes = 'Straightforward checking of procfs for the string "microsoft"'
+aggregated-from = "https://raw.githubusercontent.com/mozilla/cargo-vet/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.malloc_buf]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.0.6"
+notes = """
+Very small crate for managing malloc-ed buffers, primarily for use in the objc crate.
+There is an edge-case condition that passes slice::from_raw_parts(0x1, 0) which I'm
+not entirely certain is technically sound, but in either case I am reasonably confident
+it's not exploitable.
+"""
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.num-conv]]
+who = "Alex Franchuk <afranchuk@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.1.0"
+notes = """
+Very straightforward, simple crate. No dependencies, unsafe, extern,
+side-effectful std functions, etc.
+"""
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.num-conv]]
+who = "Lars Eggert <lars@eggert.org>"
+criteria = "safe-to-deploy"
+delta = "0.1.0 -> 0.2.0"
+notes = "Revision only removes code"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.num-derive]]
+who = "Josh Stone <jistone@redhat.com>"
+criteria = "safe-to-deploy"
+version = "0.3.3"
+notes = "All code written or reviewed by Josh Stone."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.num-derive]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.3.3 -> 0.4.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.num-derive]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.4.0 -> 0.4.2"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.objc2-core-foundation]]
+who = "Andy Leiserson <aleiserson@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.3.2"
+notes = """
+Contains substantial unsafe code, as is typical for FFI.
+
+The (non-published) `header-translator` crate that produces generated bindings
+in this crate was also reviewed, in lieu of a full review of the generated
+bindings.
+
+Users of this crate should be aware of the information in
+https://github.com/madsmtm/objc2/blob/main/crates/objc2/src/topics/frameworks_soundness.md.
+"""
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.objc2-core-graphics]]
+who = "Andy Leiserson <aleiserson@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.3.2"
+notes = """
+Contains substantial unsafe code, as is typical for FFI.
+
+The (non-published) `header-translator` crate that produces generated bindings
+in this crate was also reviewed, in lieu of a full review of the generated
+bindings.
+
+Users of this crate should be aware of the information in
+https://github.com/madsmtm/objc2/blob/main/crates/objc2/src/topics/frameworks_soundness.md.
+"""
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.objc2-encode]]
+who = "Andy Leiserson <aleiserson@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "4.1.0"
+notes = "Support library for objc2 with no unsafe code"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.objc2-foundation]]
+who = "Andy Leiserson <aleiserson@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.3.2"
+notes = """
+Contains substantial unsafe code, as is typical for FFI.
+
+The (non-published) `header-translator` crate that produces generated bindings
+in this crate was also reviewed, in lieu of a full review of the generated
+bindings.
+
+Users of this crate should be aware of the information in
+https://github.com/madsmtm/objc2/blob/main/crates/objc2/src/topics/frameworks_soundness.md.
+"""
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.objc2-io-surface]]
+who = "Andy Leiserson <aleiserson@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.3.2"
+notes = """
+Contains substantial unsafe code, as is typical for FFI.
+
+The (non-published) `header-translator` crate that produces generated bindings
+in this crate was also reviewed, in lieu of a full review of the generated
+bindings.
+
+Users of this crate should be aware of the information in
+https://github.com/madsmtm/objc2/blob/main/crates/objc2/src/topics/frameworks_soundness.md.
+"""
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.objc2-quartz-core]]
+who = "Andy Leiserson <aleiserson@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.3.2"
+notes = """
+Contains substantial unsafe code, as is typical for FFI.
+
+The (non-published) `header-translator` crate that produces generated bindings
+in this crate was also reviewed, in lieu of a full review of the generated
+bindings.
+
+Users of this crate should be aware of the information in
+https://github.com/madsmtm/objc2/blob/main/crates/objc2/src/topics/frameworks_soundness.md.
+"""
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.option-ext]]
+who = "Nika Layzell <nika@thelayzells.com>"
+criteria = "safe-to-deploy"
+version = "0.2.0"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/cargo-vet/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.peeking_take_while]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.0 -> 0.1.2"
+notes = "Small refactor of some simple iterator logic, no unsafe code or capabilities."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.percent-encoding]]
+who = "Valentin Gosu <valentin.gosu@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "2.2.0 -> 2.3.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.percent-encoding]]
+who = "Valentin Gosu <valentin.gosu@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "2.3.0 -> 2.3.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.percent-encoding]]
+who = "edgul <ed.guloien@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "2.3.1 -> 2.3.2"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.plane-split]]
+who = "Nicolas Silva <nical@fastmail.com>"
+criteria = "safe-to-deploy"
+version = "0.18.0"
+notes = "Mozilla-developed package, no unsafe code, no access to file system, network or other far reaching APIs."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.powerfmt]]
+who = "Alex Franchuk <afranchuk@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.2.0"
+notes = """
+A tiny bit of unsafe code to implement functionality that isn't in stable rust
+yet, but it's all valid. Otherwise it's a pretty simple crate.
+"""
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.proc-macro2]]
+who = "Jan-Erik Rediger <jrediger@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.94 -> 1.0.106"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.rustc-hash]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+version = "1.1.0"
+notes = "Straightforward crate with no unsafe code, does what it says on the tin."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.rustc_version]]
+who = "Nika Layzell <nika@thelayzells.com>"
+criteria = "safe-to-deploy"
+version = "0.4.0"
+notes = """
+Use of powerful capabilities is limited to invoking `rustc -vV` to get version
+information for parsing version information.
+"""
+aggregated-from = "https://raw.githubusercontent.com/mozilla/cargo-vet/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.semver]]
+who = "Ben Dean-Kawamura <bdk@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.16 -> 1.0.28"
+notes = "Very few changes, mostly removes support for older Rust versions.  Some unsafe code refactored, but it seemed to be functionally equivalent to me."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.semver]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.17 -> 1.0.16"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.serde]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.226 -> 1.0.227"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.serde]]
+who = "Jan-Erik Rediger <jrediger@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.227 -> 1.0.228"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.serde-value]]
+who = "Nika Layzell <nika@thelayzells.com>"
+criteria = "safe-to-deploy"
+version = "0.7.0"
+notes = "Basic implementation of a serde value type. No use of unsafe code."
+aggregated-from = "https://raw.githubusercontent.com/mozilla/cargo-vet/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.serde_core]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.226 -> 1.0.227"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.serde_core]]
+who = "Jan-Erik Rediger <jrediger@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.227 -> 1.0.228"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.serde_derive]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.226 -> 1.0.227"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.serde_derive]]
+who = "Jan-Erik Rediger <jrediger@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.227 -> 1.0.228"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.serde_spanned]]
+who = "Ben Dean-Kawamura <bdk@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "1.0.3"
+notes = "Relatively simple Serde trait implementations.  No IO or unsafe code."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.serde_spanned]]
+who = "Ben Dean-Kawamura <bdk@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.3 -> 1.1.1"
+notes = "No code changes, just dependency updates."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.sha2]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.10.2 -> 0.10.6"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.sha2]]
+who = "Jeff Muizelaar <jmuizelaar@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.10.6 -> 0.10.8"
+notes = """
+The bulk of this is https://github.com/RustCrypto/hashes/pull/490 which adds aarch64 support along with another PR adding longson.
+I didn't check the implementation thoroughly but there wasn't anything obviously nefarious. 0.10.8 has been out for more than a year
+which suggests no one else has found anything either.
+"""
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.shlex]]
+who = "Max Inden <mail@max-inden.de>"
+criteria = "safe-to-deploy"
+delta = "1.1.0 -> 1.3.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.smallvec]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "1.14.0 -> 1.15.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.smallvec]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "1.15.1 -> 1.15.2"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.strsim]]
+who = "Ben Dean-Kawamura <bdk@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.10.0 -> 0.11.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.strum]]
+who = "Teodor Tanasoaia <ttanasoaia@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.25.0 -> 0.26.3"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.strum_macros]]
+who = "Teodor Tanasoaia <ttanasoaia@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.25.3 -> 0.26.4"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.subtle]]
+who = "Simon Friedberger <simon@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "2.5.0"
+notes = "The goal is to provide some constant-time correctness for cryptographic implementations. The approach is reasonable, it is known to be insufficient but this is pointed out in the documentation."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.synstructure]]
+who = "Nika Layzell <nika@thelayzells.com>"
+criteria = "safe-to-deploy"
+delta = "0.13.1 -> 0.13.2"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/cargo-vet/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.thiserror]]
+who = "Jan-Erik Rediger <jrediger@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.43 -> 1.0.69"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.thiserror-impl]]
+who = "Jan-Erik Rediger <jrediger@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.43 -> 1.0.69"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.time-core]]
+who = "Kershaw Chang <kershaw@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.1.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.time-core]]
+who = "Kershaw Chang <kershaw@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.1.0 -> 0.1.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.time-core]]
+who = "Alex Franchuk <afranchuk@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.1.1 -> 0.1.2"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.time-core]]
+who = "Lars Eggert <lars@eggert.org>"
+criteria = "safe-to-deploy"
+delta = "0.1.2 -> 0.1.4"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.time-core]]
+who = "Lars Eggert <lars@eggert.org>"
+criteria = "safe-to-deploy"
+delta = "0.1.4 -> 0.1.8"
+notes = "No unsafe code"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.tinyvec_macros]]
+who = "Drew Willcoxon <adw@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.1.0 -> 0.1.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.toml_datetime]]
+who = "Jan-Erik Rediger <jrediger@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.7.5+spec-1.1.0"
+notes = "Pure data type crate with some datetime parsing. No unsafe."
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.toml_datetime]]
+who = "Ben Dean-Kawamura <bdk@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.7.3 -> 1.1.1+spec-1.1.0"
+notes = "Minimal changes, no new unsafe code."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.toml_datetime]]
+who = "Jan-Erik Rediger <jrediger@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.7.5+spec-1.1.0 -> 0.7.3"
+notes = "Version downgrade to cover the full vetted version range"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.topological-sort]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.1.0"
+notes = "Simple algorithm crate with no unsafe code or capability usage."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.tracy-rs]]
+who = "Glenn Watson <git@intuitionlibrary.com>"
+criteria = "safe-to-deploy"
+version = "0.1.2"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.unic-langid]]
+who = "Zibi Braniecki <zibi@unicode.org>"
+criteria = "safe-to-deploy"
+version = "0.9.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.unic-langid]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.9.0 -> 0.9.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.unic-langid]]
+who = "Eemeli Aro <eemeli@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.9.1 -> 0.9.5"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.unic-langid]]
+who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
+criteria = "safe-to-deploy"
+delta = "0.9.5 -> 0.9.6"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.unic-langid-impl]]
+who = "Zibi Braniecki <zibi@unicode.org>"
+criteria = "safe-to-deploy"
+version = "0.9.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.unic-langid-impl]]
+who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
+criteria = "safe-to-deploy"
+delta = "0.9.0 -> 0.9.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.unic-langid-impl]]
+who = "Eemeli Aro <eemeli@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.9.1 -> 0.9.5"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.unic-langid-impl]]
+who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
+criteria = "safe-to-deploy"
+delta = "0.9.5 -> 0.9.6"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.utf16_iter]]
+who = "Henri Sivonen <hsivonen@hsivonen.fi>"
+criteria = "safe-to-deploy"
+version = "1.0.5"
+notes = "I, Henri Sivonen, wrote this crate."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.utf8parse]]
+who = "Nika Layzell <nika@thelayzells.com>"
+criteria = "safe-to-deploy"
+delta = "0.2.1 -> 0.2.2"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/cargo-vet/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.windows-link]]
+who = "Mark Hammond <mhammond@skippinet.com.au>"
+criteria = "safe-to-deploy"
+version = "0.1.1"
+notes = "A microsoft crate allowing unsafe calls to windows apis."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.windows-link]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.1.1 -> 0.2.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.zip]]
+who = "Alex Franchuk <afranchuk@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.6.4"
+notes = """
+No unsafe code nor unwarranted dependencies. Side-effectful std usage is only
+present where expected (zip archive reading/writing and unpacking)
+"""
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.zip]]
+who = "Alex Franchuk <afranchuk@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.6.4 -> 2.1.3"
+notes = """
+There's a lot of new code and features, however it's almost entirely very
+straightforward and safe. All new dependencies are appropriate.
+`FixedSizeBlock::interpret` could be unsound if implemented on a
+non-1-byte-aligned type, however right now that is not the case
+(submitted https://github.com/zip-rs/zip2/issues/198).
+"""
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.zip]]
+who = "Lars Eggert <lars@eggert.org>"
+criteria = "safe-to-deploy"
+delta = "2.1.3 -> 2.4.2"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.zcash.audits.base64]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "0.21.3 -> 0.21.4"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.base64]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "0.21.4 -> 0.21.5"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.base64]]
+who = "Daira-Emma Hopwood <daira@jacaranda.org>"
+criteria = "safe-to-deploy"
+delta = "0.21.5 -> 0.21.7"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.bindgen]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "0.72.0 -> 0.72.1"
+notes = """
+Change to `unsafe` code is to narrow the scope of an `unsafe` block; no changes
+to the `unsafe` function being called.
+"""
+aggregated-from = "https://raw.githubusercontent.com/zcash/wallet/main/supply-chain/audits.toml"
+
+[[audits.zcash.audits.block-buffer]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "0.10.3 -> 0.10.4"
+notes = "Adds panics to prevent a block size of zero from causing unsoundness."
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.constant_time_eq]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "0.2.4 -> 0.2.5"
+notes = "No code changes."
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.constant_time_eq]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "0.2.5 -> 0.2.6"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.constant_time_eq]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "0.2.6 -> 0.3.0"
+notes = "Replaces some `unsafe` code by bumping MSRV to 1.66 (to access `core::hint::black_box`)."
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.constant_time_eq]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "0.3.0 -> 0.3.1"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.crunchy]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "0.2.3 -> 0.2.4"
+notes = """
+Build script change is to fix a bug where a path separator for an included file
+was being selected by the target OS instead of the host OS.
+"""
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.document-features]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "0.2.11 -> 0.2.12"
+aggregated-from = "https://raw.githubusercontent.com/zcash/wallet/main/supply-chain/audits.toml"
+
+[[audits.zcash.audits.dunce]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+version = "1.0.5"
+notes = """
+Does what it says on the tin. No `unsafe`, and the only IO is `std::fs::canonicalize`.
+Path and string handling looks plausibly correct.
+"""
+aggregated-from = "https://raw.githubusercontent.com/zcash/librustzcash/main/supply-chain/audits.toml"
+
+[[audits.zcash.audits.errno]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "0.3.3 -> 0.3.8"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.errno]]
+who = "Daira-Emma Hopwood <daira@jacaranda.org>"
+criteria = "safe-to-deploy"
+delta = "0.3.8 -> 0.3.9"
+aggregated-from = "https://raw.githubusercontent.com/zcash/librustzcash/main/supply-chain/audits.toml"
+
+[[audits.zcash.audits.errno]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "0.3.10 -> 0.3.11"
+notes = "The `__errno` location for vxworks and cygwin looks correct from a quick search."
+aggregated-from = "https://raw.githubusercontent.com/zcash/wallet/main/supply-chain/audits.toml"
+
+[[audits.zcash.audits.errno]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "0.3.11 -> 0.3.13"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.errno]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "0.3.13 -> 0.3.14"
+aggregated-from = "https://raw.githubusercontent.com/zcash/librustzcash/main/supply-chain/audits.toml"
+
+[[audits.zcash.audits.fluent-langneg]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "0.13.0 -> 0.13.1"
+aggregated-from = "https://raw.githubusercontent.com/zcash/wallet/main/supply-chain/audits.toml"
+
+[[audits.zcash.audits.inout]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "0.1.3 -> 0.1.4"
+aggregated-from = "https://raw.githubusercontent.com/zcash/wallet/main/supply-chain/audits.toml"
+
+[[audits.zcash.audits.num-conv]]
+who = "Kris Nuttycombe <kris@nutty.land>"
+criteria = "safe-to-deploy"
+delta = "0.2.1 -> 0.2.2"
+notes = "No changes to unsafe code, straightforward refactoring and cleanup."
+aggregated-from = "https://raw.githubusercontent.com/zcash/librustzcash/main/supply-chain/audits.toml"
+
+[[audits.zcash.audits.opaque-debug]]
+who = "Daira-Emma Hopwood <daira@jacaranda.org>"
+criteria = "safe-to-deploy"
+delta = "0.3.0 -> 0.3.1"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.rustc_version]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "0.4.0 -> 0.4.1"
+notes = "Changes to `Command` usage are to add support for `RUSTC_WRAPPER`."
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.signature]]
+who = "Daira Emma Hopwood <daira@jacaranda.org>"
+criteria = "safe-to-deploy"
+version = "2.1.0"
+notes = """
+This crate uses `#![forbid(unsafe_code)]`, has no build script, and only provides traits with some trivial default implementations.
+I did not review whether implementing these APIs would present any undocumented cryptographic hazards.
+"""
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.signature]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "2.1.0 -> 2.2.0"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.time-core]]
+who = "Kris Nuttycombe <kris@nutty.land>"
+criteria = "safe-to-deploy"
+delta = "0.1.8 -> 0.1.9"
+notes = "No unsafe code; macro additions are straightforward refactoring changes."
+aggregated-from = "https://raw.githubusercontent.com/zcash/librustzcash/main/supply-chain/audits.toml"
+
+[[audits.zcash.audits.universal-hash]]
+who = "Daira Hopwood <daira@jacaranda.org>"
+criteria = "safe-to-deploy"
+delta = "0.4.1 -> 0.5.0"
+notes = "I checked correctness of to_blocks which uses unsafe code in a safe function."
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.windows-link]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "0.2.0 -> 0.2.1"
+notes = "No code changes at all."
+aggregated-from = "https://raw.githubusercontent.com/zcash/librustzcash/main/supply-chain/audits.toml"


### PR DESCRIPTION
Independent of the #438/#439/#440 stack — branched from `master`.

## Why

`scripts/dependency-justifications.toml` requires a written reason for every crate in the tree, keyed by crate **name**. That stops a dependency being added quietly, and it is structurally blind to the attack that actually happens.

On 2026-08-20 `arrayref`, `internment` and `append-only-vec` — long-established, already justified in every tree that justifies anything — had malicious releases published from a compromised maintainer account inside a 23-minute window. The only change was one `Cargo.toml` line adding `proc-macro1`, a typosquat of proc-macro2, whose `build.rs` fetched and ran a remote payload. No code in the compromised crates had to be called, and the attacker yanked the good releases to force the resolver onto the bad ones. A name-keyed allowlist says yes to all of it.

So these gates key by **content digest** and **version** instead.

## What's here

**`scan_build_scripts.py` + `build-script-policy.toml`** — every crate that runs code at build time (141 build scripts, 50 proc macros, plus the 247-crate `[build-dependencies]` closure) needs an entry with `allow`, an acknowledged `risk`, a written `reason`, and `reviewed = ["<version>:<sha256>"]`. The digest covers the build script, a sibling `build/` dir, **and** everything reached through `mod`/`#[path]`/`include!` — 16 of the 141 span more than one file, so hashing `build.rs` alone would let a payload move one file sideways and keep the pin green. A version bump changes the digest and fails until someone reads the diff.

**`env_guard.py`** — scans build-time code for `env!`/`option_env!`/`env::var`/`env::vars`/`getenv`/`GetEnvironmentVariable`. The forbidden-name set is parsed out of `.github/workflows/*.yml`, not `os.environ`: a secret only exists in the job it's wired into, and this gate deliberately runs in a job with none, so it checks for every secret the repo *can* inject.

**`lockfile_guard.py`** — vendored files vs. registry checksums (offline), yanked versions, lockfile-vs-index checksums, and an RFC 3923 `min-publish-age` floor implemented locally because the client half hadn't shipped when arrayref happened.

**`cargo vet`** — importing the Mozilla / Google / Bytecode Alliance / Embark / ISRG / Zcash audit sets turns 862 blanket exemptions into 163 crates with real audits.

**CI** — `supply_chain_preflight` has no `needs:` and every job that compiles is downstream of it, including `clippy` and `check_crates`, because `cargo check` runs build scripts too. `cargo vendor` downloads without executing, which is what makes a before-the-build gate possible at all. Measured cost: ~2.5 min (vendor 40s, checksum verify 42s, env scan 36s, build-script scan 28s), moving the preflight wall from 2.1 to ~5 min.

## Audit

13 parallel reviewers read **192 crate-versions** of build-time code. **Zero suspicious.** Zero build scripts use network primitives. All 855 vendored crates match their registry checksums exactly. Every one of the 189 policy `reason` lines is human-audited, not generated.

Full findings: `scripts/SUPPLY_CHAIN_AUDIT_2026_08_25.md`.

## One live fix

`build_mobile_apps` hoisted `APPLE_CERT_P12` and `APPLE_CERT_PASSWORD` to **job-level `env:`** so the optional cert-import step could gate on `env.` (the `secrets.` context isn't allowed in a step `if:`). Job env is the environment of every step, and that job runs `build-ios.sh` ten times, each invoking `cargo build` — so a base64 code-signing certificate and its password sat in the environment of every build script and proc macro in a ~700-crate tree, for the whole build.

The `if:` needs a boolean, not a certificate. It now hoists `HAVE_APPLE_CERT: ${{ secrets.APPLE_CERT_P12 != '' }}` and the material is scoped to the one step that imports it into the keychain. The secret is currently empty in this repo, so nothing leaked — the exposure was structural.

## Calibration notes

Three things the first cut got wrong, and how they were corrected — worth knowing because they're the difference between a gate people keep and one they delete:

- Rules written for a 200-line `build.rs` are pure noise against a 50k-line FFI crate. Unscoped, `windows-sys` scored "high" for *declaring* `DnsQuery` and `linux-raw-sys` scored 1200 for being a crate of syscall constants — 21 high findings, none real. Reduced to the exfiltration subset for build *dependencies*, it reports 6, all genuine.
- `#[test]`/`#[cfg(test)]` items must be stripped before scanning; rustc only compiles them under `--test`. Leaving them in made `security-framework`'s three test helpers that read `PASSWORD` a hard build failure.
- A publish-age floor with no first-party exemption fires on every one of azul's own releases (it caught `printpdf`, `azul-simplecss`, `micromail`, `agg-rust-azul`). `cooldown-exempt.txt` documents why that exemption is necessary rather than convenient.

Policy files use a small TOML subset parsed by `sc_common.py` rather than `tomllib` (3.11+) — ubuntu-22.04 ships 3.10 and stock macOS ships 3.9, so a `tomllib` import in a CI gate is a gate that doesn't run. Verified: all four scripts run correctly under Python 3.9.6. The files are still valid TOML.

## Follow-ups (not in this PR)

1. `dep_tree` covers **one** feature combination (`azul-dll --features build-dll`) and omits `azul-doc` — 235 lockfile crates are outside it, including `openssl-sys`, `ring`, `pyo3`, `ext-php-rs`, `tikv-jemalloc-sys`, all of which CI compiles under other feature sets. Widening it to `--workspace --all-features` is the honest scope.
2. `ureq`'s default features pull `native-tls` → `openssl-sys`, contradicting `deny.toml`'s stated rationale for `rustls-rustcrypto`.
3. `built` bakes the *enclosing* repo's branch/commit/dirty into `turso_core`'s binary and stamps wall-clock time (non-reproducible builds).
4. Pin `PYO3_PYTHON`, `NASM`, `LIBCLANG_PATH` to absolute paths; assert `ICU4X_DATA_DIR` unset (it redirects a compile-time `include!`).
5. Enable crates.io **Trusted Publishing** — short-lived OIDC instead of a long-lived `CARGO_REGISTRY_TOKEN`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FA2rSqu6qmV8qZvhysfqxL