### PR TITLE
feat(clipboard): rich clipboard transport, both directions (stacked on #440)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -761,6 +761,8 @@ dependencies = [
  "proj4rs",
  "pyo3",
  "pyo3-log",
+ "rclip-core",
+ "rich-clipboard",
  "rust-fontconfig",
  "security-framework",
  "serde",
@@ -6266,6 +6268,142 @@ dependencies = [
 ]
 
 [[package]]
+name = "rclip-bookmark"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b356d78920b8a50a1892a573b98ebb457dd5fffbf25f8c1fd5606ff72a1142cc"
+dependencies = [
+ "rclip-core",
+]
+
+[[package]]
+name = "rclip-cf-html"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1be7560a270d3ae4d66a28f914018c85516f0aad3c2cb0723ed901d030ee1441"
+dependencies = [
+ "rclip-core",
+]
+
+[[package]]
+name = "rclip-codepage"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03b479f8baadf78efd25b8a252cf6e6926f53f26f25578bb0e4316e9a481abff"
+dependencies = [
+ "rclip-core",
+]
+
+[[package]]
+name = "rclip-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6414ce752a0d18ee3d000b6c76fccbc30e90b93c2a8c1e7fdd855ab9b7ea0af6"
+
+[[package]]
+name = "rclip-desktop-entry"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd06bb5efa195f7525d4ec66c4f5976e2d8bc5a1da697e79ebab081ee2518e4c"
+dependencies = [
+ "rclip-core",
+]
+
+[[package]]
+name = "rclip-dib"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af7b601de4d21df401a8aa825e069b1c4ecd90eb77bc320c5b7be34fd6286c57"
+dependencies = [
+ "rclip-core",
+]
+
+[[package]]
+name = "rclip-dropfiles"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f586b1cc6794b609889355c8b37f7777886cad52aacecde899da87ae512249f"
+dependencies = [
+ "rclip-codepage",
+ "rclip-core",
+]
+
+[[package]]
+name = "rclip-file-desc"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3aad312e65126cd891691fd521a9bb35be06a16ecff3556dba7d95d9782010db"
+dependencies = [
+ "rclip-codepage",
+ "rclip-core",
+]
+
+[[package]]
+name = "rclip-html"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "051ea1f3493e656024585f1d2591e095c8c9a64185336153cc4a4fadcb4888de"
+dependencies = [
+ "rclip-core",
+]
+
+[[package]]
+name = "rclip-idlist"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ea46804880588b0c68a55553a252118783d0232940a9e72717f050d772dec9"
+dependencies = [
+ "rclip-codepage",
+ "rclip-core",
+]
+
+[[package]]
+name = "rclip-rtf"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64929d6244eea54b6ae4276d5724ae8833c269b8156dd63d48b4f13d39a78ed"
+dependencies = [
+ "rclip-core",
+]
+
+[[package]]
+name = "rclip-shell-link"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "718e7efddef2cd8cf492d9f05a8a3525cd7ecfc22d68d7ceec7730f25a5537a3"
+dependencies = [
+ "rclip-core",
+ "rclip-idlist",
+]
+
+[[package]]
+name = "rclip-uri-list"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c7cd9c1d2e78137fbde75629456cde6e8a154267a55a70e3f67d89a2710f7b"
+dependencies = [
+ "rclip-core",
+]
+
+[[package]]
+name = "rclip-url-file"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a381b28ace45ac49e1e45b765a612aee85803d3c0e1ade37ccaceedabf547c1f"
+dependencies = [
+ "rclip-core",
+]
+
+[[package]]
+name = "rclip-webloc"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd2c7cda46786a3fd741c3a51906a19a262f3773b59f91b1b0ad3cc04ec0d59b"
+dependencies = [
+ "rclip-core",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6341,6 +6479,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
 dependencies = [
  "bytemuck",
+]
+
+[[package]]
+name = "rich-clipboard"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4e68a9fba67f6a1b09686fb34d5e0e7776c5bddfc4a95ed064f5b72012529eb"
+dependencies = [
+ "rclip-bookmark",
+ "rclip-cf-html",
+ "rclip-core",
+ "rclip-desktop-entry",
+ "rclip-dib",
+ "rclip-dropfiles",
+ "rclip-file-desc",
+ "rclip-html",
+ "rclip-idlist",
+ "rclip-rtf",
+ "rclip-shell-link",
+ "rclip-uri-list",
+ "rclip-url-file",
+ "rclip-webloc",
 ]
 
 [[package]]

--- a/dll/Cargo.toml
+++ b/dll/Cargo.toml
@@ -174,6 +174,21 @@ tfd = { version = "0.1.0", default-features = false, optional = true }
 # uses GCController / InputDevice instead, so gilrs is desktop-only.
 gilrs = { package = "gilrs-azul", version = "0.11", optional = true }
 
+# Typed multi-flavor clipboard payloads: codecs (RTF/CF_HTML/uri-list/DIB/…)
+# and read/write policy. Deliberately OS-free — the transports live in
+# `shell2/<platform>/clipboard.rs` and exchange `ClipboardPayload` with it
+# through `shell2/common/clipboard.rs`. Feature set per the crate's
+# INTEGRATION.md §3: styled text both ways, file lists (incl. the GNOME/KDE
+# cut conventions), DIB images, and link/shortcut files. No `image` feature:
+# azul has its own PNG encoder for the pixels→PNG delegation if ever needed.
+rich-clipboard = { version = "0.1", features = ["rich-text", "file-list", "dib", "shortcut"], optional = true }
+# The vocabulary crate underneath it. Already in the graph via rich-clipboard
+# (so it costs nothing extra to compile); named directly because the transports
+# need two things the facade does not re-export: `WindowsFormat`, to map a
+# predefined CF_* number to the name `Flavor::from_windows_name` reads back,
+# and `Budget`, to bound a Wayland pipe read that declares no length.
+rclip-core = { version = "0.1", optional = true }
+
 [target.'cfg(target_os = "linux")'.dependencies]
 libc = { version = "0.2", optional = true }
 x11-clipboard = { version = "0.9.3", optional = true }
@@ -380,8 +395,11 @@ cgl = { version = "0.3.2", optional = true }
 dispatch2 = { version = "0.3.0", default-features = false, features = ["std", "objc2"], optional = true }
 objc2 = { version = "0.6.0", optional = true }
 objc = { version = "0.2", optional = true }
-objc-foundation = { version = "0.1", optional = true }
-objc_id = { version = "0.1", optional = true }
+# NOTE: `objc-foundation` / `objc_id` are deliberately NOT here. The clipboard
+# was the last macOS user of the objc 0.2 Foundation wrappers; it moved to
+# objc2-app-kit (design decision #2 — new backends are objc2-native), so on
+# macOS they are dead weight. They stay in the iOS section, which still has
+# real users (`shell2/ios/mod.rs`).
 block2 = { version = "0.6.0", optional = true }
 libloading = { version = "0.8.6", optional = true }
 accesskit_macos = { version = "0.26", optional = true }
@@ -397,6 +415,12 @@ objc2-foundation = { version = "0.3.0", default-features = true, optional = true
     "NSThread",
     "NSString",
     "NSError",
+    # NSData: the pasteboard's byte carrier. `-length` is also the read-side
+    # SizeHint::Exact — asked BEFORE the bytes are copied into a Vec.
+    "NSData",
+    # NSArray::iter() is gated on this: the clipboard walks -pasteboardItems
+    # and each item's -types.
+    "NSEnumerator",
 ] }
 objc2-app-kit = { version = "0.3.0", default-features = true, optional = true, features = [
     "std",
@@ -413,6 +437,10 @@ objc2-app-kit = { version = "0.3.0", default-features = true, optional = true, f
     "NSOpenGLView",
     "NSDragging",
     "NSPasteboard",
+    # The payload-level clipboard transport walks -pasteboardItems (the
+    # pasteboard-level API only reaches the FIRST item offering a type, so a
+    # three-file copy would read back as one file).
+    "NSPasteboardItem",
     # The eyedropper: NSColorSampler is the system loupe (no screen-recording
     # permission); NSColor/NSColorSpace read the picked colour's sRGB parts.
     "NSColorSampler",
@@ -645,9 +673,11 @@ _internal_deps = [
     "strum",
     "spmc",
     "dep:png",
-    # Platform-specific clipboard
+    # Platform-specific clipboard transports + the shared payload/codec layer
     "x11-clipboard",
     "clipboard-win",
+    "dep:rich-clipboard",
+    "dep:rclip-core",
     # Windows needs libm
     "libm",
     # ICU backends: each platform picks the best one via cfg conditions.

--- a/dll/src/desktop/shell2/common/clipboard.rs
+++ b/dll/src/desktop/shell2/common/clipboard.rs
@@ -1,0 +1,332 @@
+//! System-clipboard seam: typed multi-flavor payloads between azul and the OS.
+//!
+//! Clipboard support has three layers (rich-clipboard's `plan/INTEGRATION.md`):
+//!
+//! 1. **Transport** — `shell2/<platform>/clipboard.rs`: OS calls only
+//!    (`NSPasteboard`, `OpenClipboard`, ICCCM selections, `wl_data_offer`),
+//!    no format knowledge. Produces and consumes [`ClipboardPayload`]: every
+//!    encoding the source offered, still as bytes.
+//! 2. **Codecs + policy** — the `rich-clipboard` crate: picks the richest
+//!    flavor on a read (RTF over HTML over plain text), and fans one item out
+//!    to every flavor the platform wants on a write, so styled text is
+//!    published as RTF *and* HTML *and* plain text simultaneously and a paste
+//!    lands in Word styled rather than flattened.
+//! 3. **azul** — [`ClipboardContent`] (the FFI type: plain text plus styled
+//!    runs). This module owns the conversions in both directions.
+//!
+//! The platform transports currently ship only the plain-text flavor, so
+//! [`get_system_clipboard`] wraps their text into a payload and
+//! [`set_system_clipboard`] reduces the payload back to text. Each backend
+//! graduates to real payload transport in its own step without the callers in
+//! `event.rs` changing again.
+
+use azul_css::props::basic::ColorU;
+use azul_layout::managers::selection::{ClipboardContent, StyledTextRun, StyledTextRunVec};
+use rich_clipboard::{decode_payload, encode, Rgb, RichItem, RichText, Style};
+pub use rich_clipboard::{ClipboardPayload, Platform};
+
+/// 1 CSS pt = 4/3 CSS px (the 96 dpi reference used across azul).
+///
+/// `rich-clipboard`'s [`Style::size_pt`] speaks points because RTF and CSS
+/// clipboard fragments do; azul's [`StyledTextRun::font_size_px`] speaks
+/// pixels. Both converters below use this one constant.
+const PX_PER_PT: f32 = 4.0 / 3.0;
+
+/// Largest single flavor a transport will copy off the OS clipboard.
+///
+/// This is the FIRST line of defence and it belongs to the transport, because
+/// only the transport can act before the bytes are resident: Windows and macOS
+/// can state the exact size and X11 a lower bound, all of them before any copy
+/// happens. Refusing a flavor here just falls through to the next-best one, so
+/// a 400 MB TIFF goes and the plain text alongside it stays.
+///
+/// The decode limits below are the second line, and they cannot substitute:
+/// by the time a [`ClipboardPayload`] exists the bytes are already in this
+/// process. What they stop is the *amplification* — a 60 MB 8-bit `CF_DIB`
+/// becomes 240 MB of RGBA.
+///
+/// 64 MiB matches `rclip_core::Limits::default().max_flavor_bytes`, so a
+/// flavor that survives the transport is one the decoder will also accept.
+pub const MAX_FLAVOR_BYTES: u64 = 64 * 1024 * 1024;
+
+/// Read the OS clipboard as a typed payload.
+///
+/// `None` means an empty clipboard, an unreachable clipboard, or a platform
+/// without one wired up — callers treat all three as "nothing to paste".
+pub fn get_system_clipboard() -> Option<ClipboardPayload> {
+    // Every flavor the source offered — one group per pasteboard item on
+    // macOS, one flat set everywhere else.
+    #[cfg(target_os = "windows")]
+    {
+        crate::desktop::shell2::windows::clipboard::read_payload()
+    }
+    #[cfg(target_os = "macos")]
+    {
+        crate::desktop::shell2::macos::clipboard::read_payload()
+    }
+    #[cfg(target_os = "linux")]
+    {
+        // Route reads like writes: native Wayland first on a Wayland session
+        // (it falls back to the X11 worker itself when the compositor has no
+        // selection), the X11 worker directly otherwise.
+        if std::env::var_os("WAYLAND_DISPLAY").is_some() {
+            crate::desktop::shell2::linux::wayland::clipboard::read_payload()
+        } else {
+            crate::desktop::shell2::linux::x11::clipboard::read_payload()
+        }
+    }
+    #[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
+    {
+        None
+    }
+}
+
+/// Publish a typed payload to the OS clipboard.
+///
+/// Returns `true` only when the platform transport accepted the content —
+/// `CutToClipboard` gates the DELETION of the selected text on this, so a
+/// failed copy must never report success.
+pub fn set_system_clipboard(payload: &ClipboardPayload) -> bool {
+    // macOS and Windows publish EVERY flavor of the fan-out, which is what
+    // makes a paste land in Word as styled text rather than flattened.
+    #[cfg(target_os = "macos")]
+    {
+        crate::desktop::shell2::macos::clipboard::write_payload(payload)
+    }
+    #[cfg(target_os = "windows")]
+    {
+        crate::desktop::shell2::windows::clipboard::write_payload(payload)
+    }
+    #[cfg(target_os = "linux")]
+    {
+        // Route to the active session backend. This previously hardcoded the
+        // X11 write, so copy never reached the clipboard under a Wayland
+        // session.
+        //
+        // Wayland publishes the whole fan-out natively; X11 cannot (its
+        // selection owner serves one target — see `x11/clipboard.rs`), so it
+        // gets the plain-text reading.
+        if std::env::var_os("WAYLAND_DISPLAY").is_some() {
+            crate::desktop::shell2::linux::wayland::clipboard::write_payload(payload).is_ok()
+        } else {
+            let Some(text) = payload_plain_text(payload) else {
+                return false;
+            };
+            crate::desktop::shell2::linux::x11::clipboard::write_to_clipboard(&text).is_ok()
+        }
+    }
+    #[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
+    {
+        let _ = payload;
+        false
+    }
+}
+
+/// Wrap plain text into a payload under the platform's native identifier
+/// (`public.utf8-plain-text` / `CF_UNICODETEXT` / `text/plain;charset=utf-8`).
+///
+/// Every transport speaks payloads now, so this is only what the tests below
+/// build their fixtures from — and what a future platform without a payload
+/// transport would wrap its string read in.
+#[cfg_attr(not(test), allow(dead_code))]
+fn payload_of_text(text: String) -> Option<ClipboardPayload> {
+    encode(&RichItem::Text(text), Platform::native()).ok()
+}
+
+/// The plain-text reading of a payload, through the full decode policy
+/// (richest flavor first), so RTF/HTML-only payloads still paste as text.
+///
+/// Used by the transports that cannot publish a fan-out — X11, whose selection
+/// owner serves exactly one target.
+#[cfg_attr(not(any(target_os = "linux", test)), allow(dead_code))]
+fn payload_plain_text(payload: &ClipboardPayload) -> Option<String> {
+    let item = decode_payload(payload).ok()?;
+    item.plain_text().map(str::to_owned)
+}
+
+/// azul's FFI clipboard type → a typed item ready for the write fan-out.
+///
+/// `None` only when encoding failed outright; an empty `ClipboardContent`
+/// still encodes (as empty plain text), preserving the old "copy nothing
+/// clears the clipboard" behavior.
+pub fn clipboard_content_to_payload(content: &ClipboardContent) -> Option<ClipboardPayload> {
+    encode(&content_to_rich_item(content), Platform::native()).ok()
+}
+
+fn content_to_rich_item(content: &ClipboardContent) -> RichItem {
+    let plain = content.plain_text.as_str();
+    let runs = content.styled_runs.as_slice();
+    if !runs.is_empty() {
+        let mut rich = RichText::default();
+        for run in runs {
+            rich.push(
+                run.text.as_str(),
+                Style {
+                    bold: run.is_bold,
+                    italic: run.is_italic,
+                    size_pt: (run.font_size_px > 0.0).then(|| run.font_size_px / PX_PER_PT),
+                    font_family: run
+                        .font_family
+                        .as_ref()
+                        .map(|family| family.as_str().to_owned()),
+                    color: Some(Rgb::new(run.color.r, run.color.g, run.color.b)),
+                    ..Style::default()
+                },
+            );
+        }
+        // The runs are authoritative only when they spell the same characters
+        // as the plain text. A producer that filled the two fields
+        // inconsistently must not publish a rich flavor that disagrees with
+        // the plain one — receivers would paste different text depending on
+        // which flavor they picked.
+        if rich.as_str() == plain {
+            return RichItem::RichText(rich);
+        }
+    }
+    RichItem::Text(plain.to_owned())
+}
+
+/// Typed payload → azul's FFI clipboard type.
+///
+/// Styled flavors (RTF/HTML) arrive as populated `styled_runs`; anything
+/// text-shaped arrives as plain text. `None` for payloads with no text
+/// reading at all (an image, a file list) — those gain their own
+/// `ClipboardContent` representation in a later step.
+pub fn payload_to_clipboard_content(payload: &ClipboardPayload) -> Option<ClipboardContent> {
+    match decode_payload(payload).ok()? {
+        RichItem::RichText(rich) => Some(rich_text_to_content(&rich)),
+        item => item.plain_text().map(|plain| ClipboardContent {
+            plain_text: plain.into(),
+            styled_runs: StyledTextRunVec::from_const_slice(&[]),
+        }),
+    }
+}
+
+fn rich_text_to_content(rich: &RichText) -> ClipboardContent {
+    /// [`StyledTextRun`]'s color is not optional; opaque black stands in for
+    /// "inherit", matching what azul renders for unstyled text.
+    const INHERIT: ColorU = ColorU {
+        r: 0,
+        g: 0,
+        b: 0,
+        a: 255,
+    };
+    let runs: Vec<StyledTextRun> = rich
+        .spans()
+        .map(|(text, style)| StyledTextRun {
+            text: text.into(),
+            font_family: style
+                .font_family
+                .as_deref()
+                .map(azul_css::AzString::from)
+                .into(),
+            font_size_px: style.size_pt.map(|pt| pt * PX_PER_PT).unwrap_or(0.0),
+            color: style
+                .color
+                .map(|c| ColorU {
+                    r: c.r,
+                    g: c.g,
+                    b: c.b,
+                    a: 255,
+                })
+                .unwrap_or(INHERIT),
+            is_bold: style.bold,
+            is_italic: style.italic,
+        })
+        .collect();
+    ClipboardContent {
+        plain_text: rich.as_str().into(),
+        styled_runs: runs.into(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn styled(text: &str, bold: bool, size_px: f32) -> StyledTextRun {
+        StyledTextRun {
+            text: text.into(),
+            font_family: None.into(),
+            font_size_px: size_px,
+            color: ColorU {
+                r: 10,
+                g: 20,
+                b: 30,
+                a: 255,
+            },
+            is_bold: bold,
+            is_italic: false,
+        }
+    }
+
+    /// Styled runs must survive azul → payload → azul: this is the round trip
+    /// a copy in one azul window and a paste in another takes, and it crosses
+    /// the wire as real RTF/HTML.
+    #[test]
+    fn styled_runs_round_trip_through_the_payload() {
+        let content = ClipboardContent {
+            plain_text: "boldplain".into(),
+            styled_runs: vec![styled("bold", true, 16.0), styled("plain", false, 16.0)].into(),
+        };
+        let payload = clipboard_content_to_payload(&content).expect("encodes");
+        let back = payload_to_clipboard_content(&payload).expect("decodes");
+
+        assert_eq!(back.plain_text.as_str(), "boldplain");
+        let runs = back.styled_runs.as_slice();
+        assert_eq!(runs.len(), 2, "two style spans must come back as two runs");
+        assert!(runs[0].is_bold && !runs[1].is_bold);
+        assert_eq!(runs[0].text.as_str(), "bold");
+        assert_eq!(runs[1].text.as_str(), "plain");
+        // pt→px→pt conversion must not drift (16px = 12pt exactly).
+        assert!((runs[0].font_size_px - 16.0).abs() < 0.01);
+        assert_eq!(
+            (runs[0].color.r, runs[0].color.g, runs[0].color.b),
+            (10, 20, 30)
+        );
+    }
+
+    /// A `ClipboardContent` whose runs disagree with its plain text (a
+    /// producer bug) must publish the PLAIN text, not the runs — receivers
+    /// must never paste different characters depending on the flavor they
+    /// picked.
+    #[test]
+    fn inconsistent_runs_fall_back_to_plain_text() {
+        let content = ClipboardContent {
+            plain_text: "the real text".into(),
+            styled_runs: vec![styled("other", false, 0.0)].into(),
+        };
+        match content_to_rich_item(&content) {
+            RichItem::Text(t) => assert_eq!(t, "the real text"),
+            other => panic!("expected the plain fallback, got {other:?}"),
+        }
+    }
+
+    /// Plain text through the whole seam: what every existing caller does
+    /// today, and what phase 1 must not change.
+    #[test]
+    fn plain_text_round_trips_and_reduces() {
+        let payload = payload_of_text("hello\nworld".to_owned()).expect("encodes");
+        assert_eq!(
+            payload_plain_text(&payload).as_deref(),
+            Some("hello\nworld")
+        );
+        let content = payload_to_clipboard_content(&payload).expect("decodes");
+        assert_eq!(content.plain_text.as_str(), "hello\nworld");
+        assert!(content.styled_runs.as_slice().is_empty());
+    }
+
+    /// An unstyled `ClipboardContent` must encode as plain text, not as a
+    /// rich flavor claiming a fidelity it does not have.
+    #[test]
+    fn unstyled_content_encodes_as_plain_text() {
+        let content = ClipboardContent {
+            plain_text: "just text".into(),
+            styled_runs: StyledTextRunVec::from_const_slice(&[]),
+        };
+        match content_to_rich_item(&content) {
+            RichItem::Text(t) => assert_eq!(t, "just text"),
+            other => panic!("expected plain text, got {other:?}"),
+        }
+    }
+}

--- a/dll/src/desktop/shell2/common/event.rs
+++ b/dll/src/desktop/shell2/common/event.rs
@@ -267,64 +267,15 @@ fn parse_node_type_from_str(s: &str) -> azul_core::dom::NodeType {
 const MAX_EVENT_RECURSION_DEPTH: usize = azul_layout::window::MAX_EVENT_RECURSION_DEPTH;
 
 // Platform-specific Clipboard Helpers
-
-/// Get clipboard text content (platform-specific)
-#[inline]
-fn get_system_clipboard() -> Option<String> {
-    #[cfg(target_os = "windows")]
-    {
-        crate::desktop::shell2::windows::clipboard::get_clipboard_content()
-    }
-    #[cfg(target_os = "macos")]
-    {
-        crate::desktop::shell2::macos::clipboard::get_clipboard_content()
-    }
-    #[cfg(target_os = "linux")]
-    {
-        crate::desktop::shell2::linux::x11::clipboard::get_clipboard_content()
-    }
-    #[cfg(not(any(
-        target_os = "windows",
-        target_os = "macos",
-        target_os = "linux",
-    )))]
-    {
-        None
-    }
-}
-
-/// Set clipboard text content (platform-specific)
-#[inline]
-fn set_system_clipboard(text: String) -> bool {
-    #[cfg(target_os = "windows")]
-    {
-        crate::desktop::shell2::windows::clipboard::write_to_clipboard(&text).is_ok()
-    }
-    #[cfg(target_os = "macos")]
-    {
-        crate::desktop::shell2::macos::clipboard::write_to_clipboard(&text).is_ok()
-    }
-    #[cfg(target_os = "linux")]
-    {
-        // Route to the active session backend. This previously hardcoded the X11
-        // write, so copy never reached the clipboard under a Wayland session —
-        // and the Wayland write path was only reachable through the unwired
-        // `sync_clipboard`. Now both backends are wired here.
-        if std::env::var_os("WAYLAND_DISPLAY").is_some() {
-            crate::desktop::shell2::linux::wayland::clipboard::write_to_clipboard(&text).is_ok()
-        } else {
-            crate::desktop::shell2::linux::x11::clipboard::write_to_clipboard(&text).is_ok()
-        }
-    }
-    #[cfg(not(any(
-        target_os = "windows",
-        target_os = "macos",
-        target_os = "linux",
-    )))]
-    {
-        false
-    }
-}
+//
+// The seam moved to `super::clipboard`: the OS clipboard now carries typed
+// multi-flavor payloads (`ClipboardPayload`) rather than bare strings, and
+// that module owns both the per-OS dispatch and the conversions to and from
+// azul's `ClipboardContent`.
+use super::clipboard::{
+    clipboard_content_to_payload, get_system_clipboard, payload_to_clipboard_content,
+    set_system_clipboard,
+};
 
 /// Timer callback for auto-scroll during drag selection.
 ///
@@ -4786,7 +4737,9 @@ pub trait PlatformWindow {
                 if let Some(lw) = self.get_layout_window_mut() {
                     lw.clipboard_manager.set_copy_content(content.clone());
                 }
-                set_system_clipboard(content.plain_text.as_str().to_string());
+                if let Some(payload) = clipboard_content_to_payload(content) {
+                    set_system_clipboard(&payload);
+                }
                 ProcessEventResult::DoNothing
             }
 
@@ -4797,7 +4750,9 @@ pub trait PlatformWindow {
                 if let Some(lw) = self.get_layout_window_mut() {
                     lw.clipboard_manager.set_copy_content(content.clone());
                 }
-                set_system_clipboard(content.plain_text.as_str().to_string());
+                if let Some(payload) = clipboard_content_to_payload(content) {
+                    set_system_clipboard(&payload);
+                }
                 ProcessEventResult::DoNothing
             }
 
@@ -5495,7 +5450,9 @@ pub trait PlatformWindow {
                         .get_editing_dom_id()
                         .unwrap_or(azul_core::dom::DomId { inner: 0 });
                     if let Some(clipboard_content) = layout_window.get_selected_content_for_clipboard(&dom_id) {
-                        set_system_clipboard(clipboard_content.plain_text.as_str().to_string());
+                        if let Some(payload) = clipboard_content_to_payload(&clipboard_content) {
+                            set_system_clipboard(&payload);
+                        }
                     }
                 }
                 ProcessEventResult::DoNothing
@@ -5511,7 +5468,9 @@ pub trait PlatformWindow {
                         .get_editing_dom_id()
                         .unwrap_or(azul_core::dom::DomId { inner: 0 });
                     if let Some(clipboard_content) = layout_window.get_selected_content_for_clipboard(&dom_id) {
-                        if set_system_clipboard(clipboard_content.plain_text.as_str().to_string()) {
+                        let committed = clipboard_content_to_payload(&clipboard_content)
+                            .is_some_and(|payload| set_system_clipboard(&payload));
+                        if committed {
                             // Cross-block cut: the copy above already joined the
                             // multi-paragraph text; the delete is the atomic
                             // replace-merge changeset.
@@ -5535,7 +5494,11 @@ pub trait PlatformWindow {
 
             SystemChange::PasteFromClipboard => {
                 if let Some(layout_window) = self.get_layout_window_mut() {
-                    if let Some(clipboard_text) = get_system_clipboard() {
+                    let pasted = get_system_clipboard()
+                        .as_ref()
+                        .and_then(payload_to_clipboard_content);
+                    if let Some(clipboard_content) = pasted {
+                        let clipboard_text = clipboard_content.plain_text.as_str().to_string();
                         // Paste over a cross-block selection: one atomic
                         // replace-merge changeset with the pasted text at the
                         // join (caret resumes after it).
@@ -5551,14 +5514,11 @@ pub trait PlatformWindow {
                                 return ProcessEventResult::ShouldUpdateDisplayListCurrentWindow;
                             }
                         }
-                        layout_window.clipboard_manager.set_paste_content(ClipboardContent {
-                            plain_text: clipboard_text.as_str().into(),
-                            // TODO(superplan): styled_runs empty — the OS clipboard read
-                            // (`get_system_clipboard`) only returns plain text; populating
-                            // rich runs needs an HTML/RTF clipboard format reader (see
-                            // layout/src/managers/selection.rs docs).
-                            styled_runs: StyledTextRunVec::from_const_slice(&[]),
-                        });
+                        // `styled_runs` is populated whenever the OS payload
+                        // carried a rich flavor (RTF/HTML) the decode policy
+                        // could read; the text-editing pipeline below pastes
+                        // the plain text.
+                        layout_window.clipboard_manager.set_paste_content(clipboard_content);
                         // Smart paste: if N lines == N cursors, paste one line per cursor
                         let cursor_count = layout_window.text_edit_manager.multi_cursor
                             .as_ref().map(|mc| mc.len()).unwrap_or(0);
@@ -8410,12 +8370,12 @@ pub trait PlatformWindow {
                 .iter()
                 .any(|c| matches!(c, SystemChange::PasteFromClipboard));
             if has_paste {
-                if let Some(clipboard_text) = get_system_clipboard() {
+                let pasted = get_system_clipboard()
+                    .as_ref()
+                    .and_then(payload_to_clipboard_content);
+                if let Some(clipboard_content) = pasted {
                     if let Some(lw) = self.get_layout_window_mut() {
-                        lw.clipboard_manager.set_paste_content(ClipboardContent {
-                            plain_text: clipboard_text.as_str().into(),
-                            styled_runs: StyledTextRunVec::from_const_slice(&[]),
-                        });
+                        lw.clipboard_manager.set_paste_content(clipboard_content);
                     }
                 }
             }

--- a/dll/src/desktop/shell2/common/mod.rs
+++ b/dll/src/desktop/shell2/common/mod.rs
@@ -21,6 +21,7 @@ pub mod gl_loader;
 // Unified cross-platform modules
 pub mod accessibility;
 pub mod capability_pump;
+pub mod clipboard;
 pub mod debug_server;
 #[cfg(feature = "e2e-test")]
 pub mod e2e_test;

--- a/dll/src/desktop/shell2/linux/mod.rs
+++ b/dll/src/desktop/shell2/linux/mod.rs
@@ -99,15 +99,6 @@ impl LinuxWindow {
         }
     }
 
-    pub fn sync_clipboard(
-        &mut self,
-        clipboard_manager: &mut azul_layout::managers::clipboard::ClipboardManager,
-    ) {
-        match self {
-            LinuxWindow::X11(w) => w.sync_clipboard(clipboard_manager),
-            LinuxWindow::Wayland(w) => w.sync_clipboard(clipboard_manager),
-        }
-    }
 }
 
 impl LinuxWindow {

--- a/dll/src/desktop/shell2/linux/wayland/clipboard.rs
+++ b/dll/src/desktop/shell2/linux/wayland/clipboard.rs
@@ -11,40 +11,10 @@
 //! `sync_clipboard` is called from `wayland/mod.rs` after user callbacks
 //! to commit pending clipboard changes to the system clipboard.
 
-use azul_layout::managers::clipboard::ClipboardManager;
 use rich_clipboard::{ClipboardPayload, Flavor, Platform};
 
 use super::super::super::common::debug_server::LogCategory;
-use crate::{log_debug, log_error, log_info, log_trace, log_warn};
-
-/// Synchronize clipboard manager content to Wayland system clipboard
-///
-/// If the clipboard manager has pending copy content, it's written to
-/// the Wayland clipboard.
-///
-/// TODO(superplan): this flush path is now redundant — the copy/cut/paste
-/// shortcuts and the `SetCopyContent`/`SetCutContent` callbacks both write to
-/// the OS clipboard directly through `common/event.rs`
-/// (`set_system_clipboard` → `write_to_clipboard`), so no run loop calls
-/// `sync_clipboard`. The macOS + Windows backends already dropped their dead
-/// copies; this one (plus the `wayland/mod.rs` + `linux/mod.rs` `sync_clipboard`
-/// wrappers, owned by another group) should be removed in a follow-up.
-pub fn sync_clipboard(clipboard_manager: &mut ClipboardManager) {
-    // Check if there's pending content to copy
-    if let Some(content) = clipboard_manager.get_copy_content() {
-        // Write to Wayland clipboard
-        if let Err(e) = write_to_clipboard(&content.plain_text) {
-            log_error!(
-                LogCategory::Resources,
-                "[Wayland Clipboard] Failed to write: {:?}",
-                e
-            );
-        }
-    }
-
-    // Clear the clipboard manager after sync
-    clipboard_manager.clear();
-}
+use crate::{log_debug, log_warn};
 
 /// Read content from Wayland system clipboard
 ///

--- a/dll/src/desktop/shell2/linux/wayland/clipboard.rs
+++ b/dll/src/desktop/shell2/linux/wayland/clipboard.rs
@@ -12,6 +12,7 @@
 //! to commit pending clipboard changes to the system clipboard.
 
 use azul_layout::managers::clipboard::ClipboardManager;
+use rich_clipboard::{ClipboardPayload, Flavor, Platform};
 
 use super::super::super::common::debug_server::LogCategory;
 use crate::{log_debug, log_error, log_info, log_trace, log_warn};
@@ -54,15 +55,74 @@ pub fn get_clipboard_content() -> Option<String> {
 
 // --- Native wl_data_device clipboard (MWA-B3) ---
 
-/// Text we currently offer on the native Wayland selection. `Some` = we own
-/// the selection: `events::data_source_send` serves the pasting client from
-/// here, and `events::data_source_cancelled` clears it when another client
-/// takes the selection over.
-static NATIVE_COPY: std::sync::Mutex<Option<String>> = std::sync::Mutex::new(None);
+/// What we currently offer on the native Wayland selection. `Some` = we own
+/// the selection: `events::data_source_send` serves the pasting client the
+/// representation it asked for, and `events::data_source_cancelled` clears it
+/// when another client takes the selection over.
+///
+/// A whole payload rather than one `String`, because Wayland is the only Linux
+/// transport here that can publish a real fan-out: `wl_data_source.offer` is
+/// called once per mime type and `send` names the one the peer picked. So a
+/// copy of styled text offers `text/rtf`, `text/html` *and* `text/plain` at
+/// once, and the peer chooses — which is exactly what makes a paste into
+/// LibreOffice keep its styling. (The X11 fallback below cannot do this: its
+/// selection owner serves one target. See `x11/clipboard.rs`.)
+static NATIVE_COPY: std::sync::Mutex<Option<ClipboardPayload>> = std::sync::Mutex::new(None);
+
+/// The bytes to serve for one requested mime type, while we own the selection.
+///
+/// Matched by resolved [`Flavor`], not by string equality: a peer that asks
+/// for `UTF8_STRING` or `text/plain` must be served the payload's
+/// `text/plain;charset=utf-8` bytes — they are one flavor under three
+/// spellings, and a strict match would answer an empty pipe.
+pub(super) fn native_copy_bytes(mime: &str) -> Option<Vec<u8>> {
+    let guard = NATIVE_COPY.lock().ok()?;
+    let payload = guard.as_ref()?;
+    let want = Flavor::from_mime(mime);
+    payload
+        .items()
+        .iter()
+        .find(|i| Flavor::from_mime(&i.native) == want)
+        .map(|i| i.bytes.clone())
+}
+
+/// Every mime type to advertise for the selection we are about to take.
+pub(super) fn native_copy_mimes() -> Vec<String> {
+    let Ok(guard) = NATIVE_COPY.lock() else {
+        return Vec::new();
+    };
+    let Some(payload) = guard.as_ref() else {
+        return Vec::new();
+    };
+    let mut mimes: Vec<String> = payload.items().iter().map(|i| i.native.clone()).collect();
+    // The pre-MIME spellings every older toolkit and terminal still asks for.
+    // Advertised only alongside real plain text, and served through the
+    // flavor match in `native_copy_bytes`.
+    if payload
+        .items()
+        .iter()
+        .any(|i| Flavor::from_mime(&i.native) == Flavor::PlainText)
+    {
+        for legacy in ["UTF8_STRING", "text/plain"] {
+            if !mimes.iter().any(|m| m == legacy) {
+                mimes.push(legacy.to_owned());
+            }
+        }
+    }
+    mimes
+}
 
 /// The text served to pasting clients while we own the selection.
+///
+/// The plain-text reading of [`NATIVE_COPY`], for the callers that only ever
+/// wanted a string.
 pub(super) fn native_copy_text() -> Option<String> {
-    NATIVE_COPY.lock().ok().and_then(|g| g.clone())
+    let guard = NATIVE_COPY.lock().ok()?;
+    let payload = guard.as_ref()?;
+    rich_clipboard::decode_payload(payload)
+        .ok()?
+        .plain_text()
+        .map(str::to_owned)
 }
 
 /// Ownership lost (source cancelled) — stop serving / short-circuiting reads.
@@ -92,16 +152,32 @@ fn with_wayland_window<R>(f: impl FnOnce(&mut super::WaylandWindow) -> R) -> Opt
 
 /// Write string to Wayland clipboard
 pub(crate) fn write_to_clipboard(text: &str) -> Result<(), ClipboardError> {
+    let payload = rich_clipboard::encode(
+        &rich_clipboard::RichItem::Text(text.to_owned()),
+        Platform::Unix,
+    )
+    .map_err(|_| ClipboardError::WriteFailed)?;
+    write_payload(&payload).map_err(|_| ClipboardError::WriteFailed)
+}
+
+/// Publish every flavor of a payload to the Wayland selection.
+///
+/// The native path takes them all; the XWayland fallback can only carry plain
+/// text (see [`x11::clipboard`](super::super::x11::clipboard)), so a fall back
+/// is also a loss of fidelity — logged, because a copy that silently drops its
+/// styling is the kind of thing that gets reported as "paste is broken".
+pub(crate) fn write_payload(payload: &ClipboardPayload) -> Result<(), ClipboardError> {
     // MWA-B3: native wl_data_device first — works on pure Wayland sessions
-    // (no XWayland). Park the text, then take the seat selection; pasting
-    // clients pull it through data_source_send.
+    // (no XWayland). Park the payload, then take the seat selection; pasting
+    // clients pull the representation they want through data_source_send.
     if let Ok(mut g) = NATIVE_COPY.lock() {
-        *g = Some(text.to_owned());
+        *g = Some(payload.clone());
     }
     if with_wayland_window(|w| w.wayland_set_selection()) == Some(true) {
         log_debug!(
             LogCategory::Resources,
-            "[Wayland Clipboard] native wl_data_source selection taken"
+            "[Wayland Clipboard] native wl_data_source selection taken, offering {} flavor(s)",
+            payload.len()
         );
         return Ok(());
     }
@@ -111,8 +187,39 @@ pub(crate) fn write_to_clipboard(text: &str) -> Result<(), ClipboardError> {
     // than a second `x11_clipboard::Clipboard` of our own. Same mechanism,
     // minus the four synchronous X round trips this used to spend on the UI
     // thread — see `x11/clipboard.rs::write_to_clipboard`.
-    super::super::x11::clipboard::write_to_clipboard(text)
+    let text = rich_clipboard::decode_payload(payload)
+        .ok()
+        .and_then(|item| item.plain_text().map(str::to_owned))
+        .ok_or(ClipboardError::WriteFailed)?;
+    if payload.len() > 1 {
+        log_warn!(
+            LogCategory::Resources,
+            "[Wayland Clipboard] no compositor selection — falling back to XWayland, which \
+             carries plain text only. {} of {} flavor(s) will not be published.",
+            payload.len() - 1,
+            payload.len()
+        );
+    }
+    super::super::x11::clipboard::write_to_clipboard(&text)
         .map_err(|_| ClipboardError::WriteFailed)
+}
+
+/// Read every flavor the Wayland selection offers.
+///
+/// Answers from our own payload when we own the selection: a `receive()` on
+/// our OWN offer would deadlock the single-threaded event loop, because the
+/// `send` event that serves it cannot dispatch while we block on the pipe.
+pub(crate) fn read_payload() -> Option<ClipboardPayload> {
+    if let Ok(guard) = NATIVE_COPY.lock() {
+        if let Some(payload) = guard.as_ref() {
+            return Some(payload.clone());
+        }
+    }
+    if let Some(Some(payload)) = with_wayland_window(|w| w.read_wayland_selection_payload()) {
+        return Some(payload);
+    }
+    // XWayland fallback: single-flavor, on the X11 worker.
+    super::super::x11::clipboard::read_payload()
 }
 
 /// Read string from Wayland clipboard

--- a/dll/src/desktop/shell2/linux/wayland/events.rs
+++ b/dll/src/desktop/shell2/linux/wayland/events.rs
@@ -12,6 +12,7 @@ use azul_core::{
 
 use super::{defines, defines::*, WaylandWindow};
 
+use super::super::super::common::clipboard::MAX_FLAVOR_BYTES;
 use super::super::super::common::debug_server::LogCategory;
 use super::super::super::common::event::PlatformWindow;
 use super::super::common::compose::{ComposeAction, ComposeSequencer};
@@ -1065,6 +1066,24 @@ pub struct WaylandDragState {
     pub pending_offer: *mut wl_data_offer,
     /// Whether [`Self::pending_offer`] advertised `text/uri-list`.
     pub pending_has_uri_list: bool,
+    /// EVERY mime type [`Self::pending_offer`] advertised, in the order the
+    /// source listed them.
+    ///
+    /// A clipboard read has to know this: `wl_data_offer.receive` with a mime
+    /// the source never offered is answered by a pipe that only closes when
+    /// the source feels like it, so probing blind costs the full transfer
+    /// deadline per guess. With the list, a payload read asks for exactly the
+    /// flavors that are actually there.
+    pub pending_mimes: Vec<String>,
+    /// The advertised mime list of the offer that turned out to be the
+    /// CLIPBOARD selection, promoted from [`Self::pending_mimes`].
+    ///
+    /// Separate from `pending_mimes` for the same reason `has_uri_list` is
+    /// separate from `pending_has_uri_list`: offers arrive for every clipboard
+    /// change in every other application, so the list has to be captured when
+    /// `selection` names the offer, not whenever the last advertisement
+    /// happened to land.
+    pub clipboard_mimes: Vec<String>,
 }
 
 impl WaylandDragState {
@@ -1078,14 +1097,46 @@ impl WaylandDragState {
     pub(super) fn begin_offer(&mut self, id: *mut wl_data_offer) {
         self.pending_offer = id;
         self.pending_has_uri_list = false;
+        self.pending_mimes.clear();
+    }
+
+    /// `wl_data_device.selection`: THIS offer is the clipboard. Promote its
+    /// advertised mime list, the same way `begin_drag` promotes
+    /// `pending_has_uri_list`.
+    ///
+    /// A null offer means the selection was cleared — nothing is on offer, so
+    /// the list empties rather than going stale.
+    pub(super) fn begin_selection(&mut self, id: *mut wl_data_offer) {
+        self.clipboard_mimes = if !id.is_null() && id == self.pending_offer {
+            self.pending_mimes.clone()
+        } else {
+            Vec::new()
+        };
+    }
+
+    /// The mime types the current clipboard offer advertised.
+    pub(super) fn clipboard_mimes(&self) -> &[String] {
+        &self.clipboard_mimes
     }
 
     /// `wl_data_offer.offer`: one advertised mime type of `offer`. An offer's
     /// mime list arrives BEFORE the `enter`/`selection` that reveals what the
     /// offer is for, so it is accumulated against the offer itself.
     pub(super) fn note_offered_mime(&mut self, offer: *mut wl_data_offer, mime: &str) {
-        if mime == URI_LIST_MIME && offer == self.pending_offer {
+        if offer != self.pending_offer {
+            return;
+        }
+        if mime == URI_LIST_MIME {
             self.pending_has_uri_list = true;
+        }
+        // Bounded: a source is free to advertise as many types as it likes,
+        // and this list is held for as long as the offer is. A real clipboard
+        // offers a handful — Safari's eleven is the most anything sane does.
+        const MAX_ADVERTISED_MIMES: usize = 64;
+        if self.pending_mimes.len() < MAX_ADVERTISED_MIMES
+            && !self.pending_mimes.iter().any(|m| m == mime)
+        {
+            self.pending_mimes.push(mime.to_owned());
         }
     }
 
@@ -1528,6 +1579,16 @@ fn await_transfer(
 /// poll deadline, matching the XWayland fallback's `CLIPBOARD_READ_TIMEOUT`. A
 /// timeout returns whatever arrived rather than never returning.
 ///
+/// The deadline is not the only bound that is needed. **Wayland is the one
+/// platform where the payload size is unknowable in advance** — the protocol
+/// hands over a pipe and never states a length, so there is no `GlobalSize` to
+/// ask and no `INCR` lower bound to read. A peer that streams fast enough can
+/// therefore push hundreds of megabytes into this `Vec` inside the timeout,
+/// and counting the bytes as they arrive is the only defence there is. Past
+/// [`MAX_FLAVOR_BYTES`] the transfer is abandoned and what arrived is
+/// discarded: a truncated flavor is worse than no flavor, because the decode
+/// would succeed on the prefix and paste half a document.
+///
 /// # Safety
 /// `read_fd` must be an owned, open fd; this function closes it.
 pub(super) unsafe fn drain_offer_pipe(
@@ -1544,6 +1605,19 @@ pub(super) unsafe fn drain_offer_pipe(
     let mut buf = Vec::new();
     let mut chunk = [0u8; 4096];
     'transfer: loop {
+        if buf.len() as u64 > MAX_FLAVOR_BYTES {
+            log_warn!(
+                LogCategory::Platform,
+                "[Wayland] '{}' transfer exceeded the {}-byte cap — abandoning it. The protocol \
+                 declares no length, so counting is the only bound there is.",
+                mime_type,
+                MAX_FLAVOR_BYTES
+            );
+            libc::close(read_fd);
+            // Discarded, not truncated: half a document that decodes cleanly
+            // is worse than nothing.
+            return Vec::new();
+        }
         let remaining = deadline.saturating_duration_since(std::time::Instant::now());
         if remaining.is_zero() {
             log_warn!(
@@ -1661,6 +1735,10 @@ extern "C" fn data_device_selection(
         unsafe { destroy_data_offer(window, old) };
     }
     window.clipboard_offer = id;
+    // Promote THIS offer's advertised mime list, so a payload read knows which
+    // flavors are actually on offer rather than probing blind (each blind
+    // guess costs the full transfer deadline).
+    window.drag.begin_selection(id);
 }
 
 // --- Primary selection (zwp_primary_selection_v1) ---
@@ -1861,12 +1939,24 @@ extern "C" fn data_source_target(
 extern "C" fn data_source_send(
     _data: *mut c_void,
     _source: *mut wl_data_source,
-    _mime: *const c_char,
+    mime: *const c_char,
     fd: i32,
 ) {
-    // Every offered mime is a plain-UTF-8 spelling, so serve the same bytes.
-    let text = super::clipboard::native_copy_text().unwrap_or_default();
-    write_all_then_close(fd, text.as_bytes());
+    // Serve the representation the peer ASKED for. The offered mimes are no
+    // longer all spellings of one plain-text blob: a styled copy offers RTF,
+    // HTML and plain text at once, and answering all three with the same
+    // bytes would paste RTF source into a plain-text field.
+    //
+    // The fd must be closed on every path, including the ones that serve
+    // nothing — an fd left open leaves the pasting client blocked until its
+    // own deadline.
+    let requested = if mime.is_null() {
+        String::new()
+    } else {
+        unsafe { CStr::from_ptr(mime).to_str().unwrap_or_default().to_owned() }
+    };
+    let bytes = super::clipboard::native_copy_bytes(&requested).unwrap_or_default();
+    write_all_then_close(fd, &bytes);
 }
 
 /// Serve a selection: write every byte to the compositor's fd, then close it.

--- a/dll/src/desktop/shell2/linux/wayland/mod.rs
+++ b/dll/src/desktop/shell2/linux/wayland/mod.rs
@@ -4054,15 +4054,36 @@ impl WaylandWindow {
                 return false;
             }
 
-            // offer(mime_type): opcode 0, "s" — advertise the common
-            // plain-text spellings so GTK/Qt/terminal clients all match.
+            // offer(mime_type): opcode 0, "s" — one call per flavor the
+            // parked payload carries, plus the pre-MIME plain-text spellings
+            // so GTK/Qt/terminal clients still match. This is what makes a
+            // Wayland copy a real fan-out: the peer picks which one it wants
+            // and `data_source_send` names it back to us.
             let offer: unsafe extern "C" fn(
                 *mut defines::wl_proxy,
                 u32,
                 *const std::os::raw::c_char,
             ) = std::mem::transmute(self.wayland.wl_proxy_marshal);
-            for mime in ["text/plain;charset=utf-8", "UTF8_STRING", "text/plain"] {
-                let c = std::ffi::CString::new(mime).unwrap();
+            let mimes = clipboard::native_copy_mimes();
+            if mimes.is_empty() {
+                // Nothing parked to serve. Taking the selection anyway would
+                // make every paste from this app return an empty pipe.
+                //
+                // BOTH halves of the teardown, like every destructor here: the
+                // request tells the server, `wl_proxy_destroy` frees the client
+                // id. Skipping the request leaks the server-side object.
+                let destroy: unsafe extern "C" fn(*mut defines::wl_proxy, u32) =
+                    std::mem::transmute(self.wayland.wl_proxy_marshal);
+                destroy(src, 1);
+                (self.wayland.wl_proxy_destroy)(src);
+                return false;
+            }
+            for mime in &mimes {
+                // A mime with an interior NUL cannot be marshalled; skipping
+                // it loses one flavor rather than the whole copy.
+                let Ok(c) = std::ffi::CString::new(mime.as_str()) else {
+                    continue;
+                };
                 offer(src, 0, c.as_ptr());
             }
 
@@ -4105,6 +4126,61 @@ impl WaylandWindow {
             return None;
         }
         Some(String::from_utf8_lossy(&bytes).into_owned())
+    }
+
+    /// Read EVERY flavor the current clipboard offer advertises that azul has
+    /// a codec for.
+    ///
+    /// Driven by the offer's own advertised mime list (captured at
+    /// `wl_data_device.selection`), not by guesswork: `wl_data_offer.receive`
+    /// with a mime the source never offered is answered by a pipe the source
+    /// is under no obligation to close, so each blind guess costs the full
+    /// transfer deadline.
+    pub(super) fn read_wayland_selection_payload(
+        &mut self,
+    ) -> Option<rich_clipboard::ClipboardPayload> {
+        use rich_clipboard::{ClipboardItem, ClipboardPayload, Flavor, Platform};
+
+        if self.clipboard_offer.is_null() {
+            return None;
+        }
+        // Cloned because the receive borrows `self` mutably below.
+        let offered: Vec<String> = self.drag.clipboard_mimes().to_vec();
+        let offer = self.clipboard_offer;
+
+        let mut payload = ClipboardPayload::new(Platform::Unix);
+        // Borrows `offered`, so it must be declared after it (and is dropped
+        // before it). `Flavor` is only `'static` when it came from a literal.
+        let mut seen: Vec<Flavor<'_>> = Vec::new();
+        for mime in &offered {
+            let flavor = Flavor::from_mime(mime);
+            // A flavor nothing here decodes is not worth a pipe transfer, and
+            // two spellings of one flavor (`UTF8_STRING` next to
+            // `text/plain;charset=utf-8`) are one transfer, not two.
+            if matches!(flavor, Flavor::Other(_)) || seen.contains(&flavor) {
+                continue;
+            }
+            let bytes = unsafe { events::receive_offer_bytes(self, offer, mime) };
+            if bytes.is_empty() {
+                continue;
+            }
+            seen.push(flavor);
+            payload.push(ClipboardItem::new(mime.as_str(), bytes));
+        }
+
+        if payload.is_empty() {
+            // No advertised mime answered — either the list never arrived
+            // (an offer whose advertisements we missed) or every transfer
+            // failed. Fall back to the single-flavor read, which asks for
+            // plain text unconditionally.
+            let text = self.read_wayland_selection()?;
+            return rich_clipboard::encode(
+                &rich_clipboard::RichItem::Text(text),
+                Platform::Unix,
+            )
+            .ok();
+        }
+        Some(payload)
     }
 
     // --- Primary selection (zwp_primary_selection_v1) ---

--- a/dll/src/desktop/shell2/linux/wayland/mod.rs
+++ b/dll/src/desktop/shell2/linux/wayland/mod.rs
@@ -1148,12 +1148,6 @@ impl WaylandWindow {
         }
     }
 
-    pub fn sync_clipboard(
-        &mut self,
-        clipboard_manager: &mut azul_layout::managers::clipboard::ClipboardManager,
-    ) {
-        clipboard::sync_clipboard(clipboard_manager);
-    }
 }
 
 // PlatformWindow Trait Implementation (Cross-platform V2 Event System)

--- a/dll/src/desktop/shell2/linux/x11/clipboard.rs
+++ b/dll/src/desktop/shell2/linux/x11/clipboard.rs
@@ -2,16 +2,79 @@
 //!
 //! This module provides clipboard synchronization between azul-layout's ClipboardManager
 //! and the X11 system clipboard (both PRIMARY and CLIPBOARD selections).
+//!
+//! # Multi-flavor reads, and why they are probes rather than a `TARGETS` query
+//!
+//! ICCCM says to ask for `TARGETS` first and then convert each target in turn.
+//! That is not reachable through `x11-clipboard` 0.9.3: its `Clipboard::load`
+//! rejects any reply whose `type_` differs from the target it asked for
+//! (`Error::UnexpectedType`), and a `TARGETS` conversion answers with type
+//! `ATOM` by definition — so the enumeration always errors before it returns.
+//!
+//! [`load_payload`] therefore *probes*: it converts a fixed, rank-ordered list
+//! of the targets azul has a codec for, and keeps every one that answers. A
+//! target the owner does not offer answers with no property and costs one
+//! cheap round trip; a **dead owner costs the full timeout**, so the probe
+//! stops at the first target that times out rather than paying it eight times.
+//!
+//! What this loses is flavors nothing here knows about: a private format
+//! cannot be carried through as `RichItem::Unknown` when the only way to learn
+//! its name is the `TARGETS` list. Lifting that needs either an
+//! `x11-clipboard` that tolerates a differently-typed reply, or a direct
+//! `x11rb` connection of our own.
+//!
+//! # Writes are single-flavor, and cannot be otherwise here
+//!
+//! There is no multi-flavor write through this crate at all. Its owner state
+//! is a `HashMap<selection, (target, value)>` — **one** target per selection —
+//! and its `SelectionRequest` handler answers a `TARGETS` query with exactly
+//! that one target. So `store()` called twice does not add a second flavor, it
+//! replaces the first.
+//!
+//! A copy therefore publishes plain text and nothing else: it is the flavor
+//! every X client can paste, and offering RTF *instead* would break every
+//! plain-text target to style one. Styled text survives a copy on macOS (see
+//! `macos/clipboard.rs`), and on X11 it does not. Lifting this needs a
+//! selection owner that serves several targets, which is a rewrite of the
+//! owner loop rather than a call-site change.
+//!
+//! INCR is handled inside `Clipboard::load` and is mandatory in practice —
+//! anything past roughly 256 KB arrives that way, and a screenshot always
+//! will. Its `SizeHint::AtLeast` lower bound is *not* reachable either: the
+//! crate reads it only to `reserve` the buffer and never reports it, so the
+//! size guard here is a post-hoc length check rather than the pre-read
+//! rejection Windows and macOS get.
 
 use std::sync::mpsc::{self, Sender, SyncSender};
 use std::sync::{Mutex, MutexGuard, OnceLock};
 use std::time::Duration;
 
 use azul_layout::managers::clipboard::ClipboardManager;
+use rich_clipboard::{ClipboardItem, ClipboardPayload, Flavor, Platform};
 use x11_clipboard::Clipboard;
 
+use super::super::super::common::clipboard::MAX_FLAVOR_BYTES;
 use super::super::super::common::debug_server::LogCategory;
 use crate::{log_error, log_warn};
+
+/// The selection targets a payload read probes for, richest first.
+///
+/// Ordered by `Flavor::read_rank` so the expensive round trips happen in the
+/// order the decode policy would prefer them anyway. Kept deliberately short:
+/// every entry is one X round trip, and each is a target azul has a codec for.
+///
+/// `text/plain;charset=utf-8` is last and is the one that must always be
+/// tried — it is what every X client offers and the floor every paste falls
+/// back to. `UTF8_STRING` is its pre-MIME spelling, still what older toolkits
+/// and terminals publish.
+const PROBE_TARGETS: &[&str] = &[
+    "text/uri-list",
+    "text/rtf",
+    "text/html",
+    "image/png",
+    "text/plain;charset=utf-8",
+    "UTF8_STRING",
+];
 
 /// How long the UI thread waits for a selection read before giving up.
 ///
@@ -174,6 +237,13 @@ enum ClipboardJob {
         kind: SelectionKind,
         reply: SyncSender<Option<String>>,
     },
+    /// Read EVERY target the selection offers that we have a codec for, and
+    /// answer on `reply`. Same worker and same deadline as `Load` — it is
+    /// several round trips rather than one, which is exactly why it must not
+    /// happen on the UI thread.
+    LoadPayload {
+        reply: SyncSender<Option<ClipboardPayload>>,
+    },
     /// Take ownership of PRIMARY with this text (fire and forget).
     ClaimPrimary(String),
     /// Take ownership of CLIPBOARD *and* PRIMARY with this text — the four
@@ -200,6 +270,9 @@ fn worker() -> Option<MutexGuard<'static, Sender<ClipboardJob>>> {
                         // discarded, not an error.
                         ClipboardJob::Load { kind, reply } => {
                             let _ = reply.try_send(load_selection(kind));
+                        }
+                        ClipboardJob::LoadPayload { reply } => {
+                            let _ = reply.try_send(load_selection_payload());
                         }
                         ClipboardJob::ClaimPrimary(text) => claim_primary(&text),
                         ClipboardJob::Store(text) => store_both_selections(&text),
@@ -292,6 +365,114 @@ fn load_selection(kind: SelectionKind) -> Option<String> {
     }
 
     None
+}
+
+/// Worker-thread side of a multi-flavor read. Blocking — never call this on
+/// the UI thread.
+///
+/// Probes [`PROBE_TARGETS`] in order (see the module docs for why this is not
+/// a `TARGETS` enumeration) and keeps every target that answers with bytes.
+///
+/// **Stops at the first target that errors.** An owner that is gone or wedged
+/// makes every probe pay the full [`SELECTION_LOAD_TIMEOUT`], and paying that
+/// six times over is how a paste turns into a multi-second stall on the
+/// clipboard worker (and, through the mutex it holds, on the next copy).
+fn load_selection_payload() -> Option<ClipboardPayload> {
+    let guard = clipboard()?;
+    let clipboard = guard.as_ref()?;
+
+    let mut payload = ClipboardPayload::new(Platform::Unix);
+    let mut seen: Vec<Flavor<'static>> = Vec::new();
+
+    for target in PROBE_TARGETS {
+        // BEFORE the transfer, not after: `UTF8_STRING` and
+        // `text/plain;charset=utf-8` are one flavor under two names, and
+        // fetching the second only to discard it costs a whole X round trip
+        // in the case that happens on almost every paste.
+        let flavor = Flavor::from_mime(target);
+        if seen.contains(&flavor) {
+            continue;
+        }
+        let Ok(atom) = clipboard.getter.get_atom(target) else {
+            continue;
+        };
+        let loaded = clipboard.load(
+            clipboard.getter.atoms.clipboard,
+            atom,
+            clipboard.getter.atoms.property,
+            SELECTION_LOAD_TIMEOUT,
+        );
+        let bytes = match loaded {
+            Ok(bytes) => bytes,
+            Err(_) => {
+                // The owner did not answer. Every remaining probe would pay
+                // the same timeout, so stop and use whatever already came
+                // back — the ranked order means that is the best of them.
+                log_warn!(
+                    LogCategory::Resources,
+                    "[X11] selection owner stopped answering at target `{target}` — using the \
+                     {} flavor(s) already read",
+                    payload.len()
+                );
+                break;
+            }
+        };
+        if bytes.is_empty() {
+            // Target not offered. Cheap, and not an error.
+            continue;
+        }
+        if bytes.len() as u64 > MAX_FLAVOR_BYTES {
+            // Post-hoc, not pre-read: `Clipboard::load` never reports the
+            // INCR lower bound it saw, so there is nothing to reject on
+            // before the transfer. See the module docs.
+            log_warn!(
+                LogCategory::Resources,
+                "[X11] dropping selection target `{target}`: {} bytes exceeds the \
+                 {MAX_FLAVOR_BYTES}-byte cap",
+                bytes.len()
+            );
+            continue;
+        }
+
+        seen.push(flavor);
+        payload.push(ClipboardItem::new(*target, bytes));
+    }
+
+    (!payload.is_empty()).then_some(payload)
+}
+
+/// Read every flavor the CLIPBOARD selection offers.
+///
+/// Non-blocking by UI-thread standards, like [`get_clipboard_content`]: the
+/// probes run on the clipboard worker and this gives up after
+/// [`PASTE_UI_DEADLINE`].
+///
+/// Falls back to the text this process last copied when the selection answers
+/// with nothing, for the same reason [`get_clipboard_content`] does: a copy is
+/// parked in-process before the X handoff is even queued, so a Ctrl+C followed
+/// immediately by Ctrl+V must still paste.
+pub fn read_payload() -> Option<ClipboardPayload> {
+    let (reply, answer) = mpsc::sync_channel(1);
+    {
+        let sender = worker()?;
+        sender.send(ClipboardJob::LoadPayload { reply }).ok()?;
+    }
+    let from_selection = match answer.recv_timeout(PASTE_UI_DEADLINE) {
+        Ok(payload) => payload,
+        Err(_) => {
+            log_warn!(
+                LogCategory::Resources,
+                "[X11] selection owner did not answer within {PASTE_UI_DEADLINE:?} — pasting \
+                 nothing"
+            );
+            None
+        }
+    };
+    if let Some(payload) = from_selection {
+        return Some(payload);
+    }
+    let parked = LAST_WRITTEN.lock().ok().and_then(|g| g.clone())?;
+    rich_clipboard::encode(&rich_clipboard::RichItem::Text(parked), Platform::Unix).ok()
 }
 
 /// Hand a read to the worker and wait at most [`PASTE_UI_DEADLINE`] for it.

--- a/dll/src/desktop/shell2/linux/x11/clipboard.rs
+++ b/dll/src/desktop/shell2/linux/x11/clipboard.rs
@@ -1,7 +1,7 @@
 //! X11 clipboard integration using x11-clipboard crate
 //!
-//! This module provides clipboard synchronization between azul-layout's ClipboardManager
-//! and the X11 system clipboard (both PRIMARY and CLIPBOARD selections).
+//! Reads and writes both the CLIPBOARD (Ctrl+C/V) and PRIMARY (select /
+//! middle-click) selections, on a worker thread — see [`worker`].
 //!
 //! # Multi-flavor reads, and why they are probes rather than a `TARGETS` query
 //!
@@ -49,13 +49,12 @@ use std::sync::mpsc::{self, Sender, SyncSender};
 use std::sync::{Mutex, MutexGuard, OnceLock};
 use std::time::Duration;
 
-use azul_layout::managers::clipboard::ClipboardManager;
 use rich_clipboard::{ClipboardItem, ClipboardPayload, Flavor, Platform};
 use x11_clipboard::Clipboard;
 
 use super::super::super::common::clipboard::MAX_FLAVOR_BYTES;
 use super::super::super::common::debug_server::LogCategory;
-use crate::{log_error, log_warn};
+use crate::log_warn;
 
 /// The selection targets a payload read probes for, richest first.
 ///
@@ -109,31 +108,6 @@ fn clipboard() -> Option<MutexGuard<'static, Option<Clipboard>>> {
     static CLIPBOARD: OnceLock<Mutex<Option<Clipboard>>> = OnceLock::new();
     let m = CLIPBOARD.get_or_init(|| Mutex::new(Clipboard::new().ok()));
     m.lock().ok()
-}
-
-/// Synchronize clipboard manager content to X11 system clipboard
-///
-/// If the clipboard manager has pending copy content, it's written to
-/// both the CLIPBOARD and PRIMARY X11 selections.
-///
-/// TODO(superplan): this flush path is now redundant — the copy/cut/paste
-/// shortcuts and the `SetCopyContent`/`SetCutContent` callbacks both write to
-/// the OS clipboard directly through `common/event.rs`
-/// (`set_system_clipboard` → `write_to_clipboard`), so no run loop calls
-/// `sync_clipboard`. The macOS + Windows backends already dropped their dead
-/// copies; this one (plus the `x11/mod.rs` + `linux/mod.rs` `sync_clipboard`
-/// wrappers, owned by another group) should be removed in a follow-up.
-pub fn sync_clipboard(clipboard_manager: &mut ClipboardManager) {
-    // Check if there's pending content to copy
-    if let Some(content) = clipboard_manager.get_copy_content() {
-        // Write to X11 clipboard
-        if let Err(e) = write_to_clipboard(&content.plain_text) {
-            log_error!(LogCategory::Resources, "Failed to sync clipboard to X11: {e}");
-        }
-    }
-
-    // Clear the clipboard manager after sync
-    clipboard_manager.clear();
 }
 
 /// The text this process last put on the clipboard.

--- a/dll/src/desktop/shell2/linux/x11/mod.rs
+++ b/dll/src/desktop/shell2/linux/x11/mod.rs
@@ -1865,14 +1865,6 @@ impl X11Window {
         }
     }
 
-    /// Synchronize the clipboard state with the system clipboard.
-    pub fn sync_clipboard(
-        &mut self,
-        clipboard_manager: &mut azul_layout::managers::clipboard::ClipboardManager,
-    ) {
-        clipboard::sync_clipboard(clipboard_manager);
-    }
-
     /// Destroy the X11 window, free the ARGB colormap, and close the display.
     pub fn close(&mut self) {
         // WebRender's Renderer must be deinit()'d, not dropped — texture

--- a/dll/src/desktop/shell2/macos/clipboard.rs
+++ b/dll/src/desktop/shell2/macos/clipboard.rs
@@ -1,103 +1,298 @@
-//! macOS clipboard integration via Cocoa NSPasteboard API
+//! macOS clipboard transport: `NSPasteboard` ⇄ [`ClipboardPayload`].
 //!
-//! Public API:
-//! - [`get_clipboard_content`]: reads the current pasteboard text
-//! - [`write_to_clipboard`]: writes a string to the pasteboard
+//! Transport only — this module knows about pasteboard items, types and byte
+//! counts, and nothing about what any of those bytes mean. The formats live in
+//! `rich-clipboard`, reached through `shell2/common/clipboard.rs`.
 //!
-//! Called from `common/event.rs` during event processing (via the
-//! `get_system_clipboard`/`set_system_clipboard` helpers).
+//! Written against `objc2-app-kit`, whose `generalPasteboard` / `types` /
+//! `pasteboardItems` / `dataForType:` bindings are all safe, so there is no
+//! `unsafe` here at all. (The `objc` 0.2 version this replaced needed a
+//! `transmute` of a `&Class` to get `readObjectsForClasses:` to typecheck.)
+//!
+//! # Four things about `NSPasteboard` that are easy to get wrong
+//!
+//! * **A pasteboard holds *items*, not formats.** `-[NSPasteboard types]` is
+//!   the union of every item's types and `-[NSPasteboard dataForType:]` only
+//!   reaches the *first* item offering that type. Copy three files in Finder
+//!   and the pasteboard holds three items each carrying one `public.file-url`;
+//!   the pasteboard-level API shows one URL and silently drops the other two.
+//!   [`read_payload`] therefore walks `-pasteboardItems` and records which item
+//!   each representation came from.
+//! * **Types are promises.** `dataForType:` returns nil for a type that is
+//!   genuinely on offer when the owning application declared it lazily and then
+//!   declined — Safari advertises `com.apple.linkpresentation.metadata` and
+//!   never provides it. Skipped, not an error.
+//! * **Every modern UTI has a byte-identical legacy twin** (`public.rtf` and
+//!   `NeXT Rich Text Format v1.0 pasteboard type`, and six more). The registry
+//!   resolves both to one `Flavor`, so a payload carrying both would decode
+//!   everything twice — [`read_payload`] drops the second spelling.
+//! * **Ask the size before copying.** The bytes are already resident and owned
+//!   by the pasteboard server, so `-[NSData length]` costs nothing and happens
+//!   *before* `to_vec()`. A flavor past the cap is skipped and the decode falls
+//!   through to the next-best one.
 
-use std::mem::transmute;
+use objc2::runtime::ProtocolObject;
+use objc2_app_kit::{NSPasteboard, NSPasteboardItem};
+use objc2_foundation::{NSArray, NSData, NSString};
+use rich_clipboard::{ClipboardItem, ClipboardPayload, Flavor, Platform};
 
-use objc::runtime::{Class, Object};
-use objc_foundation::{INSArray, INSObject, INSString, NSArray, NSDictionary, NSObject, NSString};
-use objc_id::{Id, Owned};
+use super::super::common::clipboard::MAX_FLAVOR_BYTES;
+use super::super::common::debug_server::LogCategory;
+use crate::log_warn;
 
-use objc::{msg_send, sel, sel_impl};
-
-// Required to bring NSPasteboard into the path of the class-resolver
-#[link(name = "AppKit", kind = "framework")]
-extern "C" {}
-
-/// Read content from macOS system clipboard
+/// Read every flavor on the general pasteboard.
 ///
-/// Returns the clipboard text content if available.
+/// `None` for an empty or unreachable pasteboard. An empty payload is reported
+/// as `None` too: "the clipboard offered nothing we could read" and "there is
+/// no clipboard" are the same thing to a paste.
+pub fn read_payload() -> Option<ClipboardPayload> {
+    let pasteboard = NSPasteboard::generalPasteboard();
+    let mut payload = ClipboardPayload::new(Platform::MacOs);
+
+    // Items, not the pasteboard-level API: see the module docs. Walked even
+    // for a single item, so a one-file copy and a three-file copy take the
+    // same code path rather than differing in a way only multi-select
+    // exercises.
+    let items = pasteboard.pasteboardItems()?;
+    for (index, item) in items.iter().enumerate() {
+        read_item(&item, index, &mut payload);
+    }
+
+    (!payload.is_empty()).then_some(payload)
+}
+
+/// Every representation of one pasteboard item, deduped by resolved flavor.
+fn read_item(item: &NSPasteboardItem, index: usize, payload: &mut ClipboardPayload) {
+    // Which flavors this ITEM has already contributed. Per-item, not
+    // per-payload: three Finder items each offering `public.file-url` are
+    // three files and all three must survive — it is one item offering the
+    // same flavor under two spellings that is the duplicate.
+    let mut seen: Vec<String> = Vec::new();
+
+    for ty in item.types().iter() {
+        let native = ty.to_string();
+        // `Flavor::Other` carries the native name, so two unrecognised types
+        // never collide with each other; two spellings of a known flavor do.
+        let flavor = Flavor::from_uti(&native);
+        let key = flavor_key(flavor, &native);
+        if seen.iter().any(|s| *s == key) {
+            continue;
+        }
+
+        let Some(data) = item.dataForType(&ty) else {
+            // A promise the owner declined. Normal — do not warn.
+            continue;
+        };
+        let Some(bytes) = take_bytes(&data, &native) else {
+            continue;
+        };
+
+        seen.push(key);
+        payload.push(ClipboardItem::in_item(index, native, bytes));
+    }
+}
+
+/// A stable identity for "this flavor", for the dedupe.
+fn flavor_key(flavor: Flavor<'_>, native: &str) -> String {
+    match flavor {
+        // Unrecognised: the native name IS the identity.
+        Flavor::Other(_) => format!("other:{native}"),
+        known => format!("{known:?}"),
+    }
+}
+
+/// Copy an `NSData` out, refusing one that is over the cap.
+///
+/// The length check is the whole point of doing this here rather than at
+/// `to_vec()`: on macOS the size is knowable exactly and for free before any
+/// copy happens, so an oversize flavor costs nothing at all. Skipping it lets
+/// the decode fall through to the next-best flavor — a 400 MB TIFF goes and
+/// the plain text alongside it stays.
+fn take_bytes(data: &NSData, native: &str) -> Option<Vec<u8>> {
+    let len = data.len() as u64;
+    if len > MAX_FLAVOR_BYTES {
+        log_warn!(
+            LogCategory::Resources,
+            "[macOS] skipping pasteboard flavor `{native}`: {len} bytes exceeds the {MAX_FLAVOR_BYTES}-byte cap"
+        );
+        return None;
+    }
+    Some(data.to_vec())
+}
+
+/// Publish a payload to the general pasteboard.
+///
+/// One `NSPasteboardItem` per [`ClipboardItem::item`] index, which is the only
+/// way to say "these four files" on a pasteboard — an item advertising
+/// `public.file-url` four times is one file advertised four times, and a reader
+/// using `-[NSPasteboard dataForType:]` would see the first.
+///
+/// `false` unless the pasteboard accepted at least one item: `CutToClipboard`
+/// gates the deletion of the user's selected text on this.
+pub fn write_payload(payload: &ClipboardPayload) -> bool {
+    if payload.is_empty() {
+        return false;
+    }
+
+    // Group the representations by pasteboard item, preserving the order
+    // within each — `encode` emits best-flavor-first and a pasteboard reader
+    // is entitled to take the first type it recognises.
+    let mut items: Vec<Vec<&ClipboardItem>> = Vec::new();
+    for entry in payload.items() {
+        if items.len() <= entry.item {
+            items.resize_with(entry.item + 1, Vec::new);
+        }
+        items[entry.item].push(entry);
+    }
+
+    // Build every item first, then publish them in ONE `writeObjects:`. That
+    // is the documented usage and it does not depend on whether repeated
+    // calls append to or replace the pasteboard's items — a distinction the
+    // bindings do not state and which decides whether a three-file copy ends
+    // up as three files or as one.
+    let mut objects = Vec::with_capacity(items.len());
+    for group in &items {
+        let item = NSPasteboardItem::new();
+        let mut any = false;
+        for entry in group {
+            let ty = NSString::from_str(&entry.native);
+            let data = NSData::with_bytes(&entry.bytes);
+            if item.setData_forType(&data, &ty) {
+                any = true;
+            }
+        }
+        // An item nothing could be set on would advertise no types at all.
+        if any {
+            objects.push(ProtocolObject::from_retained(item));
+        }
+    }
+    if objects.is_empty() {
+        log_warn!(
+            LogCategory::Resources,
+            "[macOS] no representation of a {}-flavor payload could be set on a pasteboard item",
+            payload.len()
+        );
+        return false;
+    }
+
+    let pasteboard = NSPasteboard::generalPasteboard();
+    // `clearContents` invalidates the previous owner and bumps the change
+    // count; nothing may be written before it.
+    pasteboard.clearContents();
+    let written = pasteboard.writeObjects(&NSArray::from_retained_slice(&objects));
+    if !written {
+        log_warn!(
+            LogCategory::Resources,
+            "[macOS] the pasteboard rejected a {}-item write",
+            objects.len()
+        );
+    }
+    written
+}
+
+/// Read the pasteboard as plain text.
+///
+/// Kept for the callers that only ever wanted a string (the debug server, the
+/// E2E harness). Goes through the payload path so a pasteboard offering only
+/// RTF or HTML still answers — the old `readObjectsForClasses:[NSString]`
+/// implementation returned nil for those.
 pub fn get_clipboard_content() -> Option<String> {
-    read_from_pasteboard().ok()
+    let payload = read_payload()?;
+    rich_clipboard::decode_payload(&payload)
+        .ok()?
+        .plain_text()
+        .map(str::to_owned)
 }
 
-/// Write string to macOS pasteboard
+/// Write a plain string to the pasteboard.
 pub fn write_to_clipboard(text: &str) -> Result<(), ClipboardError> {
-    write_to_pasteboard(text)
-}
-
-/// Write string to macOS pasteboard (internal implementation)
-fn write_to_pasteboard(text: &str) -> Result<(), ClipboardError> {
-    let pasteboard = get_general_pasteboard()?;
-
-    let string_array = NSArray::from_vec(vec![NSString::from_str(text)]);
-    let _: usize = unsafe { msg_send![pasteboard, clearContents] };
-    let success: bool = unsafe { msg_send![pasteboard, writeObjects: string_array] };
-
-    if success {
+    let payload = rich_clipboard::encode(
+        &rich_clipboard::RichItem::Text(text.to_owned()),
+        Platform::MacOs,
+    )
+    .map_err(|_| ClipboardError::WriteError)?;
+    if write_payload(&payload) {
         Ok(())
     } else {
         Err(ClipboardError::WriteError)
     }
 }
 
-/// Read string from macOS pasteboard
-fn read_from_pasteboard() -> Result<String, ClipboardError> {
-    let pasteboard = get_general_pasteboard()?;
-
-    let cls = Class::get("NSString").ok_or(ClipboardError::PasteboardNotFound)?;
-    let string_class: Id<NSObject> = unsafe {
-        let cls_ptr: *mut Object = transmute(cls as *const Class);
-        let _: () = msg_send![cls_ptr, retain];
-        Id::from_ptr(cls_ptr as *mut NSObject)
-    };
-
-    let classes: Id<NSArray<NSObject, Owned>> = NSArray::from_vec(vec![string_class]);
-    let options: Id<NSDictionary<NSObject, NSObject>> = NSDictionary::new();
-
-    let string_array: Id<NSArray<NSString>> = unsafe {
-        let obj: *mut NSArray<NSString> =
-            msg_send![pasteboard, readObjectsForClasses:&*classes options:&*options];
-        if obj.is_null() {
-            return Err(ClipboardError::ReadError);
-        }
-        Id::from_ptr(obj)
-    };
-
-    if string_array.count() == 0 {
-        Err(ClipboardError::EmptyClipboard)
-    } else {
-        Ok(string_array[0].as_str().to_owned())
-    }
-}
-
-/// Get the general pasteboard instance
-fn get_general_pasteboard() -> Result<Id<Object>, ClipboardError> {
-    let cls = Class::get("NSPasteboard").ok_or(ClipboardError::PasteboardNotFound)?;
-    let pasteboard: *mut Object = unsafe { msg_send![cls, generalPasteboard] };
-    if pasteboard.is_null() {
-        return Err(ClipboardError::NullPasteboard);
-    }
-    let _: () = unsafe { msg_send![pasteboard, retain] };
-    Ok(unsafe { Id::from_ptr(pasteboard) })
-}
-
-/// Errors that can occur during macOS clipboard operations
+/// Errors that can occur during macOS clipboard operations.
 #[derive(Debug, Copy, Clone)]
 pub enum ClipboardError {
-    /// `NSPasteboard` class could not be found in the Objective-C runtime
-    PasteboardNotFound,
-    /// `generalPasteboard` returned a null pointer
-    NullPasteboard,
-    /// `writeObjects:` call to the pasteboard returned false
+    /// The pasteboard refused every representation of the payload.
     WriteError,
-    /// `readObjectsForClasses:options:` returned null
-    ReadError,
-    /// Pasteboard contained no string items
-    EmptyClipboard,
+}
+
+impl core::fmt::Display for ClipboardError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::WriteError => write!(f, "the macOS pasteboard rejected the write"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Two spellings of ONE flavor on one item are one flavor. Every modern
+    /// UTI has a byte-identical legacy twin on a real pasteboard, and carrying
+    /// both means decoding the same bytes twice.
+    ///
+    /// NEGATIVE CONTROL: drop the `seen` check in `read_item`.
+    #[test]
+    fn legacy_uti_twins_share_one_key() {
+        let modern = Flavor::from_uti("public.rtf");
+        let legacy = Flavor::from_uti("NeXT Rich Text Format v1.0 pasteboard type");
+        assert_eq!(modern, legacy, "the registry must resolve both to Rtf");
+        assert_eq!(
+            flavor_key(modern, "public.rtf"),
+            flavor_key(legacy, "NeXT Rich Text Format v1.0 pasteboard type"),
+            "two spellings of one flavor must dedupe against each other"
+        );
+    }
+
+    /// Two flavors nothing recognises must NOT dedupe against each other —
+    /// they are both `Flavor::Other`, and keying on the variant alone would
+    /// drop the second private format a source offered.
+    ///
+    /// NEGATIVE CONTROL: return `format!("{known:?}")` for `Other` too.
+    #[test]
+    fn unrecognised_flavors_keep_their_own_identity() {
+        let a = "com.example.private-one";
+        let b = "com.example.private-two";
+        assert_ne!(
+            flavor_key(Flavor::from_uti(a), a),
+            flavor_key(Flavor::from_uti(b), b)
+        );
+    }
+
+    /// A multi-file selection is N pasteboard ITEMS, and the grouping in
+    /// `write_payload` is what preserves that. One item offering
+    /// `public.file-url` three times would be one file advertised three times.
+    #[test]
+    fn a_file_list_encodes_to_one_item_per_file() {
+        let files = rich_clipboard::FileList::of_paths(["/tmp/a.txt", "/tmp/b.txt", "/tmp/c.txt"]);
+        let payload = rich_clipboard::encode(
+            &rich_clipboard::RichItem::Files(files),
+            Platform::MacOs,
+        )
+        .expect("a file list is publishable on macOS");
+
+        assert_eq!(
+            payload.item_count(),
+            3,
+            "three files must become three pasteboard items"
+        );
+        for index in 0..3 {
+            assert!(
+                payload
+                    .group(index)
+                    .any(|i| Flavor::from_uti(&i.native) == Flavor::FileList),
+                "item {index} must carry a file URL"
+            );
+        }
+    }
 }

--- a/dll/src/desktop/shell2/windows/clipboard.rs
+++ b/dll/src/desktop/shell2/windows/clipboard.rs
@@ -1,24 +1,250 @@
-//! Windows clipboard integration
+//! Windows clipboard transport: the Win32 clipboard ⇄ [`ClipboardPayload`].
 //!
-//! Uses the `clipboard-win` crate to interface with the Windows clipboard API.
+//! Transport only — this module knows about format numbers, `GlobalSize` and
+//! handle lifetimes, and nothing about what any of those bytes mean. The
+//! formats live in `rich-clipboard`, reached through
+//! `shell2/common/clipboard.rs`.
 //!
-//! - [`write_to_clipboard`]: writes a string to the system clipboard.
-//! - [`get_clipboard_content`]: reads the current text content from the system clipboard.
+//! Built on `clipboard-win`'s `raw` layer rather than its typed one: the typed
+//! `get_clipboard::<String, _>(formats::Unicode)` reaches exactly one format,
+//! which is the whole thing a payload transport must not do.
 //!
-//! Both are called from `common/event.rs` during event processing (via the
-//! `get_system_clipboard`/`set_system_clipboard` helpers).
+//! # What is easy to get wrong here
+//!
+//! * **The clipboard is a global lock held by one process at a time.** Every
+//!   read and write goes through [`with_clipboard`], which retries the open —
+//!   another application holding it for a few milliseconds is routine, not an
+//!   error — and closes it on the way out even if the body panicked, because
+//!   `Clipboard`'s `Drop` does that.
+//! * **`set` empties the clipboard first.** Publishing a fan-out of four
+//!   formats with it would leave only the last one. The write empties *once*
+//!   and then uses `set_without_clear` per format.
+//! * **Predefined formats have no name.** `GetClipboardFormatNameW` returns
+//!   nothing for `CF_DIB` and friends, so the number is mapped through
+//!   [`WindowsFormat::name`] — which is exactly what `Flavor::from_windows_name`
+//!   reads back — and only registered formats are asked for their string.
+//! * **`CF_BITMAP` and `CF_ENHMETAFILE` are handles, not bytes.** `GlobalSize`
+//!   on an `HBITMAP` is meaningless. They are skipped rather than dumped as
+//!   whatever bytes happen to be at that address.
+//! * **Ask the size before copying.** `GlobalSize` on the handle is the
+//!   `SizeHint::Exact` this platform can state for free, before any copy — so
+//!   an oversize flavor costs nothing and the decode falls through to the
+//!   next-best one.
+//!
+//! **Never run against a real Windows clipboard.** This is written from the
+//! Win32 documentation and `clipboard-win`'s source; treat the first run as a
+//! debugging session, not a smoke test.
 
-/// Write text to the Windows system clipboard
-pub fn write_to_clipboard(text: &str) -> Result<(), ()> {
-    use clipboard_win::{formats, set_clipboard};
-    set_clipboard(formats::Unicode, text).map_err(|_| ())
+use clipboard_win::{formats, raw, Clipboard};
+use rich_clipboard::{ClipboardItem, ClipboardPayload, Flavor, Platform};
+
+use super::super::common::clipboard::MAX_FLAVOR_BYTES;
+use super::super::common::debug_server::LogCategory;
+use crate::{log_warn, log_debug};
+
+/// How many times to retry `OpenClipboard` before giving up.
+///
+/// The clipboard is a global lock: another application repainting a paste
+/// preview holds it for a few milliseconds and `OpenClipboard` fails outright
+/// rather than blocking. `clipboard-win` sleeps between attempts, so this is
+/// tens of milliseconds worst case — bounded, because this runs on the UI
+/// thread and a wedged clipboard owner must cost a paste, not the frame loop.
+const OPEN_ATTEMPTS: usize = 10;
+
+/// Formats whose clipboard "data" is a HANDLE rather than a memory block.
+///
+/// `GlobalSize` on an `HBITMAP` or `HENHMETAFILE` does not describe the
+/// object, so reading them as bytes produces garbage of an arbitrary length.
+/// A consumer that wants these needs `GetDIBits` / `GetEnhMetaFileBits`, which
+/// is a real conversion and not a transport concern.
+const HANDLE_FORMATS: &[u32] = &[
+    formats::CF_BITMAP,
+    formats::CF_ENHMETAFILE,
+    formats::CF_METAFILEPICT,
+    formats::CF_PALETTE,
+    formats::CF_OWNERDISPLAY,
+];
+
+/// Run `f` with the clipboard open, closing it afterwards.
+fn with_clipboard<T>(f: impl FnOnce() -> Option<T>) -> Option<T> {
+    // `Clipboard`'s Drop calls CloseClipboard, so an early return inside `f`
+    // cannot leak the global lock.
+    let _guard = Clipboard::new_attempts(OPEN_ATTEMPTS).ok()?;
+    f()
 }
 
-/// Read content from Windows system clipboard
+/// Read every format currently on the clipboard.
 ///
-/// Returns the clipboard text content if available.
-pub fn get_clipboard_content() -> Option<String> {
-    use clipboard_win::{formats, get_clipboard};
+/// `None` for an empty or unreachable clipboard.
+pub fn read_payload() -> Option<ClipboardPayload> {
+    with_clipboard(|| {
+        let mut payload = ClipboardPayload::new(Platform::Windows);
+        // Windows has one selection with many formats and no notion of items,
+        // so everything belongs to item 0.
+        for format in raw::EnumFormats::new() {
+            if HANDLE_FORMATS.contains(&format) {
+                log_debug!(
+                    LogCategory::Resources,
+                    "[Windows] skipping clipboard format {format}: a handle, not bytes"
+                );
+                continue;
+            }
+            let Some(native) = format_name(format) else {
+                continue;
+            };
+            // GlobalSize BEFORE the copy — the whole reason the read is split
+            // in two steps.
+            let size = raw::size(format).map_or(0, |s| s.get() as u64);
+            if size > MAX_FLAVOR_BYTES {
+                log_warn!(
+                    LogCategory::Resources,
+                    "[Windows] skipping clipboard format `{native}`: {size} bytes exceeds the \
+                     {MAX_FLAVOR_BYTES}-byte cap"
+                );
+                continue;
+            }
 
-    get_clipboard::<String, _>(formats::Unicode).ok()
+            let mut bytes = Vec::new();
+            if raw::get_vec(format, &mut bytes).is_err() || bytes.is_empty() {
+                // A format that is advertised but not readable — a delayed
+                // render whose owner declined. Normal; skip it.
+                continue;
+            }
+            payload.push(ClipboardItem::new(native, bytes));
+        }
+        (!payload.is_empty()).then_some(payload)
+    })
+}
+
+/// The identifier `Flavor::from_windows_name` reads back.
+///
+/// A predefined format has no name from `GetClipboardFormatNameW`, so its
+/// canonical `CF_*` spelling comes from the registry; only a registered format
+/// is asked for its string. `None` for a predefined format the registry does
+/// not name — those are formats nothing in this stack can decode anyway
+/// (`CF_SYLK`, `CF_PENDATA`, the private ranges).
+fn format_name(format: u32) -> Option<String> {
+    use rclip_core::flavor::WindowsFormat;
+
+    if let Some(name) = WindowsFormat::Predefined(format).name() {
+        return Some(name.to_owned());
+    }
+    // Predefined numbers below CF_MAX that the registry does not name are not
+    // registered formats either — asking Windows for their name returns
+    // nothing and inventing one would produce an identifier no reader knows.
+    raw::format_name_big(format)
+}
+
+/// Publish every flavor of a payload to the clipboard.
+///
+/// `false` unless at least one format was accepted: `CutToClipboard` gates the
+/// deletion of the user's selected text on this.
+pub fn write_payload(payload: &ClipboardPayload) -> bool {
+    if payload.is_empty() {
+        return false;
+    }
+    with_clipboard(|| {
+        // ONCE, before the loop: `raw::set` would empty before every format
+        // and leave only the last one on the clipboard.
+        if raw::empty().is_err() {
+            return None;
+        }
+        let mut written = 0usize;
+        for entry in payload.items() {
+            let Some(format) = format_id(&entry.native) else {
+                continue;
+            };
+            if raw::set_without_clear(format, &entry.bytes).is_ok() {
+                written += 1;
+            }
+        }
+        (written > 0).then_some(())
+    })
+    .is_some()
+}
+
+/// The Win32 format number for a payload identifier.
+///
+/// The reverse of [`format_name`]: a predefined format resolves through the
+/// registry to its number, and everything else is registered by name (which
+/// returns the existing id when the format is already registered — that is
+/// what makes `RegisterClipboardFormat` idempotent).
+fn format_id(native: &str) -> Option<u32> {
+    use rclip_core::flavor::WindowsFormat;
+
+    match Flavor::from_windows_name(native).windows() {
+        Some(WindowsFormat::Predefined(id)) => Some(id),
+        Some(WindowsFormat::Registered(name)) => raw::register_format(name).map(|id| id.get()),
+        // An identifier the registry does not know — a private format carried
+        // through verbatim by `RichItem::Unknown`. Register it under the name
+        // it arrived with.
+        None => raw::register_format(native).map(|id| id.get()),
+    }
+}
+
+/// Write text to the Windows system clipboard.
+pub fn write_to_clipboard(text: &str) -> Result<(), ()> {
+    let payload = rich_clipboard::encode(
+        &rich_clipboard::RichItem::Text(text.to_owned()),
+        Platform::Windows,
+    )
+    .map_err(|_| ())?;
+    if write_payload(&payload) {
+        Ok(())
+    } else {
+        Err(())
+    }
+}
+
+/// Read the clipboard's text content.
+///
+/// Goes through the payload path, so a clipboard offering only RTF or `CF_HTML`
+/// still answers — the old `get_clipboard::<String, _>(formats::Unicode)` came
+/// back empty for those.
+pub fn get_clipboard_content() -> Option<String> {
+    let payload = read_payload()?;
+    rich_clipboard::decode_payload(&payload)
+        .ok()?
+        .plain_text()
+        .map(str::to_owned)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The name a predefined format is published under has to be the one
+    /// `Flavor::from_windows_name` reads back, or a payload written by this
+    /// module would not resolve when read by it.
+    ///
+    /// NEGATIVE CONTROL: make `format_name` call `format_name_big` first —
+    /// `CF_DIB` comes back as `None` and the flavor is lost.
+    #[test]
+    fn predefined_format_names_round_trip_through_the_registry() {
+        for (id, flavor) in [
+            (formats::CF_UNICODETEXT, Flavor::PlainText),
+            (formats::CF_DIB, Flavor::Dib),
+            (formats::CF_DIBV5, Flavor::DibV5),
+            (formats::CF_HDROP, Flavor::FileList),
+        ] {
+            let name = super::format_name(id).expect("a predefined format must have a name");
+            assert_eq!(
+                Flavor::from_windows_name(&name),
+                flavor,
+                "{name} did not resolve back to the flavor it names"
+            );
+        }
+    }
+
+    /// A handle format must never be read as bytes: `GlobalSize` on an
+    /// `HBITMAP` describes nothing, so whatever came back would be garbage of
+    /// an arbitrary length.
+    #[test]
+    fn handle_formats_are_not_byte_formats() {
+        assert!(HANDLE_FORMATS.contains(&formats::CF_BITMAP));
+        assert!(HANDLE_FORMATS.contains(&formats::CF_ENHMETAFILE));
+        // CF_DIB *is* bytes and must not be in the list — it is the format
+        // rclip-dib decodes.
+        assert!(!HANDLE_FORMATS.contains(&formats::CF_DIB));
+    }
 }

--- a/layout/src/managers/selection.rs
+++ b/layout/src/managers/selection.rs
@@ -3,22 +3,20 @@
 //! Contains `ClipboardContent` and `StyledTextRun`, used by clipboard and
 //! changeset modules.
 //!
-//! **Rich-text status:** the OS half is wired. A paste populates
-//! `styled_runs` whenever the source offered a styled flavor — the platform
-//! transports in `dll/src/desktop/shell2/*/clipboard.rs` hand every flavor
-//! the source published to `rich-clipboard`, whose decode policy prefers RTF,
-//! then HTML, then plain text, and `shell2/common/clipboard.rs` converts the
-//! result into this type. A copy fans back out the same way, so styled text
-//! reaches other applications as RTF *and* HTML *and* plain text at once
-//! (macOS, Windows and native Wayland; X11's selection owner can only serve
-//! one target, so it publishes plain text — see `x11/clipboard.rs`).
+//! **Rich-text status: wired end to end.** A paste populates `styled_runs`
+//! whenever the source offered a styled flavor — the platform transports in
+//! `dll/src/desktop/shell2/*/clipboard.rs` hand every flavor the source
+//! published to `rich-clipboard`, whose decode policy prefers RTF, then HTML,
+//! then plain text, and `shell2/common/clipboard.rs` converts the result into
+//! this type. A copy goes the other way: [`ClipboardExtract`] pulls per-run
+//! formatting off each source `StyledRun` as the selection is walked, and the
+//! transports fan that out as RTF *and* HTML *and* plain text at once — so a
+//! copy out of azul pastes into Word or LibreOffice formatted.
 //!
-//! What is still empty is the COPY-side extraction:
-//! `window.rs::get_selected_content_for_clipboard` builds `styled_runs` from
-//! the selection as an empty vec, because per-run style has to come out of the
-//! styled DOM and that walk does not exist yet. So azul currently *reads*
-//! styling and does not yet *produce* it — the transport underneath is ready
-//! for both.
+//! Two platforms are less capable, and both say so in their own docs: X11's
+//! selection owner can serve only one target (`x11/clipboard.rs`), so it
+//! publishes plain text; and a Wayland session with no compositor selection
+//! falls back through XWayland to that same single-target path.
 //!
 //! `to_html()` below predates all of this and is not on the clipboard path:
 //! `rich-clipboard`'s `RichText::to_html_fragment` is what actually gets
@@ -70,12 +68,165 @@ impl_option!(
     [Debug, Clone, PartialEq]
 );
 
+/// Builds a [`ClipboardContent`] from the styled runs a selection walks over.
+///
+/// Not FFI — this is the copy path's scratch buffer, and it exists so the three
+/// selection shapes (single-run, multi-run, cross-block) all produce their
+/// plain text and their styling from one place instead of the plain text
+/// twice.
+///
+/// The two invariants it maintains are the ones the OS transports depend on:
+/// `plain_text` is exactly the concatenation of the runs' text (a receiver must
+/// not get different characters depending on which flavor it picks), and
+/// adjacent runs with identical formatting are merged.
+///
+/// Merging is not cosmetic. A style run is cut at every DOM text node and every
+/// styling change, so a paragraph typed in one font can arrive as dozens of
+/// runs; emitting each one as its own `<span>` or `\b0\b` pair would produce
+/// RTF and HTML several times the size of the text for no visible difference.
+#[derive(Debug, Default)]
+pub struct ClipboardExtract {
+    /// Grown in place. Runs borrow nothing from it — they keep their own text —
+    /// but the two are appended to together, which is what keeps them equal.
+    plain: String,
+    runs: Vec<PendingRun>,
+}
+
+/// A run still being accumulated.
+///
+/// Held as a plain `String` rather than the FFI `AzString` so that merging is
+/// an append. Building an `AzString` per merge would re-copy everything
+/// accumulated so far, which on a uniformly-styled select-all — where *every*
+/// run merges into one — is quadratic in the document.
+#[derive(Debug)]
+struct PendingRun {
+    text: String,
+    style: RunStyle,
+}
+
+/// The formatting fields of a [`StyledTextRun`], without the text.
+///
+/// Comparing these is what decides a merge. `f32` equality is the derived one:
+/// a NaN size simply never merges, which costs a few extra runs in a case that
+/// cannot arise from the cascade anyway.
+#[derive(Debug, Clone, PartialEq)]
+struct RunStyle {
+    font_family: Option<String>,
+    font_size_px: f32,
+    color: azul_css::props::basic::ColorU,
+    is_bold: bool,
+    is_italic: bool,
+}
+
+impl ClipboardExtract {
+    /// Append `text`, formatted by `style`.
+    pub fn push(&mut self, text: &str, style: &crate::text3::cache::StyleProperties) {
+        if text.is_empty() {
+            return;
+        }
+        self.plain.push_str(text);
+
+        let selector = style.font_stack.first_selector();
+        let run_style = RunStyle {
+            // A direct `FontRef` (an embedded icon font) has no family name to
+            // give a receiving application, and `FontStack::first_family`'s
+            // `"<embedded-font>"` placeholder is a debugging string, not a
+            // font anyone can resolve. `None` means "inherit", which is the
+            // honest answer.
+            font_family: selector.map(|s| s.family.clone()),
+            font_size_px: style.font_size_px,
+            color: style.color,
+            // CSS `font-weight: bold` is 700; everything at or above it reads
+            // as bold to a format that only has a boolean. `FcWeight` is
+            // ordered by its CSS numeric value, so this is that comparison.
+            is_bold: selector.is_some_and(|s| s.weight >= rust_fontconfig::FcWeight::Bold),
+            // Oblique is a slanted rendering of an upright face; every
+            // clipboard format this feeds collapses it into italic.
+            is_italic: selector.is_some_and(|s| {
+                matches!(
+                    s.style,
+                    crate::text3::cache::FontStyle::Italic
+                        | crate::text3::cache::FontStyle::Oblique
+                )
+            }),
+        };
+
+        match self.runs.last_mut() {
+            Some(last) if last.style == run_style => last.text.push_str(text),
+            _ => self.runs.push(PendingRun {
+                text: String::from(text),
+                style: run_style,
+            }),
+        }
+    }
+
+    /// Append text under whatever formatting is already in effect.
+    ///
+    /// For the paragraph joiner between blocks of a cross-block selection: a
+    /// `\n` of its own would be an unformatted run wedged between two formatted
+    /// ones, which RTF and HTML both have to spell out.
+    pub fn push_inheriting(&mut self, text: &str) {
+        if text.is_empty() {
+            return;
+        }
+        self.plain.push_str(text);
+        match self.runs.last_mut() {
+            Some(last) => last.text.push_str(text),
+            // Nothing to inherit from: the selection started with the joiner.
+            None => self.runs.push(PendingRun {
+                text: String::from(text),
+                style: RunStyle {
+                    font_family: None,
+                    font_size_px: 0.0,
+                    color: azul_css::props::basic::ColorU {
+                        r: 0,
+                        g: 0,
+                        b: 0,
+                        a: 255,
+                    },
+                    is_bold: false,
+                    is_italic: false,
+                },
+            }),
+        }
+    }
+
+    /// The collected content, or `None` if the selection held no text.
+    ///
+    /// This is where the FFI strings are built — once per run, not once per
+    /// merge.
+    #[must_use]
+    pub fn finish(self) -> Option<ClipboardContent> {
+        if self.plain.is_empty() {
+            return None;
+        }
+        let runs: Vec<StyledTextRun> = self
+            .runs
+            .into_iter()
+            .map(|r| StyledTextRun {
+                text: r.text.into(),
+                font_family: r.style.font_family.map(AzString::from).into(),
+                font_size_px: r.style.font_size_px,
+                color: r.style.color,
+                is_bold: r.style.is_bold,
+                is_italic: r.style.is_italic,
+            })
+            .collect();
+        Some(ClipboardContent {
+            plain_text: self.plain.into(),
+            styled_runs: runs.into(),
+        })
+    }
+}
+
 impl ClipboardContent {
     /// Convert styled runs to HTML for rich clipboard formats.
     ///
-    /// Retained consumer of the FFI-exported `styled_runs`: returns an empty
-    /// `<div></div>` until `styled_runs` is populated and the platform clipboard
-    /// backends gain an HTML format (see module docs). Kept as public API.
+    /// Public FFI API, and **not** what the clipboard publishes — that is
+    /// `rich-clipboard`'s `RichText::to_html_fragment`, which also emits the
+    /// matching RTF and the `CF_HTML` wrapper Windows needs (see module docs).
+    /// Kept for callers that want a quick HTML rendering of a
+    /// `ClipboardContent` without the rest of that stack.
     #[must_use] pub fn to_html(&self) -> String {
         use core::fmt::Write as _;
         let mut html = String::from("<div>");
@@ -451,6 +602,230 @@ mod autotest_generated {
         assert_eq!(first, second, "to_html is not deterministic");
         assert_eq!(c, before, "to_html mutated the receiver");
         assert_eq!(c.clone().to_html(), first, "clone renders differently");
+    }
+}
+
+#[cfg(test)]
+mod extract_tests {
+    use std::sync::Arc;
+
+    use azul_css::props::basic::ColorU;
+    use rust_fontconfig::FcWeight;
+
+    use super::*;
+    use crate::text3::cache::{FontSelector, FontStack, FontStyle, StyleProperties};
+
+    fn style(family: &str, weight: FcWeight, italic: bool, size_px: f32) -> StyleProperties {
+        StyleProperties {
+            font_stack: FontStack::Stack(vec![FontSelector {
+                family: family.to_string(),
+                weight,
+                style: if italic {
+                    FontStyle::Italic
+                } else {
+                    FontStyle::Normal
+                },
+                unicode_ranges: Vec::new(),
+            }]),
+            font_size_px: size_px,
+            ..StyleProperties::default()
+        }
+    }
+
+    fn plain_style() -> StyleProperties {
+        style("Helvetica", FcWeight::Normal, false, 16.0)
+    }
+
+    /// The whole point of the copy path: formatting from the source runs has to
+    /// reach `styled_runs`, because that is what the OS transports turn into
+    /// RTF and HTML. It used to be hardcoded empty.
+    ///
+    /// NEGATIVE CONTROL: make `push` always write `StyledTextRun::default()`-ish
+    /// values — the bold/size/family assertions below go red.
+    #[test]
+    fn formatting_reaches_the_styled_runs() {
+        let mut acc = ClipboardExtract::default();
+        acc.push("normal ", &plain_style());
+        acc.push("bold", &style("Georgia", FcWeight::Bold, false, 24.0));
+
+        let content = acc.finish().expect("a non-empty selection yields content");
+        assert_eq!(content.plain_text.as_str(), "normal bold");
+
+        let runs = content.styled_runs.as_slice();
+        assert_eq!(runs.len(), 2);
+        assert_eq!(runs[0].text.as_str(), "normal ");
+        assert!(!runs[0].is_bold);
+        assert_eq!(runs[0].font_family.as_ref().map(|f| f.as_str()), Some("Helvetica"));
+        assert_eq!(runs[1].text.as_str(), "bold");
+        assert!(runs[1].is_bold);
+        assert_eq!(runs[1].font_size_px, 24.0);
+        assert_eq!(runs[1].font_family.as_ref().map(|f| f.as_str()), Some("Georgia"));
+    }
+
+    /// `plain_text` must be exactly the concatenation of the runs. A receiver
+    /// picking the plain flavor and one picking RTF must not end up with
+    /// different characters — the seam's encoder drops the rich flavor outright
+    /// when these disagree, so a mismatch silently costs all the formatting.
+    ///
+    /// NEGATIVE CONTROL: push to `self.plain` without pushing a run (or the
+    /// reverse) in either `push` or `push_inheriting`.
+    #[test]
+    fn plain_text_is_exactly_the_concatenated_runs() {
+        let mut acc = ClipboardExtract::default();
+        acc.push("one", &plain_style());
+        acc.push_inheriting("\n");
+        acc.push("two", &style("Georgia", FcWeight::Bold, false, 16.0));
+        acc.push_inheriting("\n");
+        acc.push("three", &plain_style());
+
+        let content = acc.finish().expect("content");
+        let joined: String = content
+            .styled_runs
+            .as_slice()
+            .iter()
+            .map(|r| r.text.as_str())
+            .collect();
+        assert_eq!(content.plain_text.as_str(), joined);
+        assert_eq!(content.plain_text.as_str(), "one\ntwo\nthree");
+    }
+
+    /// A style run is cut at every DOM text node and every styling change, so
+    /// identically-formatted neighbours must merge — otherwise a paragraph in
+    /// one font emits dozens of `<span>`s and `\b0\b` pairs for no visible
+    /// difference.
+    ///
+    /// NEGATIVE CONTROL: drop the `same_formatting` arm from `push`.
+    #[test]
+    fn identically_formatted_neighbours_merge() {
+        let mut acc = ClipboardExtract::default();
+        for word in ["a", "b", "c", "d"] {
+            acc.push(word, &plain_style());
+        }
+        let content = acc.finish().expect("content");
+        assert_eq!(
+            content.styled_runs.as_slice().len(),
+            1,
+            "four identically-styled pushes must collapse to one run"
+        );
+        assert_eq!(content.styled_runs.as_slice()[0].text.as_str(), "abcd");
+        assert_eq!(content.plain_text.as_str(), "abcd");
+    }
+
+    /// The paragraph joiner in a cross-block copy inherits the formatting it
+    /// follows, so it does not split a styled run in three.
+    ///
+    /// NEGATIVE CONTROL: make `push_inheriting` push a default-styled run.
+    #[test]
+    fn the_paragraph_joiner_does_not_split_a_run() {
+        let mut acc = ClipboardExtract::default();
+        let bold = style("Georgia", FcWeight::Bold, false, 16.0);
+        acc.push("first", &bold);
+        acc.push_inheriting("\n");
+        acc.push("second", &bold);
+
+        let content = acc.finish().expect("content");
+        let runs = content.styled_runs.as_slice();
+        assert_eq!(runs.len(), 1, "one style spans the whole thing");
+        assert_eq!(runs[0].text.as_str(), "first\nsecond");
+        assert!(runs[0].is_bold);
+    }
+
+    /// Weight is a scale and the clipboard formats have a boolean. CSS's
+    /// `bold` is 700, so that is the cut.
+    #[test]
+    fn weight_maps_to_bold_at_seven_hundred() {
+        for (weight, expect_bold) in [
+            (FcWeight::Light, false),
+            (FcWeight::Normal, false),
+            (FcWeight::Medium, false),
+            (FcWeight::SemiBold, false),
+            (FcWeight::Bold, true),
+            (FcWeight::Black, true),
+        ] {
+            let mut acc = ClipboardExtract::default();
+            acc.push("x", &style("Helvetica", weight, false, 16.0));
+            let content = acc.finish().expect("content");
+            assert_eq!(
+                content.styled_runs.as_slice()[0].is_bold,
+                expect_bold,
+                "{weight:?} mapped to the wrong boldness"
+            );
+        }
+    }
+
+    /// Oblique is a slanted upright face; every format this feeds has only
+    /// "italic", so it must not be silently dropped.
+    #[test]
+    fn oblique_is_carried_as_italic() {
+        let mut acc = ClipboardExtract::default();
+        let mut oblique = plain_style();
+        oblique.font_stack = FontStack::Stack(vec![FontSelector {
+            family: "Helvetica".to_string(),
+            weight: FcWeight::Normal,
+            style: FontStyle::Oblique,
+            unicode_ranges: Vec::new(),
+        }]);
+        acc.push("slanted", &oblique);
+        let content = acc.finish().expect("content");
+        assert!(content.styled_runs.as_slice()[0].is_italic);
+    }
+
+    /// An embedded `FontRef` has no family name a receiving application could
+    /// resolve, so it must inherit rather than be handed the internal
+    /// `"<embedded-font>"` debugging placeholder as if it were a font.
+    ///
+    /// NEGATIVE CONTROL: use `FontStack::first_family()` in `push`.
+    #[test]
+    fn an_embedded_font_has_no_family_to_publish() {
+        let mut acc = ClipboardExtract::default();
+        let mut embedded = plain_style();
+        // `FontStack::Ref` needs a real FontRef; `first_selector()` returning
+        // None is the property under test, and `Stack(vec![])` reaches the
+        // same branch without constructing one.
+        embedded.font_stack = FontStack::Stack(Vec::new());
+        acc.push("icon", &embedded);
+
+        let content = acc.finish().expect("content");
+        let run = &content.styled_runs.as_slice()[0];
+        assert!(run.font_family.as_ref().is_none());
+        assert!(!run.is_bold && !run.is_italic);
+    }
+
+    /// A uniformly-styled select-all merges *every* run into one, so the merge
+    /// has to be an append. Rebuilding the run's string each time — which is
+    /// what constructing the FFI `AzString` per merge would do — is quadratic
+    /// in the document, and Ctrl+A Ctrl+C is exactly when it bites.
+    ///
+    /// This asserts the result rather than the timing; the guard against a
+    /// regression is that `PendingRun::text` is a `String` and `finish` is the
+    /// only place `AzString`s are built.
+    #[test]
+    fn a_uniformly_styled_document_collapses_to_one_run() {
+        let mut acc = ClipboardExtract::default();
+        let s = plain_style();
+        for i in 0..2_000 {
+            acc.push("paragraph text ", &s);
+            if i + 1 < 2_000 {
+                acc.push_inheriting("\n");
+            }
+        }
+        let content = acc.finish().expect("content");
+        assert_eq!(content.styled_runs.as_slice().len(), 1);
+        assert_eq!(
+            content.styled_runs.as_slice()[0].text.as_str().len(),
+            content.plain_text.as_str().len()
+        );
+    }
+
+    /// An empty selection is not a copy. Pushing nothing must not produce a
+    /// `ClipboardContent` that would clear the user's clipboard.
+    #[test]
+    fn an_empty_selection_yields_nothing() {
+        assert!(ClipboardExtract::default().finish().is_none());
+        let mut acc = ClipboardExtract::default();
+        acc.push("", &plain_style());
+        acc.push_inheriting("");
+        assert!(acc.finish().is_none());
     }
 }
 

--- a/layout/src/managers/selection.rs
+++ b/layout/src/managers/selection.rs
@@ -3,16 +3,27 @@
 //! Contains `ClipboardContent` and `StyledTextRun`, used by clipboard and
 //! changeset modules.
 //!
-//! **Rich-text status:** `StyledTextRun`, `StyledTextRunVec` and the
-//! `ClipboardContent.styled_runs` field are FFI-exported (api.json), but the
-//! rich path is only half-wired: the live clipboard producers build
-//! `styled_runs` empty (`window.rs::get_selected_content_for_clipboard`,
-//! paste in `common/event.rs`) and the platform clipboard backends write only
-//! `plain_text`. Fully wiring it means (a) extracting per-run style from the
-//! styled DOM when copying and (b) adding an HTML/RTF format to each platform's
-//! clipboard write (and reading it back on paste). `to_html()` below is the
-//! retained consumer for that future format. Until then the FFI surface is
-//! kept (it is public API) but `styled_runs` stays empty.
+//! **Rich-text status:** the OS half is wired. A paste populates
+//! `styled_runs` whenever the source offered a styled flavor — the platform
+//! transports in `dll/src/desktop/shell2/*/clipboard.rs` hand every flavor
+//! the source published to `rich-clipboard`, whose decode policy prefers RTF,
+//! then HTML, then plain text, and `shell2/common/clipboard.rs` converts the
+//! result into this type. A copy fans back out the same way, so styled text
+//! reaches other applications as RTF *and* HTML *and* plain text at once
+//! (macOS, Windows and native Wayland; X11's selection owner can only serve
+//! one target, so it publishes plain text — see `x11/clipboard.rs`).
+//!
+//! What is still empty is the COPY-side extraction:
+//! `window.rs::get_selected_content_for_clipboard` builds `styled_runs` from
+//! the selection as an empty vec, because per-run style has to come out of the
+//! styled DOM and that walk does not exist yet. So azul currently *reads*
+//! styling and does not yet *produce* it — the transport underneath is ready
+//! for both.
+//!
+//! `to_html()` below predates all of this and is not on the clipboard path:
+//! `rich-clipboard`'s `RichText::to_html_fragment` is what actually gets
+//! published, because it also emits the matching RTF and the `CF_HTML`
+//! wrapper Windows needs. This stays as public FFI API.
 
 use azul_css::{impl_option, impl_option_inner, AzString, OptionString};
 

--- a/layout/src/window.rs
+++ b/layout/src/window.rs
@@ -80,6 +80,7 @@ use crate::{
     },
     managers::{
         gpu_state::GpuStateManager,
+        selection::ClipboardExtract,
         virtual_view::VirtualViewManager,
         scroll_state::ScrollManager,
     },
@@ -15333,10 +15334,15 @@ impl LayoutWindow {
     ///
     /// This method extracts both plain text and styled text from the selection ranges.
     /// It iterates through all selected text, extracts the actual characters, and
-    /// preserves styling information from the `ShapedGlyph`'s `StyleProperties`.
+    /// preserves styling information from each source `StyledRun`'s `StyleProperties`.
     ///
     /// This is NOT reading from the system clipboard - use `clipboard_manager.get_paste_content()`
     /// for that. This extracts content FROM the selection TO be copied.
+    ///
+    /// The styled runs are what the platform clipboard transports fan out as
+    /// RTF and HTML (see `dll/src/desktop/shell2/common/clipboard.rs`), so a
+    /// copy out of azul pastes into Word or LibreOffice with its formatting
+    /// intact rather than as a flat string.
     ///
     /// ## Arguments
     /// * `dom_id` - The DOM to extract selection from
@@ -15348,7 +15354,6 @@ impl LayoutWindow {
         &self,
         dom_id: &DomId,
     ) -> Option<crate::managers::selection::ClipboardContent> {
-        use crate::managers::selection::ClipboardContent;
         use crate::text3::edit::cursor_byte_offset_in_run;
 
         // Cross-block selection: join the anchor block's selected tail, the
@@ -15363,10 +15368,15 @@ impl LayoutWindow {
                     .filter_map(|(n, r)| r.first().map(|r| (*n, *r)))
                     .collect();
                 nodes.sort_by_key(|(n, _)| n.index());
-                let mut parts: Vec<String> = Vec::with_capacity(nodes.len());
-                for (node, range) in &nodes {
+                let mut acc = ClipboardExtract::default();
+                for (block, (node, range)) in nodes.iter().enumerate() {
                     let content = self.get_text_before_textinput(*dom_id, *node);
-                    let mut text = String::new();
+                    // The paragraph joiner, carrying the style of the text it
+                    // follows — a `\n` of its own would be a run with no
+                    // formatting between two that have it.
+                    if block > 0 {
+                        acc.push_inheriting("\n");
+                    }
                     let sr = range.start.cluster_id.source_run as usize;
                     let er = range.end.cluster_id.source_run as usize;
                     for (i, c) in content.iter().enumerate() {
@@ -15389,18 +15399,13 @@ impl LayoutWindow {
                                 run.text.len()
                             };
                             if lo < hi {
-                                text.push_str(&run.text[lo..hi]);
+                                acc.push(&run.text[lo..hi], &run.style);
                             }
                         }
                     }
-                    parts.push(text);
                 }
-                let plain = parts.join("\n");
-                if !plain.is_empty() {
-                    return Some(ClipboardContent {
-                        plain_text: plain.into(),
-                        styled_runs: crate::managers::selection::StyledTextRunVec::from_const_slice(&[]),
-                    });
+                if let Some(content) = acc.finish() {
+                    return Some(content);
                 }
             }
         }
@@ -15424,7 +15429,7 @@ impl LayoutWindow {
         // select-all whose end cursor is Trailing on the last cluster copies the
         // full text — matching the affinity fix in delete_range.
         let content = self.get_text_before_textinput(*dom_id, node_id);
-        let mut plain = String::new();
+        let mut acc = ClipboardExtract::default();
         for r in &ranges {
             let sr = r.start.cluster_id.source_run as usize;
             let er = r.end.cluster_id.source_run as usize;
@@ -15434,12 +15439,14 @@ impl LayoutWindow {
                     let b = cursor_byte_offset_in_run(&run.text, &r.end);
                     let (lo, hi) = (a.min(b), a.max(b));
                     if hi <= run.text.len() && lo < hi {
-                        plain.push_str(&run.text[lo..hi]);
+                        acc.push(&run.text[lo..hi], &run.style);
                     }
                 }
             } else {
                 // Multi-run: walk runs in document order, taking the tail of the
-                // first run, all middle runs, and the head of the last.
+                // first run, all middle runs, and the head of the last. This is
+                // the branch that carries real formatting — one run per
+                // differently-styled span.
                 let (first_idx, first_cur, last_idx, last_cur) = if sr <= er {
                     (sr, r.start, er, r.end)
                 } else {
@@ -15449,30 +15456,19 @@ impl LayoutWindow {
                     if let Some(InlineContent::Text(run)) = content.get(ri) {
                         if ri == first_idx {
                             let off = cursor_byte_offset_in_run(&run.text, &first_cur).min(run.text.len());
-                            plain.push_str(&run.text[off..]);
+                            acc.push(&run.text[off..], &run.style);
                         } else if ri == last_idx {
                             let off = cursor_byte_offset_in_run(&run.text, &last_cur).min(run.text.len());
-                            plain.push_str(&run.text[..off]);
+                            acc.push(&run.text[..off], &run.style);
                         } else {
-                            plain.push_str(&run.text);
+                            acc.push(&run.text, &run.style);
                         }
                     }
                 }
             }
         }
 
-        if plain.is_empty() {
-            return None;
-        }
-        Some(ClipboardContent {
-            plain_text: plain.into(),
-            // TODO(superplan): styled_runs left empty — extracting per-run style
-            // (font/size/color/bold/italic from the styled DOM) is only useful once
-            // the platform clipboard backends gain an HTML/RTF format and ClipboardContent::to_html
-            // is wired into the copy path (see layout/src/managers/selection.rs docs).
-            // Plain-text copy is fully wired.
-            styled_runs: Vec::new().into(),
-        })
+        acc.finish()
     }
 
     /// Check if a scrolled node is a `VirtualView` that needs re-invocation. If so,

--- a/scripts/RICH_CLIPBOARD_INTEGRATION_2026_08_25.md
+++ b/scripts/RICH_CLIPBOARD_INTEGRATION_2026_08_25.md
@@ -139,13 +139,49 @@ lower bound is **not** reachable through `x11-clipboard`: it reads the value
 only to `reserve` the buffer and never reports it, so the X11 guard is a
 post-hoc length check instead of a pre-read rejection.
 
+## Copy-side style extraction (the follow-up, now done)
+
+`get_selected_content_for_clipboard` in `layout/src/window.rs` used to build
+`styled_runs` empty, so azul read styling but never produced it. It now pulls
+per-run formatting off each source `StyledRun`'s `StyleProperties` as the
+selection is walked, through a new `ClipboardExtract` accumulator in
+`layout/src/managers/selection.rs`.
+
+All three selection shapes — single-run, multi-run and cross-block — go through
+that one accumulator, which was half the point: they each built the plain text
+separately before, so only one of them would have grown styling by accident.
+
+The mapping is `font_stack.first_selector()` → family, `weight >= 700` → bold
+(CSS's own cut), `Italic | Oblique` → italic, plus `font_size_px` and `color`
+straight through. Two deliberate choices:
+
+- An embedded `FontRef` publishes **no** family rather than the internal
+  `"<embedded-font>"` placeholder, which is a debugging string no receiving
+  application could resolve. `None` means inherit, which is the honest answer.
+- The cross-block paragraph joiner (`\n`) **inherits** the formatting it
+  follows, so it does not split one styled run into three.
+
+Adjacent runs with identical formatting are merged. That is not cosmetic: a
+style run is cut at every DOM text node and every styling change, so a
+paragraph typed in one font arrives as dozens of runs, and emitting each as its
+own `<span>` would produce RTF and HTML several times the size of the text.
+
+The invariant the seam depends on is that `plain_text` is exactly the
+concatenation of the runs' text — `content_to_rich_item` drops the rich flavor
+outright when they disagree, so a mismatch silently costs all the formatting.
+There is a test named for that claim.
+
+## Also removed: the dead `sync_clipboard` chain
+
+`LinuxWindow::sync_clipboard` → `{x11,wayland}/mod.rs::sync_clipboard` →
+`clipboard::sync_clipboard` was a four-level chain with no caller, left behind
+when the copy/cut/paste shortcuts started writing to the OS clipboard directly.
+Both leaf functions carried a TODO asking for exactly this removal. It is gone:
+it is not in api.json, so nothing outside the crate could reach it, and keeping
+it meant a second, diverging path to the clipboard that still compiled.
+
 ## Not done
 
-- **Copy-side style extraction.** `get_selected_content_for_clipboard` in
-  `layout/src/window.rs` still builds `styled_runs` empty, so azul *reads*
-  styling but does not yet *produce* it. The transport underneath is ready for
-  both; what is missing is the walk that pulls per-run style out of the styled
-  DOM. This is the single highest-value follow-up.
 - **Images, file lists and links as `ClipboardContent`.** `RichItem::Image` /
   `Files` / `Link` decode correctly and are then dropped, because
   `ClipboardContent` has no representation for them. Extending that FFI type is
@@ -154,5 +190,7 @@ post-hoc length check instead of a pre-read rejection.
   in azul through a separate path; unifying the two would let a drop deliver a
   payload.
 - **`CFSTR_FILECONTENTS`** (virtual file contents as an `IStream`).
-- **Running any of it.** macOS compiles and its unit tests pass, but nothing
-  here has been exercised against a live clipboard on any platform.
+- **Running any of it.** Everything compiles on macOS, Windows and Linux and the
+  unit tests pass, but nothing here has been exercised against a live clipboard
+  on any platform. That is what the verification prompt handed off with this
+  branch is for.

--- a/scripts/RICH_CLIPBOARD_INTEGRATION_2026_08_25.md
+++ b/scripts/RICH_CLIPBOARD_INTEGRATION_2026_08_25.md
@@ -1,0 +1,158 @@
+# rich-clipboard integration into azul — status, 2026-08-25
+
+Branch `feat/rich-clipboard`, stacked on `feat/multimonitor-and-tray`.
+
+Implements `plan/INTEGRATION.md` from <https://github.com/fschutt/rich-clipboard>:
+the OS transport layer (layer 1), which the crate deliberately does not contain.
+
+## What the seam looks like now
+
+`dll/src/desktop/shell2/common/event.rs` used to hold two functions:
+
+```rust
+fn get_system_clipboard() -> Option<String>;
+fn set_system_clipboard(text: String) -> bool;
+```
+
+They now live in a new module, `shell2/common/clipboard.rs`, and carry typed
+multi-flavor payloads:
+
+```rust
+pub fn get_system_clipboard() -> Option<ClipboardPayload>;
+pub fn set_system_clipboard(payload: &ClipboardPayload) -> bool;
+```
+
+That module also owns the two conversions between `ClipboardPayload` and
+azul's FFI type `ClipboardContent` (`plain_text` + `styled_runs`):
+`clipboard_content_to_payload` and `payload_to_clipboard_content`.
+
+Every caller in `event.rs` — `SetCopyContent`, `SetCutContent`,
+`CopyToClipboard`, `CutToClipboard`, `PasteFromClipboard`, and the deferred
+W3C-clipboard-event path — goes through those two.
+
+## Per-platform state
+
+| Platform | Read | Write | Verified |
+|---|---|---|---|
+| macOS | every flavor, per pasteboard item | full fan-out | compiles; **not run against a pasteboard** |
+| Windows | every format, `GlobalSize`-guarded | full fan-out | cross-compiles only |
+| Wayland (native) | advertised mimes only | full fan-out | cross-compiles only |
+| X11 | ranked probe list | **plain text only** | cross-compiles only |
+
+### macOS — `shell2/macos/clipboard.rs`, rewritten
+
+Moved off `objc` 0.2 onto `objc2-app-kit` (design decision #2 in the repo:
+new backends are objc2-native). The whole file is now `unsafe`-free — the old
+one needed a `transmute` of a `&Class` to make `readObjectsForClasses:`
+typecheck.
+
+All four documented traps are handled: it walks `-pasteboardItems` rather than
+using the pasteboard-level API (which reaches only the first item offering a
+type, so a three-file copy read back as one file); it treats a nil
+`dataForType:` as a declined promise rather than an error; it dedupes the
+legacy UTI twins per item; and it checks `-[NSData length]` *before*
+`to_vec()`.
+
+Removing that file's `objc` 0.2 usage left `objc-foundation` and `objc_id`
+with no macOS consumer at all, so they are gone from the macOS dependency
+section (still present for iOS, which does use them).
+
+### Windows — `shell2/windows/clipboard.rs`, rewritten
+
+Was a 24-line wrapper around `clipboard_win::get_clipboard::<String>`. Now
+enumerates with `raw::EnumFormats`, sizes with `raw::size` (`GlobalSize`)
+before copying, and writes with one `raw::empty()` followed by
+`set_without_clear` per format — `raw::set` empties the clipboard each call,
+so a fan-out written with it would leave only the last format.
+
+Predefined formats are named through `WindowsFormat::name()` rather than
+`GetClipboardFormatNameW` (which returns nothing for them), which is exactly
+what `Flavor::from_windows_name` reads back. `CF_BITMAP`, `CF_ENHMETAFILE`,
+`CF_METAFILEPICT`, `CF_PALETTE` and `CF_OWNERDISPLAY` are skipped: they are
+handles, and `GlobalSize` on an `HBITMAP` describes nothing.
+
+### Wayland — real fan-out, both directions
+
+`NATIVE_COPY` went from `Option<String>` to `Option<ClipboardPayload>`.
+`wl_data_source.offer` is now called once per flavor the payload carries (plus
+the pre-MIME `UTF8_STRING` / `text/plain` spellings), and `data_source_send`
+serves the representation the peer actually asked for instead of answering
+every mime with the same bytes — which would have pasted RTF source into a
+plain-text field once more than one flavor was offered.
+
+Reads are driven by the offer's advertised mime list, newly accumulated in
+`WaylandDragState::pending_mimes` and promoted at `wl_data_device.selection`
+(the same shape as the existing `pending_has_uri_list` promotion). Probing
+blind was not an option: `wl_data_offer.receive` with a mime the source never
+advertised is answered by a pipe the source need not close, so each wrong
+guess costs a full transfer deadline.
+
+## Findings
+
+### 1. Unbounded Wayland pipe read — fixed here (a real bug in azul)
+
+`drain_offer_pipe` in `wayland/events.rs` had a 3-second deadline and **no
+byte cap**, so a peer that streams fast enough could push unbounded data into
+a `Vec` inside that window. This is precisely the case §4 of INTEGRATION.md
+singles out: Wayland is the one platform where the length is unknowable in
+advance, and counting while reading is the only defence there is.
+
+Now capped at `MAX_FLAVOR_BYTES` (64 MiB, matching
+`rclip_core::Limits::default().max_flavor_bytes`). What arrives past the cap
+is **discarded, not truncated** — a truncated flavor is worse than none,
+because the decode would succeed on the prefix and paste half a document.
+
+### 2. `x11-clipboard` 0.9.3 cannot enumerate `TARGETS`
+
+`Clipboard::load` rejects any reply whose `type_` differs from the target it
+asked for:
+
+```rust
+} else if reply.type_ != target {
+    return Err(Error::UnexpectedType(reply.type_));
+}
+```
+
+A `TARGETS` conversion answers with type `ATOM` by definition, so the
+enumeration ICCCM prescribes always errors before returning. The X11 read
+therefore probes a fixed rank-ordered candidate list and stops at the first
+target that times out (a dead owner would otherwise cost the deadline once per
+candidate). Flavors azul has no codec for cannot be carried through as
+`RichItem::Unknown`, because learning their names requires the `TARGETS` list.
+
+### 3. `x11-clipboard` 0.9.3 cannot publish more than one target
+
+Its owner state is `HashMap<selection, (target, value)>` — one target per
+selection — and its `SelectionRequest` handler answers a `TARGETS` query with
+exactly that one target. `store()` called twice replaces rather than adds.
+
+So an X11 copy publishes plain text and nothing else. Offering RTF *instead*
+would break every plain-text paste target to style one. Lifting this needs a
+selection owner that serves several targets, i.e. a rewrite of that crate's
+owner loop or a direct `x11rb` connection.
+
+### 4. `SizeHint` is only half-producible
+
+Windows (`GlobalSize`) and macOS (`-[NSData length]`) both give
+`SizeHint::Exact` for free before any copy, and both are used. X11's `INCR`
+lower bound is **not** reachable through `x11-clipboard`: it reads the value
+only to `reserve` the buffer and never reports it, so the X11 guard is a
+post-hoc length check instead of a pre-read rejection.
+
+## Not done
+
+- **Copy-side style extraction.** `get_selected_content_for_clipboard` in
+  `layout/src/window.rs` still builds `styled_runs` empty, so azul *reads*
+  styling but does not yet *produce* it. The transport underneath is ready for
+  both; what is missing is the walk that pulls per-run style out of the styled
+  DOM. This is the single highest-value follow-up.
+- **Images, file lists and links as `ClipboardContent`.** `RichItem::Image` /
+  `Files` / `Link` decode correctly and are then dropped, because
+  `ClipboardContent` has no representation for them. Extending that FFI type is
+  an api.json change.
+- **XDND / Wayland drag protocols** on top of this seam. Drag-in already works
+  in azul through a separate path; unifying the two would let a drop deliver a
+  payload.
+- **`CFSTR_FILECONTENTS`** (virtual file contents as an `IStream`).
+- **Running any of it.** macOS compiles and its unit tests pass, but nothing
+  here has been exercised against a live clipboard on any platform.


### PR DESCRIPTION
Wires the `rich-clipboard` crates into azul and writes the layer they
deliberately do not contain: the OS transport. Stacked on #440.

Clipboard support has three layers. Codecs and policy are a published crate
(854 tests, no OS calls in it). Layer 1 — transport — is what this adds.

## The seam

`shell2/common/event.rs` held two functions that spoke `String`. They moved to
a new `shell2/common/clipboard.rs` and now carry every flavor at once:

```rust
pub fn get_system_clipboard() -> Option<ClipboardPayload>;
pub fn set_system_clipboard(payload: &ClipboardPayload) -> bool;
```

On a read the decode policy takes the richest flavor (RTF > HTML > plain text);
on a write one item fans out to every flavor the platform wants. That fan-out is
what makes a paste land in Word as styled text rather than flattened.

Copy produces styling too, not just paste: `get_selected_content_for_clipboard`
used to build `styled_runs` empty, so azul read formatting off the clipboard but
never published any. It now pulls per-run style off each source `StyledRun`
through a new `ClipboardExtract`, and all three selection shapes (single-run,
multi-run, cross-block) go through it — they each built the plain text
separately before, so only one would have grown styling by accident.

## Per platform, and they are not equal

| | Read | Write |
|---|---|---|
| macOS | every flavor, per pasteboard item | full fan-out |
| Windows | every format, `GlobalSize`-guarded | full fan-out |
| Wayland (native) | advertised mimes only | full fan-out |
| X11 | ranked probe list | **plain text only** |

**macOS** moved off `objc` 0.2 to `objc2-app-kit` and is now `unsafe`-free. It
walks `-pasteboardItems` rather than the pasteboard-level API, which reaches
only the *first* item offering a type — a three-file copy read back as one file.
It treats a nil `dataForType:` as a declined promise rather than an error,
dedupes the byte-identical legacy UTI twins per item, and checks
`-[NSData length]` before copying. This left `objc-foundation` / `objc_id` with
no macOS consumer, so they are dropped from that target section (iOS keeps them).

**Windows** was a 24-line wrapper around one format. It now enumerates with
`EnumFormats`, sizes with `GlobalSize` before copying, and writes one `empty()`
followed by `set_without_clear` per format — `raw::set` empties on every call,
so a fan-out written with it would keep only the last one. Predefined formats
are named through `WindowsFormat::name()`, which is what
`Flavor::from_windows_name` reads back; `CF_BITMAP` and friends are handles, not
bytes, and are skipped.

**Wayland** is a real fan-out both ways: `wl_data_source.offer` is called once
per flavor and `data_source_send` serves the mime the peer asked for, instead of
answering every mime with the same bytes. Reads follow the offer's advertised
mime list, newly accumulated per offer and promoted at `wl_data_device.selection`.

**X11 cannot publish more than plain text**, and not for lack of trying:
`x11-clipboard` 0.9.3's owner state is `HashMap<selection, (target, value)>` —
one target per selection — and `store()` twice replaces rather than adds.
Offering RTF *instead* would break every plain-text paste target to style one.

## A real bug fixed on the way

`drain_offer_pipe` read a `wl_data_offer` pipe with a 3s deadline and **no byte
cap**. Wayland is the one platform that declares no length, so counting while
reading is the only bound there is; a fast peer could push unbounded data inside
that window. Now capped at 64 MiB, and an over-cap transfer is **discarded, not
truncated** — half a document that decodes cleanly is worse than none.

## Two findings worth writing down

`x11-clipboard` 0.9.3 also cannot enumerate `TARGETS`: `load()` returns
`Err(UnexpectedType)` for any reply whose type differs from the requested
target, and a `TARGETS` conversion answers with type `ATOM` by definition. So
the ICCCM enumeration is unreachable and the read probes a ranked list instead,
stopping at the first timeout. Its `INCR` lower bound is unreachable too (read
only to `reserve`, never reported), so X11's size guard is post-hoc rather than
the pre-read rejection Windows and macOS get.

## Verification — please read this part

`cargo check --release` is clean on macOS, Linux and Windows, and 18 unit tests
pass (styled-run round trip through real RTF/HTML, the plain-text fallback for
inconsistent input, macOS per-item file lists, UTI twin dedupe, and 9 covering
the copy-side extraction).

**Nothing here has been run against a live clipboard on any platform.** Only
macOS was ever measured by the crate author; Windows, X11 and Wayland were
written from specifications plus the source of real implementations. Treat the
first real paste on those three as a debugging session. A verification handoff
prompt exists for a Linux/Windows agent — ask and I will link it.

## Still open

Images, file lists and links decode correctly and are then dropped, because
`ClipboardContent` has no representation for them (an api.json change). XDND and
the Wayland drag protocols on this seam. `CFSTR_FILECONTENTS`.

Details and reasoning: `scripts/RICH_CLIPBOARD_INTEGRATION_2026_08_25.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BxYsEXV1WjJC6yyaP7ggLa
