### PR TITLE
feat(wacom): X11 tablet pad + real eraser identification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "AzReview"
+version = "0.1.0"
+dependencies = [
+ "azul-dll",
+]
+
+[[package]]
 name = "AzWidgets"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
     "examples/rust", # Rust examples - depends on azul-dll
     "examples/azul-paint", # AzPaint demo (SUPER_PLAN_2 P2 goal app)
+    "examples/azul-review", # AzReview — ink-first code review; tablet/pen stress test
     "examples/azul-widgets", # AzulWidgets demo (showcase of all widgets; W5 release demo)
     "examples/azul-maps", # AzMaps demo (SUPER_PLAN_2 P3 goal app)
     "examples/azul-vault", # AzulVault demo (SUPER_PLAN_2 P4 goal app)

--- a/dll/Cargo.toml
+++ b/dll/Cargo.toml
@@ -910,8 +910,20 @@ fluent = ["azul-layout", "azul-layout/fluent"]
 # icons must also pull the brotli decompressor here.
 icons = ["azul-layout", "azul-layout/icons", "dep:brotli-decompressor"]
 
-# HTTP client support for downloading resources
-http = ["azul-layout", "azul-layout/http"]
+# HTTP client support for downloading resources.
+#
+# `azul-layout?/http` — NOT the bare `azul-layout` its siblings above use — so
+# that asking for `http` cannot, by itself, drag the whole engine into a
+# `link-dynamic` build. `map-tiles` implies `http` (the tile worker calls
+# `azul_layout::http::http_get`), and a demo has to enable `map-tiles` to get a
+# tile worker at all; with the bare form that turned AzMaps' dependency-only
+# link-dynamic build into a full azul-layout + ureq + rustls compile, undoing
+# the "demos link the prebuilt libazul, no engine rebuild" arrangement.
+# Nothing is lost: the only `#[cfg(feature = "http")]` in dll/src re-exports
+# `azul_layout::http` from `desktop::`, and that module is `cabi_internal`-gated
+# — every build that can reach it already enables `azul-layout` via
+# `_internal_deps`, so the forward still fires there.
+http = ["azul-layout?/http"]
 
 # ZIP archives. The `Zip` handle (extra/zip) is always compiled so it
 # codegen-exposes unconditionally; this pulls the compressor behind it.

--- a/dll/src/desktop/extra/map/mod.rs
+++ b/dll/src/desktop/extra/map/mod.rs
@@ -112,17 +112,20 @@ pub extern "C" fn tile_fetch_worker(
         map_tile_writeback, TileFetchInit, TileReadyMsg,
     };
 
-    let (tile, url, mapcss, theme) = match init.downcast_ref::<TileFetchInit>() {
+    let (tile, url, mapcss, theme, cached_bytes) = match init.downcast_ref::<TileFetchInit>() {
         Some(i) => (
             i.tile,
             i.url.as_str().to_string(),
             i.style_css.as_str().to_string(),
             i.theme,
+            i.bytes.as_ref().to_vec(),
         ),
         None => return,
     };
 
-    let send_back = |svg: AzString, error: AzString| -> ThreadWriteBackMsg {
+    // `bytes` travels back to the main thread ONLY when we downloaded it, so a
+    // restyle does not copy the payload back and forth for nothing.
+    let send_back = |svg: AzString, error: AzString, bytes: Vec<u8>| -> ThreadWriteBackMsg {
         ThreadWriteBackMsg::new(
             WriteBackCallback {
                 cb: map_tile_writeback,
@@ -133,6 +136,7 @@ pub extern "C" fn tile_fetch_worker(
                 svg,
                 error,
                 theme,
+                bytes: azul_css::U8Vec::from_vec(bytes),
             }),
         )
     };
@@ -142,23 +146,43 @@ pub extern "C" fn tile_fetch_worker(
         eprintln!("[map] worker start tile=({},{},{}) url={}", tile.z, tile.x, tile.y, url);
     }
 
-    // 1-2. Fetch.
-    let bytes = match azul_layout::http::http_get(&url) {
-        Ok(resp) => resp.body.as_ref().to_vec(),
-        Err(e) => {
-            if dbg {
-                eprintln!("[map] worker fetch FAILED tile=({},{},{}): {e:?}", tile.z, tile.x, tile.y);
+    // 1-2. Fetch — UNLESS the cache already handed us the payload, in which
+    // case this job is a restyle and touches the network zero times. A tile's
+    // geometry is downloaded once per session however often the look changes.
+    let restyle = !cached_bytes.is_empty();
+    let bytes = if restyle {
+        if dbg {
+            eprintln!(
+                "[map] worker restyle tile=({},{},{}) theme={theme:?} — {} cached bytes, no fetch",
+                tile.z, tile.x, tile.y, cached_bytes.len()
+            );
+        }
+        cached_bytes
+    } else {
+        match azul_layout::http::http_get(&url) {
+            Ok(resp) => {
+                let b = resp.body.as_ref().to_vec();
+                if dbg {
+                    eprintln!(
+                        "[map] worker fetched tile=({},{},{}) {} bytes",
+                        tile.z, tile.x, tile.y, b.len()
+                    );
+                }
+                b
             }
-            sender.send(ThreadReceiveMsg::WriteBack(send_back(
-                AzString::from(""),
-                AzString::from(alloc::format!("fetch failed: {e:?}")),
-            )));
-            return;
+            Err(e) => {
+                if dbg {
+                    eprintln!("[map] worker fetch FAILED tile=({},{},{}): {e:?}", tile.z, tile.x, tile.y);
+                }
+                sender.send(ThreadReceiveMsg::WriteBack(send_back(
+                    AzString::from(""),
+                    AzString::from(alloc::format!("fetch failed: {e:?}")),
+                    Vec::new(),
+                )));
+                return;
+            }
         }
     };
-    if dbg {
-        eprintln!("[map] worker fetched tile=({},{},{}) {} bytes", tile.z, tile.x, tile.y, bytes.len());
-    }
 
     // Cancellation check between fetch and decode.
     if matches!(
@@ -168,16 +192,19 @@ pub extern "C" fn tile_fetch_worker(
         return;
     }
 
-    // 3-4. Decode + emit SVG.
+    // 3-4. Decode + emit SVG. `decode_mvt_tile` consumes the bytes, so keep the
+    // copy we owe the main thread first (only when we actually downloaded it).
+    let give_back = if restyle { Vec::new() } else { bytes.clone() };
     match decode_mvt_tile(bytes, tile) {
         Ok(features) => {
             let svg = features_to_svg(&features, tile, &mapcss);
             if dbg {
-                eprintln!("[map] worker decoded tile=({},{},{}) {} features svg_len={}", tile.z, tile.x, tile.y, features.len(), svg.len());
+                eprintln!("[map] worker decoded tile=({},{},{}) theme={theme:?} {} features svg_len={}", tile.z, tile.x, tile.y, features.len(), svg.len());
             }
             sender.send(ThreadReceiveMsg::WriteBack(send_back(
                 AzString::from(svg),
                 AzString::from(""),
+                give_back,
             )));
         }
         Err(e) => {
@@ -187,6 +214,7 @@ pub extern "C" fn tile_fetch_worker(
             sender.send(ThreadReceiveMsg::WriteBack(send_back(
                 AzString::from(""),
                 AzString::from(alloc::format!("decode failed: {e}")),
+                give_back,
             )));
         }
     }

--- a/dll/src/desktop/extra/map/mod.rs
+++ b/dll/src/desktop/extra/map/mod.rs
@@ -105,12 +105,8 @@ pub extern "C" fn tile_fetch_worker(
 ) {
     use azul_core::refany::{OptionRefAny, RefAny};
     use azul_css::AzString;
-    use azul_layout::thread::{
-        ThreadReceiveMsg, ThreadWriteBackMsg, WriteBackCallback,
-    };
-    use azul_layout::widgets::map::{
-        map_tile_writeback, TileFetchInit, TileReadyMsg,
-    };
+    use azul_layout::thread::{ThreadReceiveMsg, ThreadWriteBackMsg, WriteBackCallback};
+    use azul_layout::widgets::map::{map_tile_writeback, TileFetchInit, TileReadyMsg};
 
     let (tile, url, mapcss, theme, cached_bytes) = match init.downcast_ref::<TileFetchInit>() {
         Some(i) => (
@@ -143,46 +139,56 @@ pub extern "C" fn tile_fetch_worker(
 
     let dbg = std::env::var("AZ_MAP_DEBUG").is_ok();
     if dbg {
-        eprintln!("[map] worker start tile=({},{},{}) url={}", tile.z, tile.x, tile.y, url);
+        eprintln!(
+            "[map] worker start tile=({},{},{}) url={}",
+            tile.z, tile.x, tile.y, url
+        );
     }
 
     // 1-2. Fetch — UNLESS the cache already handed us the payload, in which
     // case this job is a restyle and touches the network zero times. A tile's
     // geometry is downloaded once per session however often the look changes.
     let restyle = !cached_bytes.is_empty();
-    let bytes = if restyle {
-        if dbg {
-            eprintln!(
+    let bytes =
+        if restyle {
+            if dbg {
+                eprintln!(
                 "[map] worker restyle tile=({},{},{}) theme={theme:?} — {} cached bytes, no fetch",
                 tile.z, tile.x, tile.y, cached_bytes.len()
             );
-        }
-        cached_bytes
-    } else {
-        match azul_layout::http::http_get(&url) {
-            Ok(resp) => {
-                let b = resp.body.as_ref().to_vec();
-                if dbg {
-                    eprintln!(
-                        "[map] worker fetched tile=({},{},{}) {} bytes",
-                        tile.z, tile.x, tile.y, b.len()
-                    );
-                }
-                b
             }
-            Err(e) => {
-                if dbg {
-                    eprintln!("[map] worker fetch FAILED tile=({},{},{}): {e:?}", tile.z, tile.x, tile.y);
+            cached_bytes
+        } else {
+            match azul_layout::http::http_get(&url) {
+                Ok(resp) => {
+                    let b = resp.body.as_ref().to_vec();
+                    if dbg {
+                        eprintln!(
+                            "[map] worker fetched tile=({},{},{}) {} bytes",
+                            tile.z,
+                            tile.x,
+                            tile.y,
+                            b.len()
+                        );
+                    }
+                    b
                 }
-                sender.send(ThreadReceiveMsg::WriteBack(send_back(
-                    AzString::from(""),
-                    AzString::from(alloc::format!("fetch failed: {e:?}")),
-                    Vec::new(),
-                )));
-                return;
+                Err(e) => {
+                    if dbg {
+                        eprintln!(
+                            "[map] worker fetch FAILED tile=({},{},{}): {e:?}",
+                            tile.z, tile.x, tile.y
+                        );
+                    }
+                    sender.send(ThreadReceiveMsg::WriteBack(send_back(
+                        AzString::from(""),
+                        AzString::from(alloc::format!("fetch failed: {e:?}")),
+                        Vec::new(),
+                    )));
+                    return;
+                }
             }
-        }
-    };
+        };
 
     // Cancellation check between fetch and decode.
     if matches!(
@@ -199,7 +205,14 @@ pub extern "C" fn tile_fetch_worker(
         Ok(features) => {
             let svg = features_to_svg(&features, tile, &mapcss);
             if dbg {
-                eprintln!("[map] worker decoded tile=({},{},{}) theme={theme:?} {} features svg_len={}", tile.z, tile.x, tile.y, features.len(), svg.len());
+                eprintln!(
+                    "[map] worker decoded tile=({},{},{}) theme={theme:?} {} features svg_len={}",
+                    tile.z,
+                    tile.x,
+                    tile.y,
+                    features.len(),
+                    svg.len()
+                );
             }
             sender.send(ThreadReceiveMsg::WriteBack(send_back(
                 AzString::from(svg),
@@ -209,7 +222,10 @@ pub extern "C" fn tile_fetch_worker(
         }
         Err(e) => {
             if dbg {
-                eprintln!("[map] worker decode FAILED tile=({},{},{}): {e}", tile.z, tile.x, tile.y);
+                eprintln!(
+                    "[map] worker decode FAILED tile=({},{},{}): {e}",
+                    tile.z, tile.x, tile.y
+                );
             }
             sender.send(ThreadReceiveMsg::WriteBack(send_back(
                 AzString::from(""),
@@ -235,9 +251,7 @@ pub extern "C" fn tile_fetch_worker(
 ///
 /// When the `map-tiles` feature is off the worker doesn't exist, so we fall back to
 /// the placeholder `dom()` — keeping default/mobile builds free of the dep tree.
-pub fn map_widget_dom(
-    widget: azul_layout::widgets::map::MapWidget,
-) -> azul_core::dom::Dom {
+pub fn map_widget_dom(widget: azul_layout::widgets::map::MapWidget) -> azul_core::dom::Dom {
     #[cfg(feature = "map-tiles")]
     {
         widget.dom_with_fetch(azul_layout::thread::ThreadCallback {

--- a/dll/src/desktop/extra/map/mvt.rs
+++ b/dll/src/desktop/extra/map/mvt.rs
@@ -4,7 +4,7 @@ use geo_types::Geometry;
 use geojson::{Feature, FeatureCollection};
 #[cfg(feature = "log")]
 use log::{trace, warn};
-use mvt_reader::{Reader as TileReader, error::ParserError, feature::Feature as MvtFeature};
+use mvt_reader::{error::ParserError, feature::Feature as MvtFeature, Reader as TileReader};
 use proj4rs::Proj;
 use serde_json::{Number, Value as JsonValue};
 
@@ -243,7 +243,8 @@ pub fn parse_mvt_tile(
     for layer in layers {
         trace!(
             "Processing layer '{}' (index {})",
-            layer.name, layer.layer_index
+            layer.name,
+            layer.layer_index
         );
         let tile_features = reader.get_features(layer.layer_index).unwrap_or_default();
         trace!(
@@ -264,10 +265,7 @@ pub fn parse_mvt_tile(
                     // `feature.property("layer")` — without this every feature fell
                     // through to the grey default and the whole tile rendered grey.
                     if let Some(props) = geojson_feature.properties.as_mut() {
-                        props.insert(
-                            "layer".to_string(),
-                            JsonValue::String(layer.name.clone()),
-                        );
+                        props.insert("layer".to_string(), JsonValue::String(layer.name.clone()));
                     }
                     features.push(geojson_feature);
                 }
@@ -289,8 +287,12 @@ pub fn parse_mvt_tile(
     if dbg {
         eprintln!(
             "[map] parse tile=({},{},{}) layers={} raw_features={} converted={}",
-            tile_coord.z, tile_coord.x, tile_coord.y,
-            layer_count, raw_count, features.len()
+            tile_coord.z,
+            tile_coord.x,
+            tile_coord.y,
+            layer_count,
+            raw_count,
+            features.len()
         );
     }
     Ok(features)
@@ -483,8 +485,7 @@ fn convert_mvt_geometry_to_geojson(
             let polys = polygons
                 .iter()
                 .map(|polygon| {
-                    let exterior =
-                        translate_linestring_for_tile(polygon.exterior(), tile_coord);
+                    let exterior = translate_linestring_for_tile(polygon.exterior(), tile_coord);
                     let holes = polygon
                         .interiors()
                         .iter()
@@ -617,10 +618,8 @@ mod geometry_conversion_tests {
 
     #[test]
     fn multipolygon_is_converted_not_rejected() {
-        let geom =
-            Geometry::MultiPolygon(MultiPolygon(vec![Polygon::new(square_ring(), vec![])]));
-        let out =
-            convert_mvt_geometry_to_geojson(&geom, &tc()).expect("MultiPolygon must convert");
+        let geom = Geometry::MultiPolygon(MultiPolygon(vec![Polygon::new(square_ring(), vec![])]));
+        let out = convert_mvt_geometry_to_geojson(&geom, &tc()).expect("MultiPolygon must convert");
         match out.value {
             geojson::Value::MultiPolygon(polys) => {
                 assert_eq!(polys.len(), 1, "one polygon");
@@ -634,8 +633,8 @@ mod geometry_conversion_tests {
     #[test]
     fn multilinestring_is_converted_not_rejected() {
         let geom = Geometry::MultiLineString(MultiLineString(vec![square_ring()]));
-        let out = convert_mvt_geometry_to_geojson(&geom, &tc())
-            .expect("MultiLineString must convert");
+        let out =
+            convert_mvt_geometry_to_geojson(&geom, &tc()).expect("MultiLineString must convert");
         match out.value {
             geojson::Value::MultiLineString(lines) => {
                 assert_eq!(lines.len(), 1);
@@ -651,8 +650,7 @@ mod geometry_conversion_tests {
             Point::new(10.0f32, 20.0),
             Point::new(30.0, 40.0),
         ]));
-        let out =
-            convert_mvt_geometry_to_geojson(&geom, &tc()).expect("MultiPoint must convert");
+        let out = convert_mvt_geometry_to_geojson(&geom, &tc()).expect("MultiPoint must convert");
         match out.value {
             geojson::Value::MultiPoint(pts) => assert_eq!(pts.len(), 2),
             other => panic!("expected MultiPoint, got {other:?}"),
@@ -674,7 +672,9 @@ mod geometry_conversion_tests {
         ));
         let point = Geometry::Point(Point::new(50.0f32, 50.0));
         assert!(matches!(
-            convert_mvt_geometry_to_geojson(&point, &tc()).unwrap().value,
+            convert_mvt_geometry_to_geojson(&point, &tc())
+                .unwrap()
+                .value,
             geojson::Value::Point(_)
         ));
     }

--- a/dll/src/desktop/extra/map/svg.rs
+++ b/dll/src/desktop/extra/map/svg.rs
@@ -68,7 +68,10 @@ fn default_style(layer_name: &str) -> LayerStyle {
         LayerStyle::make("none", "#ffffff", 1.6)
     } else if lower.contains("transportation") || lower.contains("road") {
         LayerStyle::make("none", "#f0e8d8", 0.8)
-    } else if lower.contains("park") || lower.contains("landcover") || lower.contains("landuse_grass") {
+    } else if lower.contains("park")
+        || lower.contains("landcover")
+        || lower.contains("landuse_grass")
+    {
         LayerStyle::make("#c8e0c0", "#a8c89c", 0.4)
     } else if lower.contains("boundary") || lower.contains("admin") {
         LayerStyle::make("none", "#9a8aa0", 0.6)
@@ -128,7 +131,9 @@ impl MapCss {
             let mut stroke = "none".to_string();
             let mut stroke_width = 0.5_f32;
             for decl in body.split(';') {
-                let Some(colon) = decl.find(':') else { continue };
+                let Some(colon) = decl.find(':') else {
+                    continue;
+                };
                 let prop = decl[..colon].trim().to_ascii_lowercase();
                 let val = decl[colon + 1..].trim();
                 match prop.as_str() {
@@ -148,7 +153,14 @@ impl MapCss {
                 }
                 continue;
             }
-            rules.insert(key, LayerStyle { fill, stroke, stroke_width });
+            rules.insert(
+                key,
+                LayerStyle {
+                    fill,
+                    stroke,
+                    stroke_width,
+                },
+            );
         }
         Self { rules, canvas_fill }
     }
@@ -352,10 +364,7 @@ fn emit_polygon<F: Fn(f64, f64) -> (f64, f64)>(
             }
             let (x, y) = project(p[0], p[1]);
             if i == 0 {
-                let _ = core::fmt::Write::write_fmt(
-                    out,
-                    format_args!("{}{:.2},{:.2}", cmd, x, y),
-                );
+                let _ = core::fmt::Write::write_fmt(out, format_args!("{}{:.2},{:.2}", cmd, x, y));
             } else {
                 let _ = core::fmt::Write::write_fmt(out, format_args!(" L{:.2},{:.2}", x, y));
             }
@@ -371,11 +380,7 @@ fn emit_polygon<F: Fn(f64, f64) -> (f64, f64)>(
     out.push_str("\" fill-rule=\"evenodd\" />");
 }
 
-fn write_points<F: Fn(f64, f64) -> (f64, f64)>(
-    out: &mut String,
-    line: &[Vec<f64>],
-    project: &F,
-) {
+fn write_points<F: Fn(f64, f64) -> (f64, f64)>(out: &mut String, line: &[Vec<f64>], project: &F) {
     for (i, p) in line.iter().enumerate() {
         if p.len() < 2 {
             continue;
@@ -394,9 +399,15 @@ mod tests {
 
     fn line_feature(layer: &str, class: Option<&str>) -> geojson::Feature {
         let mut props = serde_json::Map::new();
-        props.insert("layer".to_string(), serde_json::Value::String(layer.to_string()));
+        props.insert(
+            "layer".to_string(),
+            serde_json::Value::String(layer.to_string()),
+        );
         if let Some(c) = class {
-            props.insert("class".to_string(), serde_json::Value::String(c.to_string()));
+            props.insert(
+                "class".to_string(),
+                serde_json::Value::String(c.to_string()),
+            );
         }
         geojson::Feature {
             bbox: None,
@@ -413,17 +424,38 @@ mod tests {
     #[test]
     fn a_theme_drives_the_canvas_and_colours_a_motorway_by_class() {
         use azul_layout::widgets::map::MapTheme;
-        let tile = MapTileId { z: 11, x: 327, y: 791 };
+        let tile = MapTileId {
+            z: 11,
+            x: 327,
+            y: 791,
+        };
         // Dark Matter: dark base, motorway lighter than a minor road.
         let dark = MapTheme::Dark.stylesheet();
         let dark = dark.as_str();
-        let svg = features_to_svg(&[line_feature("transportation", Some("motorway"))], tile, dark);
-        assert!(svg.contains("fill=\"#0c0c0c\""), "the theme's canvas fill is the base rect: {svg}");
-        assert!(svg.contains("stroke=\"#333333\""), "transportation.motorway rule applies: {svg}");
+        let svg = features_to_svg(
+            &[line_feature("transportation", Some("motorway"))],
+            tile,
+            dark,
+        );
+        assert!(
+            svg.contains("fill=\"#0c0c0c\""),
+            "the theme's canvas fill is the base rect: {svg}"
+        );
+        assert!(
+            svg.contains("stroke=\"#333333\""),
+            "transportation.motorway rule applies: {svg}"
+        );
         let svg = features_to_svg(&[line_feature("transportation", Some("minor"))], tile, dark);
-        assert!(svg.contains("stroke=\"#222222\""), "no `.minor` rule: the layer rule applies: {svg}");
+        assert!(
+            svg.contains("stroke=\"#222222\""),
+            "no `.minor` rule: the layer rule applies: {svg}"
+        );
         // No theme: the built-in light base and palette, unchanged.
-        let svg = features_to_svg(&[line_feature("transportation", Some("motorway"))], tile, "");
+        let svg = features_to_svg(
+            &[line_feature("transportation", Some("motorway"))],
+            tile,
+            "",
+        );
         assert!(svg.contains("fill=\"#d6d8db\""), "{svg}");
         assert!(svg.contains("stroke=\"#f0e8d8\""), "{svg}");
     }
@@ -442,13 +474,29 @@ mod tests {
             MapTheme::AppleDark,
         ] {
             let sheet = MapCss::parse(theme.stylesheet().as_str());
-            assert!(sheet.canvas_fill.is_some(), "{theme:?}: no canvas rule parsed");
-            assert!(sheet.rules.contains_key("water"), "{theme:?}: no water rule");
-            assert!(sheet.rules.contains_key("transportation.motorway"), "{theme:?}: no motorway rule");
+            assert!(
+                sheet.canvas_fill.is_some(),
+                "{theme:?}: no canvas rule parsed"
+            );
+            assert!(
+                sheet.rules.contains_key("water"),
+                "{theme:?}: no water rule"
+            );
+            assert!(
+                sheet.rules.contains_key("transportation.motorway"),
+                "{theme:?}: no motorway rule"
+            );
             let water = sheet.resolve("water", None);
-            assert!(water.fill.starts_with('#'), "{theme:?}: water fill {:?}", water.fill);
+            assert!(
+                water.fill.starts_with('#'),
+                "{theme:?}: water fill {:?}",
+                water.fill
+            );
             // a `.class` key never captures a plain layer by substring
-            assert_eq!(sheet.resolve("transportation", None).stroke, sheet.rules["transportation"].stroke);
+            assert_eq!(
+                sheet.resolve("transportation", None).stroke,
+                sheet.rules["transportation"].stroke
+            );
         }
     }
 
@@ -483,7 +531,15 @@ mod tests {
         f.properties = Some(props);
 
         // Point features (place/POI label anchors) must NOT be drawn as dots.
-        let svg = features_to_svg(&[f], MapTileId { z: 11, x: 327, y: 791 }, "");
+        let svg = features_to_svg(
+            &[f],
+            MapTileId {
+                z: 11,
+                x: 327,
+                y: 791,
+            },
+            "",
+        );
         assert!(!svg.contains("<circle"));
     }
 
@@ -539,6 +595,9 @@ mod tests {
             }
             rest = &data[end..];
         }
-        assert!(checked >= 8, "expected path coordinates to check, got {checked}: {svg}");
+        assert!(
+            checked >= 8,
+            "expected path coordinates to check, got {checked}: {svg}"
+        );
     }
 }

--- a/dll/src/desktop/shell2/linux/x11/mod.rs
+++ b/dll/src/desktop/shell2/linux/x11/mod.rs
@@ -663,6 +663,17 @@ pub(super) fn absolute_origin_plan(
         _ => AbsoluteOriginPlan::Translate,
     }
 }
+/// Ring / strip valuator of a tablet PAD, and the range needed to normalise it.
+///
+/// `xf86-input-wacom` labels these `Abs Wheel` (Intuos touch ring), `Abs Ring`
+/// / `Abs Ring2`, or `Abs Strip X` / `Abs Strip Y`. All are absolute valuators
+/// with a device-specific range, so the raw value means nothing without min/max.
+#[derive(Debug, Clone, Copy, Default)]
+struct PadAxes {
+    /// `(valuator number, min, max)` of the ring or strip, if the pad has one.
+    ring: Option<(i32, f64, f64)>,
+}
+
 
 /// The smooth-scroll (XI2.1) axes of ONE physical device.
 ///
@@ -771,6 +782,8 @@ fn init_xinput2(
     c_int,
     std::collections::HashMap<c_int, (i32, i32, i32, f64)>,
     std::collections::HashMap<c_int, ScrollAxes>,
+    std::collections::HashSet<c_int>,
+    std::collections::HashMap<c_int, PadAxes>,
 ) {
     use std::collections::HashMap;
     unsafe {
@@ -784,7 +797,14 @@ fn init_xinput2(
             &mut first_err,
         ) == 0
         {
-            return (None, 0, HashMap::new(), HashMap::new());
+            return (
+                None,
+                0,
+                HashMap::new(),
+                HashMap::new(),
+                std::collections::HashSet::new(),
+                HashMap::new(),
+            );
         }
         let xi = match dlopen::Xi::new() {
             Ok(x) => x,
@@ -796,7 +816,14 @@ fn init_xinput2(
                      touch/pen input will NOT work in this window",
                     e
                 );
-                return (None, 0, HashMap::new(), HashMap::new());
+                return (
+                    None,
+                    0,
+                    HashMap::new(),
+                    HashMap::new(),
+                    std::collections::HashSet::new(),
+                    HashMap::new(),
+                );
             }
         };
         let (mut maj, mut min) = (2i32, 2i32);
@@ -825,15 +852,38 @@ fn init_xinput2(
         let p_atom = (xlib.XInternAtom)(display, b"Abs Pressure\0".as_ptr() as *const _, 0);
         let tx_atom = (xlib.XInternAtom)(display, b"Abs Tilt X\0".as_ptr() as *const _, 0);
         let ty_atom = (xlib.XInternAtom)(display, b"Abs Tilt Y\0".as_ptr() as *const _, 0);
+        // Pad ring / strip. `xf86-input-wacom` uses `Abs Wheel` on Intuos touch
+        // rings and `Abs Ring`/`Abs Strip *` elsewhere, so all are accepted.
+        let ring_atoms = [
+            (xlib.XInternAtom)(display, b"Abs Wheel\0".as_ptr() as *const _, 0),
+            (xlib.XInternAtom)(display, b"Abs Ring\0".as_ptr() as *const _, 0),
+            (xlib.XInternAtom)(display, b"Abs Ring2\0".as_ptr() as *const _, 0),
+            (xlib.XInternAtom)(display, b"Abs Strip X\0".as_ptr() as *const _, 0),
+            (xlib.XInternAtom)(display, b"Abs Strip Y\0".as_ptr() as *const _, 0),
+        ];
         let mut map = HashMap::new();
         let mut scroll: HashMap<c_int, ScrollAxes> = HashMap::new();
+        let mut erasers: std::collections::HashSet<c_int> = std::collections::HashSet::new();
+        let mut pads: HashMap<c_int, PadAxes> = HashMap::new();
         let mut ndev = 0i32;
         let devs = (xi.XIQueryDevice)(display, defines::XIAllDevices, &mut ndev);
         if !devs.is_null() {
             for i in 0..ndev as isize {
                 let dev = &*devs.offset(i);
+                // XI2 has no "what kind of tool is this" field, so the driver's
+                // device NAME is the only signal — `xf86-input-wacom` emits
+                // "<tablet> Pen stylus", "<tablet> Pen eraser", "<tablet> Pad pad".
+                // Same convention the touchpad detection below already relies on.
+                let dev_name = if dev.name.is_null() {
+                    String::new()
+                } else {
+                    std::ffi::CStr::from_ptr(dev.name).to_string_lossy().to_lowercase()
+                };
+                let is_eraser = dev_name.contains("eraser");
+                let is_pad = dev_name.ends_with(" pad") || dev_name.contains(" pad ");
                 let (mut p, mut tx, mut ty, mut pmax) = (-1i32, -1i32, -1i32, 1.0f64);
                 let mut axes = ScrollAxes::default();
+                let mut pad_axes = PadAxes::default();
                 for c in 0..dev.num_classes as isize {
                     let cls = *dev.classes.offset(c);
                     if cls.is_null() {
@@ -856,6 +906,15 @@ fn init_xinput2(
                         continue;
                     }
                     let v = &*(cls as *const defines::XIValuatorClassInfo);
+                    if is_pad && ring_atoms.contains(&v.label) && pad_axes.ring.is_none() {
+                        // Absolute valuator with a device-specific range: keep
+                        // min/max, the raw number is meaningless without them.
+                        let (lo, hi) = (v.min, v.max);
+                        if hi > lo {
+                            pad_axes.ring = Some((v.number, lo, hi));
+                        }
+                        continue;
+                    }
                     if v.label == p_atom {
                         p = v.number;
                         pmax = if v.max > 0.0 { v.max } else { 1.0 };
@@ -867,6 +926,30 @@ fn init_xinput2(
                 }
                 if p >= 0 || tx >= 0 || ty >= 0 {
                     map.insert(dev.deviceid, (p, tx, ty, pmax));
+                }
+                if is_eraser {
+                    erasers.insert(dev.deviceid);
+                }
+                if is_pad {
+                    // A pad is a SLAVE device that is usually floating: its
+                    // buttons are not routed through a master pointer, so the
+                    // XIAllMasterDevices selection above never delivers them.
+                    // Select on this device explicitly or the pad stays silent.
+                    let mut pad_mask = [0u8; 3];
+                    for e in [
+                        defines::XI_ButtonPress,
+                        defines::XI_ButtonRelease,
+                        defines::XI_Motion,
+                    ] {
+                        pad_mask[(e >> 3) as usize] |= 1 << (e & 7);
+                    }
+                    let mut pad_evmask = defines::XIEventMask {
+                        deviceid: dev.deviceid,
+                        mask_len: pad_mask.len() as c_int,
+                        mask: pad_mask.as_mut_ptr(),
+                    };
+                    (xi.XISelectEvents)(display, window, &mut pad_evmask, 1);
+                    pads.insert(dev.deviceid, pad_axes);
                 }
                 if axes.vert.is_some() || axes.horiz.is_some() {
                     // XI2 exposes no "is a touchpad" bit. The device NAME is
@@ -887,7 +970,7 @@ fn init_xinput2(
             }
             (xi.XIFreeDeviceInfo)(devs);
         }
-        (Some(xi), opcode, map, scroll)
+        (Some(xi), opcode, map, scroll, erasers, pads)
     }
 }
 
@@ -1255,6 +1338,56 @@ fn handle_xi_device_event(
             // otherwise every click / move / wheel is silently dropped (dead
             // caret, hover, drag-select, scroll).
 
+            // Tablet PAD: ExpressKeys and the touch ring/strip. Handled BEFORE
+            // the pointer translation below and returned from, because a pad is
+            // not a pointer — it has no cursor and no meaningful surface
+            // coordinates, so letting it fall through would synthesise clicks
+            // and moves at whatever stale position the event carries.
+            if let Some(&pad_axes) = win.pad_devices.get(&ev.sourceid) {
+                match evtype {
+                    defines::XI_ButtonPress | defines::XI_ButtonRelease => {
+                        // XI2 buttons are 1-based; `express_keys` is a 0-based
+                        // u32 bitset, so button 1 is bit 0. Anything past 32
+                        // is dropped rather than wrapped onto another key.
+                        let index = ev.detail - 1;
+                        if (0..32).contains(&index) {
+                            let bit = 1u32 << index;
+                            if evtype == defines::XI_ButtonPress {
+                                win.pad_state.express_keys |= bit;
+                            } else {
+                                win.pad_state.express_keys &= !bit;
+                            }
+                        }
+                    }
+                    defines::XI_Motion => {
+                        if let Some((number, lo, hi)) = pad_axes.ring {
+                            // The ring reports an ABSOLUTE position in a
+                            // device-specific range, and only while a finger is
+                            // on it — an absent valuator this frame means the
+                            // finger lifted, which is the only "released" signal
+                            // the protocol gives.
+                            match decode_valuator(ev, number) {
+                                Some(v) => {
+                                    let span = hi - lo;
+                                    win.pad_state.touch_ring =
+                                        (((v - lo) / span) as f32).clamp(0.0, 1.0);
+                                    win.pad_state.touch_ring_active = true;
+                                }
+                                None => win.pad_state.touch_ring_active = false,
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+                win.pad_state.device_id = ev.sourceid as u64;
+                if let Some(lw) = win.common.layout_window.as_mut() {
+                    lw.gesture_drag_manager.update_pad_state(win.pad_state);
+                }
+                // `handle_xi_event` owns the cookie for the whole of this
+                // call, so this returns rather than freeing anything.
+                return result;
+            }
+
             // Pen/tablet: additionally feed pressure/tilt for known pen devices.
             // Key the valuator map by sourceid (the originating SLAVE/physical
             // device), NOT deviceid: events selected on XIAllMasterDevices carry
@@ -1274,7 +1407,7 @@ fn handle_xi_device_event(
                         pressure,
                         (tilt_x, tilt_y),
                         in_contact,
-                        false, // eraser: identified via tool/button labels, not valuators
+                        win.eraser_devices.contains(&ev.sourceid),
                         false,
                         ev.deviceid as u64,
                         0.0,
@@ -1521,6 +1654,12 @@ pub struct X11Window {
     pen_valuators: std::collections::HashMap<c_int, (i32, i32, i32, f64)>,
     /// deviceid -> smooth-scroll (XI2.1) axes of that device.
     scroll_valuators: std::collections::HashMap<c_int, ScrollAxes>,
+    /// Slave device ids that are the ERASER end of a stylus, by device name.
+    eraser_devices: std::collections::HashSet<c_int>,
+    /// Slave device ids that are tablet PADs (ExpressKeys + ring/strip).
+    pad_devices: std::collections::HashMap<c_int, PadAxes>,
+    /// Accumulated pad state, published to the gesture manager on each event.
+    pad_state: azul_layout::managers::gesture::WacomPadState,
     /// `(deviceid, valuator number)` -> last absolute value seen. Scroll
     /// valuators accumulate, so a delta needs the previous reading.
     scroll_last_values: std::collections::HashMap<(c_int, c_int), f64>,
@@ -2197,7 +2336,7 @@ impl X11Window {
         unsafe { (xlib.XSelectInput)(display, window_handle, event_mask) };
 
         // XInput2: select touch + pen/tablet events (best-effort; core events otherwise).
-        let (xi, xi_opcode, pen_valuators, scroll_valuators) =
+        let (xi, xi_opcode, pen_valuators, scroll_valuators, eraser_devices, pad_devices) =
             init_xinput2(&xlib, display, window_handle);
         let modifier_masks = query_modifier_masks(&xlib, display);
 
@@ -2638,6 +2777,9 @@ impl X11Window {
             xi_opcode,
             pen_valuators,
             scroll_valuators,
+            eraser_devices,
+            pad_devices,
+            pad_state: azul_layout::managers::gesture::WacomPadState::default(),
             scroll_last_values: std::collections::HashMap::new(),
             modifier_masks,
             pressed_key_vks: std::collections::BTreeMap::new(),

--- a/examples/azul-maps/Cargo.toml
+++ b/examples/azul-maps/Cargo.toml
@@ -16,7 +16,16 @@ description = """
 publish = false
 
 [dependencies]
-azul = { path = "../../dll", package = "azul-dll", default-features = false, features = ["link-dynamic"] }
+# `map-tiles` is what makes `map_widget_dom` wire the MVT fetch worker instead
+# of returning the placeholder DOM — see the contract test in src/lib.rs. It has
+# to be asked for HERE, not left to the dylib: `link-dynamic` only reaches the
+# `build-dll` libazul (which does carry the feature) while nothing unifies
+# `cabi_internal` into azul-dll. `examples/rust` takes azul-dll's DEFAULT
+# features, and those include `link-static` -> `cabi_export` -> `cabi_internal`,
+# so any build covering both packages flips this crate to compiling the engine
+# in-crate out of the unified feature set — where `map-tiles` was absent, and
+# AzMaps shipped a map that could never fetch a tile.
+azul = { path = "../../dll", package = "azul-dll", default-features = false, features = ["link-dynamic", "map-tiles"] }
 
 # On Android the crate builds as a NativeActivity cdylib: link the android-activity
 # glue into libazul (so it provides android_main / ANativeActivity_onCreate) and

--- a/examples/azul-maps/src/lib.rs
+++ b/examples/azul-maps/src/lib.rs
@@ -201,6 +201,73 @@ mod pan_tests {
     }
 }
 
+/// This demo only paints tiles if the engine it links carries `map-tiles`.
+///
+/// `MapWidget::dom()` routes through `azul_dll::unified::map::map_widget_dom`
+/// (pinned by `dll/tests/map_binding_contract.rs`), and that function is split
+/// on the feature: WITH `map-tiles` it hands the widget the MVT fetch worker,
+/// WITHOUT it it returns the bare placeholder DOM and every tile stays
+/// `Pending` forever — a map you can pan over an empty loading grid.
+///
+/// Which half compiles is decided by the features THIS manifest asks azul-dll
+/// for, not by the libazul the binary might load at run time. `link-dynamic`
+/// alone looks sufficient — the dylib is built with `build-dll`, which does
+/// enable `map-tiles` — but the moment anything else in the workspace unifies
+/// `cabi_internal` into azul-dll (`examples/rust` takes azul-dll's DEFAULT
+/// features, and the default set contains `link-static` → `cabi_export` →
+/// `cabi_internal`), `dll/build.rs` stops linking the dylib altogether
+/// ("dynamic linking is unused") and the engine is compiled straight into this
+/// binary out of the unified feature set. `map-tiles` is not in that set unless
+/// this manifest asks for it, so a workspace-wide `cargo build` silently
+/// produced a worker-less AzMaps while a lone `cargo build -p AzMaps` did not.
+///
+/// The desktop dependency lost `map-tiles` in f08458b3c ("demos link the
+/// prebuilt static libazul.a"); iOS and Android kept it, which is why only
+/// desktop regressed. Symptom on the binary:
+/// `AZ_MAP_DEBUG=1 ./target/release/AzMaps` printing
+/// `[map] spawn_pending: ABORT — no fetch_callback on the cache`, forever.
+#[cfg(test)]
+mod engine_feature_tests {
+    const MANIFEST: &str = include_str!("../Cargo.toml");
+
+    /// Every `azul-dll` dependency line this manifest declares — one per
+    /// target family (desktop default, android, ios).
+    fn azul_dll_dependency_lines() -> Vec<&'static str> {
+        MANIFEST
+            .lines()
+            .map(str::trim)
+            .filter(|l| !l.starts_with('#'))
+            .filter(|l| l.contains(r#"package = "azul-dll""#))
+            .collect()
+    }
+
+    #[test]
+    fn the_demo_asks_the_engine_for_the_tile_pipeline_on_every_target() {
+        let deps = azul_dll_dependency_lines();
+        assert!(
+            !deps.is_empty(),
+            "this manifest declares no azul-dll dependency at all — the selector \
+             below is stale, not the manifest"
+        );
+
+        for dep in &deps {
+            assert!(
+                dep.contains("\"map-tiles\""),
+                "an azul-dll dependency of AzMaps does not enable `map-tiles`:\n  \
+                 {dep}\n\
+                 Without it `map_widget_dom` compiles its \
+                 `#[cfg(not(feature = \"map-tiles\"))]` half, which returns the \
+                 placeholder DOM and wires NO tile-fetch worker — the demo pans a \
+                 permanently empty grid. Enabling it here is what makes the demo \
+                 correct in BOTH link modes: it is harmless when the dylib supplies \
+                 the worker, and it is the only thing that supplies it when cargo \
+                 unifies `cabi_internal` in and the engine gets compiled into this \
+                 binary instead."
+            );
+        }
+    }
+}
+
 // ───────── Styles ─────────────────────────────────────────────────────
 
 const ROOT: &str = "display: flex; flex-direction: column; height: 100%;";

--- a/examples/azul-review/Cargo.toml
+++ b/examples/azul-review/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "AzReview"
+version = "0.1.0"
+edition = "2021"
+authors = ["Felix Schütt <felix.schuett@maps4print.com>"]
+license = "MIT"
+description = """
+    AzReview — ink-first code review. Code is rendered as PAPER PAGES in a
+    VirtualView; a pen/highlighter overlay is the source of truth and the
+    structured findings are DERIVED from it, never the reverse. Exercises the
+    tablet surface end to end: PenState (pressure/tilt/eraser), the Wacom PAD
+    (ExpressKeys pick the semantic colour, the ring scrolls), multi-touch, and
+    the microphone API for spoken rationale bound to a stroke cluster.
+"""
+publish = false
+
+[dependencies]
+azul = { path = "../../dll", package = "azul-dll", default-features = false, features = ["link-dynamic"] }
+
+[lib]
+name = "azul_review"
+path = "src/lib.rs"
+crate-type = ["rlib"]
+
+[[bin]]
+name = "AzReview"
+path = "src/main.rs"

--- a/examples/azul-review/examples/zip_smoke.rs
+++ b/examples/azul-review/examples/zip_smoke.rs
@@ -1,0 +1,34 @@
+//! Proves the ZIP surface works ACROSS THE C ABI, not just in Rust.
+//!
+//! `azul-dll`'s own unit tests call `Zip` as a Rust type; they would pass even
+//! if codegen never emitted a single `AzZip_*` symbol. This links against
+//! `libazul` the way any other binding does, so it fails if the api.json entry,
+//! the generated shim or the export list is wrong - which is the part that
+//! actually breaks.
+//!
+//! Run: `cargo run --release -p AzReview --example zip_smoke`
+
+fn main() {
+    let mut z = azul::zip::Zip::new();
+    z.add_file("session.json", u8vec(br#"{"format":"azreview/1"}"#));
+    z.add_file("clip-0.wav", u8vec(&vec![7u8; 1024]));
+    assert_eq!(z.file_count(), 2, "entries did not accumulate");
+
+    let dir = std::env::temp_dir().join("azreview-smoke");
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("s.zip");
+    assert!(z.to_file(path.to_string_lossy().as_ref()), "to_file failed");
+
+    let disk = std::fs::read(&path).unwrap();
+    assert_eq!(&disk[0..2], b"PK", "not a zip: {:?}", &disk[0..4]);
+
+    let back = azul::zip::Zip::from_file(path.to_string_lossy().as_ref());
+    assert_eq!(back.file_count(), 2, "round trip lost entries");
+    assert_eq!(back.get_file("session.json").as_ref(), br#"{"format":"azreview/1"}"#);
+    assert_eq!(back.get_file("clip-0.wav").as_ref().len(), 1024);
+    println!("OK  {} bytes on disk, {} entries back", disk.len(), back.file_count());
+}
+
+fn u8vec(v: &[u8]) -> azul::vec::U8Vec {
+    azul::vec::U8Vec::copy_from_bytes(&v[0], 0, v.len())
+}

--- a/examples/azul-review/src/code.rs
+++ b/examples/azul-review/src/code.rs
@@ -1,0 +1,107 @@
+//! Loading a tree of files and cutting each into PAGES.
+//!
+//! Pagination, not scrolling, is deliberate. Paper gives spatial memory — "the
+//! Mutex question was top-right of the third sheet" — and continuous scrolling
+//! destroys it. Fixed page boundaries per session mean ink stays where you
+//! remember putting it.
+
+use std::path::{Path, PathBuf};
+
+/// Code lines per page. Fixed for the session so page boundaries are stable.
+pub const LINES_PER_PAGE: usize = 46;
+
+/// Extensions worth reviewing. Everything else is noise in the file browser.
+const REVIEWABLE: &[&str] = &[
+    "rs", "toml", "md", "c", "h", "cpp", "hpp", "py", "js", "ts", "sh", "yml", "yaml", "json",
+];
+
+#[derive(Debug, Clone)]
+pub struct SourceFile {
+    pub path: PathBuf,
+    /// Path shown in the UI, relative to the review root.
+    pub display: String,
+    pub lines: Vec<String>,
+}
+
+impl SourceFile {
+    pub fn page_count(&self) -> usize {
+        self.lines.len().div_ceil(LINES_PER_PAGE).max(1)
+    }
+
+    /// Lines of one page, plus the 1-based number of the first of them.
+    pub fn page(&self, page: usize) -> (usize, &[String]) {
+        let start = page * LINES_PER_PAGE;
+        if start >= self.lines.len() {
+            return (start + 1, &[]);
+        }
+        let end = (start + LINES_PER_PAGE).min(self.lines.len());
+        (start + 1, &self.lines[start..end])
+    }
+}
+
+/// Load a review target: either a whole repo or a single directory.
+///
+/// One entry point for both because the difference is only which paths get
+/// skipped — a git repo has `target/` and `.git/` worth ignoring, a plain
+/// directory (say `doc/guide/`) usually has neither.
+pub fn load_tree(root: &Path, limit: usize) -> Vec<SourceFile> {
+    let mut out = Vec::new();
+    walk(root, root, &mut out, limit, 0);
+    out.sort_by(|a, b| a.display.cmp(&b.display));
+    out
+}
+
+fn walk(root: &Path, dir: &Path, out: &mut Vec<SourceFile>, limit: usize, depth: usize) {
+    // A repo can hold hundreds of thousands of files; a review session opens a
+    // handful. Bound both so a mistyped root cannot hang the UI.
+    if out.len() >= limit || depth > 12 {
+        return;
+    }
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    let mut entries: Vec<_> = entries.filter_map(Result::ok).collect();
+    entries.sort_by_key(std::fs::DirEntry::file_name);
+    for e in entries {
+        if out.len() >= limit {
+            return;
+        }
+        let p = e.path();
+        let name = e.file_name().to_string_lossy().to_string();
+        if name.starts_with('.') || name == "target" || name == "node_modules" {
+            continue;
+        }
+        if p.is_dir() {
+            walk(root, &p, out, limit, depth + 1);
+        } else if is_reviewable(&p) {
+            if let Some(f) = load_file(root, &p) {
+                out.push(f);
+            }
+        }
+    }
+}
+
+fn is_reviewable(p: &Path) -> bool {
+    p.extension()
+        .and_then(|e| e.to_str())
+        .is_some_and(|e| REVIEWABLE.contains(&e))
+}
+
+fn load_file(root: &Path, p: &Path) -> Option<SourceFile> {
+    let text = std::fs::read_to_string(p).ok()?;
+    // A generated or minified file is one enormous line; rendering it as a
+    // page of code is useless and slow.
+    if text.lines().count() > 20_000 {
+        return None;
+    }
+    let display = p
+        .strip_prefix(root)
+        .unwrap_or(p)
+        .to_string_lossy()
+        .to_string();
+    Some(SourceFile {
+        path: p.to_path_buf(),
+        display,
+        lines: text.lines().map(|l| l.replace('\t', "    ")).collect(),
+    })
+}

--- a/examples/azul-review/src/ink.rs
+++ b/examples/azul-review/src/ink.rs
@@ -1,0 +1,196 @@
+//! Ink rasterisation — the metaball field from AzPaint, retuned for a MARKER.
+//!
+//! Two differences from the paint app it borrows from:
+//!
+//! 1. **Translucent, not opaque.** A highlighter must let the glyphs show
+//!    through, so the field is composited at a fixed low alpha rather than
+//!    replacing the pixel.
+//! 2. **Alpha does not accumulate along a stroke.** Real marker ink is
+//!    absorbed by the paper: dragging back over the same spot does not get
+//!    darker. Summing per-dab alpha (which is what a naive metaball sum does)
+//!    made slow strokes blotchy and fast ones translucent, so coverage is
+//!    computed as a MAX over the field rather than a sum.
+
+
+use crate::model::{InkPoint, Semantic, Stroke};
+
+/// Base half-width of a pen dab at full pressure, in logical px.
+const PEN_RADIUS: f32 = 1.6;
+/// Highlighter dabs are much wider — a marker nib, not a ballpoint.
+const MARKER_RADIUS: f32 = 9.0;
+/// Marker coverage never exceeds this, so code stays readable underneath.
+const MARKER_ALPHA: f32 = 0.38;
+
+/// Smooth falloff, 1.0 at the centre of a dab and 0.0 at its edge.
+///
+/// The quartic is deliberate: a linear falloff makes two overlapping dabs meet
+/// in a visible crease, which is exactly the "weird edges on metaball merge"
+/// artefact. This one has zero derivative at both ends, so merges are smooth.
+fn kernel(q: f32) -> f32 {
+    if q >= 1.0 {
+        return 0.0;
+    }
+    let t = 1.0 - q * q;
+    t * t
+}
+
+/// Rasterise all strokes for one page into an RGBA buffer.
+///
+/// Highlighter and pen are drawn in two passes, lowest layer first, so pen
+/// commentary always reads on top of the region it refers to — the same
+/// stacking the paper has by physical accident.
+pub fn rasterize_page(strokes: &[&Stroke], w: u32, h: u32) -> Vec<u8> {
+    let mut buf = vec![0u8; (w as usize) * (h as usize) * 4];
+    for pass_highlighter in [true, false] {
+        for s in strokes {
+            if s.semantic.is_highlighter() != pass_highlighter {
+                continue;
+            }
+            draw_stroke(&mut buf, w, h, s);
+        }
+    }
+    buf
+}
+
+fn draw_stroke(buf: &mut [u8], w: u32, h: u32, stroke: &Stroke) {
+    let color = stroke.semantic.color();
+    let marker = stroke.semantic.is_highlighter();
+    let base = if marker { MARKER_RADIUS } else { PEN_RADIUS };
+
+    // Coverage for THIS stroke only, so overlap within one stroke maxes
+    // instead of accumulating, while separate strokes still layer normally.
+    let mut cov = vec![0f32; (w as usize) * (h as usize)];
+
+    for pair in stroke.points.windows(2) {
+        splat_segment(&mut cov, w, h, pair[0], pair[1], base, marker);
+    }
+    if stroke.points.len() == 1 {
+        splat_dab(&mut cov, w, h, stroke.points[0], base, marker);
+    }
+
+    let max_a = if marker { MARKER_ALPHA } else { 1.0 };
+    for i in 0..cov.len() {
+        let a = (cov[i]).min(1.0) * max_a;
+        if a <= 0.001 {
+            continue;
+        }
+        let o = i * 4;
+        let (dr, dg, db, da) = (
+            buf[o] as f32 / 255.0,
+            buf[o + 1] as f32 / 255.0,
+            buf[o + 2] as f32 / 255.0,
+            buf[o + 3] as f32 / 255.0,
+        );
+        let (sr, sg, sb) = (
+            color.r as f32 / 255.0,
+            color.g as f32 / 255.0,
+            color.b as f32 / 255.0,
+        );
+        // Source-over.
+        let out_a = a + da * (1.0 - a);
+        if out_a <= 0.0 {
+            continue;
+        }
+        buf[o] = (((sr * a + dr * da * (1.0 - a)) / out_a) * 255.0) as u8;
+        buf[o + 1] = (((sg * a + dg * da * (1.0 - a)) / out_a) * 255.0) as u8;
+        buf[o + 2] = (((sb * a + db * da * (1.0 - a)) / out_a) * 255.0) as u8;
+        buf[o + 3] = (out_a * 255.0) as u8;
+    }
+}
+
+/// Walk a segment in sub-dab steps so a fast stroke is still continuous.
+///
+/// Stepping by a fraction of the radius rather than a fixed pixel count is
+/// what keeps a quick flick from turning into a dotted line — the pointer only
+/// samples so often, and the gap between samples is arbitrary.
+fn splat_segment(
+    cov: &mut [f32],
+    w: u32,
+    h: u32,
+    a: InkPoint,
+    b: InkPoint,
+    base: f32,
+    marker: bool,
+) {
+    let dx = b.x - a.x;
+    let dy = b.y - a.y;
+    let dist = (dx * dx + dy * dy).sqrt();
+    let step = (base * 0.35).max(0.75);
+    let n = ((dist / step).ceil() as usize).max(1);
+    for i in 0..=n {
+        let t = i as f32 / n as f32;
+        let p = InkPoint {
+            x: a.x + dx * t,
+            y: a.y + dy * t,
+            pressure: a.pressure + (b.pressure - a.pressure) * t,
+            tilt_x: a.tilt_x + (b.tilt_x - a.tilt_x) * t,
+            tilt_y: a.tilt_y + (b.tilt_y - a.tilt_y) * t,
+        };
+        splat_dab(cov, w, h, p, base, marker);
+    }
+}
+
+/// One dab. Tilt elongates it along the tilt direction, so a tilted pen paints
+/// a directional, stretched blob the way a real nib does.
+fn splat_dab(cov: &mut [f32], w: u32, h: u32, p: InkPoint, base: f32, marker: bool) {
+    // A marker keeps a constant nib width; a pen thins with lighter pressure.
+    let r = if marker {
+        base
+    } else {
+        base * (0.35 + 0.65 * p.pressure.clamp(0.0, 1.0))
+    };
+    let tilt_mag = (p.tilt_x * p.tilt_x + p.tilt_y * p.tilt_y).sqrt().min(1.0);
+    let elong = 1.0 + tilt_mag * 1.6;
+    let (ax, ay) = if tilt_mag > 0.01 {
+        (p.tilt_x / tilt_mag, p.tilt_y / tilt_mag)
+    } else {
+        (1.0, 0.0)
+    };
+
+    let reach = (r * elong).ceil() as i32 + 1;
+    let cx = p.x;
+    let cy = p.y;
+    for yy in (cy as i32 - reach)..=(cy as i32 + reach) {
+        if yy < 0 || yy >= h as i32 {
+            continue;
+        }
+        for xx in (cx as i32 - reach)..=(cx as i32 + reach) {
+            if xx < 0 || xx >= w as i32 {
+                continue;
+            }
+            let ox = xx as f32 + 0.5 - cx;
+            let oy = yy as f32 + 0.5 - cy;
+            // Project into the dab's own frame: along the tilt axis it is
+            // `elong` times longer, across it unchanged.
+            let along = ox * ax + oy * ay;
+            let across = -ox * ay + oy * ax;
+            let q = ((along / elong).powi(2) + across.powi(2)).sqrt() / r.max(0.01);
+            let v = kernel(q);
+            if v > 0.0 {
+                let i = yy as usize * w as usize + xx as usize;
+                // MAX, not +=: marker ink does not darken on re-traverse.
+                if v > cov[i] {
+                    cov[i] = v;
+                }
+            }
+        }
+    }
+}
+
+/// Convert a pen sample into an ink point, defaulting sanely for a finger or
+/// mouse (no pressure, no tilt) so touch still draws.
+pub fn point_from(x: f32, y: f32, pressure: f32, tilt_x: f32, tilt_y: f32) -> InkPoint {
+    InkPoint {
+        x,
+        y,
+        pressure: if pressure <= 0.0 { 0.55 } else { pressure.clamp(0.05, 1.0) },
+        tilt_x,
+        tilt_y,
+    }
+}
+
+/// Semantic of the eraser end of a stylus — flipping the pen erases, which is
+/// the gesture everyone already knows.
+pub const fn eraser_semantic() -> Option<Semantic> {
+    None
+}

--- a/examples/azul-review/src/lib.rs
+++ b/examples/azul-review/src/lib.rs
@@ -32,6 +32,8 @@
 use std::path::PathBuf;
 
 use azul::prelude::*;
+use azul::task::TerminateTimer;
+use azul::time::SystemTimeDiff;
 
 pub mod code;
 pub mod ink;
@@ -77,6 +79,11 @@ pub struct AppState {
     /// the only place in the app that sees the engine's scroll offset. Drives
     /// which number the page rail highlights.
     pub visible_page: usize,
+    /// Which annotation burst new strokes join. Bumped by the idle timer.
+    pub epoch: u64,
+    /// The idle timer's id, kept so each pen-up can RESTART one timer instead
+    /// of piling up a fresh one per stroke.
+    pub idle_timer: TimerId,
     pub root: PathBuf,
     pub status: String,
     /// Pad ExpressKeys as of the last frame, so a press EDGE can be detected.
@@ -105,11 +112,16 @@ impl AppState {
 
 /// Cluster strokes into findings.
 ///
-/// Clustering is spatial AND temporal, because that is how the marks were
-/// made: strokes drawn close together, close in time, and carrying the same
-/// intent are one remark. Two `.unwrap()` highlights on opposite ends of a
-/// page minutes apart are two findings; the brace and the words next to it are
-/// one.
+/// # The epoch does the work
+///
+/// Two marks are one remark when they were MADE as one remark, and the only
+/// honest record of that is the pause between them — which is why the boundary
+/// comes from the idle timer (`ANNOTATION_IDLE_MS`) and not from geometry.
+/// Position alone cannot tell a second thought about a line from a correction
+/// of the first, and both happen constantly.
+///
+/// Line proximity is still required WITHIN an epoch, because one uninterrupted
+/// burst of marking often covers several unrelated places on a page.
 fn derive_findings(
     strokes: &[Stroke],
     file: &code::SourceFile,
@@ -124,10 +136,9 @@ fn derive_findings(
         let l0 = first_line + (y0 / ui::LINE_H).floor().max(0.0) as usize;
         let l1 = first_line + (y1 / ui::LINE_H).floor().max(0.0) as usize;
 
-        // Merge into an existing finding when the intent matches and the line
-        // ranges touch — the brace and the note beside it become one remark.
         let merged = out.iter_mut().find(|f| {
-            f.semantic == s.semantic
+            f.epoch == s.epoch
+                && f.semantic == s.semantic
                 && l0 <= f.last_line.saturating_add(2)
                 && l1.saturating_add(2) >= f.first_line
         });
@@ -148,6 +159,7 @@ fn derive_findings(
             last_line: l1,
             voice_note: voice,
             stroke_count: 1,
+            epoch: s.epoch,
         });
     }
     out.sort_by_key(|f| f.first_line);
@@ -179,6 +191,8 @@ pub fn run() {
         clips: Vec::new(),
         level_samples: 0,
         visible_page: 0,
+        epoch: 0,
+        idle_timer: TimerId::unique(),
         root,
         status,
         last_pad_keys: 0,
@@ -224,7 +238,8 @@ pub extern "C" fn on_ink_down(mut data: RefAny, mut info: CallbackInfo) -> Updat
     // code, it does not say anything about it. Letting it carry `issue` would
     // produce findings whose ink shape contradicts their label.
     let semantic = s.tool.semantic_for(s.active);
-    s.live = Some(Stroke { page, semantic, points: vec![p], id });
+    let epoch = s.epoch;
+    s.live = Some(Stroke { page, semantic, points: vec![p], id, epoch });
 
     // The audio pen starts recording by being used. Any other way round means
     // remembering to arm it first, and the remark worth saying out loud is the
@@ -295,8 +310,8 @@ pub extern "C" fn on_ink_move(mut data: RefAny, mut info: CallbackInfo) -> Updat
 /// down to pick another up, and a tool change that costs a trip to a toolbar
 /// reproduces exactly that interruption. A one-dab stroke would be invisible
 /// anyway, so nothing is lost by spending it.
-pub extern "C" fn on_ink_up(mut data: RefAny, info: CallbackInfo) -> Update {
-    let is_click = {
+pub extern "C" fn on_ink_up(mut data: RefAny, mut info: CallbackInfo) -> Update {
+    let (is_click, timer_id) = {
         let Some(mut s) = data.downcast_mut::<AppState>() else {
             return Update::DoNothing;
         };
@@ -304,18 +319,79 @@ pub extern "C" fn on_ink_up(mut data: RefAny, info: CallbackInfo) -> Update {
             return Update::DoNothing;
         };
         if done.points.len() < CLICK_POINT_LIMIT {
-            true
+            (true, s.idle_timer)
         } else {
             s.strokes.push(done);
             s.rederive();
             session::save(&s);
-            false
+            (false, s.idle_timer)
         }
     };
     if is_click {
         return on_cycle_tool(data, info);
     }
+    arm_idle_timer(&mut info, data, timer_id);
     Update::RefreshDom
+}
+
+/// How long the ink must stay still before the annotation is considered
+/// finished.
+///
+/// Long enough to survive lifting the pen to look at the code, short enough
+/// that two genuinely separate remarks are not welded together. It is a
+/// judgement about pen-and-paper rhythm, not a tuning constant with a right
+/// answer — but SOME threshold is required, because the alternative is
+/// guessing from geometry, which cannot distinguish a correction from a new
+/// thought about the same line.
+const ANNOTATION_IDLE_MS: u64 = 1_800;
+
+/// (Re)start the idle timer, so it always measures from the LAST stroke.
+///
+/// One timer id reused rather than a fresh one per stroke: a dense burst of
+/// marking would otherwise leave dozens of pending timers, every one of which
+/// would fire and split the annotation it was supposed to keep whole.
+fn arm_idle_timer(info: &mut CallbackInfo, data: RefAny, id: TimerId) {
+    info.remove_timer(id);
+    let timer = Timer::create(
+        data,
+        TimerCallback { cb: on_annotation_idle, ctx: OptionRefAny::None },
+        info.get_system_time_fn(),
+    )
+    .with_delay(Duration::System(SystemTimeDiff::from_millis(ANNOTATION_IDLE_MS)));
+    info.add_timer(id, timer);
+}
+
+/// The pen has been still long enough: seal this annotation.
+///
+/// Sealing is what makes the next stroke a NEW remark rather than a
+/// continuation. It also closes an open audio clip, because the spoken
+/// rationale belongs to the marks that were on the page while it was being
+/// said — letting it run into the next annotation would bind it to ink it has
+/// nothing to do with.
+pub extern "C" fn on_annotation_idle(
+    mut data: RefAny,
+    _: TimerCallbackInfo,
+) -> TimerCallbackReturn {
+    let Some(mut s) = data.downcast_mut::<AppState>() else {
+        return TimerCallbackReturn {
+            should_update: Update::DoNothing,
+            should_terminate: TerminateTimer::Terminate,
+        };
+    };
+    s.epoch += 1;
+    if let Some(clip) = s.recording.take() {
+        s.clips.push(clip);
+        s.level_samples = 0;
+    }
+    s.status = format!("annotation {} sealed", s.epoch);
+    session::save(&s);
+    TimerCallbackReturn {
+        // One-shot: the next pen-up arms a fresh one. A repeating timer would
+        // keep bumping the epoch through an idle session and scatter later ink
+        // across epochs nobody ever drew in.
+        should_update: Update::RefreshDom,
+        should_terminate: TerminateTimer::Terminate,
+    }
 }
 
 /// Below this many samples the gesture was a click, not a mark.
@@ -370,6 +446,66 @@ pub extern "C" fn on_jump_to_page(mut data: RefAny, mut info: CallbackInfo) -> U
     // Highlight the target immediately. The VirtualView will confirm it on its
     // next invoke; without this the rail would not move until the strip did.
     s.visible_page = page;
+    Update::RefreshDom
+}
+
+/// Ink menu → pick a semantic.
+///
+/// Separate from `on_pick_semantic` because a menu item carries its OWN
+/// `RefAny` payload rather than a node dataset: there is no hit node to read an
+/// `IndexTag` off, so the index arrives as the callback's data and the app
+/// state has to be reached some other way.
+pub extern "C" fn on_menu_semantic(mut data: RefAny, mut info: CallbackInfo) -> Update {
+    let Some(tag) = data.downcast_ref::<ui::IndexTag>().map(|t| t.index) else {
+        return Update::DoNothing;
+    };
+    let Some(&sem) = Semantic::ALL.get(tag) else {
+        return Update::DoNothing;
+    };
+    let Some(mut app) = info.get_dataset(info.get_hit_node()).into_option() else {
+        // The menu is on the DOM ROOT, so a menu click has no meaningful hit
+        // node to carry state — see `on_menu_save` for why the other menu
+        // items get the app handle directly instead.
+        return Update::DoNothing;
+    };
+    let Some(mut s) = app.downcast_mut::<AppState>() else {
+        return Update::DoNothing;
+    };
+    s.active = sem;
+    Update::RefreshDom
+}
+
+/// Session menu → write the archive now.
+pub extern "C" fn on_menu_save(mut data: RefAny, _: CallbackInfo) -> Update {
+    let Some(mut s) = data.downcast_mut::<AppState>() else {
+        return Update::DoNothing;
+    };
+    s.status = if session::save(&s) {
+        format!("saved to {}", scratch_dir().display())
+    } else {
+        "save FAILED".to_string()
+    };
+    Update::RefreshDom
+}
+
+/// Session menu → open the archive folder in the desktop file manager.
+pub extern "C" fn on_menu_reveal(mut data: RefAny, _: CallbackInfo) -> Update {
+    let dir = scratch_dir();
+    let _ = std::fs::create_dir_all(&dir);
+    // Shelling out rather than going through a toolkit API because there is no
+    // "reveal in file manager" in the C API to go through — noted rather than
+    // hidden, since everything else in this app deliberately does.
+    #[cfg(target_os = "macos")]
+    let _ = std::process::Command::new("open").arg(&dir).spawn();
+    #[cfg(target_os = "linux")]
+    let _ = std::process::Command::new("xdg-open").arg(&dir).spawn();
+    #[cfg(target_os = "windows")]
+    let _ = std::process::Command::new("explorer").arg(&dir).spawn();
+
+    let Some(mut s) = data.downcast_mut::<AppState>() else {
+        return Update::DoNothing;
+    };
+    s.status = format!("archives in {}", dir.display());
     Update::RefreshDom
 }
 

--- a/examples/azul-review/src/lib.rs
+++ b/examples/azul-review/src/lib.rs
@@ -1,0 +1,459 @@
+//! AzReview — ink-first code review.
+//!
+//! # The inversion
+//!
+//! Every code-review tool makes you produce STRUCTURE first: click a line,
+//! type a comment. Drawing, where it exists at all, is decoration on top.
+//! Reviewing on paper works the other way round — you mark the code, and the
+//! structure (which lines, which file, what kind of remark) is something a
+//! reader infers afterwards from where the ink sits.
+//!
+//! This app takes the paper order as the real one. **The ink is the source of
+//! truth; findings are derived and re-derived from it.** Nothing in the UI can
+//! create a finding directly, which is what keeps the two from ever
+//! disagreeing.
+//!
+//! # Why it lives here
+//!
+//! It is also the stress test for the tablet surface, and it uses all of it at
+//! once rather than one feature at a time:
+//!
+//! * `PenState` — pressure drives nib width, tilt elongates the dab, and
+//!   flipping the stylus erases (`is_eraser`).
+//! * The Wacom **PAD** — ExpressKeys select the semantic colour without
+//!   leaving the page, and the ring scrolls. That producer landed on this
+//!   branch; before it, `get_wacom_pad()` returned `None` on every platform.
+//! * Touch — a finger draws with a default pressure, so the app is usable on a
+//!   tablet with no stylus at all.
+//! * Microphone — audio recorded while drawing is bound to the strokes made in
+//!   that window. The terse mark is the headline; the spoken part is the
+//!   reasoning nobody wants to write by hand.
+
+use std::path::PathBuf;
+
+use azul::prelude::*;
+
+pub mod code;
+pub mod ink;
+pub mod model;
+pub mod session;
+pub mod ui;
+
+use model::{Finding, Semantic, Stroke, Tool, VoiceClip};
+
+/// Autosave lands here. A review is long and interruptible; losing ink to a
+/// crash would make the tool untrustworthy for the one job it has.
+pub(crate) fn scratch_dir() -> PathBuf {
+    std::env::var("AZ_REVIEW_DIR").map_or_else(
+        |_| std::env::temp_dir().join("azreview"),
+        PathBuf::from,
+    )
+}
+
+pub struct AppState {
+    pub files: Vec<code::SourceFile>,
+    /// Index into `files`, or `None` before anything is opened.
+    pub current: Option<usize>,
+    /// All ink for the CURRENT file, keyed by page inside the stroke itself.
+    pub strokes: Vec<Stroke>,
+    /// In-progress stroke, promoted into `strokes` on pen-up.
+    pub live: Option<Stroke>,
+    pub next_stroke_id: u64,
+    pub active: Semantic,
+    /// Which nib is in hand. Cycled by a left click so the hand never has to
+    /// leave the page to change tools.
+    pub tool: Tool,
+    /// Findings derived from `strokes`. Never edited directly.
+    pub findings: Vec<Finding>,
+    pub recording: Option<VoiceClip>,
+    /// Clips already closed. Without this a finished clip would be dropped on
+    /// the next record toggle, and the audio for every remark but the last one
+    /// would never reach the archive.
+    pub clips: Vec<VoiceClip>,
+    /// Samples in the live clip as of the last DOM build, so the meter can be
+    /// redrawn on a stroke boundary rather than per audio frame.
+    pub level_samples: usize,
+    /// Leftmost sheet in the strip, written by the `VirtualView` callback -
+    /// the only place in the app that sees the engine's scroll offset. Drives
+    /// which number the page rail highlights.
+    pub visible_page: usize,
+    pub root: PathBuf,
+    pub status: String,
+    /// Pad ExpressKeys as of the last frame, so a press EDGE can be detected.
+    /// Without this the held key would re-fire the colour change every event.
+    pub last_pad_keys: u32,
+}
+
+impl AppState {
+    pub(crate) fn file(&self) -> Option<&code::SourceFile> {
+        self.current.and_then(|i| self.files.get(i))
+    }
+
+    /// Re-derive every finding from the ink.
+    ///
+    /// Called after any change to `strokes`. Cheap enough to run wholesale:
+    /// a session is hundreds of strokes, not millions, and re-deriving
+    /// wholesale is what guarantees the findings cannot drift from the ink.
+    fn rederive(&mut self) {
+        let Some(file) = self.file().cloned() else {
+            self.findings.clear();
+            return;
+        };
+        self.findings = derive_findings(&self.strokes, &file, &self.recording);
+    }
+}
+
+/// Cluster strokes into findings.
+///
+/// Clustering is spatial AND temporal, because that is how the marks were
+/// made: strokes drawn close together, close in time, and carrying the same
+/// intent are one remark. Two `.unwrap()` highlights on opposite ends of a
+/// page minutes apart are two findings; the brace and the words next to it are
+/// one.
+fn derive_findings(
+    strokes: &[Stroke],
+    file: &code::SourceFile,
+    recording: &Option<VoiceClip>,
+) -> Vec<Finding> {
+    let mut out: Vec<Finding> = Vec::new();
+    for s in strokes {
+        let (_, y0, _, y1) = s.bounds();
+        // Which lines does the ink physically cover? This is the whole of
+        // "lazy anchoring" — the user never states a range.
+        let (first_line, _) = file.page(s.page);
+        let l0 = first_line + (y0 / ui::LINE_H).floor().max(0.0) as usize;
+        let l1 = first_line + (y1 / ui::LINE_H).floor().max(0.0) as usize;
+
+        // Merge into an existing finding when the intent matches and the line
+        // ranges touch — the brace and the note beside it become one remark.
+        let merged = out.iter_mut().find(|f| {
+            f.semantic == s.semantic
+                && l0 <= f.last_line.saturating_add(2)
+                && l1.saturating_add(2) >= f.first_line
+        });
+        if let Some(f) = merged {
+            f.first_line = f.first_line.min(l0);
+            f.last_line = f.last_line.max(l1);
+            f.stroke_count += 1;
+            continue;
+        }
+        let voice = recording
+            .as_ref()
+            .filter(|c| c.stroke_ids.contains(&s.id))
+            .map(|c| format!("{} samples of spoken rationale", c.samples.len()));
+        out.push(Finding {
+            semantic: s.semantic,
+            file: file.display.clone(),
+            first_line: l0,
+            last_line: l1,
+            voice_note: voice,
+            stroke_count: 1,
+        });
+    }
+    out.sort_by_key(|f| f.first_line);
+    out
+}
+
+// ───────── entry point ─────────
+
+pub fn run() {
+    let root = std::env::args()
+        .nth(1)
+        .map_or_else(|| std::env::current_dir().unwrap_or_default(), PathBuf::from);
+    let files = code::load_tree(&root, 400);
+    let status = if files.is_empty() {
+        format!("no reviewable files under {}", root.display())
+    } else {
+        format!("{} files — pick one to start", files.len())
+    };
+    let state = AppState {
+        current: if files.is_empty() { None } else { Some(0) },
+        files,
+        strokes: Vec::new(),
+        live: None,
+        next_stroke_id: 1,
+        active: Semantic::Scope,
+        tool: Tool::Marker,
+        findings: Vec::new(),
+        recording: None,
+        clips: Vec::new(),
+        level_samples: 0,
+        visible_page: 0,
+        root,
+        status,
+        last_pad_keys: 0,
+    };
+    let data = RefAny::new(state);
+    let app = App::create(data, AppConfig::create());
+    let mut window = WindowCreateOptions::create(ui::layout);
+    window.window_state.title = "AzReview".into();
+    app.run(window);
+}
+
+// ───────── input ─────────
+
+/// Pen/touch down: start a stroke.
+pub extern "C" fn on_ink_down(mut data: RefAny, mut info: CallbackInfo) -> Update {
+    let Some(page) = ui::page_of(&mut info) else {
+        return Update::DoNothing;
+    };
+    let Some(mut s) = data.downcast_mut::<AppState>() else {
+        return Update::DoNothing;
+    };
+    let Some((p, is_eraser)) = ui::sample(&mut info) else {
+        return Update::DoNothing;
+    };
+    if is_eraser {
+        // Flipping the stylus erases the topmost stroke under the tip. Ink is
+        // the source of truth, so erasing ink is how a finding is withdrawn —
+        // there is no separate "delete finding" affordance to keep in sync.
+        let hit = s.strokes.iter().rposition(|st| {
+            let (x0, y0, x1, y1) = st.bounds();
+            st.page == page && p.x >= x0 - 6.0 && p.x <= x1 + 6.0 && p.y >= y0 - 6.0 && p.y <= y1 + 6.0
+        });
+        if let Some(i) = hit {
+            s.strokes.remove(i);
+            s.rederive();
+            return Update::RefreshDom;
+        }
+        return Update::DoNothing;
+    }
+    let id = s.next_stroke_id;
+    s.next_stroke_id += 1;
+    // The MARKER can only ever mean "region": a fat translucent nib points at
+    // code, it does not say anything about it. Letting it carry `issue` would
+    // produce findings whose ink shape contradicts their label.
+    let semantic = s.tool.semantic_for(s.active);
+    s.live = Some(Stroke { page, semantic, points: vec![p], id });
+
+    // The audio pen starts recording by being used. Any other way round means
+    // remembering to arm it first, and the remark worth saying out loud is the
+    // one made without stopping to think about the tool.
+    if s.tool.records_audio() && s.recording.is_none() {
+        s.recording = Some(VoiceClip { sample_rate: 48_000, ..VoiceClip::default() });
+    }
+    if let Some(clip) = s.recording.as_mut() {
+        clip.stroke_ids.push(id);
+    }
+    Update::DoNothing
+}
+
+/// Left click with no drag cycles the nib.
+///
+/// On paper the two-layer grammar came from physically swapping pens, and the
+/// swap is the friction: one goes down before the other comes up. A click that
+/// changes tool without moving the hand is the whole reason this is not a
+/// toolbar button.
+pub extern "C" fn on_cycle_tool(mut data: RefAny, _: CallbackInfo) -> Update {
+    let Some(mut s) = data.downcast_mut::<AppState>() else {
+        return Update::DoNothing;
+    };
+    s.tool = s.tool.next();
+    // Leaving the audio pen closes the clip rather than leaving it open: the
+    // binding is to the strokes drawn WITH that nib, and a clip that kept
+    // running would bind speech to marks made by a different tool.
+    if !s.tool.records_audio() {
+        if let Some(clip) = s.recording.take() {
+            s.clips.push(clip);
+        }
+    }
+    s.status = format!("{} - {}", s.tool.label(), s.active.label());
+    Update::RefreshDom
+}
+
+/// Pen/touch move: extend the live stroke.
+pub extern "C" fn on_ink_move(mut data: RefAny, mut info: CallbackInfo) -> Update {
+    let Some(mut s) = data.downcast_mut::<AppState>() else {
+        return Update::DoNothing;
+    };
+    if s.live.is_none() {
+        return Update::DoNothing;
+    }
+    let Some((p, _)) = ui::sample(&mut info) else {
+        return Update::DoNothing;
+    };
+    if let Some(live) = s.live.as_mut() {
+        // Drop samples that did not move: the pointer reports at a fixed rate
+        // even when the pen is still, and a pile of coincident dabs is both
+        // wasted raster work and a source of blotching.
+        let far = live
+            .points
+            .last()
+            .is_none_or(|l| (l.x - p.x).abs() + (l.y - p.y).abs() > 0.35);
+        if far {
+            live.points.push(p);
+        }
+    }
+    // Repaint without rebuilding the DOM — the ink layer is an image callback.
+    Update::RefreshDom
+}
+
+/// Pen/touch up: commit the stroke, or - if nothing was drawn - cycle the nib.
+///
+/// A press-and-release that never moved is a CLICK, and a click cycles the
+/// tool. That overload is the point: swapping pens on paper means putting one
+/// down to pick another up, and a tool change that costs a trip to a toolbar
+/// reproduces exactly that interruption. A one-dab stroke would be invisible
+/// anyway, so nothing is lost by spending it.
+pub extern "C" fn on_ink_up(mut data: RefAny, info: CallbackInfo) -> Update {
+    let is_click = {
+        let Some(mut s) = data.downcast_mut::<AppState>() else {
+            return Update::DoNothing;
+        };
+        let Some(done) = s.live.take() else {
+            return Update::DoNothing;
+        };
+        if done.points.len() < CLICK_POINT_LIMIT {
+            true
+        } else {
+            s.strokes.push(done);
+            s.rederive();
+            session::save(&s);
+            false
+        }
+    };
+    if is_click {
+        return on_cycle_tool(data, info);
+    }
+    Update::RefreshDom
+}
+
+/// Below this many samples the gesture was a click, not a mark.
+///
+/// Not 1: a real dab jitters, and a stylus reports a sample or two before the
+/// hand starts moving. Two points is still under a pixel of travel (`on_ink_move`
+/// already drops samples closer than 0.35px), so this cannot eat a stroke
+/// anyone meant to draw.
+const CLICK_POINT_LIMIT: usize = 3;
+
+/// The Wacom PAD, polled on every pointer event.
+///
+/// This is the producer that landed on this branch. ExpressKeys pick the
+/// semantic colour so the palette never has to be visited with the pen, which
+/// is the single biggest interruption in a paper review — putting one pen down
+/// to pick another up.
+pub extern "C" fn on_pad(mut data: RefAny, info: CallbackInfo) -> Update {
+    let Some(pad) = info.get_wacom_pad().into_option() else {
+        return Update::DoNothing;
+    };
+    let Some(mut s) = data.downcast_mut::<AppState>() else {
+        return Update::DoNothing;
+    };
+    // Edge-triggered: a held key must not re-fire every event.
+    let pressed = pad.express_keys & !s.last_pad_keys;
+    s.last_pad_keys = pad.express_keys;
+    if pressed == 0 {
+        return Update::DoNothing;
+    }
+    let index = pressed.trailing_zeros() as usize;
+    if let Some(&sem) = Semantic::ALL.get(index) {
+        s.active = sem;
+        s.status = format!("pad key {index} -> {}", sem.label());
+        return Update::RefreshDom;
+    }
+    Update::DoNothing
+}
+
+/// A page number in the rail: scroll that sheet to the left edge.
+///
+/// Scrolls rather than jumps because the strip is one continuous surface: an
+/// instant teleport across forty sheets destroys the sense of WHERE page 50 is
+/// relative to page 12, which is the only thing the rail exists to preserve.
+pub extern "C" fn on_jump_to_page(mut data: RefAny, mut info: CallbackInfo) -> Update {
+    let Some(page) = ui::index_of(&mut info) else {
+        return Update::DoNothing;
+    };
+    ui::scroll_to_page(&mut info, page);
+    let Some(mut s) = data.downcast_mut::<AppState>() else {
+        return Update::DoNothing;
+    };
+    // Highlight the target immediately. The VirtualView will confirm it on its
+    // next invoke; without this the rail would not move until the strip did.
+    s.visible_page = page;
+    Update::RefreshDom
+}
+
+/// Toolbar colour pick.
+pub extern "C" fn on_pick_semantic(mut data: RefAny, mut info: CallbackInfo) -> Update {
+    let Some(index) = ui::index_of(&mut info) else {
+        return Update::DoNothing;
+    };
+    let Some(mut s) = data.downcast_mut::<AppState>() else {
+        return Update::DoNothing;
+    };
+    if let Some(&sem) = Semantic::ALL.get(index) {
+        s.active = sem;
+    }
+    Update::RefreshDom
+}
+
+/// File browser pick — switches file and clears the page's ink from view.
+pub extern "C" fn on_pick_file(mut data: RefAny, mut info: CallbackInfo) -> Update {
+    let Some(index) = ui::index_of(&mut info) else {
+        return Update::DoNothing;
+    };
+    let Some(mut s) = data.downcast_mut::<AppState>() else {
+        return Update::DoNothing;
+    };
+    if index >= s.files.len() {
+        return Update::DoNothing;
+    }
+    session::save(&s);
+    s.current = Some(index);
+    // Ink is per-file; switching files parks the current sheet rather than
+    // carrying its marks onto unrelated code.
+    s.strokes.clear();
+    s.live = None;
+    s.rederive();
+    s.status = s.files[index].display.clone();
+    Update::RefreshDom
+}
+
+/// Start/stop voice capture. While recording, every stroke id is appended to
+/// the clip, which is what binds spoken rationale to specific ink.
+///
+/// A closed clip is PARKED, never dropped: it is already bound to strokes that
+/// are still on the page, and losing it would leave those marks claiming a
+/// voice note the archive does not contain.
+pub extern "C" fn on_toggle_record(mut data: RefAny, _: CallbackInfo) -> Update {
+    let Some(mut s) = data.downcast_mut::<AppState>() else {
+        return Update::DoNothing;
+    };
+    if let Some(clip) = s.recording.take() {
+        s.status = format!("recording stopped - {} samples kept", clip.samples.len());
+        s.clips.push(clip);
+        s.level_samples = 0;
+        session::save(&s);
+    } else {
+        s.recording = Some(VoiceClip { sample_rate: 48_000, ..VoiceClip::default() });
+        s.status = "recording - strokes drawn now carry this audio".to_string();
+    }
+    Update::RefreshDom
+}
+
+/// Microphone frames while recording.
+pub extern "C" fn on_audio_frame(
+    mut data: RefAny,
+    _: CallbackInfo,
+    frame: azul::widgets::AudioFrame,
+) -> Update {
+    let Some(mut s) = data.downcast_mut::<AppState>() else {
+        return Update::DoNothing;
+    };
+    let Some(clip) = s.recording.as_mut() else {
+        return Update::DoNothing;
+    };
+    clip.samples.extend(frame.samples.as_ref().iter().copied());
+    let total = clip.samples.len();
+
+    // Audio arrives at ~100 Hz. Repainting per frame would spend the whole
+    // budget on a meter, so the bar advances only when a packet crosses a
+    // visible step - which is exactly when the bar would change anyway.
+    let step = ui::METER_PACKET_SAMPLES;
+    if total / step > s.level_samples / step {
+        s.level_samples = total;
+        return Update::RefreshDom;
+    }
+    s.level_samples = total;
+    Update::DoNothing
+}

--- a/examples/azul-review/src/main.rs
+++ b/examples/azul-review/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    azul_review::run();
+}

--- a/examples/azul-review/src/model.rs
+++ b/examples/azul-review/src/model.rs
@@ -59,6 +59,21 @@ impl Semantic {
         }
     }
 
+    /// Material icon name for the palette button.
+    ///
+    /// A glyph rather than the word: five spelled-out labels ate most of the
+    /// toolbar, and the palette is picked by muscle memory and pad key anyway —
+    /// the word was only ever read once.
+    pub const fn icon(self) -> &'static str {
+        match self {
+            Self::Scope => "highlight",
+            Self::Issue => "report_problem",
+            Self::Question => "help_outline",
+            Self::Duplicate => "difference",
+            Self::Praise => "star",
+        }
+    }
+
     /// Highlighter strokes are wide and translucent and go UNDER the glyphs;
     /// pen strokes are narrow, opaque, and go over them. This single bool is
     /// what makes the two-layer grammar work.
@@ -90,6 +105,14 @@ pub struct Stroke {
     pub points: Vec<InkPoint>,
     /// Monotonic id, also the stroke's temporal order — clustering uses it.
     pub id: u64,
+    /// Which annotation this stroke belongs to.
+    ///
+    /// Bumped by the idle timer, NOT inferred from geometry. Whether two marks
+    /// are one remark or two is a fact about how they were made, and the pause
+    /// between them is the only honest record of it — a spatial rule cannot
+    /// tell a second thought about the same line from a correction of the
+    /// first, and both happen constantly.
+    pub epoch: u64,
 }
 
 impl Stroke {
@@ -129,6 +152,9 @@ pub struct Finding {
     pub voice_note: Option<String>,
     /// How many strokes produced it — a cheap confidence signal.
     pub stroke_count: usize,
+    /// The annotation burst this came from. Two findings can share a line
+    /// range and still be separate remarks; the epoch is what says so.
+    pub epoch: u64,
 }
 
 /// Audio captured while drawing, bound to the strokes made in that window.
@@ -170,6 +196,15 @@ impl Tool {
             Self::Marker => "marker",
             Self::Pen => "pen",
             Self::AudioPen => "audio pen",
+        }
+    }
+
+    /// Material icon name for the nib readout.
+    pub const fn icon(self) -> &'static str {
+        match self {
+            Self::Marker => "brush",
+            Self::Pen => "draw",
+            Self::AudioPen => "record_voice_over",
         }
     }
 

--- a/examples/azul-review/src/model.rs
+++ b/examples/azul-review/src/model.rs
@@ -1,0 +1,196 @@
+//! The review model.
+//!
+//! THE INK IS THE SOURCE OF TRUTH. Every structured finding in this file is
+//! DERIVED from strokes — never the other way round. That inversion is the
+//! whole point: existing review tools make you produce structure first (click
+//! a line, type a comment) and offer drawing as decoration. On paper the order
+//! is reversed, and the paper workflow is the one that actually works.
+
+use azul::prelude::*;
+
+/// What a stroke MEANS, chosen by the toolbar or a pad ExpressKey.
+///
+/// Deliberately small. On paper the grammar that emerged unprompted was two
+/// layers — highlighter marks *what*, pen says *something about it* — so the
+/// palette encodes intent, not decoration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Semantic {
+    /// Highlighter. Marks a REGION of interest and nothing more.
+    Scope,
+    /// "This is wrong."
+    Issue,
+    /// "Why is this like this?" — lands in the open-questions queue.
+    Question,
+    /// "This duplicates something else." Two of these can be linked.
+    Duplicate,
+    /// "This is good" — worth capturing; reviews that only ever say
+    /// `issue:` train models to be uniformly negative.
+    Praise,
+}
+
+impl Semantic {
+    pub const ALL: [Self; 5] = [
+        Self::Scope,
+        Self::Issue,
+        Self::Question,
+        Self::Duplicate,
+        Self::Praise,
+    ];
+
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Scope => "scope",
+            Self::Issue => "issue",
+            Self::Question => "question",
+            Self::Duplicate => "duplicate",
+            Self::Praise => "praise",
+        }
+    }
+
+    /// The ink colour. `Scope` is the pink highlighter from the paper sheets;
+    /// the rest are pen colours.
+    pub const fn color(self) -> ColorU {
+        match self {
+            Self::Scope => ColorU { r: 255, g: 64, b: 152, a: 255 },
+            Self::Issue => ColorU { r: 214, g: 45, b: 32, a: 255 },
+            Self::Question => ColorU { r: 32, g: 92, b: 214, a: 255 },
+            Self::Duplicate => ColorU { r: 150, g: 60, b: 200, a: 255 },
+            Self::Praise => ColorU { r: 24, g: 140, b: 70, a: 255 },
+        }
+    }
+
+    /// Highlighter strokes are wide and translucent and go UNDER the glyphs;
+    /// pen strokes are narrow, opaque, and go over them. This single bool is
+    /// what makes the two-layer grammar work.
+    pub const fn is_highlighter(self) -> bool {
+        matches!(self, Self::Scope)
+    }
+}
+
+/// One sampled point of a stroke. Pressure/tilt come straight from `PenState`
+/// and drive the metaball field, so a tilted pen paints a directional dab.
+#[derive(Debug, Clone, Copy)]
+pub struct InkPoint {
+    pub x: f32,
+    pub y: f32,
+    pub pressure: f32,
+    pub tilt_x: f32,
+    pub tilt_y: f32,
+}
+
+/// A single continuous pen-down..pen-up stroke, in PAGE-LOCAL logical pixels.
+///
+/// Page-local, not viewport-local, on purpose: the page is the stable frame of
+/// reference. Scrolling, zooming or re-paginating must not move ink relative
+/// to the code it annotates.
+#[derive(Debug, Clone)]
+pub struct Stroke {
+    pub page: usize,
+    pub semantic: Semantic,
+    pub points: Vec<InkPoint>,
+    /// Monotonic id, also the stroke's temporal order — clustering uses it.
+    pub id: u64,
+}
+
+impl Stroke {
+    /// Axis-aligned bounds in page-local pixels, used for spatial clustering
+    /// and for inferring which lines the stroke covers.
+    pub fn bounds(&self) -> (f32, f32, f32, f32) {
+        let mut b = (f32::MAX, f32::MAX, f32::MIN, f32::MIN);
+        for p in &self.points {
+            b.0 = b.0.min(p.x);
+            b.1 = b.1.min(p.y);
+            b.2 = b.2.max(p.x);
+            b.3 = b.3.max(p.y);
+        }
+        if self.points.is_empty() {
+            (0.0, 0.0, 0.0, 0.0)
+        } else {
+            b
+        }
+    }
+}
+
+/// A finding DERIVED from a cluster of strokes.
+///
+/// Nothing constructs this directly. It is produced by `derive_findings`, and
+/// re-derived whenever the ink changes — so editing ink edits the finding, and
+/// the two can never disagree.
+#[derive(Debug, Clone)]
+pub struct Finding {
+    pub semantic: Semantic,
+    pub file: String,
+    /// Inferred from where the ink sits, NOT declared by the user. This is
+    /// "lazy anchoring": you never say "lines 899-911", the tool works it out.
+    pub first_line: usize,
+    pub last_line: usize,
+    /// Spoken rationale bound to this cluster, if the mic was recording while
+    /// the strokes were drawn.
+    pub voice_note: Option<String>,
+    /// How many strokes produced it — a cheap confidence signal.
+    pub stroke_count: usize,
+}
+
+/// Audio captured while drawing, bound to the strokes made in that window.
+///
+/// Held as raw samples: transcription is out of scope here, but the binding
+/// (WHICH strokes this audio belongs to) is the part that must be captured
+/// live and cannot be reconstructed afterwards.
+#[derive(Debug, Default)]
+pub struct VoiceClip {
+    pub samples: Vec<f32>,
+    pub sample_rate: u32,
+    /// Stroke ids made while this clip was recording.
+    pub stroke_ids: Vec<u64>,
+}
+
+/// Which nib is in hand.
+///
+/// On paper the two-layer grammar came from physically swapping pens, and the
+/// swap is the friction: you put one down to pick another up. Here a left
+/// click cycles, so the tool changes without the hand leaving the page.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Tool {
+    /// Fat translucent nib. Marks a REGION and forces `Semantic::Scope` —
+    /// a marker cannot say anything, only point.
+    Marker,
+    /// Small pointy nib. Carries whatever semantic is selected.
+    Pen,
+    /// Pointy nib that also RECORDS while it draws, binding the audio to the
+    /// strokes made in that window. The terse mark is the headline; the spoken
+    /// part is the reasoning nobody wants to write by hand.
+    AudioPen,
+}
+
+impl Tool {
+    pub const ALL: [Self; 3] = [Self::Marker, Self::Pen, Self::AudioPen];
+
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Marker => "marker",
+            Self::Pen => "pen",
+            Self::AudioPen => "audio pen",
+        }
+    }
+
+    /// Next tool in the cycle.
+    pub const fn next(self) -> Self {
+        match self {
+            Self::Marker => Self::Pen,
+            Self::Pen => Self::AudioPen,
+            Self::AudioPen => Self::Marker,
+        }
+    }
+
+    /// The marker always means "region"; the others carry the palette choice.
+    pub const fn semantic_for(self, selected: Semantic) -> Semantic {
+        match self {
+            Self::Marker => Semantic::Scope,
+            Self::Pen | Self::AudioPen => selected,
+        }
+    }
+
+    pub const fn records_audio(self) -> bool {
+        matches!(self, Self::AudioPen)
+    }
+}

--- a/examples/azul-review/src/session.rs
+++ b/examples/azul-review/src/session.rs
@@ -1,0 +1,283 @@
+//! Session persistence: one ZIP holding a JSON model plus the raw audio.
+//!
+//! # Everything here goes through the Azul API
+//!
+//! No `zip`, `serde` or `hound` crate is reachable from this file. The archive
+//! is `azul::zip::Zip` (`AzZip_*` over the C ABI) and the model is
+//! `azul::json::Json` (`AzJson_*`), so this file is a demonstration that the
+//! toolkit can write a real session format, not a Rust program borrowing Rust
+//! libraries. A C or Python port of AzReview would call the same entry points.
+//!
+//! # Why a ZIP and not a directory
+//!
+//! A review is ink plus speech. The ink is small and structured, the audio is
+//! large and opaque, and the two are useless apart - a clip that has lost its
+//! stroke ids is just noise. One file that cannot be half-copied is the cheapest
+//! way to keep them together.
+//!
+//! # Why the layout is flat
+//!
+//! Audio lands as `clip-0.wav`, `clip-1.wav`, ... beside `session.json`, with
+//! no nesting. `session.json` names each clip, so the directory structure would
+//! carry no information the JSON does not already hold - and a flat archive is
+//! one `unzip` away from being usable by anything.
+//!
+//! # Why the analysis is not here
+//!
+//! This is collection only. What the marks MEAN is a question for a later tool
+//! reading these archives in bulk; deciding it now, per session, would bake
+//! today's guess into the recorded data and make the corpus unusable when the
+//! guess changes.
+
+use azul::json::{Json, JsonKeyValue};
+use azul::vec::{JsonKeyValueVec, JsonVec, U8Vec};
+use azul::zip::Zip;
+
+use crate::model::{Finding, Stroke, VoiceClip};
+use crate::AppState;
+
+// --------------------------------------------------------------------------
+// Small bridges into the C-ABI vector types.
+//
+// The FFI vectors have no `From<Vec<T>>` - they are built from a pointer and a
+// length, which is what a non-Rust caller has too. `copy_from_array` CLONES
+// each element, so the source vector is still ours to drop.
+// --------------------------------------------------------------------------
+
+fn bytes(v: &[u8]) -> U8Vec {
+    v.first()
+        .map_or_else(U8Vec::create, |first| {
+            U8Vec::copy_from_bytes(first, 0, v.len())
+        })
+}
+
+fn obj(entries: Vec<JsonKeyValue>) -> Json {
+    let vec = entries.first().map_or_else(JsonKeyValueVec::create, |first| {
+        JsonKeyValueVec::copy_from_array(first, entries.len())
+    });
+    Json::object(vec)
+}
+
+fn arr(items: Vec<Json>) -> Json {
+    let vec = items
+        .first()
+        .map_or_else(JsonVec::create, |first| JsonVec::copy_from_array(first, items.len()));
+    Json::array(vec)
+}
+
+fn kv_str(key: &str, value: &str) -> JsonKeyValue {
+    JsonKeyValue::create(key, Json::string(value))
+}
+
+fn kv_int(key: &str, value: usize) -> JsonKeyValue {
+    JsonKeyValue::create(key, Json::int(value as i64))
+}
+
+/// Rounded to 2 decimals. Ink is sampled in logical pixels off a ~1000 Hz
+/// digitizer; the extra digits are noise that would triple the file size.
+fn kv_num(key: &str, value: f32) -> JsonKeyValue {
+    JsonKeyValue::create(key, Json::float(f64::from((value * 100.0).round() / 100.0)))
+}
+
+// --------------------------------------------------------------------------
+// Model -> JSON
+// --------------------------------------------------------------------------
+
+fn stroke_json(s: &Stroke) -> Json {
+    let points = s
+        .points
+        .iter()
+        .map(|p| {
+            obj(vec![
+                kv_num("x", p.x),
+                kv_num("y", p.y),
+                kv_num("pressure", p.pressure),
+                kv_num("tilt_x", p.tilt_x),
+                kv_num("tilt_y", p.tilt_y),
+            ])
+        })
+        .collect::<Vec<_>>();
+    obj(vec![
+        JsonKeyValue::create("id", Json::int(s.id as i64)),
+        kv_int("page", s.page),
+        kv_str("semantic", s.semantic.label()),
+        JsonKeyValue::create("points", arr(points)),
+    ])
+}
+
+/// Findings are DERIVED, and they are written anyway.
+///
+/// Redundant with the strokes by construction - which is the point. Whatever
+/// derives findings will change; keeping the derivation this session actually
+/// used makes it possible to tell a later change from a change in the ink.
+fn finding_json(f: &Finding) -> Json {
+    let mut e = vec![
+        kv_str("semantic", f.semantic.label()),
+        kv_str("file", &f.file),
+        kv_int("first_line", f.first_line),
+        kv_int("last_line", f.last_line),
+        kv_int("stroke_count", f.stroke_count),
+    ];
+    if let Some(v) = &f.voice_note {
+        e.push(kv_str("voice_note", v));
+    }
+    obj(e)
+}
+
+fn clip_json(index: usize, c: &VoiceClip) -> Json {
+    let ids = c
+        .stroke_ids
+        .iter()
+        .map(|id| Json::int(*id as i64))
+        .collect::<Vec<_>>();
+    obj(vec![
+        kv_str("audio", &wav_name(index)),
+        JsonKeyValue::create("sample_rate", Json::int(i64::from(c.sample_rate))),
+        kv_int("samples", c.samples.len()),
+        // The binding, and the only part that cannot be reconstructed later:
+        // which marks were on the page while this was being said.
+        JsonKeyValue::create("stroke_ids", arr(ids)),
+    ])
+}
+
+fn wav_name(index: usize) -> String {
+    format!("clip-{index}.wav")
+}
+
+// --------------------------------------------------------------------------
+// Audio
+// --------------------------------------------------------------------------
+
+/// 16-bit mono PCM WAV.
+///
+/// Written by hand rather than pulled from a crate: it is 44 bytes of header,
+/// and a dependency here would be exactly the Rust-only shortcut this app is
+/// meant to avoid. WAV over anything smaller because the archive is an input to
+/// tools that do not exist yet - every one of them can read WAV.
+fn wav(samples: &[f32], sample_rate: u32) -> Vec<u8> {
+    let data_len = samples.len() * 2;
+    let mut out = Vec::with_capacity(44 + data_len);
+    let mut tag = |s: &str| out.extend_from_slice(s.as_bytes());
+    tag("RIFF");
+    out.extend_from_slice(&u32::try_from(36 + data_len).unwrap_or(u32::MAX).to_le_bytes());
+    out.extend_from_slice(b"WAVEfmt ");
+    out.extend_from_slice(&16u32.to_le_bytes()); // fmt chunk size
+    out.extend_from_slice(&1u16.to_le_bytes()); // PCM
+    out.extend_from_slice(&1u16.to_le_bytes()); // mono
+    out.extend_from_slice(&sample_rate.to_le_bytes());
+    out.extend_from_slice(&(sample_rate * 2).to_le_bytes()); // byte rate
+    out.extend_from_slice(&2u16.to_le_bytes()); // block align
+    out.extend_from_slice(&16u16.to_le_bytes()); // bits per sample
+    out.extend_from_slice(b"data");
+    out.extend_from_slice(&u32::try_from(data_len).unwrap_or(u32::MAX).to_le_bytes());
+    for s in samples {
+        // Clamp before scaling: a mic peak above 1.0 would wrap to a loud click
+        // rather than clipping, and a click in the middle of a spoken remark is
+        // worse than the lost headroom.
+        let v = (s.clamp(-1.0, 1.0) * f32::from(i16::MAX)) as i16;
+        out.extend_from_slice(&v.to_le_bytes());
+    }
+    out
+}
+
+// --------------------------------------------------------------------------
+// Write
+// --------------------------------------------------------------------------
+
+/// Build the whole archive in memory and write it.
+///
+/// Whole-archive rewrite on every save, not an append: a review is at most a
+/// few MB, and a partially-appended ZIP after a crash is unreadable - which
+/// would defeat the reason autosave exists.
+///
+/// Written to a sibling temp path and renamed, for the same reason. Autosave
+/// runs on every pen-up, so it is running most of the time the app is; a crash
+/// during the write must not be able to destroy the previous good archive.
+pub fn save(s: &AppState) -> bool {
+    let dir = crate::scratch_dir();
+    if std::fs::create_dir_all(&dir).is_err() {
+        return false;
+    }
+
+    let mut zip = Zip::new();
+
+    let clips: Vec<&VoiceClip> = s.clips.iter().chain(s.recording.iter()).collect();
+    for (i, c) in clips.iter().enumerate() {
+        zip.add_file(wav_name(i), bytes(&wav(&c.samples, c.sample_rate)));
+    }
+
+    let model = obj(vec![
+        kv_str("format", "azreview/1"),
+        kv_str("root", &s.root.display().to_string()),
+        kv_str(
+            "file",
+            s.file().map_or("", |f| f.display.as_str()),
+        ),
+        JsonKeyValue::create(
+            "strokes",
+            arr(s.strokes.iter().map(stroke_json).collect()),
+        ),
+        JsonKeyValue::create(
+            "findings",
+            arr(s.findings.iter().map(finding_json).collect()),
+        ),
+        JsonKeyValue::create(
+            "clips",
+            arr(clips
+                .iter()
+                .enumerate()
+                .map(|(i, c)| clip_json(i, c))
+                .collect()),
+        ),
+    ]);
+    zip.add_file(
+        "session.json",
+        bytes(model.to_string_pretty().as_str().as_bytes()),
+    );
+
+    let final_path = archive_path(s);
+    let temp_path = final_path.with_extension("zip.part");
+    if !zip.to_file(temp_path.to_string_lossy().as_ref()) {
+        return false;
+    }
+    std::fs::rename(&temp_path, &final_path).is_ok()
+}
+
+/// One archive per reviewed file, named after it.
+///
+/// Per-file rather than per-session because ink is already per-file: switching
+/// files parks the sheet, and an archive that spanned files would have to be
+/// rewritten in full every time one of them changed.
+fn archive_path(s: &AppState) -> std::path::PathBuf {
+    let stem = s
+        .file()
+        .map_or_else(|| "session".to_string(), |f| f.display.replace(['/', '\\'], "_"));
+    crate::scratch_dir().join(format!("{stem}.azreview.zip"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_wav_header_declares_the_sample_count_it_actually_carries() {
+        let w = wav(&[0.0, 0.5, -0.5, 1.0], 48_000);
+        assert_eq!(&w[0..4], b"RIFF");
+        assert_eq!(&w[8..12], b"WAVE");
+        assert_eq!(&w[36..40], b"data");
+        let declared = u32::from_le_bytes([w[40], w[41], w[42], w[43]]) as usize;
+        assert_eq!(declared, 8, "4 samples x 2 bytes");
+        assert_eq!(w.len(), 44 + declared);
+    }
+
+    #[test]
+    fn a_peak_above_full_scale_clips_instead_of_wrapping() {
+        // Wrapping would turn a loud syllable into a click - louder than the
+        // signal it replaced, and in the middle of the spoken rationale.
+        let w = wav(&[2.0, -2.0], 48_000);
+        let a = i16::from_le_bytes([w[44], w[45]]);
+        let b = i16::from_le_bytes([w[46], w[47]]);
+        assert!(a > 32_000, "positive peak wrapped: {a}");
+        assert!(b < -32_000, "negative peak wrapped: {b}");
+    }
+}

--- a/examples/azul-review/src/ui.rs
+++ b/examples/azul-review/src/ui.rs
@@ -1,0 +1,613 @@
+//! The sheet: file browser, toolbar, paginated code, ink overlay, margin.
+//!
+//! Light theme and print-quality typography on purpose — the surface should
+//! look like the printouts it replaces, because that is the mental model that
+//! already works.
+
+use azul::prelude::*;
+use azul::callbacks::RenderImageCallbackInfo;
+use azul::dom::{IdOrClass, RenderImageCallback};
+use azul::vec::IdOrClassVec;
+use azul::image::{ImageRef, RawImageFormat};
+use azul::vec::U8VecRef;
+use azul::image::{RawImage, RawImageData};
+
+use crate::{code, ink, model::Semantic, AppState};
+
+/// Line height in logical px. Shared by the renderer and by the code that
+/// infers WHICH LINES a stroke covers — if these two ever disagree, every
+/// annotation silently anchors to the wrong place.
+pub const LINE_H: f32 = 15.0;
+/// Page width, sized for ~110 columns of the mono face.
+const PAGE_W: f32 = 760.0;
+/// Left gutter for line numbers; ink to the left of this is margin commentary.
+const GUTTER_W: f32 = 52.0;
+/// Gap between sheets in the strip. Wide enough that the shadow of one page
+/// does not read as part of the next.
+const PAGE_GAP: f32 = 24.0;
+
+/// One "packet" for the level meter.
+///
+/// The mic delivers frames far faster than anything can be looked at, so the
+/// meter advances per block of samples rather than per frame — the bar moves at
+/// a readable rate and the DOM is not rebuilt a hundred times a second.
+pub const METER_PACKET_SAMPLES: usize = 4096;
+
+/// How many packets fill the meter before it wraps. Roughly 20 s at 48 kHz -
+/// long enough for a spoken remark, short enough that the bar visibly moves.
+const METER_SPAN_PACKETS: usize = 240;
+
+fn page_h() -> f32 {
+    code::LINES_PER_PAGE as f32 * LINE_H + 40.0
+}
+
+/// One page plus its gap: the column stride of the horizontal sheet strip.
+fn page_stride() -> f32 {
+    PAGE_W + PAGE_GAP
+}
+
+/// Which page a pointer event landed on, from the node's dataset.
+///
+/// The page index is carried on the ink node rather than computed from scroll
+/// position: the VirtualView materialises an arbitrary window of pages, so
+/// "third page from the top of the viewport" is not stable.
+pub fn page_of(info: &mut CallbackInfo) -> Option<usize> {
+    info.get_dataset(info.get_hit_node())
+        .into_option()
+        .and_then(|mut d| d.downcast_ref::<PageTag>().map(|t| t.page))
+}
+
+/// Sample the pointer as an ink point, preferring the pen.
+///
+/// Falls back to the plain cursor so a finger or a mouse still draws — the app
+/// must not be dead on a machine with no tablet attached.
+pub fn sample(info: &mut CallbackInfo) -> Option<(crate::model::InkPoint, bool)> {
+    if let Some(pen) = info.get_pen_state().into_option() {
+        if pen.in_contact {
+            return Some((
+                ink::point_from(
+                    pen.position.x,
+                    pen.position.y,
+                    pen.pressure,
+                    pen.tilt.x_tilt,
+                    pen.tilt.y_tilt,
+                ),
+                pen.is_eraser,
+            ));
+        }
+    }
+    let p = info.get_cursor_relative_to_node().into_option()?;
+    Some((ink::point_from(p.x, p.y, 0.0, 0.0, 0.0), false))
+}
+
+/// Index carried on a clickable row, read back in the callback.
+///
+/// azul callbacks are plain `extern "C" fn`s and cannot close over a value, so
+/// "which item was clicked" travels as a dataset on the node itself.
+#[derive(Debug, Clone, Copy)]
+pub struct IndexTag {
+    pub index: usize,
+}
+
+/// The index of the clicked row, if it carries one.
+pub fn index_of(info: &mut CallbackInfo) -> Option<usize> {
+    info.get_dataset(info.get_hit_node())
+        .into_option()
+        .and_then(|mut d| d.downcast_ref::<IndexTag>().map(|t| t.index))
+}
+
+/// Marks an ink layer with the page it belongs to.
+#[derive(Debug, Clone, Copy)]
+pub struct PageTag {
+    pub page: usize,
+}
+
+pub extern "C" fn layout(data: RefAny, _: LayoutCallbackInfo) -> Dom {
+    let mut d = data.clone();
+    let Some(s) = d.downcast_ref::<AppState>() else {
+        return Dom::create_body();
+    };
+
+    let mut root = Dom::create_body().with_css(
+        "display: flex; flex-direction: row; background: #e9e7e2; font-family: sans-serif;",
+    );
+    root.add_child(sidebar(&s, &data));
+
+    let mut center = Dom::create_div()
+        .with_css("display: flex; flex-direction: column; flex-grow: 1; min-width: 0px;");
+    center.add_child(toolbar(&s, &data));
+    center.add_child(page_rail(&s, &data));
+    center.add_child(sheet(&s, &data));
+    center.add_child(status_bar(&s));
+    root.add_child(center);
+    root.add_child(margin_panel(&s, &data));
+    root
+}
+
+/// File browser. Works against a whole repo or a single directory — the only
+/// difference is what `load_tree` skipped.
+fn sidebar(s: &AppState, data: &RefAny) -> Dom {
+    let mut col = Dom::create_div().with_css(
+        "display: flex; flex-direction: column; width: 250px; flex-shrink: 0; \
+         background: #f7f6f3; border-right: 1px solid #cfcbc4; overflow: auto;",
+    );
+    col.add_child(
+        Dom::create_div_with_text("Files")
+            .with_css("font-weight: bold; font-size: 12px; padding: 10px; color: #55514a;"),
+    );
+    for (i, f) in s.files.iter().enumerate() {
+        let active = s.current == Some(i);
+        let css = if active {
+            "padding: 4px 10px; font-size: 11px; background: #dfe7f5; color: #1a1a1a;"
+        } else {
+            "padding: 4px 10px; font-size: 11px; color: #3c3a36;"
+        };
+        col.add_child(
+            Dom::create_div_with_text(f.display.as_str())
+                .with_dataset(OptionRefAny::Some(RefAny::new(IndexTag { index: i })))
+                .with_css(css)
+                .with_callback(
+                    EventFilter::Hover(HoverEventFilter::MouseUp),
+                    data.clone(),
+                    // index is carried by the closure-free indexed callback
+                    crate::on_pick_file,
+                ),
+        );
+    }
+    col
+}
+
+/// Semantic palette. Pad ExpressKeys select the same five, in this order.
+fn toolbar(s: &AppState, data: &RefAny) -> Dom {
+    let mut bar = Dom::create_div().with_css(
+        "display: flex; flex-direction: row; align-items: center; gap: 8px; \
+         padding: 8px 12px; background: #f7f6f3; border-bottom: 1px solid #cfcbc4;",
+    );
+    for (i, sem) in Semantic::ALL.iter().enumerate() {
+        let c = sem.color();
+        let selected = *sem == s.active;
+        let css = format!(
+            "padding: 5px 12px; font-size: 12px; border-radius: 4px; \
+             background: rgba({},{},{},{}); color: {}; border: {};",
+            c.r,
+            c.g,
+            c.b,
+            if selected { "1.0" } else { "0.18" },
+            if selected { "#ffffff" } else { "#2b2b2b" },
+            if selected { "2px solid #2b2b2b" } else { "1px solid #cfcbc4" },
+        );
+        bar.add_child(
+            Dom::create_div_with_text(format!("{}  [{}]", sem.label(), i + 1).as_str())
+                .with_dataset(OptionRefAny::Some(RefAny::new(IndexTag { index: i })))
+                .with_css(css.as_str())
+                .with_callback(
+                    EventFilter::Hover(HoverEventFilter::MouseUp),
+                    data.clone(),
+                    crate::on_pick_semantic,
+                ),
+        );
+    }
+    // Which nib is in hand. A readout, not a control: the tool changes by
+    // clicking on the PAGE, so that the hand never leaves it. Showing it in the
+    // toolbar anyway is the only way to know what a click just switched to.
+    bar.add_child(
+        Dom::create_div_with_text(format!("nib: {}  (click page to cycle)", s.tool.label()).as_str())
+            .with_css(
+                "margin-left: 16px; padding: 5px 12px; font-size: 12px; border-radius: 4px; \
+                 background: #ffffff; color: #2b2b2b; border: 1px dashed #a9a49b;",
+            ),
+    );
+
+    let rec = s.recording.is_some();
+    if rec {
+        bar.add_child(meter(s));
+    }
+    bar.add_child(
+        Dom::create_div_with_text(if rec { "◉ recording" } else { "○ record" })
+            .with_css(if rec {
+                "margin-left: 10px; padding: 5px 12px; font-size: 12px; border-radius: 4px; \
+                 background: #d62d20; color: white;"
+            } else {
+                "margin-left: auto; padding: 5px 12px; font-size: 12px; border-radius: 4px; \
+                 background: #ffffff; color: #2b2b2b; border: 1px solid #cfcbc4;"
+            })
+            .with_callback(
+                EventFilter::Hover(HoverEventFilter::MouseUp),
+                data.clone(),
+                crate::on_toggle_record,
+            ),
+    );
+    bar
+}
+
+/// PCM packets arriving, as a bar.
+///
+/// Deliberately a COUNT of packets rather than an amplitude meter: what needs
+/// confirming while speaking is that audio is still being captured, and a level
+/// meter answers that only while there is sound — it reads identically for
+/// "silent" and "the mic died", which is the failure this exists to catch.
+fn meter(s: &AppState) -> Dom {
+    let packets = s.level_samples / METER_PACKET_SAMPLES;
+    let filled = (packets % METER_SPAN_PACKETS) as f32 / METER_SPAN_PACKETS as f32;
+    let mut wrap = Dom::create_div().with_css(
+        "margin-left: auto; display: flex; flex-direction: row; align-items: center; gap: 6px;",
+    );
+    wrap.add_child(
+        Dom::create_div_with_text(format!("{packets} pkt").as_str())
+            .with_css("font-size: 11px; color: #6b665e; font-family: monospace;"),
+    );
+    let mut holder = Dom::create_div().with_css("width: 160px;");
+    holder.add_child(ProgressBar::create(filled * 100.0).dom());
+    wrap.add_child(holder);
+    wrap
+}
+
+/// DOM id of the sheet strip, so a page button can scroll it.
+///
+/// A jump has to move the SCROLL CONTAINER, and the button is nowhere near it
+/// in the tree — an id is how a callback names a node it did not hit.
+pub const STRIP_ID: &str = "sheet-strip";
+
+/// Page numbers as a horizontal button row: `… 49 50 51 52 …`.
+///
+/// # Why numbers and not a scrollbar
+///
+/// The thing worth remembering about a review is "FooItem was on page 50, near
+/// the top". A scrollbar gives a fraction, which nobody memorises; a page
+/// number is a stable name for a place, and printing it above the sheet is what
+/// makes that recall possible at all.
+///
+/// The whole row is built — a number is a few glyphs, and unlike the sheets
+/// there is nothing here worth virtualising.
+fn page_rail(s: &AppState, data: &RefAny) -> Dom {
+    let mut rail = Dom::create_div().with_css(
+        "display: flex; flex-direction: row; align-items: center; gap: 3px; \
+         padding: 4px 12px; background: #efede8; border-bottom: 1px solid #cfcbc4; \
+         overflow-x: auto; overflow-y: hidden; flex-shrink: 0;",
+    );
+    let Some(file) = s.file() else { return rail };
+    for page in 0..file.page_count() {
+        let here = page == s.visible_page;
+        let css = if here {
+            "padding: 2px 9px; font-size: 11px; font-family: monospace; border-radius: 3px; \
+             background: #2b2b2b; color: #ffffff; flex-shrink: 0;"
+        } else {
+            "padding: 2px 9px; font-size: 11px; font-family: monospace; border-radius: 3px; \
+             background: #ffffff; color: #55514a; border: 1px solid #d8d4cd; flex-shrink: 0;"
+        };
+        rail.add_child(
+            // Page numbers are 1-based on the button, 0-based in the model —
+            // the printout it imitates has no page zero.
+            Dom::create_div_with_text(format!("{}", page + 1).as_str())
+                .with_dataset(OptionRefAny::Some(RefAny::new(IndexTag { index: page })))
+                .with_css(css)
+                .with_callback(
+                    EventFilter::Hover(HoverEventFilter::MouseUp),
+                    data.clone(),
+                    crate::on_jump_to_page,
+                ),
+        );
+    }
+    rail
+}
+
+/// Scroll the strip so `page` is the leftmost sheet.
+pub fn scroll_to_page(info: &mut CallbackInfo, page: usize) {
+    let dom = info.get_hit_node().dom;
+    let node = info.get_node_id_by_id_attribute(dom, STRIP_ID);
+    info.scroll_to(
+        dom,
+        node,
+        LogicalPosition::create(page as f32 * page_stride(), 0.0),
+    );
+}
+
+/// The paginated code as a HORIZONTAL strip of sheets.
+///
+/// # Why sideways
+///
+/// Code is already tall and narrow; stacking pages vertically means the same
+/// scroll gesture serves two different jobs — moving within a page and moving
+/// between pages — and the boundary between them is invisible. Laid out
+/// sideways a page is one screen, and paging is a distinct movement, which is
+/// what makes a stack of printouts navigable in a way a scroll never is.
+///
+/// # Why a VirtualView
+///
+/// Same reason AzWriter uses one: a 4000-line file is ~90 sheets, and building
+/// them all to show three would style and lay out every line of the file on
+/// every pointer move. The callback materialises the window around the scroll
+/// position and declares the rest as scrollbar geometry.
+fn sheet(s: &AppState, data: &RefAny) -> Dom {
+    let mut area = Dom::create_div().with_css(
+        // `hidden`, not `auto`: the VirtualView node below IS the scroll
+        // container. An `auto` wrapper would also claim a scroll id and eat the
+        // wheel events the VirtualView needs to page.
+        "flex-grow: 1; min-height: 0px; background: #e9e7e2; display: flex; \
+         flex-direction: column; overflow: hidden; padding: 18px;",
+    );
+    if s.file().is_none() {
+        area.add_child(
+            Dom::create_div_with_text("Open a file to begin")
+                .with_css("color: #7a756c; padding: 40px;"),
+        );
+        return area;
+    }
+    area.add_child(
+        Dom::create_virtual_view(
+            RefAny::new(SheetStrip { app: data.clone() }),
+            sheets_virtual_view,
+        )
+        .with_ids_and_classes(IdOrClassVec::from_item(IdOrClass::id(STRIP_ID))),
+    );
+    area
+}
+
+/// Payload of the sheet strip's `VirtualView`.
+///
+/// Only the app handle: everything the callback needs (which file, which ink)
+/// already lives in `AppState`, and a second copy here could go stale between
+/// a DOM rebuild and the next materialisation.
+struct SheetStrip {
+    app: RefAny,
+}
+
+/// Materialise the pages around the horizontal scroll position.
+extern "C" fn sheets_virtual_view(
+    mut data: RefAny,
+    info: VirtualViewCallbackInfo,
+) -> VirtualViewReturn {
+    // Two handles to the same state, on purpose: reading it needs a borrow that
+    // outlives the loop, and the page callbacks need a handle to clone from
+    // while that borrow is live. One variable cannot be both.
+    let mut app = {
+        let Some(strip) = data.downcast_ref::<SheetStrip>() else {
+            return VirtualViewReturn::default();
+        };
+        strip.app.clone()
+    };
+    let cb_app = app.clone();
+
+    let stride = page_stride();
+    let strip_h = page_h();
+
+    let (dom, first, count, total, leftmost) = {
+        let Some(s) = app.downcast_ref::<AppState>() else {
+            return VirtualViewReturn::default();
+        };
+        let Some(file) = s.file() else {
+            return VirtualViewReturn::default();
+        };
+        let total = file.page_count().max(1);
+
+        // One page of overscan on each side: paging is a fast gesture, and a
+        // sheet that only starts existing once its edge is on screen arrives
+        // visibly late.
+        let viewport_w = info.bounds.get_logical_size().width;
+        // Round, not truncate: the page filling most of the viewport is the one
+        // the reader would call "the page they are on", and truncating names
+        // the page that is one pixel from having scrolled away.
+        let leftmost = ((info.scroll_offset.x.max(0.0) / stride).round() as usize).min(total - 1);
+        let first_visible = (info.scroll_offset.x.max(0.0) / stride) as usize;
+        let first = first_visible.saturating_sub(1);
+        let visible = (viewport_w / stride).ceil() as usize + 2;
+        let count = visible.max(2).min(total.saturating_sub(first));
+
+        let mut row = Dom::create_div()
+            .with_css("display: flex; flex-direction: row; align-items: flex-start;");
+        for page in first..first + count {
+            row.add_child(page_sheet(&s, &cb_app, file, page));
+        }
+        (row, first, count, total, leftmost)
+    };
+
+    // Tell the rail which number to highlight. Written here rather than derived
+    // in `layout` because the scroll offset lives in the engine: this callback
+    // is the only place in the app that ever sees it.
+    //
+    // The rail therefore lags the strip by one DOM build. Forcing a rebuild
+    // from here would be worse — every frame of a scroll would regenerate the
+    // whole tree to move one highlight.
+    if let Some(mut s) = app.downcast_mut::<AppState>() {
+        s.visible_page = leftmost;
+    }
+
+    VirtualViewReturn::with_dom(
+        dom,
+        // Where the window we just built sits in the strip.
+        LogicalRect::create(
+            LogicalPosition::create(first as f32 * stride, 0.0),
+            LogicalSize::create(count as f32 * stride, strip_h),
+        ),
+        // The whole file — scrollbar geometry only.
+        LogicalRect::create(
+            LogicalPosition::create(0.0, 0.0),
+            LogicalSize::create(total as f32 * stride, strip_h),
+        ),
+    )
+}
+
+fn page_sheet(s: &AppState, data: &RefAny, file: &code::SourceFile, page: usize) -> Dom {
+    let (first_line, lines) = file.page(page);
+    let mut sheet = Dom::create_div().with_css(format!(
+        "position: relative; width: {}px; height: {}px; background: #ffffff; \
+         border: 1px solid #b9b4ab; box-shadow: 0px 1px 4px #00000030; \
+         margin-right: {}px; flex-shrink: 0; box-sizing: border-box; \
+         padding: 20px; overflow: hidden;",
+        PAGE_W as isize,
+        page_h() as isize,
+        PAGE_GAP as isize,
+    ).as_str());
+
+    // Code, one row per line, gutter then text.
+    let mut col = Dom::create_div().with_css("display: flex; flex-direction: column;");
+    for (i, line) in lines.iter().enumerate() {
+        let mut row = Dom::create_div().with_css(format!(
+            "display: flex; flex-direction: row; height: {LINE_H}px;"
+        ).as_str());
+        row.add_child(
+            Dom::create_div_with_text(format!("{}", first_line + i).as_str()).with_css(format!(
+                "width: {}px; flex-shrink: 0; text-align: right; padding-right: 10px; \
+                 font-family: monospace; font-size: 11px; color: #b0aaa0;",
+                GUTTER_W as isize - 10,
+            ).as_str()),
+        );
+        row.add_child(
+            Dom::create_div_with_text(line.as_str()).with_css(
+                "font-family: monospace; font-size: 11px; color: #1f1f1f; white-space: pre;",
+            ),
+        );
+        col.add_child(row);
+    }
+    sheet.add_child(col);
+
+    // The ink layer sits ON TOP of the code and receives the pointer, so the
+    // whole page is drawable including the margins — marginalia is where half
+    // the review lives.
+    let page_strokes: Vec<_> = s.strokes.iter().filter(|st| st.page == page).collect();
+    let has_live = s.live.as_ref().is_some_and(|l| l.page == page);
+    let cache = RefAny::new(InkLayer {
+        strokes: page_strokes.into_iter().cloned().collect(),
+        live: if has_live { s.live.clone() } else { None },
+    });
+    sheet.add_child(
+        Dom::create_image(ImageRef::callback(
+            RenderImageCallback::create(render_ink).to_core(),
+            cache,
+        ))
+        .with_dataset(OptionRefAny::Some(RefAny::new(PageTag { page })))
+        .with_css(format!(
+            "position: absolute; top: 0px; left: 0px; width: {}px; height: {}px;",
+            PAGE_W as isize,
+            page_h() as isize,
+        ).as_str())
+        .with_callback(
+            EventFilter::Hover(HoverEventFilter::MouseDown),
+            data.clone(),
+            crate::on_ink_down,
+        )
+        .with_callback(
+            EventFilter::Hover(HoverEventFilter::MouseOver),
+            data.clone(),
+            crate::on_ink_move,
+        )
+        .with_callback(
+            EventFilter::Hover(HoverEventFilter::MouseUp),
+            data.clone(),
+            crate::on_ink_up,
+        ),
+    );
+    sheet
+}
+
+/// Per-page ink handed to the render callback.
+struct InkLayer {
+    strokes: Vec<crate::model::Stroke>,
+    live: Option<crate::model::Stroke>,
+}
+
+extern "C" fn render_ink(mut data: RefAny, info: RenderImageCallbackInfo) -> ImageRef {
+    // Logical, not physical: the stroke model is in logical px (that is what
+    // `PenState.position` reports), so rasterising at physical size would
+    // paint every dab at half coordinates on a 2x display.
+    let size = info.get_bounds().get_logical_size();
+    let (w, h) = (size.width.max(1.0) as u32, size.height.max(1.0) as u32);
+    let Some(layer) = data.downcast_ref::<InkLayer>() else {
+        return ImageRef::null_image(w as usize, h as usize, RawImageFormat::RGBA8, U8VecRef::from(&[][..]));
+    };
+    let mut all: Vec<&crate::model::Stroke> = layer.strokes.iter().collect();
+    if let Some(l) = layer.live.as_ref() {
+        all.push(l);
+    }
+    let buf = ink::rasterize_page(&all, w, h);
+    let img = RawImage {
+        pixels: RawImageData::U8(buf.into()),
+        width: w as usize,
+        height: h as usize,
+        // The ink is composited source-over onto a transparent sheet, so the
+        // colour channels are NOT premultiplied.
+        premultiplied_alpha: false,
+        data_format: RawImageFormat::RGBA8,
+        tag: Vec::new().into(),
+    };
+    ImageRef::new_rawimage(img).into_option().unwrap_or_else(|| {
+        ImageRef::null_image(w as usize, h as usize, RawImageFormat::RGBA8, U8VecRef::from(&[][..]))
+    })
+}
+
+/// Derived findings, plus the open-questions queue.
+fn margin_panel(s: &AppState, _data: &RefAny) -> Dom {
+    let mut col = Dom::create_div().with_css(
+        "display: flex; flex-direction: column; width: 300px; flex-shrink: 0; \
+         background: #f7f6f3; border-left: 1px solid #cfcbc4; overflow: auto;",
+    );
+    col.add_child(
+        Dom::create_div_with_text("Derived findings")
+            .with_css("font-weight: bold; font-size: 12px; padding: 10px; color: #55514a;"),
+    );
+    if s.findings.is_empty() {
+        col.add_child(
+            Dom::create_div_with_text("Draw on the code — findings appear here.")
+                .with_css("font-size: 11px; color: #8a857c; padding: 0px 10px 10px 10px;"),
+        );
+    }
+    for f in &s.findings {
+        let c = f.semantic.color();
+        let mut card = Dom::create_div().with_css(format!(
+            "margin: 6px 10px; padding: 8px; background: white; border-radius: 4px; \
+             border-left: 4px solid rgb({},{},{});",
+            c.r, c.g, c.b
+        ).as_str());
+        card.add_child(
+            Dom::create_div_with_text(format!(
+                "{}  L{}-{}",
+                f.semantic.label(),
+                f.first_line,
+                f.last_line
+            ).as_str())
+            .with_css("font-size: 11px; font-weight: bold; color: #2b2b2b;"),
+        );
+        if let Some(v) = &f.voice_note {
+            card.add_child(
+                Dom::create_div_with_text(v.as_str())
+                    .with_css("font-size: 10px; color: #6b665e; margin-top: 4px;"),
+            );
+        }
+        col.add_child(card);
+    }
+
+    // The "?" queue: every question-shaped mark, gathered so none is lost.
+    let questions: Vec<_> = s
+        .findings
+        .iter()
+        .filter(|f| f.semantic == Semantic::Question)
+        .collect();
+    if !questions.is_empty() {
+        col.add_child(
+            Dom::create_div_with_text(format!("Open questions ({})", questions.len()).as_str())
+                .with_css("font-weight: bold; font-size: 12px; padding: 12px 10px 4px 10px; color: #55514a;"),
+        );
+        for q in questions {
+            col.add_child(
+                Dom::create_div_with_text(format!("? {}:{}", q.file, q.first_line).as_str())
+                    .with_css("font-size: 11px; color: #205cd6; padding: 2px 10px;"),
+            );
+        }
+    }
+    col
+}
+
+fn status_bar(s: &AppState) -> Dom {
+    let pages = s.file().map_or(0, code::SourceFile::page_count);
+    let clips = s.clips.len() + usize::from(s.recording.is_some());
+    let mut bar = Dom::create_div().with_css(
+        "display: flex; flex-direction: row; align-items: center; gap: 16px; \
+         padding: 5px 12px; font-size: 11px; color: #55514a; background: #f7f6f3; \
+         border-top: 1px solid #cfcbc4;",
+    );
+    bar.add_child(Dom::create_div_with_text(
+        format!("{pages} sheets  ·  {} strokes  ·  {clips} clips", s.strokes.len()).as_str(),
+    ));
+    bar.add_child(Dom::create_div_with_text(s.status.as_str()).with_css("margin-left: auto;"));
+    bar
+}

--- a/examples/azul-review/src/ui.rs
+++ b/examples/azul-review/src/ui.rs
@@ -6,22 +6,38 @@
 
 use azul::prelude::*;
 use azul::callbacks::RenderImageCallbackInfo;
-use azul::dom::{IdOrClass, RenderImageCallback};
-use azul::vec::IdOrClassVec;
+use azul::dom::{AccessibilityInfo, IdOrClass, RenderImageCallback};
+use azul::menu::{Menu, MenuItem, StringMenuItem};
+use azul::vec::{IdOrClassVec, MenuItemVec};
 use azul::image::{ImageRef, RawImageFormat};
 use azul::vec::U8VecRef;
 use azul::image::{RawImage, RawImageData};
 
 use crate::{code, ink, model::Semantic, AppState};
 
+
 /// Line height in logical px. Shared by the renderer and by the code that
 /// infers WHICH LINES a stroke covers — if these two ever disagree, every
 /// annotation silently anchors to the wrong place.
 pub const LINE_H: f32 = 15.0;
 /// Page width, sized for ~110 columns of the mono face.
-const PAGE_W: f32 = 760.0;
+const PAGE_W: f32 = 1000.0;
 /// Left gutter for line numbers; ink to the left of this is margin commentary.
 const GUTTER_W: f32 = 52.0;
+
+/// Blank paper to the RIGHT of the code, and the reason the sheet is this wide.
+///
+/// This is where handwritten remarks actually go — on a printout the note sits
+/// beside the line it is about, not on top of it. Without a real margin there
+/// is nowhere to write that does not obscure the code, so every mark has to be
+/// a highlight and the pen half of the grammar becomes unusable.
+///
+/// The findings panel that used to occupy this space was the same information
+/// twice, restated as a list — the "structure first" habit this app exists to
+/// invert. The ink IS the record.
+const MARGIN_GUTTER_W: f32 = 260.0;
+/// Paper edge around everything.
+const PAGE_PAD: f32 = 32.0;
 /// Gap between sheets in the strip. Wide enough that the shadow of one page
 /// does not read as part of the next.
 const PAGE_GAP: f32 = 24.0;
@@ -96,6 +112,17 @@ pub fn index_of(info: &mut CallbackInfo) -> Option<usize> {
         .and_then(|mut d| d.downcast_ref::<IndexTag>().map(|t| t.index))
 }
 
+/// An `AccessibilityInfo` carrying nothing but a name.
+///
+/// Every control in this toolbar is icon-first, and an icon-only control reads
+/// to a screen reader as a private-use codepoint — which is to say, as noise.
+fn named(name: &str) -> AccessibilityInfo {
+    AccessibilityInfo {
+        accessibility_name: OptionString::Some(name.into()),
+        ..AccessibilityInfo::default()
+    }
+}
+
 /// Marks an ink layer with the page it belongs to.
 #[derive(Debug, Clone, Copy)]
 pub struct PageTag {
@@ -120,41 +147,185 @@ pub extern "C" fn layout(data: RefAny, _: LayoutCallbackInfo) -> Dom {
     center.add_child(sheet(&s, &data));
     center.add_child(status_bar(&s));
     root.add_child(center);
-    root.add_child(margin_panel(&s, &data));
-    root
+    // No findings panel. Derived findings are still computed and still written
+    // to the archive, but restating them beside the page was the same content
+    // twice — and the second copy was a LIST, which is the "structure first"
+    // shape this app exists to invert. The remark lives in the page's own
+    // margin, where it was written.
+    root.with_menu_bar(menu_bar(&data))
 }
 
-/// File browser. Works against a whole repo or a single directory — the only
-/// difference is what `load_tree` skipped.
+/// The native menu bar, on the DOM root.
+///
+/// Everything here is also reachable from the page or the pad, on purpose: the
+/// menu is for discovering that a command exists and for the keyboard, not a
+/// path anyone should have to use mid-review. Its real job is being the place
+/// a macOS user looks first.
+fn menu_bar(data: &RefAny) -> Menu {
+    let mut items: Vec<MenuItem> = Vec::new();
+
+    let mut ink = StringMenuItem::create("Ink");
+    for (i, sem) in Semantic::ALL.iter().enumerate() {
+        ink = ink.with_child(MenuItem::String(
+            StringMenuItem::create(sem.label())
+                .with_callback(RefAny::new(IndexTag { index: i }), crate::on_menu_semantic),
+        ));
+    }
+    ink = ink.with_child(MenuItem::Separator);
+    ink = ink.with_child(MenuItem::String(
+        StringMenuItem::create("Cycle nib")
+            .with_callback(data.clone(), crate::on_cycle_tool),
+    ));
+    ink = ink.with_child(MenuItem::String(
+        StringMenuItem::create("Start / stop recording")
+            .with_callback(data.clone(), crate::on_toggle_record),
+    ));
+    items.push(MenuItem::String(ink));
+
+    let mut session = StringMenuItem::create("Session");
+    session = session.with_child(MenuItem::String(
+        StringMenuItem::create("Save now").with_callback(data.clone(), crate::on_menu_save),
+    ));
+    session = session.with_child(MenuItem::String(
+        StringMenuItem::create("Reveal archive folder")
+            .with_callback(data.clone(), crate::on_menu_reveal),
+    ));
+    items.push(MenuItem::String(session));
+
+    // `copy_from_ptr` is the only bulk constructor the FFI vectors expose;
+    // it deep-clones each element, so `items` is still ours to drop.
+    Menu::create(MenuItemVec::copy_from_ptr(&items[0], items.len()))
+}
+
+/// File browser, in the shape of a Finder list view.
+///
+/// # Why a tree and not the flat paths it used to show
+///
+/// `load_tree` returns paths like `layout/src/widgets/accordion.rs`, and shown
+/// flat they are unreadable at 11px — every row starts with the same forty
+/// characters. Folding the shared prefixes into folder rows costs one pass and
+/// makes the shape of the review target legible, which is most of what a file
+/// list is for.
+///
+/// Rows carry a type ICON rather than a spelled-out kind for the same reason
+/// Finder does: at this size the glyph is read faster than the word, and the
+/// word would push the filename out of the column.
 fn sidebar(s: &AppState, data: &RefAny) -> Dom {
     let mut col = Dom::create_div().with_css(
-        "display: flex; flex-direction: column; width: 250px; flex-shrink: 0; \
-         background: #f7f6f3; border-right: 1px solid #cfcbc4; overflow: auto;",
+        // `min-height: 0px` is what makes this scroll at all. Without it the
+        // column's height resolves to its CONTENT in the flex row, so it grows
+        // past the window instead of overflowing, and `overflow-y` never has
+        // anything to act on.
+        "display: flex; flex-direction: column; width: 260px; flex-shrink: 0; \
+         min-height: 0px; height: 100%; background: #f7f6f3; \
+         border-right: 1px solid #cfcbc4;",
     );
     col.add_child(
-        Dom::create_div_with_text("Files")
-            .with_css("font-weight: bold; font-size: 12px; padding: 10px; color: #55514a;"),
+        Dom::create_div_with_text("Name")
+            .with_css(
+                "font-size: 11px; padding: 7px 10px; color: #6b665e; flex-shrink: 0; \
+                 border-bottom: 1px solid #d8d4cd; background: #efede8;",
+            ),
     );
+
+    let mut list = Dom::create_div()
+        .with_css("flex-grow: 1; min-height: 0px; overflow-y: auto; overflow-x: hidden;");
+
+    // Emit a folder row whenever a path component differs from the previous
+    // row's. The file list is sorted by display path, so one linear pass is
+    // enough — no tree needs to be built.
+    let mut prev: Vec<String> = Vec::new();
     for (i, f) in s.files.iter().enumerate() {
-        let active = s.current == Some(i);
-        let css = if active {
-            "padding: 4px 10px; font-size: 11px; background: #dfe7f5; color: #1a1a1a;"
-        } else {
-            "padding: 4px 10px; font-size: 11px; color: #3c3a36;"
-        };
-        col.add_child(
-            Dom::create_div_with_text(f.display.as_str())
-                .with_dataset(OptionRefAny::Some(RefAny::new(IndexTag { index: i })))
-                .with_css(css)
-                .with_callback(
-                    EventFilter::Hover(HoverEventFilter::MouseUp),
-                    data.clone(),
-                    // index is carried by the closure-free indexed callback
-                    crate::on_pick_file,
-                ),
-        );
+        let parts: Vec<&str> = f.display.split(['/', '\\']).collect();
+        let (dirs, name) = parts.split_at(parts.len().saturating_sub(1));
+        for (depth, comp) in dirs.iter().enumerate() {
+            if prev.get(depth).map(String::as_str) == Some(*comp) {
+                continue;
+            }
+            list.add_child(finder_row(comp, depth, "folder", "#4a90d9", false, None, data));
+        }
+        prev = dirs.iter().map(|c| (*c).to_string()).collect();
+        let leaf = name.first().copied().unwrap_or(f.display.as_str());
+        list.add_child(finder_row(
+            leaf,
+            dirs.len(),
+            file_icon(leaf),
+            "#7d786f",
+            s.current == Some(i),
+            Some(i),
+            data,
+        ));
     }
+    col.add_child(list);
     col
+}
+
+/// A Finder-style icon for a file, by extension.
+const fn file_icon(name: &str) -> &'static str {
+    // No `Path::extension` here: the row only has a display name, and a
+    // trailing-dot or extensionless file must still get an icon rather than
+    // an empty box.
+    let bytes = name.as_bytes();
+    let mut i = bytes.len();
+    while i > 0 {
+        i -= 1;
+        if bytes[i] == b'.' {
+            let ext = bytes.split_at(i + 1).1;
+            return match ext {
+                b"rs" | b"c" | b"h" | b"cpp" | b"hpp" | b"py" | b"js" | b"ts" => "code",
+                b"sh" => "terminal",
+                b"md" => "article",
+                b"toml" | b"yml" | b"yaml" | b"json" => "data_object",
+                _ => "insert_drive_file",
+            };
+        }
+    }
+    "insert_drive_file"
+}
+
+/// One row of the file list: indent, icon, label.
+fn finder_row(
+    label: &str,
+    depth: usize,
+    icon: &str,
+    icon_color: &str,
+    selected: bool,
+    index: Option<usize>,
+    data: &RefAny,
+) -> Dom {
+    let mut row = Dom::create_div().with_css(
+        format!(
+            "display: flex; flex-direction: row; align-items: center; gap: 6px; \
+             padding: 3px 10px 3px {}px; font-size: 11px; flex-shrink: 0; \
+             background: {}; color: {};",
+            10 + depth * 16,
+            if selected { "#3478f6" } else { "transparent" },
+            if selected { "#ffffff" } else { "#2b2b2b" },
+        )
+        .as_str(),
+    );
+    row.add_child(
+        Dom::create_icon(icon).with_css(
+            format!(
+                "font-size: 14px; color: {};",
+                if selected { "#ffffff" } else { icon_color },
+            )
+            .as_str(),
+        ),
+    );
+    row.add_child(Dom::create_div_with_text(label));
+    match index {
+        Some(i) => row
+            .with_dataset(OptionRefAny::Some(RefAny::new(IndexTag { index: i })))
+            .with_callback(
+                EventFilter::Hover(HoverEventFilter::MouseUp),
+                data.clone(),
+                crate::on_pick_file,
+            ),
+        // A folder row is a heading, not a target: `load_tree` already flattened
+        // the tree, so there is nothing to expand or collapse.
+        None => row,
+    }
 }
 
 /// Semantic palette. Pad ExpressKeys select the same five, in this order.
@@ -166,20 +337,34 @@ fn toolbar(s: &AppState, data: &RefAny) -> Dom {
     for (i, sem) in Semantic::ALL.iter().enumerate() {
         let c = sem.color();
         let selected = *sem == s.active;
-        let css = format!(
-            "padding: 5px 12px; font-size: 12px; border-radius: 4px; \
-             background: rgba({},{},{},{}); color: {}; border: {};",
-            c.r,
-            c.g,
-            c.b,
-            if selected { "1.0" } else { "0.18" },
-            if selected { "#ffffff" } else { "#2b2b2b" },
-            if selected { "2px solid #2b2b2b" } else { "1px solid #cfcbc4" },
+        let mut swatch = Dom::create_div().with_css(
+            format!(
+                "display: flex; flex-direction: row; align-items: center; gap: 5px; \
+                 padding: 5px 10px; font-size: 12px; border-radius: 4px; \
+                 background: rgba({},{},{},{}); color: {}; border: {};",
+                c.r,
+                c.g,
+                c.b,
+                if selected { "1.0" } else { "0.18" },
+                if selected { "#ffffff" } else { "#2b2b2b" },
+                if selected { "2px solid #2b2b2b" } else { "1px solid #cfcbc4" },
+            )
+            .as_str(),
+        );
+        swatch.add_child(Dom::create_icon(sem.icon()).with_css("font-size: 15px;"));
+        // The number stays: it is the pad ExpressKey and the keyboard shortcut,
+        // and unlike the name it cannot be inferred from the glyph.
+        swatch.add_child(
+            Dom::create_div_with_text(format!("{}", i + 1).as_str())
+                .with_css("font-size: 10px; opacity: 0.75;"),
         );
         bar.add_child(
-            Dom::create_div_with_text(format!("{}  [{}]", sem.label(), i + 1).as_str())
+            swatch
                 .with_dataset(OptionRefAny::Some(RefAny::new(IndexTag { index: i })))
-                .with_css(css.as_str())
+                // Without a name a screen reader reads the icon's private-use
+                // codepoint, and the only text child is the shortcut digit —
+                // "1" is a worse answer than nothing.
+                .with_accessibility_info(named(sem.label()))
                 .with_callback(
                     EventFilter::Hover(HoverEventFilter::MouseUp),
                     data.clone(),
@@ -190,27 +375,40 @@ fn toolbar(s: &AppState, data: &RefAny) -> Dom {
     // Which nib is in hand. A readout, not a control: the tool changes by
     // clicking on the PAGE, so that the hand never leaves it. Showing it in the
     // toolbar anyway is the only way to know what a click just switched to.
-    bar.add_child(
-        Dom::create_div_with_text(format!("nib: {}  (click page to cycle)", s.tool.label()).as_str())
-            .with_css(
-                "margin-left: 16px; padding: 5px 12px; font-size: 12px; border-radius: 4px; \
-                 background: #ffffff; color: #2b2b2b; border: 1px dashed #a9a49b;",
-            ),
+    let mut nib = Dom::create_div().with_css(
+        "display: flex; flex-direction: row; align-items: center; gap: 6px; \
+         margin-left: 16px; padding: 5px 12px; font-size: 12px; border-radius: 4px; \
+         background: #ffffff; color: #2b2b2b; border: 1px dashed #a9a49b;",
     );
+    nib.add_child(Dom::create_icon(s.tool.icon()).with_css("font-size: 15px;"));
+    nib.add_child(Dom::create_div_with_text(s.tool.label()));
+    bar.add_child(nib);
 
     let rec = s.recording.is_some();
     if rec {
         bar.add_child(meter(s));
     }
+    let mut record = Dom::create_div().with_css(if rec {
+        "display: flex; flex-direction: row; align-items: center; gap: 6px; \
+         margin-left: 10px; padding: 5px 12px; font-size: 12px; border-radius: 4px; \
+         background: #d62d20; color: white;"
+    } else {
+        "display: flex; flex-direction: row; align-items: center; gap: 6px; \
+         margin-left: auto; padding: 5px 12px; font-size: 12px; border-radius: 4px; \
+         background: #ffffff; color: #2b2b2b; border: 1px solid #cfcbc4;"
+    });
+    record.add_child(
+        Dom::create_icon(if rec { "fiber_manual_record" } else { "mic" })
+            .with_css("font-size: 15px;"),
+    );
+    record.add_child(Dom::create_div_with_text(if rec { "recording" } else { "record" }));
     bar.add_child(
-        Dom::create_div_with_text(if rec { "◉ recording" } else { "○ record" })
-            .with_css(if rec {
-                "margin-left: 10px; padding: 5px 12px; font-size: 12px; border-radius: 4px; \
-                 background: #d62d20; color: white;"
+        record
+            .with_accessibility_info(named(if rec {
+                "stop recording"
             } else {
-                "margin-left: auto; padding: 5px 12px; font-size: 12px; border-radius: 4px; \
-                 background: #ffffff; color: #2b2b2b; border: 1px solid #cfcbc4;"
-            })
+                "start recording"
+            }))
             .with_callback(
                 EventFilter::Hover(HoverEventFilter::MouseUp),
                 data.clone(),
@@ -263,7 +461,8 @@ fn page_rail(s: &AppState, data: &RefAny) -> Dom {
     let mut rail = Dom::create_div().with_css(
         "display: flex; flex-direction: row; align-items: center; gap: 3px; \
          padding: 4px 12px; background: #efede8; border-bottom: 1px solid #cfcbc4; \
-         overflow-x: auto; overflow-y: hidden; flex-shrink: 0;",
+         overflow-x: auto; overflow-y: hidden; flex-shrink: 0; \
+         width: 100%; box-sizing: border-box;",
     );
     let Some(file) = s.file() else { return rail };
     for page in 0..file.page_count() {
@@ -338,7 +537,13 @@ fn sheet(s: &AppState, data: &RefAny) -> Dom {
             RefAny::new(SheetStrip { app: data.clone() }),
             sheets_virtual_view,
         )
-        .with_ids_and_classes(IdOrClassVec::from_item(IdOrClass::id(STRIP_ID))),
+        .with_ids_and_classes(IdOrClassVec::from_item(IdOrClass::id(STRIP_ID)))
+        // WITHOUT this the strip collapses to a sliver. A VirtualView is a
+        // block box whose materialised window the engine places absolutely, so
+        // it contributes NOTHING to the node's own content height — an `auto`
+        // height therefore resolves to nearly nothing no matter how tall the
+        // sheets are. It has to be told to fill the column.
+        .with_css("flex-grow: 1; min-height: 0px; width: 100%;"),
     );
     area
 }
@@ -433,14 +638,31 @@ fn page_sheet(s: &AppState, data: &RefAny, file: &code::SourceFile, page: usize)
         "position: relative; width: {}px; height: {}px; background: #ffffff; \
          border: 1px solid #b9b4ab; box-shadow: 0px 1px 4px #00000030; \
          margin-right: {}px; flex-shrink: 0; box-sizing: border-box; \
-         padding: 20px; overflow: hidden;",
+         padding: {}px; overflow: hidden;",
         PAGE_W as isize,
         page_h() as isize,
         PAGE_GAP as isize,
+        PAGE_PAD as isize,
     ).as_str());
 
-    // Code, one row per line, gutter then text.
-    let mut col = Dom::create_div().with_css("display: flex; flex-direction: column;");
+    // A faint rule where the code stops and the margin begins. Printouts have
+    // no such line, but on screen there is no paper texture to tell you the
+    // right-hand third is writeable — without it the margin reads as padding
+    // and never gets used.
+    sheet.add_child(Dom::create_div().with_css(format!(
+        "position: absolute; top: {}px; bottom: {}px; left: {}px; width: 1px; \
+         background: #ece8e1;",
+        PAGE_PAD as isize / 2,
+        PAGE_PAD as isize / 2,
+        (PAGE_W - MARGIN_GUTTER_W) as isize,
+    ).as_str()));
+
+    // Code, one row per line, gutter then text. Clipped to the width left of
+    // the margin so a long line runs under the rule instead of through it.
+    let mut col = Dom::create_div().with_css(format!(
+        "display: flex; flex-direction: column; width: {}px; overflow: hidden;",
+        (PAGE_W - MARGIN_GUTTER_W - PAGE_PAD) as isize,
+    ).as_str());
     for (i, line) in lines.iter().enumerate() {
         let mut row = Dom::create_div().with_css(format!(
             "display: flex; flex-direction: row; height: {LINE_H}px;"
@@ -533,68 +755,6 @@ extern "C" fn render_ink(mut data: RefAny, info: RenderImageCallbackInfo) -> Ima
     ImageRef::new_rawimage(img).into_option().unwrap_or_else(|| {
         ImageRef::null_image(w as usize, h as usize, RawImageFormat::RGBA8, U8VecRef::from(&[][..]))
     })
-}
-
-/// Derived findings, plus the open-questions queue.
-fn margin_panel(s: &AppState, _data: &RefAny) -> Dom {
-    let mut col = Dom::create_div().with_css(
-        "display: flex; flex-direction: column; width: 300px; flex-shrink: 0; \
-         background: #f7f6f3; border-left: 1px solid #cfcbc4; overflow: auto;",
-    );
-    col.add_child(
-        Dom::create_div_with_text("Derived findings")
-            .with_css("font-weight: bold; font-size: 12px; padding: 10px; color: #55514a;"),
-    );
-    if s.findings.is_empty() {
-        col.add_child(
-            Dom::create_div_with_text("Draw on the code — findings appear here.")
-                .with_css("font-size: 11px; color: #8a857c; padding: 0px 10px 10px 10px;"),
-        );
-    }
-    for f in &s.findings {
-        let c = f.semantic.color();
-        let mut card = Dom::create_div().with_css(format!(
-            "margin: 6px 10px; padding: 8px; background: white; border-radius: 4px; \
-             border-left: 4px solid rgb({},{},{});",
-            c.r, c.g, c.b
-        ).as_str());
-        card.add_child(
-            Dom::create_div_with_text(format!(
-                "{}  L{}-{}",
-                f.semantic.label(),
-                f.first_line,
-                f.last_line
-            ).as_str())
-            .with_css("font-size: 11px; font-weight: bold; color: #2b2b2b;"),
-        );
-        if let Some(v) = &f.voice_note {
-            card.add_child(
-                Dom::create_div_with_text(v.as_str())
-                    .with_css("font-size: 10px; color: #6b665e; margin-top: 4px;"),
-            );
-        }
-        col.add_child(card);
-    }
-
-    // The "?" queue: every question-shaped mark, gathered so none is lost.
-    let questions: Vec<_> = s
-        .findings
-        .iter()
-        .filter(|f| f.semantic == Semantic::Question)
-        .collect();
-    if !questions.is_empty() {
-        col.add_child(
-            Dom::create_div_with_text(format!("Open questions ({})", questions.len()).as_str())
-                .with_css("font-weight: bold; font-size: 12px; padding: 12px 10px 4px 10px; color: #55514a;"),
-        );
-        for q in questions {
-            col.add_child(
-                Dom::create_div_with_text(format!("? {}:{}", q.file, q.first_line).as_str())
-                    .with_css("font-size: 11px; color: #205cd6; padding: 2px 10px;"),
-            );
-        }
-    }
-    col
 }
 
 fn status_bar(s: &AppState) -> Dom {

--- a/examples/azul-writer/src/editor_ui.rs
+++ b/examples/azul-writer/src/editor_ui.rs
@@ -262,7 +262,20 @@ extern "C" fn pages_virtual_view(
             // includes page 0 at startup by construction.
             .with_ids_and_classes(
                 vec![azul_core::dom::IdOrClass::Class("mw-doc".into())].into(),
-            );
+            )
+            // The WHOLE writable area of the sheet is the editing host, the way
+            // a word processor's page is: `with_css` appends, so this only adds
+            // a floor to the content root's height.
+            //
+            // Without it the content root is exactly as tall as its blocks — on
+            // a new document, one empty line — so a click anywhere else on the
+            // white page landed on the sheet `<div>`, which is not editable and
+            // not focusable. Nothing took the click, no caret appeared, and the
+            // document could not be typed into. Filling the sheet's content box
+            // (`height: 1123px` minus the 96px margins, via `box-sizing:
+            // border-box`) makes every click inside the margins reach the
+            // editable host, which then seeds the caret at the end of the text.
+            .with_css("min-height: 100%;");
         col.add_child(Dom::create_div().with_css(&page_css).with_child(page));
     }
 

--- a/examples/azul-writer/src/editor_ui.rs
+++ b/examples/azul-writer/src/editor_ui.rs
@@ -53,8 +53,10 @@ pub fn title_band(state: &AppState, data: &RefAny) -> Dom {
     let title = format!("{} - AzWriter", state.document.display_name());
     let mut band = QuickAccessBar::office_2013(AzString::from(title)).with_leading(word_logo());
     band.actions = QuickAccessActionVec::from_vec(vec![
-        QuickAccessAction::new(s("save"))
-            .with_on_click(data.clone(), crate::on_save_clicked as ButtonOnClickCallbackType),
+        QuickAccessAction::new(s("save")).with_on_click(
+            data.clone(),
+            crate::on_save_clicked as ButtonOnClickCallbackType,
+        ),
         QuickAccessAction::new(s("undo"))
             .with_on_click(data.clone(), crate::on_undo as ButtonOnClickCallbackType),
         QuickAccessAction::new(s("redo"))
@@ -243,9 +245,8 @@ extern "C" fn pages_virtual_view(
          overflow: hidden;",
         page_w as isize, page_h as isize,
     );
-    let mut col = Dom::create_div().with_css(
-        "display: flex; flex-direction: column; align-items: center;",
-    );
+    let mut col =
+        Dom::create_div().with_css("display: flex; flex-direction: column; align-items: center;");
     for page in pages.into_iter().map(|p| p.dom) {
         // C11: the engine records structural edits on this editable subtree
         // and fires DocumentEdit; the app applies them to its model.
@@ -311,7 +312,10 @@ pub fn status_bar(state: &AppState, data: &RefAny, page_count: usize) -> Dom {
 
     let views = StatusBarViewSwitcher::office_2013()
         .with_active_view(state.view_mode)
-        .with_on_select(data.clone(), crate::on_view_select as StatusBarOnViewSelectCallbackType);
+        .with_on_select(
+            data.clone(),
+            crate::on_view_select as StatusBarOnViewSelectCallbackType,
+        );
 
     let mut zoom = StatusBarZoom::office_2013().with_percent(state.zoom_percent);
     zoom.on_zoom_out = Some(azul_layout::widgets::button::ButtonOnClick {

--- a/layout/src/cpurender/compositor.rs
+++ b/layout/src/cpurender/compositor.rs
@@ -136,6 +136,100 @@ pub struct Layer {
     pub composite_dirty: bool,
 }
 
+/// Widest or tallest a compositor layer may be, in device pixels.
+///
+/// Nothing a real layout produces comes close — this exists purely so that a
+/// nonsense extent cannot become an allocation. Chosen to match the usual
+/// maximum GPU texture dimension, so the CPU path refuses the same sizes the
+/// GPU path could never hold either.
+const MAX_LAYER_DIM: u32 = 16_384;
+
+/// The device-pixel size of a layer's backing pixmap, or `(0, 0)` when the
+/// layout handed us a size nothing could be drawn at.
+///
+/// # Why this is not just `as u32`
+///
+/// `f32 as u32` SATURATES in Rust. An infinite (or merely absurd) extent
+/// silently becomes `u32::MAX`, and the caller then asks `AzulPixmap::new` for
+/// `u32::MAX * height * 4` bytes — a ~900 GB `vec![255u8; _]` that macOS
+/// overcommits, touches, and is then killed over. The failure looks nothing
+/// like its cause: no panic, no allocation error, just a `SIGKILL` seconds
+/// later with the memory sitting in swap.
+///
+/// # Why it is loud
+///
+/// A non-finite layer size is ALWAYS a layout bug — there is no legitimate way
+/// to ask for an infinitely wide box. Clamping quietly would leave that bug in
+/// place and merely stop it from killing the process, so this panics in debug
+/// builds and warns once in release, naming the node so the layout that
+/// produced it can be found. The clamp is the seatbelt, not the fix.
+/// The DOM node a display-list item came from, for diagnostics only.
+fn node_of(display_list: &DisplayList, index: usize) -> Option<azul_core::dom::NodeId> {
+    display_list.node_mapping.get(index).and_then(|n| *n)
+}
+
+fn layer_pixel_size(
+    size: LogicalSize,
+    dpi_factor: f32,
+    node: Option<azul_core::dom::NodeId>,
+) -> (u32, u32) {
+    let dw = size.width * dpi_factor;
+    let dh = size.height * dpi_factor;
+
+    if !dw.is_finite() || !dh.is_finite() {
+        report_impossible_layer_size(size, dpi_factor, node, "not finite");
+        return (0, 0);
+    }
+    let over = dw.ceil() > MAX_LAYER_DIM as f32 || dh.ceil() > MAX_LAYER_DIM as f32;
+    if over {
+        report_impossible_layer_size(size, dpi_factor, node, "past MAX_LAYER_DIM");
+    }
+    let px = |v: f32| -> u32 {
+        if v <= 0.0 {
+            0
+        } else {
+            (v.ceil() as u32).min(MAX_LAYER_DIM)
+        }
+    };
+    (px(dw), px(dh))
+}
+
+/// Say — once — that a layer was asked for at a size that cannot be real.
+///
+/// `debug_assert` rather than a hard panic so a release build still renders
+/// (minus the offending layer) instead of dying on a bug the user cannot fix,
+/// while every test and debug run stops exactly where the bad size was born.
+fn report_impossible_layer_size(
+    size: LogicalSize,
+    dpi_factor: f32,
+    node: Option<azul_core::dom::NodeId>,
+    why: &str,
+) {
+    #[cfg(feature = "std")]
+    {
+        static ANNOUNCE: std::sync::Once = std::sync::Once::new();
+        ANNOUNCE.call_once(|| {
+            eprintln!(
+                "[azul][compositor] layer for node {node:?} requested at \
+                 {}x{} logical (dpi {dpi_factor}) — {why}. This is a LAYOUT bug: \
+                 no box has an infinite used size. The layer is being skipped or \
+                 clamped so the process survives; the wrong size is still wrong.",
+                size.width, size.height,
+            );
+        });
+    }
+    // Not under `cfg(test)`: this module's own tests feed the guard infinities
+    // on purpose to prove it holds, and they must assert on the RESULT rather
+    // than die inside the thing they are testing.
+    #[cfg(not(test))]
+    debug_assert!(
+        false,
+        "compositor: layer for node {node:?} at {}x{} logical (dpi {dpi_factor}) is {why}",
+        size.width,
+        size.height,
+    );
+}
+
 /// The `w × h` device-pixel window of `parent` whose top-left sits at
 /// (`ox`, `oy`) in the parent's pixel space, as RGBA bytes; pixels outside
 /// the parent are transparent black.
@@ -300,8 +394,7 @@ impl CompositorState {
                     ..
                 } => {
                     let bounds = *clip_bounds.inner();
-                    let pw = (bounds.size.width * dpi_factor).ceil() as u32;
-                    let ph = (bounds.size.height * dpi_factor).ceil() as u32;
+                    let (pw, ph) = layer_pixel_size(bounds.size, dpi_factor, node_of(display_list, i));
                     if pw > 0 && ph > 0 {
                         let new_id = self.alloc_layer_id();
                         let mut layer = Layer::new(new_id, bounds, pw, ph);
@@ -334,8 +427,7 @@ impl CompositorState {
                         .and_then(|k| live_opacities.get(&k.id).copied())
                         .unwrap_or(*opacity);
                     let b = *bounds.inner();
-                    let pw = (b.size.width * dpi_factor).ceil() as u32;
-                    let ph = (b.size.height * dpi_factor).ceil() as u32;
+                    let (pw, ph) = layer_pixel_size(b.size, dpi_factor, node_of(display_list, i));
                     let promote = effective < 1.0 && pw > 0 && ph > 0;
                     opacity_promoted.push(promote);
                     if promote {
@@ -367,8 +459,7 @@ impl CompositorState {
                     let has_blur = filters.iter().any(|f| matches!(f, StyleFilter::Blur(_)));
                     if has_blur {
                         let b = *bounds.inner();
-                        let pw = (b.size.width * dpi_factor).ceil() as u32;
-                        let ph = (b.size.height * dpi_factor).ceil() as u32;
+                        let (pw, ph) = layer_pixel_size(b.size, dpi_factor, node_of(display_list, i));
                         if pw > 0 && ph > 0 {
                             let new_id = self.alloc_layer_id();
                             let mut layer = Layer::new(new_id, b, pw, ph);
@@ -423,8 +514,8 @@ impl CompositorState {
                     ref_frame_promoted.push(!is_identity);
                     if !is_identity {
                         let b = *bounds.inner();
-                        let pw = (b.size.width * dpi_factor).ceil().max(1.0) as u32;
-                        let ph = (b.size.height * dpi_factor).ceil().max(1.0) as u32;
+                        let (pw, ph) = layer_pixel_size(b.size, dpi_factor, node_of(display_list, i));
+                        let (pw, ph) = (pw.max(1), ph.max(1));
                         let new_id = self.alloc_layer_id();
                         let mut layer = Layer::new(new_id, b, pw, ph);
                         layer.static_clip = clip_stack.iter().copied().reduce(intersect_logical_rects);
@@ -470,8 +561,7 @@ impl CompositorState {
                 // blitting the content (see `composite_layer_recursive`).
                 DisplayListItem::PushBackdropFilter { bounds, filters } => {
                     let b = *bounds.inner();
-                    let pw = (b.size.width * dpi_factor).ceil() as u32;
-                    let ph = (b.size.height * dpi_factor).ceil() as u32;
+                    let (pw, ph) = layer_pixel_size(b.size, dpi_factor, node_of(display_list, i));
                     if pw > 0 && ph > 0 && !filters.is_empty() {
                         let new_id = self.alloc_layer_id();
                         let mut layer = Layer::new(new_id, b, pw, ph);
@@ -2921,6 +3011,54 @@ pub fn coalesce_damage_rects(rects: &mut Vec<LogicalRect>) {
 // ============================================================================
 // scroll_shift_region — unit tests (#14 single-axis, #16 diagonal pan)
 // ============================================================================
+
+#[cfg(test)]
+mod layer_size_is_never_an_allocation_bomb {
+    use super::*;
+
+    use azul_core::geom::LogicalSize;
+
+    fn sz(w: f32, h: f32) -> LogicalSize {
+        LogicalSize::new(w, h)
+    }
+
+    #[test]
+    fn an_infinite_size_is_not_a_size() {
+        // `as u32` saturates, so this used to be u32::MAX — and the caller then
+        // asked for u32::MAX * height * 4 bytes.
+        assert_eq!(layer_pixel_size(sz(f32::INFINITY, 27.0), 2.0, None), (0, 0));
+        assert_eq!(layer_pixel_size(sz(100.0, f32::INFINITY), 2.0, None), (0, 0));
+        assert_eq!(layer_pixel_size(sz(f32::NAN, 27.0), 2.0, None), (0, 0));
+        assert_eq!(layer_pixel_size(sz(100.0, 27.0), f32::NAN, None), (0, 0));
+    }
+
+    #[test]
+    fn a_finite_but_absurd_size_is_clamped_rather_than_saturated() {
+        // Finite overflow is the same bomb with an extra step: 1e30 * 2 still
+        // saturates the cast.
+        assert_eq!(
+            layer_pixel_size(sz(1e30, 27.0), 2.0, None),
+            (MAX_LAYER_DIM, 54),
+        );
+    }
+
+    #[test]
+    fn a_non_positive_extent_is_zero_not_a_wrapped_huge_number() {
+        // `-5.0 as u32` is 0 today, but only because the cast saturates at the
+        // bottom too — state it, so a future refactor cannot turn it negative.
+        assert_eq!(layer_pixel_size(sz(-5.0, 27.0), 2.0, None), (0, 54));
+        assert_eq!(layer_pixel_size(sz(0.0, 0.0), 2.0, None), (0, 0));
+    }
+
+    #[test]
+    fn ordinary_sizes_are_unchanged_by_the_guard() {
+        // The guard must be invisible to every layout that was already fine,
+        // rounding up exactly as the old cast did.
+        assert_eq!(layer_pixel_size(sz(1000.0, 730.0), 2.0, None), (2000, 1460));
+        assert_eq!(layer_pixel_size(sz(27.5, 13.5), 2.0, None), (55, 27));
+        assert_eq!(layer_pixel_size(sz(1.0, 1.0), 1.0, None), (1, 1));
+    }
+}
 
 #[cfg(test)]
 mod translate_hint_contract {

--- a/layout/src/cpurender/raster.rs
+++ b/layout/src/cpurender/raster.rs
@@ -3805,9 +3805,10 @@ fn render_image(
         DecodedImage::Gl(_) => return,
     };
 
-    // Area/bilinear blit: each destination pixel samples its source footprint
-    // (`image_scale::sample`) instead of nearest-neighbour indexing a
-    // pre-converted RGBA buffer.
+    // Area/bilinear blit: each destination pixel takes the value
+    // `image_scale::sample` would give it, but the per-pixel invariants are
+    // hoisted and the source rows are converted once each — see
+    // `blit_sampled_image`.
     let dst_x = rect.x as i32;
     let dst_y = rect.y as i32;
     let dst_w = rect.width as u32;
@@ -3823,44 +3824,390 @@ fn render_image(
             (c.y + c.height) as i32,
         ));
 
-    for py in 0..dst_h {
-        for px in 0..dst_w {
-            let tx = dst_x + px as i32;
-            let ty = dst_y + py as i32;
-            if tx < 0 || ty < 0 || tx >= pw as i32 || ty >= ph as i32 {
-                continue;
-            }
-            // Clip check
-            if tx < clip_x1 || ty < clip_y1 || tx >= clip_x2 || ty >= clip_y2 {
-                continue;
-            }
+    let Some(win) = visible_dst_window(
+        dst_x,
+        dst_y,
+        dst_w,
+        dst_h,
+        pw,
+        ph,
+        (clip_x1, clip_y1, clip_x2, clip_y2),
+    ) else {
+        return;
+    };
 
-            let [sr, sg, sb, sa8] = crate::image_scale::sample(&src, dst_w, dst_h, px, py);
-            let di = ((ty as u32 * pw + tx as u32) * 4) as usize;
+    blit_sampled_image(pixmap, &src, dst_x, dst_y, dst_w, dst_h, win, &mut RowConversions::new());
+}
 
-            if di + 3 < pixmap.data.len() {
-                let sa = u32::from(sa8);
-                if sa == 255 {
-                    pixmap.data[di] = sr;
-                    pixmap.data[di + 1] = sg;
-                    pixmap.data[di + 2] = sb;
-                    pixmap.data[di + 3] = 255;
-                } else if sa > 0 {
-                    // Alpha blend: dst = src * sa + dst * (255 - sa)
-                    let da = 255 - sa;
-                    pixmap.data[di] =
-                        ((u32::from(sr) * sa + u32::from(pixmap.data[di]) * da) / 255) as u8;
-                    pixmap.data[di + 1] =
-                        ((u32::from(sg) * sa + u32::from(pixmap.data[di + 1]) * da) / 255) as u8;
-                    pixmap.data[di + 2] =
-                        ((u32::from(sb) * sa + u32::from(pixmap.data[di + 2]) * da) / 255) as u8;
-                    pixmap.data[di + 3] =
-                        ((sa + u32::from(pixmap.data[di + 3]) * da / 255).min(255)) as u8;
-                }
+/// The sub-window of a `dst_w × dst_h` image blit that is actually painted:
+/// the destination rect intersected with the clip AND the pixmap, expressed in
+/// the image's OWN destination-pixel coordinates as `(px_lo, py_lo, px_hi,
+/// py_hi)` half-open. `None` when nothing of the image is visible.
+///
+/// # Why the loop must be narrowed rather than filtered
+///
+/// `image_scale::sample` is a pure function of `(px, py)` and the FULL
+/// destination size, so restricting which `(px, py)` the loop visits cannot
+/// change any painted pixel's value. The blit used to walk all
+/// `dst_w × dst_h` pixels and `continue` on the clip test: a 40 px damage
+/// strip over a 2078×1132 canvas still ran 2.35 M iterations to paint 83 k
+/// pixels. Narrowing the loop also lets everything the sampler needs be set
+/// up ONCE for the pixels that are actually painted — per-column tap
+/// positions, and the source rows those taps land on.
+fn visible_dst_window(
+    dst_x: i32,
+    dst_y: i32,
+    dst_w: u32,
+    dst_h: u32,
+    pw: u32,
+    ph: u32,
+    clip: (i32, i32, i32, i32),
+) -> Option<(u32, u32, u32, u32)> {
+    let (clip_x1, clip_y1, clip_x2, clip_y2) = clip;
+    let x_lo = clip_x1.max(0).max(dst_x);
+    let y_lo = clip_y1.max(0).max(dst_y);
+    let x_hi = clip_x2
+        .min(i32::try_from(pw).unwrap_or(i32::MAX))
+        .min(dst_x.saturating_add(i32::try_from(dst_w).unwrap_or(i32::MAX)));
+    let y_hi = clip_y2
+        .min(i32::try_from(ph).unwrap_or(i32::MAX))
+        .min(dst_y.saturating_add(i32::try_from(dst_h).unwrap_or(i32::MAX)));
+    if x_hi <= x_lo || y_hi <= y_lo {
+        return None;
+    }
+    // Both differences are non-negative: `x_lo >= dst_x` and `x_hi > x_lo`.
+    Some((
+        (x_lo - dst_x) as u32,
+        (y_lo - dst_y) as u32,
+        (x_hi - dst_x) as u32,
+        (y_hi - dst_y) as u32,
+    ))
+}
+
+/// Must match `image_scale::MAX_TAPS`. Divergence is caught by
+/// `the_fast_blit_is_byte_identical_to_image_scale_sample`, which compares the
+/// blit against `image_scale::sample` itself.
+const BLIT_MAX_TAPS: u32 = 4;
+
+/// How many source rows the blit converted to straight RGBA.
+///
+/// Exists so a test can pin the COMPLEXITY rather than a wall clock: each
+/// source row a destination row needs is converted once and reused by every
+/// destination row that lands on it, so this stays O(source rows touched) —
+/// never O(destination rows × taps), which is what a per-pixel
+/// `image_scale::sample` effectively did (four `SrcImage::pixel` calls per
+/// destination pixel, each re-deriving the format and re-clamping).
+struct RowConversions(usize);
+
+impl RowConversions {
+    const fn new() -> Self {
+        Self(0)
+    }
+}
+
+/// One source row as straight RGBA8, plus which row it holds.
+struct RgbaRow {
+    /// Source y this buffer holds, or `None` when empty.
+    y: Option<u32>,
+    /// `src.width * 4` bytes.
+    bytes: Vec<u8>,
+}
+
+impl RgbaRow {
+    fn new(width: usize) -> Self {
+        Self { y: None, bytes: vec![0u8; width * 4] }
+    }
+}
+
+/// Convert source row `y` into `out` as straight RGBA8. The format match runs
+/// ONCE per row instead of once per tap (four times per destination pixel).
+fn source_row_to_rgba(src: &crate::image_scale::SrcImage<'_>, y: u32, out: &mut [u8]) {
+    use azul_core::resources::RawImageFormat;
+    let Some(bpp) = crate::image_scale::bytes_per_pixel(src.format) else {
+        out.fill(0);
+        return;
+    };
+    let w = src.width as usize;
+    let base = y as usize * w * bpp;
+    let row = &src.bytes[base..base + w * bpp];
+    match src.format {
+        RawImageFormat::RGBA8 => out.copy_from_slice(row),
+        RawImageFormat::BGRA8 => {
+            for (o, p) in out.chunks_exact_mut(4).zip(row.chunks_exact(4)) {
+                o[0] = p[2];
+                o[1] = p[1];
+                o[2] = p[0];
+                o[3] = p[3];
             }
         }
+        RawImageFormat::RGB8 => {
+            for (o, p) in out.chunks_exact_mut(4).zip(row.chunks_exact(3)) {
+                o[0] = p[0];
+                o[1] = p[1];
+                o[2] = p[2];
+                o[3] = 255;
+            }
+        }
+        RawImageFormat::BGR8 => {
+            for (o, p) in out.chunks_exact_mut(4).zip(row.chunks_exact(3)) {
+                o[0] = p[2];
+                o[1] = p[1];
+                o[2] = p[0];
+                o[3] = 255;
+            }
+        }
+        // A coverage/luma plane replicated to RGB with an OPAQUE alpha.
+        RawImageFormat::R8 => {
+            for (o, p) in out.chunks_exact_mut(4).zip(row.iter()) {
+                o[0] = *p;
+                o[1] = *p;
+                o[2] = *p;
+                o[3] = 255;
+            }
+        }
+        // `bytes_per_pixel` already returned `None` for anything else.
+        _ => out.fill(0),
+    }
+}
+
+/// Composite one straight-RGBA destination row into the pixmap. Split out of
+/// the sampling loops so the float work above is a flat, branch-free pass that
+/// vectorizes, and the branchy alpha decision reads bytes.
+fn composite_rgba_row(pixmap: &mut AzulPixmap, di_base: usize, stage: &[u8]) {
+    for (i, q) in stage.chunks_exact(4).enumerate() {
+        let di = di_base + i * 4;
+        if di + 3 >= pixmap.data.len() {
+            break;
+        }
+        let sa = u32::from(q[3]);
+        if sa == 255 {
+            pixmap.data[di] = q[0];
+            pixmap.data[di + 1] = q[1];
+            pixmap.data[di + 2] = q[2];
+            pixmap.data[di + 3] = 255;
+        } else if sa > 0 {
+            // Alpha blend: dst = src * sa + dst * (255 - sa)
+            let da = 255 - sa;
+            pixmap.data[di] = ((u32::from(q[0]) * sa + u32::from(pixmap.data[di]) * da) / 255) as u8;
+            pixmap.data[di + 1] =
+                ((u32::from(q[1]) * sa + u32::from(pixmap.data[di + 1]) * da) / 255) as u8;
+            pixmap.data[di + 2] =
+                ((u32::from(q[2]) * sa + u32::from(pixmap.data[di + 2]) * da) / 255) as u8;
+            pixmap.data[di + 3] =
+                ((sa + u32::from(pixmap.data[di + 3]) * da / 255).min(255)) as u8;
+        }
+    }
+}
+
+/// Blit `src` into `pixmap` at `dst_x, dst_y` scaled to `dst_w × dst_h`,
+/// painting only the destination sub-window `win = (px_lo, py_lo, px_hi,
+/// py_hi)`.
+///
+/// # What this is
+///
+/// The value written for destination pixel `(px, py)` is EXACTLY
+/// `image_scale::sample(src, dst_w, dst_h, px, py)` — same taps, same f32
+/// expressions, same rounding, bit for bit (pinned by
+/// `the_fast_blit_is_byte_identical_to_image_scale_sample`). What differs is
+/// how often the work that does not depend on the pixel is done.
+///
+/// # Why it is not a `sample()` call per pixel
+///
+/// `sample` is the golden reference: pure, per-pixel, no state. Calling it per
+/// destination pixel made every pixel pay two f32 divisions to re-derive the
+/// scale, and four `SrcImage::pixel` calls that each re-matched the pixel
+/// format, re-clamped the coordinates and re-bounds-checked the buffer. On the
+/// path that actually matters — a HiDPI window compositing a logical-sized
+/// canvas, i.e. a 2× bilinear UPSCALE over the whole window — that is ~19 ns
+/// per destination pixel, and AzPaint at 1055×677 points blits 2.35 M of them
+/// on every pointer move: ~45 ms per frame, which is the whole frame budget
+/// three times over. It measured 12× the nearest-neighbour blit it replaced.
+///
+/// This keeps the quality and gets the cost back:
+///
+/// * the scale, tap counts and per-column tap positions are computed once,
+/// * each source row is converted to straight RGBA once (`RgbaRow`) and reused
+///   by every destination row that samples it — a 2× upscale touches one new
+///   source row every two destination rows,
+/// * the bilinear case is separable: the horizontal partial
+///   `p00·(1−tx) + p10·tx` is kept in f32 per source row, so the per-destination
+///   -pixel work is one lerp of two f32 rows. Keeping the partial in f32 is what
+///   makes the result bit-identical rather than merely close.
+#[allow(clippy::cast_possible_truncation, clippy::cast_precision_loss, clippy::cast_sign_loss)]
+#[allow(clippy::too_many_arguments)] // a blit is a rect, a source and a window
+fn blit_sampled_image(
+    pixmap: &mut AzulPixmap,
+    src: &crate::image_scale::SrcImage<'_>,
+    dst_x: i32,
+    dst_y: i32,
+    dst_w: u32,
+    dst_h: u32,
+    win: (u32, u32, u32, u32),
+    conversions: &mut RowConversions,
+) {
+    let (px_lo, py_lo, px_hi, py_hi) = win;
+    // `is_sampleable` is what lets every read below skip its bounds check: it
+    // proves `bytes.len() >= width * height * bytes_per_pixel`.
+    if px_hi <= px_lo || py_hi <= py_lo || !src.is_sampleable() {
+        return;
+    }
+    let scale_x = src.width as f32 / dst_w.max(1) as f32;
+    let scale_y = src.height as f32 / dst_h.max(1) as f32;
+    let vis_w = (px_hi - px_lo) as usize;
+    let pw = pixmap.width;
+    let src_w = src.width as usize;
+    let last_x = src.width as i32 - 1;
+    let last_y = src.height as i32 - 1;
+
+    let mut stage = vec![0u8; vis_w * 4];
+
+    if scale_x <= 1.0 && scale_y <= 1.0 {
+        // ---- upscale / 1:1 — separable bilinear over a two-row cache -------
+        // Per visible column: the two source x taps (as RGBA byte offsets) and
+        // the horizontal weight. `fx` is written exactly as `image_scale`
+        // writes it, so `tx` is bit-identical.
+        let mut cols: Vec<(u32, u32, f32)> = Vec::with_capacity(vis_w);
+        for dx in px_lo..px_hi {
+            let fx = (dx as f32 + 0.5) * scale_x - 0.5;
+            let x0f = fx.floor();
+            let tx = fx - x0f;
+            let x0 = (x0f as i32).clamp(0, last_x) as u32;
+            let x1 = (x0f as i32 + 1).clamp(0, last_x) as u32;
+            cols.push((x0 * 4, x1 * 4, tx));
+        }
+        let mut rgba = RgbaRow::new(src_w);
+        // The horizontal partials for the two source rows the current
+        // destination row lerps between.
+        let mut h0 = vec![0f32; vis_w * 4];
+        let mut h1 = vec![0f32; vis_w * 4];
+        let (mut have0, mut have1) = (u32::MAX, u32::MAX);
+        for py in py_lo..py_hi {
+            let fy = (py as f32 + 0.5) * scale_y - 0.5;
+            let y0f = fy.floor();
+            let ty = fy - y0f;
+            let y0 = (y0f as i32).clamp(0, last_y) as u32;
+            let y1 = (y0f as i32 + 1).clamp(0, last_y) as u32;
+
+            if have0 != y0 {
+                if have1 == y0 {
+                    core::mem::swap(&mut h0, &mut h1);
+                    have0 = y0;
+                    have1 = u32::MAX;
+                } else {
+                    if rgba.y != Some(y0) {
+                        source_row_to_rgba(src, y0, &mut rgba.bytes);
+                        rgba.y = Some(y0);
+                        conversions.0 += 1;
+                    }
+                    horizontal_lerp_row(&rgba.bytes, &cols, &mut h0);
+                    have0 = y0;
+                }
+            }
+            if have1 != y1 {
+                if y1 == y0 {
+                    h1.copy_from_slice(&h0);
+                } else {
+                    if rgba.y != Some(y1) {
+                        source_row_to_rgba(src, y1, &mut rgba.bytes);
+                        rgba.y = Some(y1);
+                        conversions.0 += 1;
+                    }
+                    horizontal_lerp_row(&rgba.bytes, &cols, &mut h1);
+                }
+                have1 = y1;
+            }
+
+            let w0 = 1.0 - ty;
+            for ((o, &a), &b) in stage.iter_mut().zip(h0.iter()).zip(h1.iter()) {
+                *o = (a * w0 + b * ty).round().clamp(0.0, 255.0) as u8;
+            }
+            let ty_px = (dst_y + py as i32) as u32;
+            let tx_px = (dst_x + px_lo as i32) as u32;
+            composite_rgba_row(pixmap, ((ty_px * pw + tx_px) * 4) as usize, &stage);
+        }
+        return;
     }
 
+    // ---- downscale on at least one axis — bounded area average -------------
+    let nx = (scale_x.ceil() as u32).clamp(1, BLIT_MAX_TAPS);
+    let ny = (scale_y.ceil() as u32).clamp(1, BLIT_MAX_TAPS);
+    // Per visible column, the `nx` source x taps as RGBA byte offsets.
+    let mut cols: Vec<[u32; BLIT_MAX_TAPS as usize]> = Vec::with_capacity(vis_w);
+    for dx in px_lo..px_hi {
+        let cx = (dx as f32 + 0.5) * scale_x;
+        let mut taps = [0u32; BLIT_MAX_TAPS as usize];
+        for (t, slot) in taps.iter_mut().enumerate().take(nx as usize) {
+            let fx = cx + ((t as f32 + 0.5) / nx as f32 - 0.5) * scale_x;
+            *slot = (fx.floor() as i32).clamp(0, last_x) as u32 * 4;
+        }
+        cols.push(taps);
+    }
+    // Up to `ny` source rows are live at once; consecutive destination rows
+    // reuse most of them, so the cache is indexed by source y.
+    let mut rows: Vec<RgbaRow> = (0..ny as usize).map(|_| RgbaRow::new(src_w)).collect();
+    let n = nx * ny;
+    let half = n / 2;
+    for py in py_lo..py_hi {
+        let cy = (py as f32 + 0.5) * scale_y;
+        let mut live = [0usize; BLIT_MAX_TAPS as usize];
+        // Bitmask of cache slots THIS destination row already depends on, so
+        // an eviction can never throw away a row a later tap still needs.
+        // There are `ny` slots and at most `ny - 1` are claimed when a miss
+        // happens, so a free slot always exists.
+        let mut claimed = 0u32;
+        for (t, slot) in live.iter_mut().enumerate().take(ny as usize) {
+            let fy = cy + ((t as f32 + 0.5) / ny as f32 - 0.5) * scale_y;
+            let y = (fy.floor() as i32).clamp(0, last_y) as u32;
+            let idx = match rows.iter().position(|r| r.y == Some(y)) {
+                Some(i) => i,
+                None => {
+                    let victim =
+                        (0..rows.len()).find(|i| claimed & (1u32 << i) == 0).unwrap_or(0);
+                    source_row_to_rgba(src, y, &mut rows[victim].bytes);
+                    rows[victim].y = Some(y);
+                    conversions.0 += 1;
+                    victim
+                }
+            };
+            claimed |= 1u32 << idx;
+            *slot = idx;
+        }
+        for (i, taps) in cols.iter().enumerate() {
+            let (mut r, mut g, mut b, mut a) = (0u32, 0u32, 0u32, 0u32);
+            for &row_idx in live.iter().take(ny as usize) {
+                let row = &rows[row_idx].bytes;
+                for &off in taps.iter().take(nx as usize) {
+                    let o = off as usize;
+                    r += u32::from(row[o]);
+                    g += u32::from(row[o + 1]);
+                    b += u32::from(row[o + 2]);
+                    a += u32::from(row[o + 3]);
+                }
+            }
+            let s = &mut stage[i * 4..i * 4 + 4];
+            s[0] = ((r + half) / n) as u8;
+            s[1] = ((g + half) / n) as u8;
+            s[2] = ((b + half) / n) as u8;
+            s[3] = ((a + half) / n) as u8;
+        }
+        let ty_px = (dst_y + py as i32) as u32;
+        let tx_px = (dst_x + px_lo as i32) as u32;
+        composite_rgba_row(pixmap, ((ty_px * pw + tx_px) * 4) as usize, &stage);
+    }
+}
+
+/// The horizontal half of the separable bilinear pass: `p00·(1−tx) + p10·tx`
+/// per channel, kept in f32 so the vertical pass reproduces `image_scale`'s
+/// arithmetic exactly.
+fn horizontal_lerp_row(rgba: &[u8], cols: &[(u32, u32, f32)], out: &mut [f32]) {
+    for (o, &(x0, x1, tx)) in out.chunks_exact_mut(4).zip(cols.iter()) {
+        let (i0, i1) = (x0 as usize, x1 as usize);
+        let (a, b) = (&rgba[i0..i0 + 4], &rgba[i1..i1 + 4]);
+        let w = 1.0 - tx;
+        for c in 0..4 {
+            o[c] = f32::from(a[c]) * w + f32::from(b[c]) * tx;
+        }
+    }
 }
 
 fn build_rect_path(rect: &AzRect) -> PathStorage {
@@ -6918,6 +7265,201 @@ mod autotest_generated {
             );
         }
         assert_eq!(px_at(&p, 2, 2), [255, 255, 255, 255], "outside the bounds");
+    }
+
+    /// The blit exactly as it was written before the fast path: one
+    /// `image_scale::sample` per destination pixel, composited with the
+    /// documented formula. Deliberately duplicated here — it is the thing the
+    /// production blit must keep agreeing with, so it has to exist somewhere
+    /// the production code cannot drift it.
+    fn reference_blit(
+        pixmap: &mut AzulPixmap,
+        src: &crate::image_scale::SrcImage<'_>,
+        dst_x: i32,
+        dst_y: i32,
+        dst_w: u32,
+        dst_h: u32,
+    ) {
+        let pw = pixmap.width;
+        let ph = pixmap.height;
+        for py in 0..dst_h {
+            for px in 0..dst_w {
+                let tx = dst_x + px as i32;
+                let ty = dst_y + py as i32;
+                if tx < 0 || ty < 0 || tx >= pw as i32 || ty >= ph as i32 {
+                    continue;
+                }
+                let [sr, sg, sb, sa8] = crate::image_scale::sample(src, dst_w, dst_h, px, py);
+                let di = ((ty as u32 * pw + tx as u32) * 4) as usize;
+                if di + 3 >= pixmap.data.len() {
+                    continue;
+                }
+                let sa = u32::from(sa8);
+                if sa == 255 {
+                    pixmap.data[di] = sr;
+                    pixmap.data[di + 1] = sg;
+                    pixmap.data[di + 2] = sb;
+                    pixmap.data[di + 3] = 255;
+                } else if sa > 0 {
+                    let da = 255 - sa;
+                    pixmap.data[di] =
+                        ((u32::from(sr) * sa + u32::from(pixmap.data[di]) * da) / 255) as u8;
+                    pixmap.data[di + 1] =
+                        ((u32::from(sg) * sa + u32::from(pixmap.data[di + 1]) * da) / 255) as u8;
+                    pixmap.data[di + 2] =
+                        ((u32::from(sb) * sa + u32::from(pixmap.data[di + 2]) * da) / 255) as u8;
+                    pixmap.data[di + 3] =
+                        ((sa + u32::from(pixmap.data[di + 3]) * da / 255).min(255)) as u8;
+                }
+            }
+        }
+    }
+
+    /// A deterministic, non-uniform source in `fmt`. Uniform data would let a
+    /// wrong tap position pass, and a wrong swizzle pass too.
+    fn noisy_src(fmt: azul_core::resources::RawImageFormat, w: u32, h: u32) -> Vec<u8> {
+        let bpp = crate::image_scale::bytes_per_pixel(fmt).expect("a sampleable format");
+        (0..(w as usize * h as usize * bpp))
+            .map(|i| ((i * 37 + 11) % 256) as u8)
+            .collect()
+    }
+
+    #[test]
+    fn the_fast_image_blit_is_byte_identical_to_image_scale_sample() {
+        // `image_scale::sample` is the golden reference every consumer of the
+        // scaler agrees with, and the blit no longer CALLS it once per
+        // destination pixel — that cost ~19 ns/px, which on the path that
+        // actually matters (a HiDPI window compositing a logical-sized canvas,
+        // i.e. a 2x bilinear upscale over the whole window) is ~45 ms of blit
+        // for one frame. The arithmetic is what could silently drift, so every
+        // destination byte must still be the byte the reference produces, in
+        // every format and on both sides of the upscale/downscale branch.
+        use azul_core::resources::RawImageFormat as F;
+        for fmt in [F::RGBA8, F::BGRA8, F::RGB8, F::BGR8, F::R8] {
+            let (sw, sh) = (13u32, 7u32);
+            let bytes = noisy_src(fmt, sw, sh);
+            let src =
+                crate::image_scale::SrcImage { bytes: &bytes, format: fmt, width: sw, height: sh };
+            assert!(src.is_sampleable(), "{fmt:?} must be sampleable");
+            for (dw, dh) in [
+                (13u32, 7u32), // 1:1
+                (40, 23),      // upscale both axes
+                (5, 3),        // downscale both axes
+                (40, 3),       // upscale x, downscale y
+                (5, 23),       // downscale x, upscale y
+                (1, 1),        // extreme downscale
+                (13, 23),      // 1:1 on x, upscale on y
+            ] {
+                let mut fast = pixmap(dw + 4, dh + 4);
+                let mut want = pixmap(dw + 4, dh + 4);
+                blit_sampled_image(
+                    &mut fast,
+                    &src,
+                    2,
+                    2,
+                    dw,
+                    dh,
+                    (0, 0, dw, dh),
+                    &mut RowConversions::new(),
+                );
+                reference_blit(&mut want, &src, 2, 2, dw, dh);
+                assert_eq!(
+                    snap(&fast),
+                    snap(&want),
+                    "{fmt:?} {sw}x{sh} -> {dw}x{dh}: the fast blit must be BYTE-IDENTICAL to \
+                     image_scale::sample, not merely close"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn a_clipped_image_blit_narrows_its_loop_to_the_clip() {
+        // THE STRUCTURAL BUG. The blit walked every pixel of the image NODE and
+        // `continue`d on the clip test, so a 40 px damage strip over a
+        // 2078x1132 canvas still ran 2.35 M loop iterations — and, until this,
+        // 2.35 M `image_scale::sample` calls. The window the loop runs over
+        // must be the clip, not the node.
+        let win = visible_dst_window(100, 50, 2000, 1000, 4000, 2000, (140, 90, 180, 130))
+            .expect("the clip overlaps the image");
+        assert_eq!(win, (40, 40, 80, 80), "the loop must cover only the clipped 40x40");
+
+        // Nothing visible -> no loop at all, not a full-node walk that writes
+        // nothing.
+        assert!(
+            visible_dst_window(100, 50, 10, 10, 4000, 2000, (500, 500, 600, 600)).is_none(),
+            "a clip that misses the image must produce no window"
+        );
+
+        // The pixmap edge clamps exactly like the clip does: an image hanging
+        // off the top-left starts at the first on-screen pixel.
+        let win =
+            visible_dst_window(-20, -30, 100, 100, 50, 40, (i32::MIN, i32::MIN, i32::MAX, i32::MAX))
+                .expect("partly on screen");
+        assert_eq!(win, (20, 30, 70, 70));
+    }
+
+    #[test]
+    fn each_source_row_is_converted_once_not_once_per_destination_row() {
+        // THE COMPLEXITY INVARIANT, and the reason the fix is not just
+        // "inline sample()". A per-pixel `image_scale::sample` re-read the
+        // source through `SrcImage::pixel` FOUR times per destination pixel,
+        // each re-deriving the pixel format and re-clamping — 9.4 M
+        // format-dispatched reads for one 2x upscale of AzPaint's canvas.
+        //
+        // Converting each source row to straight RGBA once and reusing it
+        // makes the format dispatch O(source rows touched). Asserting that
+        // count is stable under machine load, unlike a millisecond threshold.
+        use azul_core::resources::RawImageFormat as F;
+
+        // 4x UPSCALE: 40 source rows feeding 160 destination rows.
+        let (sw, sh) = (50u32, 40u32);
+        let bytes = noisy_src(F::RGBA8, sw, sh);
+        let src =
+            crate::image_scale::SrcImage { bytes: &bytes, format: F::RGBA8, width: sw, height: sh };
+        let (dw, dh) = (200u32, 160u32);
+        let mut p = pixmap(dw, dh);
+        let mut conv = RowConversions::new();
+        blit_sampled_image(&mut p, &src, 0, 0, dw, dh, (0, 0, dw, dh), &mut conv);
+        assert!(
+            conv.0 <= sh as usize + 1,
+            "a {sh}-row source must be converted about once per row, not per destination row: \
+             {} conversions",
+            conv.0
+        );
+        assert!(
+            conv.0 < dh as usize,
+            "conversions ({}) must not scale with the {dh} destination rows",
+            conv.0
+        );
+
+        // 4x DOWNSCALE: every destination row averages 4 source rows, and the
+        // tap rows advance monotonically — so each source row is still read
+        // once, never once per tap.
+        let (sw, sh) = (200u32, 160u32);
+        let bytes = noisy_src(F::RGBA8, sw, sh);
+        let src =
+            crate::image_scale::SrcImage { bytes: &bytes, format: F::RGBA8, width: sw, height: sh };
+        let (dw, dh) = (50u32, 40u32);
+        let mut p = pixmap(dw, dh);
+        let mut conv = RowConversions::new();
+        blit_sampled_image(&mut p, &src, 0, 0, dw, dh, (0, 0, dw, dh), &mut conv);
+        assert!(
+            conv.0 <= sh as usize,
+            "a {sh}-row source downscaled 4x must convert at most {sh} rows, got {}",
+            conv.0
+        );
+
+        // A CLIPPED blit touches only the source rows its window needs — the
+        // point of narrowing the loop.
+        let mut p = pixmap(dw, dh);
+        let mut conv = RowConversions::new();
+        blit_sampled_image(&mut p, &src, 0, 0, dw, dh, (0, 0, dw, 4), &mut conv);
+        assert!(
+            conv.0 <= 4 * BLIT_MAX_TAPS as usize,
+            "4 clipped destination rows must not convert the whole {sh}-row source: {}",
+            conv.0
+        );
     }
 
     #[test]

--- a/layout/src/event_determination.rs
+++ b/layout/src/event_determination.rs
@@ -998,8 +998,30 @@ pub fn determine_all_events(
             }
         }
 
-        // Detect DoubleClick (targeted at hovered node)
-        if manager.detect_double_click() {
+        // Detect DoubleClick (targeted at hovered node), ONCE — on the release
+        // that completes the gesture.
+        //
+        // `detect_double_click()` is a pure predicate over the two most recent
+        // ENDED input sessions and nothing consumes them: they stay the newest
+        // pair until the next PRESS. So without an edge of its own this raised
+        // the same double-click on every later pass — and the pass that carries
+        // it recurses (a focus change or a `RefreshDom` re-enters
+        // `process_window_events`), advancing only `previous_window_state`,
+        // never the gesture manager. That is why double-clicking the custom
+        // title bar in AzWidgets maximized the window and instantly restored
+        // it: the framework's `-azul-app-region: drag` handler TOGGLES
+        // `flags.frame`, and it ran twice for one gesture.
+        //
+        // The mouse-release edge is the right gate because that release is what
+        // ends the second session and makes the predicate true in the first
+        // place. An INJECTED native double-click is exempt: it has its own
+        // consumption (the event loop clears the latch at the end of the pass)
+        // and its injection point — `CallbackChange::InjectNativeGesture`, the
+        // e2e `double_click` op, iOS/Android recognizers — carries no button
+        // transition to hang an edge off.
+        if manager.has_injected_double_click()
+            || (event_was_mouse_release && manager.detect_double_click())
+        {
             events.push(SyntheticEvent::new(
                 EventType::DoubleClick,
                 EventSource::User,
@@ -2725,6 +2747,81 @@ mod autotest_generated {
         g.inject_native_gesture(NativeGestureEvent::DoubleClick);
         let events = run(&s, &s, &HoverManager::new(), Some(&g), None);
         assert_eq!(count(&events, EventType::DoubleClick), 1);
+    }
+
+    /// Two complete press/release cycles at the same spot, the way the shell
+    /// records them (`record_gesture_input` -> `start_input_session` /
+    /// `end_current_session`).
+    fn manager_after_a_real_double_click() -> GestureAndDragManager {
+        let mut g = GestureAndDragManager::new();
+        // 6 ticks == 100 ms at the nominal 60 fps `SystemTick` rate, well
+        // inside the 500 ms double-click window.
+        for tick in [0_u64, 6] {
+            g.start_input_session(
+                LogicalPosition::new(40.0, 12.0),
+                ts(tick),
+                1,
+                WindowPosition::Uninitialized,
+                LogicalPosition::new(40.0, 12.0),
+            );
+            g.end_current_session();
+        }
+        g
+    }
+
+    fn left_down_at(x: f32, y: f32) -> FullWindowState {
+        let mut s = cursor_at(x, y);
+        s.mouse_state.left_down = true;
+        s
+    }
+
+    #[test]
+    fn a_double_click_is_raised_by_the_release_that_completes_it() {
+        let g = manager_after_a_real_double_click();
+        let events = run(
+            &cursor_at(40.0, 12.0),
+            &left_down_at(40.0, 12.0),
+            &HoverManager::new(),
+            Some(&g),
+            None,
+        );
+        assert_eq!(count(&events, EventType::DoubleClick), 1);
+    }
+
+    #[test]
+    fn a_completed_double_click_is_not_raised_again_by_a_later_pass() {
+        // `detect_double_click()` is a pure predicate over the two most recent
+        // ENDED sessions, and nothing consumes them — they stay the newest pair
+        // until the next PRESS. Every pass after the release therefore used to
+        // raise the SAME double-click again: the recursion inside
+        // `process_window_events` (which advances `previous_window_state` but
+        // not the gesture manager) fires immediately, a mouse move fires later.
+        // Because the `-azul-app-region: drag` handler TOGGLES `flags.frame`,
+        // that is a window that maximizes and instantly restores itself.
+        let g = manager_after_a_real_double_click();
+        let released = cursor_at(40.0, 12.0);
+
+        // 1. The recursion: previous == current, so no button transition at all.
+        let recursed = run(&released, &released, &HoverManager::new(), Some(&g), None);
+        assert_eq!(
+            count(&recursed, EventType::DoubleClick),
+            0,
+            "the same double-click was raised again on re-entry: {recursed:?}"
+        );
+
+        // 2. A later pass carrying an unrelated change (the cursor moved).
+        let moved = run(
+            &cursor_at(41.0, 13.0),
+            &released,
+            &HoverManager::new(),
+            Some(&g),
+            None,
+        );
+        assert_eq!(
+            count(&moved, EventType::DoubleClick),
+            0,
+            "the same double-click was raised again on a mouse move: {moved:?}"
+        );
     }
 
     #[test]

--- a/layout/src/headless.rs
+++ b/layout/src/headless.rs
@@ -471,10 +471,19 @@ fn compute_node_chains(
 
 /// A resolved `VirtualView` child-DOM placement.
 ///
-/// The composite rect in window space plus the host-side chain (scroll
-/// frames AND reference frames) active at the `VirtualView` item.
+/// TWO rectangles, and they are not the same one:
+///
+/// * `rect` — where the child dom's 0-relative boxes LAND, i.e.
+///   `bounds.origin + content_offset`. Scrolling moves this.
+/// * `clips` — the VIEWPORTS the child is visible through: every enclosing
+///   `VirtualView`'s own `bounds`, each paired with the host-side chain
+///   active where that viewport lives. Scrolling does NOT move these.
+///
+/// Plus the host-side chain (scroll frames AND reference frames) active at
+/// the innermost `VirtualView` item.
 struct Placement {
     rect: LogicalRect,
+    clips: Vec<(LogicalRect, Vec<HitChainLink>)>,
     chain: Vec<HitChainLink>,
 }
 
@@ -506,10 +515,10 @@ fn resolve_virtual_view_placements(
         // bounded depth; each pass resolves one nesting level
         let mut changed = false;
         for (host_dom, lr) in layout_results {
-            let (host_offset, host_chain) = if host_dom.inner == 0 {
-                (LogicalPosition::zero(), Vec::new())
+            let (host_offset, host_clips, host_chain) = if host_dom.inner == 0 {
+                (LogicalPosition::zero(), Vec::new(), Vec::new())
             } else if let Some(p) = placements.get(host_dom) {
-                (p.rect.origin, p.chain.clone())
+                (p.rect.origin, p.clips.clone(), p.chain.clone())
             } else {
                 continue;
             };
@@ -592,14 +601,36 @@ fn resolve_virtual_view_placements(
                             },
                             size: b.size,
                         };
+                        // …and the VIEWPORT it shows through, which is the
+                        // host box itself. `content_offset` moves the CONTENT
+                        // through the viewport; it does not move the viewport.
+                        // Clipping to `absolute` instead made the visible
+                        // window travel with the scroll: on a document scrolled
+                        // one page down, `content_offset.y` is a whole page
+                        // NEGATIVE, so the clip sat a page ABOVE the canvas and
+                        // rejected every node of the child dom. Clicks in the
+                        // page then hit nothing at all — no caret, no
+                        // selection, no typing — while the renderer (which
+                        // clips to `bounds`, see cpurender/raster.rs) went on
+                        // drawing the text the user was aiming at.
+                        let viewport = LogicalRect {
+                            origin: LogicalPosition {
+                                x: b.origin.x + host_offset.x,
+                                y: b.origin.y + host_offset.y,
+                            },
+                            size: b.size,
+                        };
+                        let mut clips = host_clips.clone();
+                        clips.push((viewport, stack.clone()));
                         let differs = placements.get(child_dom_id).is_none_or(|p| {
-                            p.rect != absolute || p.chain != stack
+                            p.rect != absolute || p.clips != clips || p.chain != stack
                         });
                         if differs {
                             placements.insert(
                                 *child_dom_id,
                                 Placement {
                                     rect: absolute,
+                                    clips,
                                     chain: stack.clone(),
                                 },
                             );
@@ -705,13 +736,20 @@ impl CpuHitTester {
             let nodes = &layout_result.layout_tree.nodes;
             let styled_dom = &layout_result.styled_dom;
 
-            // Child DOM: shift into window space + clip to the composite rect.
-            let (offset, dom_clip, base_chain_vec) = placements.get(dom_id).map_or_else(
-                || (LogicalPosition::zero(), None, Vec::new()),
-                |p| (p.rect.origin, Some(p.rect), p.chain.clone()),
+            // Child DOM: shift into window space by the placement origin, and
+            // clip to the host VIEWPORTS — a different rect, see `Placement`.
+            let (offset, dom_clip_rects, base_chain_vec) = placements.get(dom_id).map_or_else(
+                || (LogicalPosition::zero(), Vec::new(), Vec::new()),
+                |p| (p.rect.origin, p.clips.clone(), p.chain.clone()),
             );
             let base_chain = intern_chain(&mut self.chains, &mut chain_lookup, base_chain_vec);
-            let dom_clip_entry = dom_clip.map(|r| (r, base_chain));
+            let dom_clips: Vec<(LogicalRect, u32)> = dom_clip_rects
+                .into_iter()
+                .map(|(rect, chain)| {
+                    let interned = intern_chain(&mut self.chains, &mut chain_lookup, chain);
+                    (rect, interned)
+                })
+                .collect();
 
             let scroll_ids = &layout_result.scroll_ids;
             let transform_nodes = gpu
@@ -804,7 +842,7 @@ impl CpuHitTester {
                     positions,
                     idx,
                     offset,
-                    dom_clip_entry,
+                    &dom_clips,
                     &chain_of,
                 );
 
@@ -1125,11 +1163,11 @@ pub fn compute_scroll_child_rect(
     )
 }
 
-/// Compute the hit-test clip boxes for a layout node: the host `VirtualView`
-/// composite bounds (`dom_clip_entry`) plus every clipping ancestor's border
-/// box (any `overflow` other than `visible`), each tagged with the chain of
-/// the clip OWNER's strict scroll ancestors so the query can shift each box
-/// into its own scrolled space.
+/// Compute the hit-test clip boxes for a layout node: the enclosing
+/// `VirtualView` VIEWPORTS (`dom_clips`, outermost host first) plus every
+/// clipping ancestor's border box (any `overflow` other than `visible`), each
+/// tagged with the chain of the clip OWNER's strict scroll ancestors so the
+/// query can shift each box into its own scrolled space.
 ///
 /// Clipping is tracked per-axis because `overflow-x` / `overflow-y` are
 /// independent — an axis the ancestor does not clip is widened to
@@ -1145,7 +1183,7 @@ fn compute_node_clips(
     positions: &PositionVec,
     node_index: usize,
     offset: LogicalPosition,
-    dom_clip_entry: Option<(LogicalRect, u32)>,
+    dom_clips: &[(LogicalRect, u32)],
     chain_of: &[u32],
 ) -> Vec<(LogicalRect, u32)> {
     // A non-finite edge must degrade to "unclipped on that side", never be
@@ -1166,8 +1204,8 @@ fn compute_node_clips(
     }
 
     let mut clips = Vec::new();
-    if let Some((dc, chain)) = dom_clip_entry {
-        clips.push((sanitize_clip_rect(dc), chain));
+    for (dc, chain) in dom_clips {
+        clips.push((sanitize_clip_rect(*dc), *chain));
     }
 
     // Walk ancestors. A node's own overflow clips its descendants, not itself, so
@@ -1242,7 +1280,7 @@ fn compute_node_clip(
         positions,
         node_index,
         offset,
-        dom_clip.map(|r| (r, 0)),
+        &dom_clip.map(|r| (r, 0)).into_iter().collect::<Vec<_>>(),
         &chain_of,
     );
     if clips.is_empty() {
@@ -1398,6 +1436,22 @@ mod autotest_generated {
             bounds: WindowLogicalRect::new(bounds.origin, bounds.size),
             clip_rect: WindowLogicalRect::new(bounds.origin, bounds.size),
             content_offset: Default::default(),
+        }
+    }
+
+    /// A `VirtualView` whose materialized window is offset from the viewport —
+    /// what a scrolled virtual document produces
+    /// (`materialized_origin - scroll_offset`).
+    fn virtual_view_scrolled(
+        child: usize,
+        bounds: LogicalRect,
+        content_offset: LogicalPosition,
+    ) -> DisplayListItem {
+        DisplayListItem::VirtualView {
+            child_dom_id: dom(child),
+            bounds: WindowLogicalRect::new(bounds.origin, bounds.size),
+            clip_rect: WindowLogicalRect::new(bounds.origin, bounds.size),
+            content_offset,
         }
     }
 
@@ -1825,6 +1879,59 @@ mod autotest_generated {
         assert!(
             tester.hit_test(p(180.0, 180.0)).is_empty(),
             "inside the child's 200x200 rect but outside the 50x50 composite clip"
+        );
+    }
+
+    #[test]
+    fn a_scrolled_virtual_views_clip_stays_on_the_viewport_it_does_not_travel_with_the_content() {
+        // Host dom 0 shows child dom 1 through a 50x50 VIEWPORT at (100,100).
+        // The child is scrolled: `content_offset` is (0,-80), so the renderer
+        // draws the child's local (0,0) at (100,20) — 80px of it above the
+        // viewport, the rest visible from y=100 down (cpurender/raster.rs
+        // pushes `-vv_origin - content_offset` and clips to `bounds`).
+        //
+        // The hit test used the SHIFTED rect as the clip too, which moves the
+        // window the user is looking through. Both directions are wrong and
+        // both are asserted here.
+        let mut results = BTreeMap::new();
+        results.insert(
+            dom(0),
+            layout_result(
+                styled(""),
+                Vec::new(),
+                Vec::new(),
+                vec![virtual_view_scrolled(
+                    1,
+                    r(100.0, 100.0, 50.0, 50.0),
+                    p(0.0, -80.0),
+                )],
+            ),
+        );
+        results.insert(
+            dom(1),
+            layout_result(
+                styled(""),
+                vec![hot(Some(1), Some((200.0, 200.0)), None)],
+                vec![p(0.0, 0.0)],
+                Vec::new(),
+            ),
+        );
+
+        let mut tester = CpuHitTester::new();
+        tester.rebuild_from_layout(&results);
+
+        assert_eq!(
+            tester.hit_test(p(120.0, 120.0)),
+            vec![(dom(1), NodeId::new(1))],
+            "a point inside BOTH the viewport and the drawn child must hit it — \
+             clipping to `bounds.origin + content_offset` moved the viewport \
+             80px up and rejected it, which is a page canvas that goes dead as \
+             soon as you scroll"
+        );
+        assert!(
+            tester.hit_test(p(120.0, 60.0)).is_empty(),
+            "the part of the child scrolled ABOVE the viewport is not visible, \
+             so it must not take the click either"
         );
     }
 

--- a/layout/src/managers/a11y.rs
+++ b/layout/src/managers/a11y.rs
@@ -72,6 +72,37 @@ pub fn is_exposed_to_accessibility(node_data: &NodeData) -> bool {
         )
 }
 
+/// Does this declaration actually say what KIND of control the node is?
+///
+/// ONE definition, deliberately — three surfaces resolve a node's role (the
+/// accesskit tree's `A11yManager::build_node`, its no-layout fallback in
+/// `A11yManager::update_tree`, and the iOS/Android `A11ySnapshot`) and they
+/// must not disagree about it.
+///
+/// `AccessibilityRole::Unknown` is what `AccessibilityInfo::default()` hands
+/// out, and it is the value `AccessibilityInfo::assign` treats as "not
+/// specified" when it merges a patch. It therefore means *the declaration is
+/// silent about the kind of control*, NOT *this control is of an unknown
+/// kind* — so it must never outrank the element's own type.
+///
+/// It used to. Because `build_node` selected the role as "if there is any
+/// `AccessibilityInfo` at all, its `role` wins", the one-field form the engine
+/// itself recommends —
+///
+/// ```ignore
+/// slider.dom().with_accessibility_name("Volume")
+/// ```
+///
+/// — replaced the node's real role with `Role::Unknown`, which VoiceOver skips
+/// exactly the way it skips `GenericContainer`. Naming a control DELETED it
+/// from the accessibility tree, so the more accessibility an app declared the
+/// less of it a screen reader could reach: 25 of AzWidgets' 691 nodes were
+/// `Unknown` for this reason alone.
+#[must_use]
+pub fn accessibility_role_is_specified(role: &AccessibilityRole) -> bool {
+    !matches!(role, AccessibilityRole::Unknown)
+}
+
 /// Cursor/selection info passed to the a11y tree builder.
 /// Used to set `text_selection` on contenteditable nodes so screen readers
 /// can announce the cursor position and selection range.
@@ -237,7 +268,15 @@ impl A11yManager {
                 let mut node = if let Some((layout_node, _layout_idx, abs_pos)) = layout_info {
                     Self::build_node(node_data, layout_node, abs_pos, a11y_info_ref, hidpi_factor, window_size)
                 } else {
-                    let role = a11y_info_ref.map_or_else(|| Self::node_type_to_role(&node_data.node_type), |info| Self::map_role(&info.role));
+                    // Same rule as `build_node` (which this branch stands in
+                    // for when the node has no layout yet): only a SPECIFIED
+                    // role overrides the element's own type.
+                    let role = match a11y_info_ref {
+                        Some(info) if accessibility_role_is_specified(&info.role) => {
+                            Self::map_role(&info.role)
+                        }
+                        _ => Self::node_type_to_role(&node_data.node_type),
+                    };
                     let mut builder = Node::new(role);
                     if let NodeType::Text(text) = &node_data.node_type {
                         builder.set_label(text.as_str());
@@ -504,13 +543,19 @@ impl A11yManager {
         hidpi_factor: f32,
         window_size: LogicalSize,
     ) -> Node {
-        // Set role based on NodeType or AccessibilityInfo.
+        // Set role based on NodeType or AccessibilityInfo. A DECLARED role
+        // wins; an `Unknown` one is not a declaration at all — see
+        // `accessibility_role_is_specified`, which is why naming a control no
+        // longer erases its role.
         let role = if node_data.is_contenteditable() {
             Role::MultilineTextInput
-        } else if let Some(info) = a11y_info {
-            Self::map_role(&info.role)
         } else {
-            Self::node_type_to_role(&node_data.node_type)
+            match a11y_info {
+                Some(info) if accessibility_role_is_specified(&info.role) => {
+                    Self::map_role(&info.role)
+                }
+                _ => Self::node_type_to_role(&node_data.node_type),
+            }
         };
 
         let mut builder = Node::new(role);
@@ -1131,6 +1176,65 @@ mod autotest_generated {
             target_node: A11yNodeId(1),
             data,
         }
+    }
+
+    /// A `DomLayoutResult` carrying a real `StyledDom` but an EMPTY layout
+    /// tree. `update_tree`'s tree SHAPE — who is whose child, what is
+    /// reachable, where focus lands — is a pure function of `node_data` +
+    /// `node_hierarchy`; the layout tree only supplies bounds. So this is
+    /// enough to reproduce exactly the tree a real window publishes, with no
+    /// solver pass and no fonts.
+    fn layout_result_of(styled_dom: azul_core::styled_dom::StyledDom) -> DomLayoutResult {
+        use std::{collections::HashMap, sync::Arc};
+
+        use azul_core::geom::LogicalRect;
+
+        use crate::solver3::{display_list::DisplayList, layout_tree::LayoutTree};
+
+        DomLayoutResult {
+            styled_dom,
+            layout_tree: LayoutTree {
+                nodes: Vec::new(),
+                warm: Vec::new(),
+                cold: Vec::new(),
+                root: 0,
+                dom_to_layout: BTreeMap::new(),
+                children_arena: Vec::new(),
+                children_offsets: Vec::new(),
+                subtree_needs_intrinsic: Vec::new(),
+            },
+            calculated_positions: Vec::new(),
+            viewport: LogicalRect::zero(),
+            display_list: Arc::new(DisplayList::default()),
+            scroll_ids: HashMap::new(),
+            scroll_id_to_node_id: HashMap::new(),
+        }
+    }
+
+    /// `update_tree` over a set of real DOMs, one per `DomId`, in id order.
+    fn update_over_doms(doms: Vec<azul_core::dom::Dom>) -> TreeUpdate {
+        use azul_core::styled_dom::StyledDom;
+
+        let mut layout_results = BTreeMap::new();
+        for (i, dom) in doms.into_iter().enumerate() {
+            layout_results.insert(
+                DomId { inner: i },
+                layout_result_of(StyledDom::create_from_dom(dom)),
+            );
+        }
+        let scroll_manager = ScrollManager::new();
+        let overrides = BTreeMap::new();
+        A11yManager::update_tree(
+            A11yNodeId(0),
+            &layout_results,
+            &scroll_manager,
+            &AzString::from("Azul Widget Showcase"),
+            LogicalSize::new(1000.0, 700.0),
+            None,
+            1.0,
+            &overrides,
+            None,
+        )
     }
 
     /// `update_tree` with no DOMs at all — the smallest legal input.
@@ -2294,6 +2398,188 @@ mod autotest_generated {
             update.focus,
             A11yNodeId(0),
             "with no content nodes, focus must fall back to the root"
+        );
+    }
+
+    // ---------------------------------------------------------------------
+    // Naming a control must not DELETE it (the AzWidgets a11y regression)
+    // ---------------------------------------------------------------------
+
+    #[test]
+    fn naming_a_node_keeps_the_role_its_element_type_implies() {
+        // The one-field form the engine's own lint recommends. It produces
+        // `AccessibilityInfo { name: Some(..), role: Unknown, .. }`, and
+        // `Unknown` is `Default`'s "not specified" — so the element's own kind
+        // must survive. It used to be replaced by `Role::Unknown`, which
+        // VoiceOver skips exactly the way it skips `GenericContainer`: naming a
+        // control removed it from the tree.
+        for (node_type, expected) in [
+            (NodeType::Button, Role::Button),
+            (NodeType::Div, Role::Group),
+            (NodeType::A, Role::Link),
+            (NodeType::Input, Role::TextInput),
+            (NodeType::H1, Role::Heading),
+        ] {
+            let mut a11y = AccessibilityInfo::default();
+            a11y.accessibility_name = OptionString::Some(AzString::from("Accent colour"));
+            assert_eq!(
+                a11y.role,
+                AccessibilityRole::Unknown,
+                "the fixture must exercise the unspecified-role case"
+            );
+
+            let node = A11yManager::build_node(
+                &NodeData::create_node(node_type.clone()),
+                &plain_hot(),
+                None,
+                Some(&a11y),
+                1.0,
+                LogicalSize::new(800.0, 600.0),
+            );
+            assert_eq!(
+                node.role(),
+                expected,
+                "{node_type:?} lost its role to a name-only declaration"
+            );
+            assert_eq!(node.label(), Some("Accent colour"), "the name must survive too");
+        }
+    }
+
+    #[test]
+    fn a_declared_role_still_outranks_the_element_type() {
+        // The other half of the contract: an explicit role is authoritative.
+        let mut a11y = info(AccessibilityRole::Slider);
+        a11y.accessibility_name = OptionString::Some(AzString::from("Volume"));
+        let node = A11yManager::build_node(
+            &NodeData::create_node(NodeType::Div),
+            &plain_hot(),
+            None,
+            Some(&a11y),
+            1.0,
+            LogicalSize::new(800.0, 600.0),
+        );
+        assert_eq!(node.role(), Role::Slider);
+    }
+
+    #[test]
+    fn no_named_node_in_a_widget_showcase_tree_is_announced_as_unknown() {
+        // Whole-tree statement of the same bug, over the shape AzWidgets
+        // actually builds: a labelled section whose control carries a name and
+        // nothing else. `Role::Unknown` must not appear anywhere.
+        use azul_core::dom::Dom;
+
+        let labelled = |caption: &str, control: Dom| {
+            Dom::create_div()
+                .with_child(Dom::create_span_with_text(caption))
+                // Exactly what `examples/azul-widgets`' `labelled()` helper
+                // does: the caption a sighted user reads IS the control's name.
+                .with_child(control.with_accessibility_name(caption))
+        };
+        let body = Dom::create_body().with_child(
+            Dom::create_div()
+                .with_child(labelled("Accent colour", Dom::create_div()))
+                .with_child(labelled("Volume", Dom::create_div()))
+                .with_child(labelled("Subscribe", Dom::create_div())),
+        );
+
+        let update = update_over_doms(vec![body]);
+        let unknown: Vec<_> = update
+            .nodes
+            .iter()
+            .filter(|(_, n)| n.role() == Role::Unknown)
+            .map(|(id, n)| (*id, n.label()))
+            .collect();
+        assert!(
+            unknown.is_empty(),
+            "named controls fell out of the tree as Role::Unknown: {unknown:?}"
+        );
+    }
+
+    #[test]
+    fn the_ios_android_snapshot_resolves_roles_the_same_way_the_accesskit_tree_does() {
+        // `A11ySnapshot` is the platform-neutral twin for the two shells
+        // accesskit has no backend for. It carried the identical defect, and a
+        // second copy of a rule is how the two drift apart — both now go
+        // through `accessibility_role_is_specified`.
+        use azul_core::{dom::Dom, styled_dom::StyledDom};
+
+        use crate::managers::{a11y_snapshot::A11ySnapshot, gpu_state::GpuStateManager};
+
+        let mut layout_results = BTreeMap::new();
+        layout_results.insert(
+            DomId { inner: 0 },
+            layout_result_of(StyledDom::create_from_dom(Dom::create_body().with_child(
+                Dom::create_button("Subscribe", azul_core::a11y::SmallAriaInfo::label("Subscribe"))
+                    .with_accessibility_name("Subscribe"),
+            ))),
+        );
+        let gpu = GpuStateManager::new(
+            azul_core::task::Duration::from_millis(0),
+            azul_core::task::Duration::from_millis(0),
+        );
+        let snapshot = A11ySnapshot::build(
+            &layout_results,
+            &ScrollManager::new(),
+            &gpu,
+            None,
+            "t",
+            LogicalSize::new(800.0, 600.0),
+        );
+        let unknown: Vec<_> = snapshot
+            .elements
+            .iter()
+            .filter(|e| e.role == AccessibilityRole::Unknown)
+            .map(|e| e.label.clone())
+            .collect();
+        assert!(
+            unknown.is_empty(),
+            "named elements came back with an Unknown role: {unknown:?}"
+        );
+    }
+
+    #[test]
+    fn a_well_formed_multi_dom_tree_passes_through_the_guard_untouched() {
+        // The consistency guard exists to neutralise MALFORMED input. On a
+        // well-formed one — including the main window merged with a
+        // `<transient-window>` child DOM — it must be a NO-OP: every node
+        // present, reachable exactly once, nothing re-hung on the root. (The
+        // AzWidgets a11y regression was blamed on this guard; it is not the
+        // culprit, and this pins that.)
+        use azul_core::dom::Dom;
+
+        let page = |name: &str| {
+            Dom::create_body()
+                .with_child(Dom::create_span_with_text(name))
+                .with_child(
+                    Dom::create_div()
+                        .with_child(Dom::create_span_with_text("one"))
+                        .with_child(Dom::create_span_with_text("two")),
+                )
+        };
+        let update = update_over_doms(vec![page("main"), page("popup")]);
+
+        let by_id: HashMap<A11yNodeId, &Node> =
+            update.nodes.iter().map(|(id, n)| (*id, n)).collect();
+        let root = by_id[&A11yNodeId(0)];
+        assert_eq!(
+            root.children().len(),
+            2,
+            "one root child per DOM, and no orphan re-hung alongside them: {:?}",
+            root.children()
+        );
+
+        let mut reachable = std::collections::HashSet::new();
+        let mut stack = vec![A11yNodeId(0)];
+        while let Some(id) = stack.pop() {
+            assert!(reachable.insert(id), "{id:?} is reachable twice");
+            if let Some(n) = by_id.get(&id) {
+                stack.extend(n.children().iter().copied());
+            }
+        }
+        assert_eq!(
+            reachable.len(),
+            update.nodes.len(),
+            "the guard dropped nodes from a well-formed tree"
         );
     }
 

--- a/layout/src/managers/a11y_snapshot.rs
+++ b/layout/src/managers/a11y_snapshot.rs
@@ -210,10 +210,18 @@ impl A11ySnapshot {
                     }
                 }
 
-                let role = node_data.get_accessibility_info().map_or_else(
-                    || node_type_to_role(&node_data.node_type),
-                    |info| info.role,
-                );
+                // A DECLARED role wins; `Unknown` is the default that means
+                // "not specified" and must not erase the element's own kind.
+                // Same rule the accesskit tree applies — see
+                // `crate::managers::a11y::accessibility_role_is_specified`.
+                let role = match node_data.get_accessibility_info() {
+                    Some(info)
+                        if crate::managers::a11y::accessibility_role_is_specified(&info.role) =>
+                    {
+                        info.role
+                    }
+                    _ => node_type_to_role(&node_data.node_type),
+                };
 
                 let mut checked = None;
                 let mut disabled = false;

--- a/layout/src/managers/focus_cursor.rs
+++ b/layout/src/managers/focus_cursor.rs
@@ -476,6 +476,42 @@ fn find_first_matching_focusable_node(
     })
 }
 
+/// The child DOMs `host` mounts through `VirtualView` items, transitively, in
+/// display-list order.
+///
+/// Read off the host's display list — the same place
+/// `headless::resolve_virtual_view_placements` reads it — because that is the
+/// only host→child link available to a function that is handed nothing but
+/// `layout_results`. Bounded by the number of layout results, so a cyclic or
+/// self-referential item cannot spin.
+fn nested_dom_ids(
+    layout_results: &BTreeMap<DomId, DomLayoutResult>,
+    host: DomId,
+) -> Vec<DomId> {
+    use crate::solver3::display_list::DisplayListItem;
+
+    let mut out: Vec<DomId> = Vec::new();
+    let mut queue: Vec<DomId> = vec![host];
+    let mut head = 0usize;
+    let limit = layout_results.len().saturating_add(1);
+    while head < queue.len() && head < limit {
+        let current = queue[head];
+        head += 1;
+        let Some(lr) = layout_results.get(&current) else {
+            continue;
+        };
+        for item in lr.display_list.items.iter() {
+            if let DisplayListItem::VirtualView { child_dom_id, .. } = item {
+                if *child_dom_id != host && !out.contains(child_dom_id) {
+                    out.push(*child_dom_id);
+                    queue.push(*child_dom_id);
+                }
+            }
+        }
+    }
+    out
+}
+
 /// Resolve a `FocusTarget`, or QUEUE it when there is no layout to resolve
 /// against yet.
 ///
@@ -529,7 +565,31 @@ pub fn resolve_focus_target(
     match focus_target {
         Path(FocusTargetPath { dom, css_path }) => {
             let layout = ctx.get_layout(dom)?;
-            Ok(find_first_matching_focusable_node(layout, dom, css_path))
+            if let Some(found) = find_first_matching_focusable_node(layout, dom, css_path) {
+                return Ok(Some(found));
+            }
+            // A `VirtualView` mounts its callback's DOM as a SEPARATE layout
+            // result under its own DomId. To the app that subtree is part of
+            // the same document — it wrote it, it gets its edit callbacks —
+            // but a selector resolved against the HOST dom alone could never
+            // see it, so `set_focus_to_path` matched nothing and the caller's
+            // focus request was applied as "clear focus".
+            //
+            // That is why an app whose editable content lives in a VirtualView
+            // (AzWriter's page canvas) opened with no caret at all: its
+            // startup focus targeted `.mw-doc`, which is a class on the page
+            // content root inside the nested dom.
+            for nested in nested_dom_ids(layout_results, *dom) {
+                let Some(nested_layout) = layout_results.get(&nested) else {
+                    continue;
+                };
+                if let Some(found) =
+                    find_first_matching_focusable_node(nested_layout, &nested, css_path)
+                {
+                    return Ok(Some(found));
+                }
+            }
+            Ok(None)
         }
 
         Id(dom_node_id) => {
@@ -695,6 +755,25 @@ mod autotest_generated {
             scroll_ids: HashMap::new(),
             scroll_id_to_node_id: HashMap::new(),
         }
+    }
+
+    /// A host display list that mounts `child` through a `VirtualView` item —
+    /// the only host→child link `resolve_focus_target` can read.
+    fn virtual_view_display_list(child: DomId) -> DisplayList {
+        use azul_core::geom::{LogicalPosition, LogicalSize};
+
+        use crate::solver3::display_list::{DisplayListItem, WindowLogicalRect};
+
+        let bounds =
+            WindowLogicalRect::new(LogicalPosition::zero(), LogicalSize::new(100.0, 100.0));
+        let mut dl = DisplayList::default();
+        dl.items.push(DisplayListItem::VirtualView {
+            child_dom_id: child,
+            bounds,
+            clip_rect: bounds,
+            content_offset: LogicalPosition::zero(),
+        });
+        dl
     }
 
     fn window(entries: Vec<(DomId, StyledDom)>) -> BTreeMap<DomId, DomLayoutResult> {
@@ -1432,6 +1511,83 @@ mod autotest_generated {
             css_path: class_path("no-such-class"),
         });
         assert_eq!(resolve_focus_target(&target, &results, None), Ok(None));
+    }
+
+    /// A `VirtualView` mounts its DOM under its OWN DomId, so a selector the
+    /// app resolves against the host dom must still find it — otherwise an app
+    /// whose editable content lives in a VirtualView can never focus it by
+    /// path, and the request lands as "clear focus".
+    ///
+    /// This is AzWriter's startup caret: `set_focus_to_path(ROOT, ".mw-doc")`,
+    /// where `.mw-doc` is on the page content root inside the nested dom.
+    #[test]
+    fn resolve_focus_target_path_reaches_into_a_virtual_views_nested_dom() {
+        let host = StyledDom::create_from_dom(Dom::create_body().with_child(Dom::create_div()));
+        let mut page = Dom::create_div();
+        page.set_contenteditable(true);
+        let nested = StyledDom::create_from_dom(
+            Dom::create_body().with_child(
+                page.with_ids_and_classes(
+                    vec![azul_core::dom::IdOrClass::Class("mw-doc".into())].into(),
+                ),
+            ),
+        );
+
+        let mut results = window(vec![(dom(0), host), (dom(1), nested)]);
+        results
+            .get_mut(&dom(0))
+            .unwrap()
+            .display_list = std::sync::Arc::new(virtual_view_display_list(dom(1)));
+
+        let target = FocusTarget::Path(FocusTargetPath {
+            dom: dom(0),
+            css_path: class_path("mw-doc"),
+        });
+        assert_eq!(
+            resolve_focus_target(&target, &results, None),
+            Ok(Some(nid(1, 1))),
+            "the selector must resolve into the dom the VirtualView mounted; \
+             answering None here is applied by every caller as 'clear focus', \
+             which is why the editor opened with no caret"
+        );
+    }
+
+    #[test]
+    fn resolve_focus_target_path_still_prefers_the_host_dom_over_a_nested_one() {
+        // Both doms carry `.target`; the host's match wins, so adding the
+        // nested search cannot steal a focus that already resolved.
+        let host = StyledDom::create_from_dom(
+            Dom::create_body().with_child(
+                Dom::create_div()
+                    .with_tab_index(TabIndex::Auto)
+                    .with_ids_and_classes(
+                        vec![azul_core::dom::IdOrClass::Class("target".into())].into(),
+                    ),
+            ),
+        );
+        let nested = StyledDom::create_from_dom(
+            Dom::create_body().with_child(
+                Dom::create_div()
+                    .with_tab_index(TabIndex::Auto)
+                    .with_ids_and_classes(
+                        vec![azul_core::dom::IdOrClass::Class("target".into())].into(),
+                    ),
+            ),
+        );
+        let mut results = window(vec![(dom(0), host), (dom(1), nested)]);
+        results
+            .get_mut(&dom(0))
+            .unwrap()
+            .display_list = std::sync::Arc::new(virtual_view_display_list(dom(1)));
+
+        let target = FocusTarget::Path(FocusTargetPath {
+            dom: dom(0),
+            css_path: class_path("target"),
+        });
+        assert_eq!(
+            resolve_focus_target(&target, &results, None),
+            Ok(Some(nid(0, 1)))
+        );
     }
 
     #[test]

--- a/layout/src/managers/gesture.rs
+++ b/layout/src/managers/gesture.rs
@@ -1081,11 +1081,32 @@ impl GestureAndDragManager {
         }
     }
 
+    /// Did the PLATFORM report a double-click (as opposed to this manager
+    /// inferring one from the session history)?
+    ///
+    /// The injected gesture is CONSUMED — the event loop clears the latch at
+    /// the end of the pass that saw it — whereas [`Self::detect_double_click`]
+    /// is a pure predicate over the session history that stays true until the
+    /// next press. Event *determination* has to tell those two apart, because
+    /// only the injected one may fire without a mouse-release edge.
+    #[must_use]
+    pub const fn has_injected_double_click(&self) -> bool {
+        matches!(self.native_gesture, Some(NativeGestureEvent::DoubleClick))
+    }
+
     /// Detect if last two sessions form a double-click.
     ///
     /// Returns true if timing and distance match double-click criteria.
+    ///
+    /// PURE PREDICATE, deliberately: `CallbackInfo::was_double_clicked` asks it
+    /// during dispatch, so it must still answer `true` after the event that
+    /// carried the double-click was raised. Nothing here is consumed — the two
+    /// ended sessions stay the newest pair until the next press — so a CALLER
+    /// that turns this into an event owes it an edge of its own (see
+    /// `determine_all_events`, which only raises `DoubleClick` on the release
+    /// that completes the gesture).
     #[must_use] pub fn detect_double_click(&self) -> bool {
-        if matches!(self.native_gesture, Some(NativeGestureEvent::DoubleClick)) {
+        if self.has_injected_double_click() {
             return true;
         }
         let sessions = &self.input_sessions;

--- a/layout/src/managers/scroll_state.rs
+++ b/layout/src/managers/scroll_state.rs
@@ -657,6 +657,9 @@ impl ScrollManager {
             eff_y,
         );
         let (dom_id, node_id) = target?;
+        let (delta_x, delta_y) = self.map_wheel_onto_the_only_scrollable_axis(
+            dom_id, node_id, delta_x, delta_y,
+        );
         let input = ScrollInput {
             dom_id,
             node_id,
@@ -700,6 +703,51 @@ impl ScrollManager {
             }
         }
         fallback
+    }
+
+    /// A vertical wheel over a box that can ONLY scroll horizontally moves it
+    /// horizontally.
+    ///
+    /// Every browser does this, and without it a horizontal strip — a page
+    /// rail, a tab bar, a filmstrip — is simply dead to the normal gesture. A
+    /// mouse wheel has no horizontal axis at all, and on a Mac trackpad a
+    /// genuine horizontal swipe is frequently claimed by the system for
+    /// back/forward navigation, so the vertical delta is in practice the only
+    /// input such a box can ever receive.
+    ///
+    /// Only applies when the delta is purely vertical and the target has no
+    /// vertical travel whatsoever: a box that scrolls both ways keeps both
+    /// axes, and a real horizontal delta is passed through untouched.
+    ///
+    /// The RAW device delta was already stored in `pending_wheel_event` above,
+    /// so wheel-as-zoom widgets still see what the hardware actually reported.
+    fn map_wheel_onto_the_only_scrollable_axis(
+        &self,
+        dom_id: DomId,
+        node_id: NodeId,
+        delta_x: f32,
+        delta_y: f32,
+    ) -> (f32, f32) {
+        const EPS: f32 = 0.5;
+        if delta_x.abs() > EPS || delta_y.abs() <= EPS {
+            return (delta_x, delta_y);
+        }
+        let Some(state) = self.states.get(&(dom_id, node_id)) else {
+            return (delta_x, delta_y);
+        };
+        let effective_width = state
+            .virtual_scroll_size
+            .map_or(state.content_rect.size.width, |s| s.width);
+        let effective_height = state
+            .virtual_scroll_size
+            .map_or(state.content_rect.size.height, |s| s.height);
+        let max_x = (effective_width - state.container_rect.size.width).max(0.0);
+        let max_y = (effective_height - state.container_rect.size.height).max(0.0);
+        if max_y <= EPS && max_x > EPS {
+            (delta_y, 0.0)
+        } else {
+            (delta_x, delta_y)
+        }
     }
 
     /// MWA-B10: the a11y tree's scroll surface for a node — current offset
@@ -2936,6 +2984,52 @@ mod autotest_generated {
         assert!(m.can_consume_delta(DOM, node(0), 0.0, f32::NEG_INFINITY));
         assert!(m.can_consume_delta(DOM, node(0), 0.0, f32::MAX));
         assert!(!m.can_consume_delta(DOM, node(999), 0.0, f32::MAX), "unknown node");
+    }
+
+    // ======================================== map_wheel_onto_the_only_scrollable_axis
+
+    #[test]
+    fn a_vertical_wheel_scrolls_a_strip_that_can_only_move_horizontally() {
+        // A page rail / tab bar / filmstrip. A mouse wheel has no horizontal
+        // axis, so without this the strip cannot be scrolled by wheel at all.
+        let m = mgr(size(100.0, 40.0), size(900.0, 40.0));
+        assert_eq!(
+            m.map_wheel_onto_the_only_scrollable_axis(DOM, node(0), 0.0, 30.0),
+            (30.0, 0.0),
+        );
+    }
+
+    #[test]
+    fn a_box_that_scrolls_both_ways_keeps_the_axes_the_device_reported() {
+        // Transposing here would make a vertical gesture pan sideways on any
+        // ordinary two-way scroller — far worse than the dead strip it fixes.
+        let m = mgr(size(100.0, 100.0), size(900.0, 900.0));
+        assert_eq!(
+            m.map_wheel_onto_the_only_scrollable_axis(DOM, node(0), 0.0, 30.0),
+            (0.0, 30.0),
+        );
+    }
+
+    #[test]
+    fn a_real_horizontal_delta_is_never_rewritten() {
+        // A trackpad swipe that already carries x must pass through untouched,
+        // or a diagonal gesture would lose its vertical component.
+        let m = mgr(size(100.0, 40.0), size(900.0, 40.0));
+        assert_eq!(
+            m.map_wheel_onto_the_only_scrollable_axis(DOM, node(0), -12.0, 30.0),
+            (-12.0, 30.0),
+        );
+    }
+
+    #[test]
+    fn a_strip_with_nothing_to_scroll_is_left_alone() {
+        // No travel on either axis: rewriting would hand the physics a delta
+        // for an axis that cannot move, which reads as an overscroll bounce.
+        let m = mgr(size(100.0, 40.0), size(100.0, 40.0));
+        assert_eq!(
+            m.map_wheel_onto_the_only_scrollable_axis(DOM, node(0), 0.0, 30.0),
+            (0.0, 30.0),
+        );
     }
 
     // ==================================================== select_scroll_target

--- a/layout/src/solver3/layout_tree.rs
+++ b/layout/src/solver3/layout_tree.rs
@@ -4190,6 +4190,32 @@ fn establishes_new_block_formatting_context(styled_dom: &StyledDom, node_id: Nod
 // +spec:display-property:46e71c - Maps outer display (block/inline) and inner display (flow/flow-root/table/flex/grid) to FormattingContext
 // +spec:display-property:aa582d - maps display types to formatting contexts (inline-level, block-level, atomic inline, block container)
 #[allow(clippy::match_same_arms)] // enum/value mapping/dispatch table: one arm per input variant (or cross-type bindings that can't merge)
+/// A CHILDLESS block that is (or sits inside) a `contenteditable` editing host
+/// still establishes an inline formatting context.
+///
+/// `layout_ifc` keeps ONE line box — the editing-host strut — for an IFC root
+/// with no inline content that is editable: the line the caret stands on, the
+/// height `display_list::empty_editable_caret_rect` paints into, and the box a
+/// click has to land in. A block with NO CHILDREN AT ALL never reached that
+/// code, because `has_only_inline_children` answers false for "no children"
+/// (an empty box is neither inline nor block content), so the box became a
+/// Block FC and collapsed to zero height.
+///
+/// A brand-new document is exactly one such box: an empty `<p>` inside the
+/// editable content root. With no line box there was nothing to click, nothing
+/// to paint a caret on, and no way to start typing — you could only get a
+/// caret into a document that already had text in it.
+///
+/// Non-editable empty blocks are untouched: they keep collapsing to nothing.
+fn is_empty_editing_host_line(styled_dom: &StyledDom, node_id: NodeId) -> bool {
+    let hierarchy = styled_dom.node_hierarchy.as_container();
+    let has_children = hierarchy
+        .get(node_id)
+        .and_then(|h| h.first_child_id(node_id))
+        .is_some();
+    !has_children && crate::solver3::getters::is_node_contenteditable_inherited(styled_dom, node_id)
+}
+
 fn determine_formatting_context_for_display(
     styled_dom: &StyledDom,
     node_id: NodeId,
@@ -4219,7 +4245,9 @@ fn determine_formatting_context_for_display(
             establishes_new_context: true,
         },
         LayoutDisplay::Block | LayoutDisplay::ListItem => {
-            if has_only_inline_children(styled_dom, node_id) {
+            if has_only_inline_children(styled_dom, node_id)
+                || is_empty_editing_host_line(styled_dom, node_id)
+            {
                 #[cfg(feature = "web_lift")]
                 unsafe { crate::az_mark(((0x60B60 + (node_id.index() & 7) * 4)) as u32, (0xC0DE0002) as u32); }
                 FormattingContext::Inline

--- a/layout/src/solver3/sizing.rs
+++ b/layout/src/solver3/sizing.rs
@@ -71,6 +71,15 @@ fn resolve_px_with_box_model(
     }
 
     let percent = px.to_percent()?;
+    // css-sizing-3 §5.2.1 (febf0c): a percentage that would resolve against an
+    // INDEFINITE size cannot resolve at all. Returning None routes every caller
+    // to its own "no constraint" answer — min-* becomes 0, max-* becomes
+    // unbounded — instead of manufacturing an infinite length that a later
+    // clamp would then FORCE onto the box (a percent min-width was enough to
+    // re-infect a width the main resolution had already fixed up).
+    if !containing.is_finite() {
+        return None;
+    }
     let (margin, border, padding) = if is_horizontal {
         (
             (box_props.margin.left, box_props.margin.right),
@@ -1784,7 +1793,22 @@ pub fn calculate_used_size_for_node(
         }
     };
     // css-sizing-3: "the used value is floored to preserve a non-negative inner size"
-    let resolved_width = resolved_width.max(0.0);
+    //
+    // And a net over EVERY arm above: a width that came out non-finite means
+    // some input resolved against the indefinite (measurement-pass) containing
+    // block — a percentage, a calc() with percent terms, anything. Spec-wise
+    // such a size "behaves as auto" (febf0c), and auto under an indefinite
+    // constraint is the max-content contribution (see
+    // auto_block_inline_size_definite_or_max_content). Letting the infinity
+    // through instead PERSISTS it as the node's used size, and no later stage
+    // survives that — it becomes an infinite clip, u32::MAX device pixels, and
+    // a ~900 GB pixmap request. Not loud: this is a legitimate, per-frame
+    // situation during measurement, not a bug to report.
+    let resolved_width = if resolved_width.is_finite() {
+        resolved_width.max(0.0)
+    } else {
+        intrinsic.max_content_width.max(0.0)
+    };
 
     // +spec:height-calculation:7880e3 - Distinction between box types for height/margin calculation
     // +spec:height-calculation:753d8d - Height calculation for various box types (§10.6)
@@ -1914,7 +1938,12 @@ pub fn calculate_used_size_for_node(
         }
     };
     // css-sizing-3: "the used value is floored to preserve a non-negative inner size"
-    let resolved_height = resolved_height.max(0.0);
+    // Same indefinite-input net as resolved_width above.
+    let resolved_height = if resolved_height.is_finite() {
+        resolved_height.max(0.0)
+    } else {
+        intrinsic.max_content_height.max(0.0)
+    };
 
     // +spec:replaced-elements:5a85ce - abs-pos replaced: derive auto width from height × intrinsic ratio
     // +spec:replaced-elements:aedb26 - abs-pos replaced: both auto, ratio but no intrinsic w/h → block constraint
@@ -2682,15 +2711,27 @@ mod autotest_generated {
     }
 
     #[test]
-    fn resolve_px_percentage_against_a_degenerate_containing_block_is_zero() {
+    fn resolve_px_percentage_against_a_degenerate_containing_block_cannot_resolve() {
+        // A non-finite containing dimension is INDEFINITE, and css-sizing-3
+        // says a percentage against it cannot resolve — so the answer is None,
+        // routing each caller to its own "no constraint" fallback. The old
+        // contract answered Some(0.0) instead, which zeroed a percent
+        // max-width under a measurement pass and crushed the box.
         let bp = zero_props();
         let px = PixelValue::const_percent(50);
-        for cb in [-800.0, f32::NAN, f32::NEG_INFINITY] {
-            let r = resolve_px_with_box_model(&px, cb, &bp, true, 16.0, 16.0)
-                .expect("a percentage always resolves to Some");
-            assert!(!r.is_nan(), "NaN escaped for cb={cb}");
-            assert_eq!(r, 0.0, "cb={cb}");
+        for cb in [f32::NAN, f32::NEG_INFINITY, f32::INFINITY] {
+            assert_eq!(
+                resolve_px_with_box_model(&px, cb, &bp, true, 16.0, 16.0),
+                None,
+                "cb={cb} is indefinite and must not resolve"
+            );
         }
+        // A negative but FINITE containing block is still definite — it
+        // resolves, floored to zero.
+        assert_eq!(
+            resolve_px_with_box_model(&px, -800.0, &bp, true, 16.0, 16.0),
+            Some(0.0)
+        );
     }
 
     #[test]
@@ -3717,9 +3758,53 @@ mod autotest_generated {
             assert!(!r.width.is_nan() && !r.height.is_nan(), "NaN for cb={cb:?}");
             assert!(r.width >= 0.0 && r.height >= 0.0, "negative size for cb={cb:?}");
         }
-        // An infinite CB stays infinite (saturation), never NaN.
+        // An infinite CB is a MEASUREMENT constraint, not a length: a
+        // percentage against it behaves as auto (max-content), never as an
+        // infinite used size. The earlier form of this test asserted the
+        // saturation instead — a green test encoding the very bug that grew a
+        // u32::MAX-wide compositor layer.
         let r = used_size(&dom, PCT, size(f32::INFINITY, f32::INFINITY), &bp);
-        assert!(r.width.is_infinite() && r.width.is_sign_positive());
+        assert!(
+            r.width.is_finite() && r.height.is_finite(),
+            "percent against an indefinite CB must behave as auto, got {r:?}"
+        );
+    }
+
+    #[test]
+    fn a_percent_min_width_cannot_reinfect_a_width_with_infinity() {
+        // The main width resolution already treats an indefinite CB as auto —
+        // but min/max constraints are clamped on AFTERWARDS. A percent
+        // min-width resolved against the same indefinite CB used to come out
+        // infinite, and `.max(min_w)` then forced the finished width back to
+        // infinity. Per css-sizing-3 an unresolvable percentage minimum is
+        // simply ignored.
+        let dom = constraints_dom();
+        let bp = zero_props();
+        let r = used_size(&dom, PCTMIN, size(f32::INFINITY, f32::INFINITY), &bp);
+        assert!(
+            r.width.is_finite(),
+            "percent min-width against an indefinite CB must be ignored, got {r:?}"
+        );
+    }
+
+    #[test]
+    fn every_node_shape_yields_a_finite_used_size_under_a_measurement_pass() {
+        // Taffy's MinContent/MaxContent passes hand the bridge an INFINITE
+        // available size on purpose, and whatever this function returns is
+        // PERSISTED as the node's real used size. So for every CSS shape in
+        // the fixture — plain px, percent, clamped, box-sizing, auto, vw, em —
+        // the answer under that constraint must be a finite number. One
+        // infinity here became an infinite clip rect, a u32::MAX-wide
+        // compositor layer, and a ~900 GB allocation.
+        let dom = constraints_dom();
+        let bp = zero_props();
+        for id in [PLAIN, PCT, CLAMPED, MAXED, PCTMIN, BBOX, AUTOBLOCK, VWMIN, EM, HCLAMPED, ROW10] {
+            let r = used_size(&dom, id, size(f32::INFINITY, f32::INFINITY), &bp);
+            assert!(
+                r.width.is_finite() && r.height.is_finite(),
+                "node {id:?} leaked a non-finite used size under max-content: {r:?}"
+            );
+        }
     }
 
     #[test]

--- a/layout/src/solver3/sizing.rs
+++ b/layout/src/solver3/sizing.rs
@@ -1448,6 +1448,41 @@ fn auto_block_inline_size(cb: &LogicalSize, bp: &BoxProps) -> f32 {
     aw.max(0.0)
 }
 
+/// Stretch-fit inline size, or the max-content size when there is nothing to
+/// stretch to.
+///
+/// CSS Sizing 3 §5.1: stretch-fit is defined against a **definite** available
+/// size. Under a max-content constraint there is none — Taffy hands the bridge
+/// `AvailableSpace::MaxContent`, which `compute_non_flex_layout` deliberately
+/// turns into `f32::INFINITY` so text can report its intrinsic width — and an
+/// `auto` box must then resolve to its max-content contribution instead.
+///
+/// Stretching to it produced an INFINITE used width that was persisted like any
+/// other, and infinity is not a number later stages survive: the display list
+/// built an infinite clip rect, `f32 as u32` saturated it to `u32::MAX` device
+/// pixels, and the CPU compositor asked for a ~900 GB pixmap. Downstream every
+/// scroll clamp computed from that box (`max_x`) is equally meaningless, so the
+/// box could not be scrolled either.
+///
+/// Kept as a separate small `#[inline(never)]` fn taking `&` args and returning
+/// `f32` for the same reason [`auto_block_inline_size`] is: the M12.7 remill
+/// lift mis-reads `cb.width` when the load happens inside the ~6 KB
+/// `calculate_used_size_for_node`.
+#[inline(never)]
+fn auto_block_inline_size_definite_or_max_content(
+    cb: &LogicalSize,
+    bp: &BoxProps,
+    max_content_width: f32,
+) -> f32 {
+    if cb.width.is_finite() {
+        auto_block_inline_size(cb, bp)
+    } else {
+        // `.max(0.0)` also normalises a NaN intrinsic to 0 — an unmeasured box
+        // is zero-sized, never a size that poisons everything downstream.
+        max_content_width.max(0.0)
+    }
+}
+
 #[allow(clippy::match_same_arms)] // enum/value mapping/dispatch table: one arm per input variant (or cross-type bindings that can't merge)
 #[allow(clippy::too_many_lines, clippy::cognitive_complexity)] // large but cohesive: single-purpose layout/render/parse routine (one branch per case)
 /// # Errors
@@ -1477,7 +1512,14 @@ pub fn calculate_used_size_for_node(
         // Since anonymous boxes don't have a DOM node, we default to horizontal-tb.
         // The parent's writing mode is already reflected in containing_block_size.
         return Ok(LogicalSize::new(
-            containing_block_size.width,
+            // Same indefinite-available-space rule as the named case below: an
+            // anonymous box under a max-content constraint is max-content wide,
+            // not infinitely wide.
+            if containing_block_size.width.is_finite() {
+                containing_block_size.width
+            } else {
+                intrinsic.max_content_width.max(0.0)
+            },
             if intrinsic.max_content_height > 0.0 {
                 intrinsic.max_content_height
             } else {
@@ -1647,7 +1689,11 @@ pub fn calculate_used_size_for_node(
                     // return comes back in D0 as the call's SSA result (opt can't forward
                     // the init over it), and with D8-D15 preserved across calc's later
                     // calls the value survives to the return.
-                    auto_block_inline_size(containing_block_size, box_props)
+                    auto_block_inline_size_definite_or_max_content(
+                        containing_block_size,
+                        box_props,
+                        intrinsic.max_content_width,
+                    )
                 }
                 LayoutDisplay::InlineBlock | LayoutDisplay::InlineGrid | LayoutDisplay::InlineFlex => {
                     // +spec:width-calculation:c01de8 - inline-block auto width uses shrink-to-fit (§10.3.9)
@@ -2748,6 +2794,51 @@ mod autotest_generated {
             let r = auto_block_inline_size(&cb, &bp);
             assert!(!r.is_nan(), "NaN escaped for cb.width={}", cb.width);
             assert_eq!(r, 0.0);
+        }
+    }
+
+    #[test]
+    fn an_indefinite_containing_block_resolves_auto_to_max_content_not_infinity() {
+        // Taffy's MinContent/MaxContent measurement passes hand the bridge an
+        // INFINITE available width on purpose. Stretching to it produced an
+        // infinite used width that was then persisted, and infinity is not a
+        // number later stages survive — it became a `u32::MAX`-wide compositor
+        // layer and a ~900 GB pixmap request.
+        let r = auto_block_inline_size_definite_or_max_content(
+            &size(f32::INFINITY, 0.0),
+            &props(10.0, 2.0, 5.0),
+            420.0,
+        );
+        assert_eq!(r, 420.0, "auto under a max-content constraint is max-content");
+    }
+
+    #[test]
+    fn a_definite_containing_block_still_stretch_fits() {
+        // The guard must be invisible to every layout that was already correct:
+        // 800 - (10+2+5)*2 = 766, exactly as before.
+        let r = auto_block_inline_size_definite_or_max_content(
+            &size(800.0, 600.0),
+            &props(10.0, 2.0, 5.0),
+            420.0,
+        );
+        assert_eq!(r, 766.0);
+    }
+
+    #[test]
+    fn auto_inline_size_is_finite_for_every_containing_block() {
+        // Including the cases that reach this from a measurement pass with an
+        // unmeasured (NaN/negative) intrinsic — a zero-width box is recoverable,
+        // a non-finite one poisons the display list, the clip and the scroll clamp.
+        for cb in [f32::INFINITY, f32::NEG_INFINITY, f32::NAN, 800.0, -800.0] {
+            for mc in [420.0, 0.0, -1.0, f32::NAN] {
+                let r = auto_block_inline_size_definite_or_max_content(
+                    &size(cb, 0.0),
+                    &props(1.0, 1.0, 1.0),
+                    mc,
+                );
+                assert!(r.is_finite(), "cb={cb} max_content={mc} produced {r}");
+                assert!(r >= 0.0, "cb={cb} max_content={mc} produced {r}");
+            }
         }
     }
 

--- a/layout/src/solver3/sizing.rs
+++ b/layout/src/solver3/sizing.rs
@@ -1,11 +1,8 @@
 //! Intrinsic and used size calculations for layout nodes
 
-use crate::solver3::layout_tree::LayoutNodeId;
 use crate::debug_log;
-use std::{
-    collections::BTreeSet,
-    sync::Arc,
-};
+use crate::solver3::layout_tree::LayoutNodeId;
+use std::{collections::BTreeSet, sync::Arc};
 
 use azul_core::{
     dom::{FormattingContext, NodeId, NodeType},
@@ -17,7 +14,10 @@ use azul_css::{
     css::CssPropertyValue,
     props::{
         basic::PixelValue,
-        layout::{LayoutDisplay, LayoutFlexDirection, LayoutFlexWrap, LayoutFloat, LayoutHeight, LayoutPosition, LayoutWidth, LayoutWritingMode},
+        layout::{
+            LayoutDisplay, LayoutFlexDirection, LayoutFlexWrap, LayoutFloat, LayoutHeight,
+            LayoutPosition, LayoutWidth, LayoutWritingMode,
+        },
         property::{CssProperty, CssPropertyType},
     },
     LayoutDebugMessage,
@@ -37,11 +37,11 @@ use crate::{
         fc::split_text_for_whitespace,
         geometry::{BoxProps, IntrinsicSizes, WritingModeContext},
         getters::{
-            get_css_box_sizing, get_css_height, get_css_width, get_display_property,
-            get_direction_property, get_element_font_size, get_flex_direction, get_float,
+            get_css_box_sizing, get_css_height, get_css_width, get_direction_property,
+            get_display_property, get_element_font_size, get_flex_direction, get_float,
             get_style_properties, get_text_orientation_property, get_writing_mode, MultiValue,
         },
-        layout_tree::{LayoutNodeHot, LayoutTree, get_display_type},
+        layout_tree::{get_display_type, LayoutNodeHot, LayoutTree},
         positioning::get_position_type,
         LayoutContext, LayoutError, Result,
     },
@@ -115,7 +115,8 @@ fn resolve_px_with_box_model(
 // +spec:containing-block:8ad6f4 - Percentage resolution against containing block (editorial note: transferred percentages)
 // +spec:containing-block:257f3b - Block-axis percentages resolve against containing block size
 // +spec:containing-block:f1344e - percentage min/max-width resolved against containing block width; negative CB width yields zero
-#[must_use] pub fn resolve_percentage_with_box_model(
+#[must_use]
+pub fn resolve_percentage_with_box_model(
     containing_block_dimension: f32,
     percentage: f32,
     _margins: (f32, f32),
@@ -168,7 +169,9 @@ pub fn calculate_intrinsic_sizes<T: ParsedFontTrait>(
     // is in 121-142. compute_dirty_ancestor_closure RETURNS a HashSet by sret — prime suspect:
     // sret-slot overlapping new_tree, or the hashbrown empty-map bug. 0x407B4 (post-compute_dirty)
     // isolates compute_dirty vs calculator-creation.
-    unsafe { crate::az_mark(0x607B0_u32, (tree.nodes.len() as u32)); }
+    unsafe {
+        crate::az_mark(0x607B0_u32, (tree.nodes.len() as u32));
+    }
     if dirty_nodes.is_empty() {
         return Ok(());
     }
@@ -183,7 +186,9 @@ pub fn calculate_intrinsic_sizes<T: ParsedFontTrait>(
     // excel.html even when only 3 nodes were actually dirty.
     let dirty_closure = compute_dirty_ancestor_closure(tree, dirty_nodes);
     // [az-diag g59 REVERT] 0x407B4 = nodes.len AFTER compute_dirty_ancestor_closure (its HashSet sret).
-    unsafe { crate::az_mark(0x607B4_u32, (tree.nodes.len() as u32)); }
+    unsafe {
+        crate::az_mark(0x607B4_u32, (tree.nodes.len() as u32));
+    }
 
     let mut calculator = IntrinsicSizeCalculator::new(ctx, text_cache);
     calculator.dirty_closure = Some(dirty_closure);
@@ -207,10 +212,16 @@ pub fn calculate_intrinsic_sizes<T: ParsedFontTrait>(
     unsafe {
         crate::az_mark(0x60730_u32, (tree.root as u32));
         crate::az_mark(0x60734_u32, (tree.nodes.len() as u32));
-        crate::az_mark(0x60738_u32, u32::from(tree.get(LayoutNodeId::new(tree.root)).is_some()));
+        crate::az_mark(
+            0x60738_u32,
+            u32::from(tree.get(LayoutNodeId::new(tree.root)).is_some()),
+        );
         // [az-diag g55] 0x4075C = the `tree` ptr the CALLEE sees. Compare with 0x40748
         // (caller's &new_tree). Same → nodes-field-offset mis-lift; differ → &mut arg mis-passed.
-        crate::az_mark(0x6075C_u32, ((std::ptr::from_ref::<LayoutTree>(tree) as usize) as u32));
+        crate::az_mark(
+            0x6075C_u32,
+            ((std::ptr::from_ref::<LayoutTree>(tree) as usize) as u32),
+        );
     }
     calculator.calculate_intrinsic_recursive(tree, tree.root, false)?;
     debug_log!(ctx, "Finished intrinsic size calculation");
@@ -269,7 +280,9 @@ impl<'a, 'b, 'c, T: ParsedFontTrait> IntrinsicSizeCalculator<'a, 'b, 'c, T> {
     ) -> Result<IntrinsicSizes> {
         // [az-diag g52 REVERT] 0x40720 = node_index entering calculate_intrinsic_recursive
         // (last value after the run = the node that InvalidTree'd or the stray child).
-        unsafe { crate::az_mark(0x60720_u32, (node_index as u32)); }
+        unsafe {
+            crate::az_mark(0x60720_u32, (node_index as u32));
+        }
         // Fast path: if this subtree has no dirty nodes AND we
         // already have a cached intrinsic, return the cached value
         // and skip the whole descent. Caller is the ancestor-closure
@@ -350,21 +363,21 @@ impl<'a, 'b, 'c, T: ParsedFontTrait> IntrinsicSizeCalculator<'a, 'b, 'c, T> {
         };
         // Propagate STF flag: children inherit `ancestor_is_stf=true` if any
         // ancestor up to and including self is STF.
-        let self_is_stf = tree
-            .get(LayoutNodeId::new(node_index))
-            .is_some_and(|n| {
-                crate::solver3::layout_tree::is_shrink_to_fit_context(
-                    self.ctx.styled_dom,
-                    n.dom_node_id,
-                    n.formatting_context,
-                )
-            });
+        let self_is_stf = tree.get(LayoutNodeId::new(node_index)).is_some_and(|n| {
+            crate::solver3::layout_tree::is_shrink_to_fit_context(
+                self.ctx.styled_dom,
+                n.dom_node_id,
+                n.formatting_context,
+            )
+        });
         let child_ancestor_is_stf = ancestor_is_stf || self_is_stf;
 
         let mut child_intrinsics = Vec::with_capacity(n);
         for &child_index in children {
             // [az-diag g52 REVERT] 0x40728 = child_index about to recurse (last = the stray).
-            unsafe { crate::az_mark(0x60728_u32, (child_index as u32)); }
+            unsafe {
+                crate::az_mark(0x60728_u32, (child_index as u32));
+            }
             // [g52 FIX] Defensive: reconcile can mis-list a stray/out-of-range child_index
             // (a Text node mis-listed as a layout child, or a lift artifact in the children
             // array). The unguarded recursion would hit `tree.get(child_index).ok_or(InvalidTree)`
@@ -381,13 +394,18 @@ impl<'a, 'b, 'c, T: ParsedFontTrait> IntrinsicSizeCalculator<'a, 'b, 'c, T> {
 
         // Then calculate this node's intrinsic size based on its children
         let _p_self = crate::probe::Probe::span("intrinsic_node_compute");
-        let mut intrinsic = self.calculate_node_intrinsic_sizes(tree, node_index, &child_intrinsics)?;
+        let mut intrinsic =
+            self.calculate_node_intrinsic_sizes(tree, node_index, &child_intrinsics)?;
 
         // +spec:min-max-sizing:970fef - if min-width/min-height is a <length>, use as floor for intrinsic sizes
-        if let Some(dom_id) = tree.get(LayoutNodeId::new(node_index)).and_then(|n| n.dom_node_id) {
-            use crate::solver3::getters::{get_css_min_width, get_css_min_height, MultiValue};
+        if let Some(dom_id) = tree
+            .get(LayoutNodeId::new(node_index))
+            .and_then(|n| n.dom_node_id)
+        {
+            use crate::solver3::getters::{get_css_min_height, get_css_min_width, MultiValue};
 
-            let node_state = &self.ctx.styled_dom.styled_nodes.as_container()[dom_id].styled_node_state;
+            let node_state =
+                &self.ctx.styled_dom.styled_nodes.as_container()[dom_id].styled_node_state;
 
             // Resolve em against the element's OWN font-size and rem against the root.
             let em = get_element_font_size(self.ctx.styled_dom, dom_id, node_state);
@@ -403,7 +421,7 @@ impl<'a, 'b, 'c, T: ParsedFontTrait> IntrinsicSizeCalculator<'a, 'b, 'c, T> {
             // so border-box declarations shed their border+padding first.
             // Applied BEFORE the min floors so an explicit min still wins.
             {
-                use azul_css::props::layout::dimensions::{LayoutWidth, LayoutHeight};
+                use azul_css::props::layout::dimensions::{LayoutHeight, LayoutWidth};
                 use azul_css::props::layout::LayoutBoxSizing;
                 let box_sizing = match get_css_box_sizing(self.ctx.styled_dom, dom_id, node_state) {
                     MultiValue::Exact(v) => v,
@@ -418,8 +436,11 @@ impl<'a, 'b, 'c, T: ParsedFontTrait> IntrinsicSizeCalculator<'a, 'b, 'c, T> {
                 {
                     if let Some(mut w) = super::calc::resolve_pixel_value_no_percent(&px, em, rem) {
                         if box_sizing == LayoutBoxSizing::BorderBox {
-                            w = (w - bp.border.left - bp.border.right
-                                - bp.padding.left - bp.padding.right)
+                            w = (w
+                                - bp.border.left
+                                - bp.border.right
+                                - bp.padding.left
+                                - bp.padding.right)
                                 .max(0.0);
                         }
                         intrinsic.min_content_width = w;
@@ -431,8 +452,11 @@ impl<'a, 'b, 'c, T: ParsedFontTrait> IntrinsicSizeCalculator<'a, 'b, 'c, T> {
                 {
                     if let Some(mut h) = super::calc::resolve_pixel_value_no_percent(&px, em, rem) {
                         if box_sizing == LayoutBoxSizing::BorderBox {
-                            h = (h - bp.border.top - bp.border.bottom
-                                - bp.padding.top - bp.padding.bottom)
+                            h = (h
+                                - bp.border.top
+                                - bp.border.bottom
+                                - bp.padding.top
+                                - bp.padding.bottom)
                                 .max(0.0);
                         }
                         intrinsic.min_content_height = h;
@@ -441,15 +465,21 @@ impl<'a, 'b, 'c, T: ParsedFontTrait> IntrinsicSizeCalculator<'a, 'b, 'c, T> {
                 }
             }
 
-            if let MultiValue::Exact(mw) = get_css_min_width(self.ctx.styled_dom, dom_id, node_state) {
-                if let Some(min_w) = super::calc::resolve_pixel_value_no_percent(&mw.inner, em, rem) {
+            if let MultiValue::Exact(mw) =
+                get_css_min_width(self.ctx.styled_dom, dom_id, node_state)
+            {
+                if let Some(min_w) = super::calc::resolve_pixel_value_no_percent(&mw.inner, em, rem)
+                {
                     intrinsic.min_content_width = intrinsic.min_content_width.max(min_w);
                     intrinsic.max_content_width = intrinsic.max_content_width.max(min_w);
                 }
             }
 
-            if let MultiValue::Exact(mh) = get_css_min_height(self.ctx.styled_dom, dom_id, node_state) {
-                if let Some(min_h) = super::calc::resolve_pixel_value_no_percent(&mh.inner, em, rem) {
+            if let MultiValue::Exact(mh) =
+                get_css_min_height(self.ctx.styled_dom, dom_id, node_state)
+            {
+                if let Some(min_h) = super::calc::resolve_pixel_value_no_percent(&mh.inner, em, rem)
+                {
                     intrinsic.min_content_height = intrinsic.min_content_height.max(min_h);
                     intrinsic.max_content_height = intrinsic.max_content_height.max(min_h);
                 }
@@ -477,7 +507,9 @@ impl<'a, 'b, 'c, T: ParsedFontTrait> IntrinsicSizeCalculator<'a, 'b, 'c, T> {
         node_index: usize,
         child_intrinsics: &[(usize, IntrinsicSizes)],
     ) -> Result<IntrinsicSizes> {
-        let node = tree.get(LayoutNodeId::new(node_index)).ok_or(LayoutError::InvalidTree)?;
+        let node = tree
+            .get(LayoutNodeId::new(node_index))
+            .ok_or(LayoutError::InvalidTree)?;
 
         // +spec:block-formatting-context:30def2 - replaced elements use physical 300x150 default, not re-oriented by writing-mode
         // +spec:display-property:015c41 - replaced elements default to 300x150 intrinsic size per css-sizing-3 §5.1
@@ -498,7 +530,7 @@ impl<'a, 'b, 'c, T: ParsedFontTrait> IntrinsicSizeCalculator<'a, 'b, 'c, T> {
                     preferred_aspect_ratio: None,
                 });
             }
-            
+
             // +spec:containing-block:bb5a12 - replaced element intrinsic sizes using initial containing block
             // +spec:display-property:7127f9 - intrinsic sizes of replaced elements without natural sizes (300x150 fallback, aspect ratio)
             // +spec:display-property:f9cede - replaced elements derive intrinsic size from natural dimensions
@@ -594,12 +626,13 @@ impl<'a, 'b, 'c, T: ParsedFontTrait> IntrinsicSizeCalculator<'a, 'b, 'c, T> {
                                 return true;
                             }
                             let display = get_display_type(self.ctx.styled_dom, dom_id);
-                            matches!(display,
+                            matches!(
+                                display,
                                 LayoutDisplay::Inline
-                                | LayoutDisplay::InlineBlock
-                                | LayoutDisplay::InlineFlex
-                                | LayoutDisplay::InlineGrid
-                                | LayoutDisplay::InlineTable
+                                    | LayoutDisplay::InlineBlock
+                                    | LayoutDisplay::InlineFlex
+                                    | LayoutDisplay::InlineGrid
+                                    | LayoutDisplay::InlineTable
                             )
                         })
                 });
@@ -607,7 +640,7 @@ impl<'a, 'b, 'c, T: ParsedFontTrait> IntrinsicSizeCalculator<'a, 'b, 'c, T> {
                 // IFC root only if there are inline children and NO block children.
                 // If there are block children, text nodes get anonymous block wrappers.
                 let is_ifc_root = has_inline_child && !has_block_child;
-                
+
                 // Also check if this block has direct text content (text nodes in DOM)
                 // but ONLY if there are no block-level layout children
                 let has_direct_text = if has_block_child {
@@ -615,13 +648,14 @@ impl<'a, 'b, 'c, T: ParsedFontTrait> IntrinsicSizeCalculator<'a, 'b, 'c, T> {
                 } else if let Some(dom_id) = node.dom_node_id {
                     let node_hierarchy = &self.ctx.styled_dom.node_hierarchy.as_container();
                     dom_id.az_children(node_hierarchy).any(|child_id| {
-                        let child_node_data = &self.ctx.styled_dom.node_data.as_container()[child_id];
+                        let child_node_data =
+                            &self.ctx.styled_dom.node_data.as_container()[child_id];
                         matches!(child_node_data.get_node_type(), NodeType::Text(_))
                     })
                 } else {
                     false
                 };
-                
+
                 if is_ifc_root || has_direct_text {
                     // This block is an IFC root - measure all inline content ONCE
                     self.calculate_ifc_root_intrinsic_sizes(tree, node_index)
@@ -681,7 +715,8 @@ impl<'a, 'b, 'c, T: ParsedFontTrait> IntrinsicSizeCalculator<'a, 'b, 'c, T> {
                 let has_direct_text = if let Some(dom_id) = node.dom_node_id {
                     let node_hierarchy = &self.ctx.styled_dom.node_hierarchy.as_container();
                     dom_id.az_children(node_hierarchy).any(|child_id| {
-                        let child_node_data = &self.ctx.styled_dom.node_data.as_container()[child_id];
+                        let child_node_data =
+                            &self.ctx.styled_dom.node_data.as_container()[child_id];
                         matches!(child_node_data.get_node_type(), NodeType::Text(_))
                     })
                 } else {
@@ -710,7 +745,7 @@ impl<'a, 'b, 'c, T: ParsedFontTrait> IntrinsicSizeCalculator<'a, 'b, 'c, T> {
             _ => self.calculate_block_intrinsic_sizes(tree, node_index, child_intrinsics),
         }
     }
-    
+
     // +spec:intrinsic-sizing:ea2c2c - §5.1 min-content size = size as float with auto; max-content = no wrapping
     /// Calculate intrinsic sizes for an IFC root (a block containing inline content).
     /// This collects ALL inline descendants' text and measures it ONCE.
@@ -749,7 +784,16 @@ impl<'a, 'b, 'c, T: ParsedFontTrait> IntrinsicSizeCalculator<'a, 'b, 'c, T> {
             collect_inline_content(self.ctx, tree, node_index)
         };
         #[cfg(feature = "web_lift")]
-        unsafe { crate::az_mark((0x60760) as u32, (if collect_result.is_ok() { 0x00000001u32 } else { 0x000000EEu32 }) as u32); }
+        unsafe {
+            crate::az_mark(
+                (0x60760) as u32,
+                (if collect_result.is_ok() {
+                    0x00000001u32
+                } else {
+                    0x000000EEu32
+                }) as u32,
+            );
+        }
         let inline_content: Vec<InlineContent> = collect_result?;
 
         if inline_content.is_empty() {
@@ -775,7 +819,10 @@ impl<'a, 'b, 'c, T: ParsedFontTrait> IntrinsicSizeCalculator<'a, 'b, 'c, T> {
         // element reports a min-content SMALLER than its true unbreakable width and
         // the flex/shrink-to-fit algorithm clips it.
         let mut constraints = UnifiedConstraints::default();
-        if let Some(dom_id) = tree.get(LayoutNodeId::new(node_index)).and_then(|n| n.dom_node_id) {
+        if let Some(dom_id) = tree
+            .get(LayoutNodeId::new(node_index))
+            .and_then(|n| n.dom_node_id)
+        {
             use crate::solver3::getters::{get_white_space_property, MultiValue};
             use azul_css::props::style::text::StyleWhiteSpace;
             let node_state =
@@ -875,12 +922,16 @@ impl<'a, 'b, 'c, T: ParsedFontTrait> IntrinsicSizeCalculator<'a, 'b, 'c, T> {
         node_index: usize,
         child_intrinsics: &[(usize, IntrinsicSizes)],
     ) -> Result<IntrinsicSizes> {
-        let node = tree.get(LayoutNodeId::new(node_index)).ok_or(LayoutError::InvalidTree)?;
-        let writing_mode = node.dom_node_id.map_or_else(LayoutWritingMode::default, |dom_id| {
-            let node_state =
-                &self.ctx.styled_dom.styled_nodes.as_container()[dom_id].styled_node_state;
-            get_writing_mode(self.ctx.styled_dom, dom_id, node_state).unwrap_or_default()
-        });
+        let node = tree
+            .get(LayoutNodeId::new(node_index))
+            .ok_or(LayoutError::InvalidTree)?;
+        let writing_mode = node
+            .dom_node_id
+            .map_or_else(LayoutWritingMode::default, |dom_id| {
+                let node_state =
+                    &self.ctx.styled_dom.styled_nodes.as_container()[dom_id].styled_node_state;
+                get_writing_mode(self.ctx.styled_dom, dom_id, node_state).unwrap_or_default()
+            });
 
         // NOTE: Text content detection is now handled in calculate_node_intrinsic_sizes
         // which calls calculate_ifc_root_intrinsic_sizes for blocks with inline content.
@@ -897,19 +948,28 @@ impl<'a, 'b, 'c, T: ParsedFontTrait> IntrinsicSizeCalculator<'a, 'b, 'c, T> {
         let mut is_first_child = true;
 
         for &child_index in tree.children(node_index) {
-            if let Some(child_intrinsic) = child_intrinsics.iter().find(|(k, _)| k == &child_index).map(|(_, v)| v) {
+            if let Some(child_intrinsic) = child_intrinsics
+                .iter()
+                .find(|(k, _)| k == &child_index)
+                .map(|(_, v)| v)
+            {
                 // +spec:intrinsic-sizing:ed72bb - intrinsic contributions based on outer size, auto margins as zero
                 let child_node = tree.get(LayoutNodeId::new(child_index));
                 let (cross_extras, main_border_padding, main_margin_start, main_margin_end) =
                     child_node.map_or((0.0, 0.0, 0.0, 0.0), |cn| {
                         let bp = cn.box_props.unpack();
-                        let h = bp.margin.left + bp.margin.right
-                              + bp.border.left + bp.border.right
-                              + bp.padding.left + bp.padding.right;
-                        let v_bp = bp.border.top + bp.border.bottom
-                              + bp.padding.top + bp.padding.bottom;
+                        let h = bp.margin.left
+                            + bp.margin.right
+                            + bp.border.left
+                            + bp.border.right
+                            + bp.padding.left
+                            + bp.padding.right;
+                        let v_bp =
+                            bp.border.top + bp.border.bottom + bp.padding.top + bp.padding.bottom;
                         match writing_mode {
-                            LayoutWritingMode::HorizontalTb => (h, v_bp, bp.margin.top, bp.margin.bottom),
+                            LayoutWritingMode::HorizontalTb => {
+                                (h, v_bp, bp.margin.top, bp.margin.bottom)
+                            }
                             _ => (v_bp, h, bp.margin.left, bp.margin.right),
                         }
                     });
@@ -940,7 +1000,8 @@ impl<'a, 'b, 'c, T: ParsedFontTrait> IntrinsicSizeCalculator<'a, 'b, 'c, T> {
                 } else {
                     // Sibling gap: collapsed margin between prev bottom and current top
                     let collapsed_gap = crate::solver3::fc::collapse_margins(
-                        last_margin_main_end, main_margin_start
+                        last_margin_main_end,
+                        main_margin_start,
                     );
                     total_main_size += collapsed_gap;
                 }
@@ -987,14 +1048,19 @@ impl<'a, 'b, 'c, T: ParsedFontTrait> IntrinsicSizeCalculator<'a, 'b, 'c, T> {
         node_index: usize,
         child_intrinsics: &[(usize, IntrinsicSizes)],
     ) -> Result<IntrinsicSizes> {
-        let node = tree.get(LayoutNodeId::new(node_index)).ok_or(LayoutError::InvalidTree)?;
+        let node = tree
+            .get(LayoutNodeId::new(node_index))
+            .ok_or(LayoutError::InvalidTree)?;
 
         // Determine flex-direction to know if main axis is horizontal or vertical
         let is_row = node.dom_node_id.is_none_or(|dom_id| {
             let node_state =
                 &self.ctx.styled_dom.styled_nodes.as_container()[dom_id].styled_node_state;
             match get_flex_direction(self.ctx.styled_dom, dom_id, node_state) {
-                MultiValue::Exact(dir) => matches!(dir, LayoutFlexDirection::Row | LayoutFlexDirection::RowReverse),
+                MultiValue::Exact(dir) => matches!(
+                    dir,
+                    LayoutFlexDirection::Row | LayoutFlexDirection::RowReverse
+                ),
                 _ => true, // default is row
             }
         });
@@ -1006,7 +1072,11 @@ impl<'a, 'b, 'c, T: ParsedFontTrait> IntrinsicSizeCalculator<'a, 'b, 'c, T> {
         let mut max_cross_max: f32 = 0.0;
 
         for &child_index in tree.children(node_index) {
-            if let Some(child_intrinsic) = child_intrinsics.iter().find(|(k, _)| k == &child_index).map(|(_, v)| v) {
+            if let Some(child_intrinsic) = child_intrinsics
+                .iter()
+                .find(|(k, _)| k == &child_index)
+                .map(|(_, v)| v)
+            {
                 let (child_main_min, child_main_max, child_cross_min, child_cross_max) = if is_row {
                     (
                         child_intrinsic.min_content_width,
@@ -1040,15 +1110,23 @@ impl<'a, 'b, 'c, T: ParsedFontTrait> IntrinsicSizeCalculator<'a, 'b, 'c, T> {
             let node_state =
                 &self.ctx.styled_dom.styled_nodes.as_container()[dom_id].styled_node_state;
             let wrap_prop = crate::solver3::getters::get_flex_wrap_prop(
-                self.ctx.styled_dom, dom_id, node_state,
+                self.ctx.styled_dom,
+                dom_id,
+                node_state,
             );
-            wrap_prop.is_none_or(|val| matches!(
+            wrap_prop.is_none_or(|val| {
+                matches!(
                     val.get_property_or_default().unwrap_or_default(),
                     LayoutFlexWrap::NoWrap
-                ))
+                )
+            })
         });
 
-        let min_main = if is_single_line { sum_main_min } else { max_main_min };
+        let min_main = if is_single_line {
+            sum_main_min
+        } else {
+            max_main_min
+        };
         let max_main = sum_main_max;
 
         if is_row {
@@ -1092,7 +1170,9 @@ impl<'a, 'b, 'c, T: ParsedFontTrait> IntrinsicSizeCalculator<'a, 'b, 'c, T> {
         // Iterate rows — children may be row groups (thead/tbody/tfoot) or direct rows
         let mut rows: Vec<usize> = Vec::new();
         for &child_idx in tree.children(node_index) {
-            let Some(child) = tree.get(LayoutNodeId::new(child_idx)) else { continue };
+            let Some(child) = tree.get(LayoutNodeId::new(child_idx)) else {
+                continue;
+            };
             match child.formatting_context {
                 FormattingContext::TableRow => rows.push(child_idx),
                 FormattingContext::TableRowGroup => {
@@ -1112,7 +1192,10 @@ impl<'a, 'b, 'c, T: ParsedFontTrait> IntrinsicSizeCalculator<'a, 'b, 'c, T> {
         for &row_idx in &rows {
             let mut row_height = 0.0f32;
             for (col, &cell_idx) in tree.children(row_idx).iter().enumerate() {
-                let cell_intrinsic = child_intrinsics.iter().find(|(k, _)| k == &cell_idx).map(|(_, v)| *v)
+                let cell_intrinsic = child_intrinsics
+                    .iter()
+                    .find(|(k, _)| k == &cell_idx)
+                    .map(|(_, v)| *v)
                     .unwrap_or_default();
                 // Also check if cell has IFC content we can measure
                 let cell_is = if cell_intrinsic.max_content_width > 0.0 {
@@ -1127,8 +1210,10 @@ impl<'a, 'b, 'c, T: ParsedFontTrait> IntrinsicSizeCalculator<'a, 'b, 'c, T> {
                 let cell_node = tree.get(LayoutNodeId::new(cell_idx));
                 let (h_extras, v_extras) = cell_node.map_or((0.0, 0.0), |cn| {
                     let bp = cn.box_props.unpack();
-                    (bp.padding.left + bp.padding.right + bp.border.left + bp.border.right,
-                     bp.padding.top + bp.padding.bottom + bp.border.top + bp.border.bottom)
+                    (
+                        bp.padding.left + bp.padding.right + bp.border.left + bp.border.right,
+                        bp.padding.top + bp.padding.bottom + bp.border.top + bp.border.bottom,
+                    )
                 });
 
                 let cell_min = cell_is.min_content_width + h_extras;
@@ -1183,14 +1268,25 @@ fn collect_inline_content_for_sizing<T: ParsedFontTrait>(
     ifc_root_index: usize,
     out: &mut Vec<InlineContent>,
 ) -> Result<()> {
-    debug_log!(ctx, "Collecting inline content from node {} for intrinsic sizing", ifc_root_index);
+    debug_log!(
+        ctx,
+        "Collecting inline content from node {} for intrinsic sizing",
+        ifc_root_index
+    );
 
     // [g78] fill the caller's out-param (was a local Vec returned by value → Ok→Err mis-lift).
     // Recursively collect inline content from this node and its inline descendants
     collect_inline_content_recursive(ctx, tree, ifc_root_index, out)?;
     // [g73] B8 = top-level recursion returned Ok (collect_inline_content complete).
-    unsafe { crate::az_mark(0x6071C_u32, (0xB8u32)); }
-    debug_log!(ctx, "Collected {} inline content items from node {}", out.len(), ifc_root_index);
+    unsafe {
+        crate::az_mark(0x6071C_u32, (0xB8u32));
+    }
+    debug_log!(
+        ctx,
+        "Collected {} inline content items from node {}",
+        out.len(),
+        ifc_root_index
+    );
 
     Ok(())
 }
@@ -1216,9 +1312,13 @@ fn collect_inline_content_recursive<T: ParsedFontTrait>(
     // FAILURE distinctly (inline-phase=0xBAD) so a node_index that fails HERE (before B1) is
     // visible even though a PRIOR successful call already wrote B8. This is the suspected
     // InvalidTree site (phase stuck at 0xA0 + B8 reached ⇒ a 2nd IFC call fails at this get).
-    unsafe { crate::az_mark(0x60754_u32, (node_index as u32)); }
+    unsafe {
+        crate::az_mark(0x60754_u32, (node_index as u32));
+    }
     let Some(node) = tree.get(LayoutNodeId::new(node_index)) else {
-        unsafe { crate::az_mark(0x6071C_u32, (0xBADu32)); }
+        unsafe {
+            crate::az_mark(0x6071C_u32, (0xBADu32));
+        }
         return Err(LayoutError::InvalidTree);
     };
 
@@ -1232,12 +1332,15 @@ fn collect_inline_content_recursive<T: ParsedFontTrait>(
     // First check if THIS node is a text node
     if let Some(text) = extract_text_from_node(ctx.styled_dom, dom_id) {
         let style_props = crate::solver3::getters::get_style_properties_cached(
-                        &mut ctx.style_cache,
-                        ctx.styled_dom,
-                        dom_id,
-                        ctx.system_style.as_ref(),
-                        azul_css::props::basic::PhysicalSize::new(ctx.viewport_size.width, ctx.viewport_size.height),
-                    );
+            &mut ctx.style_cache,
+            ctx.styled_dom,
+            dom_id,
+            ctx.system_style.as_ref(),
+            azul_css::props::basic::PhysicalSize::new(
+                ctx.viewport_size.width,
+                ctx.viewport_size.height,
+            ),
+        );
         debug_log!(ctx, "Found text in node {}: '{}'", node_index, text);
         // Use split_text_for_whitespace to correctly handle white-space: pre with \n
         let text_items = split_text_for_whitespace(ctx.styled_dom, dom_id, &text, &style_props);
@@ -1262,25 +1365,31 @@ fn collect_inline_content_recursive<T: ParsedFontTrait>(
         if let NodeType::Text(text_data) = child_dom_node.get_node_type() {
             let text = text_data.as_str().to_string();
             let style_props = crate::solver3::getters::get_style_properties_cached(
-                        &mut ctx.style_cache,
-                        ctx.styled_dom,
-                        child_id,
-                        ctx.system_style.as_ref(),
-                        azul_css::props::basic::PhysicalSize::new(ctx.viewport_size.width, ctx.viewport_size.height),
-                    );
-            debug_log!(ctx, "Found text in DOM child of node {}: '{}'", node_index, text);
-            // Use split_text_for_whitespace to correctly handle white-space: pre with \n
-            let text_items = split_text_for_whitespace(
+                &mut ctx.style_cache,
                 ctx.styled_dom,
                 child_id,
-                &text,
-                &style_props,
+                ctx.system_style.as_ref(),
+                azul_css::props::basic::PhysicalSize::new(
+                    ctx.viewport_size.width,
+                    ctx.viewport_size.height,
+                ),
             );
+            debug_log!(
+                ctx,
+                "Found text in DOM child of node {}: '{}'",
+                node_index,
+                text
+            );
+            // Use split_text_for_whitespace to correctly handle white-space: pre with \n
+            let text_items =
+                split_text_for_whitespace(ctx.styled_dom, child_id, &text, &style_props);
             content.extend(text_items);
         }
     }
     // [g73] B6 = DOM-children loop done (about to process_layout_children).
-    unsafe { crate::az_mark(0x6071C_u32, (0xB6u32)); }
+    unsafe {
+        crate::az_mark(0x6071C_u32, (0xB6u32));
+    }
 
     process_layout_children(ctx, tree, node_index, content)
 }
@@ -1297,18 +1406,27 @@ fn process_layout_children<T: ParsedFontTrait>(
     use azul_css::props::layout::{LayoutHeight, LayoutWidth};
 
     // [g73] PLC entry: 0x60708 = 0xC0<<24 | node_index (which node's children we process).
-    unsafe { crate::az_mark(0x60708_u32, (0xC000_0000_u32 | (node_index as u32 & 0x00FF_FFFF))); }
+    unsafe {
+        crate::az_mark(
+            0x60708_u32,
+            (0xC000_0000_u32 | (node_index as u32 & 0x00FF_FFFF)),
+        );
+    }
     // Process layout tree children (these are elements with layout properties)
     for &child_index in tree.children(node_index) {
         // [g73] PLC loop: 0x6070C = current child_index being processed.
-        unsafe { crate::az_mark(0x6070C_u32, (child_index as u32)); }
+        unsafe {
+            crate::az_mark(0x6070C_u32, (child_index as u32));
+        }
         // 2026-06-02: was `.ok_or(LayoutError::InvalidTree)?` — a stray/invalid child_index in
         // tree.children (likely a Text node mis-listed during reconcile, since Text is INLINE
         // content not a layout-tree node) aborted the WHOLE intrinsic-sizing pass with
         // InvalidTree BEFORE the inline text got measured → label height 0. Skip gracefully so
         // measurement continues (the inline text is collected separately above, at the
         // collect_inline_content_recursive DOM-children loop). REAL fix = reconcile not listing it.
-        let Some(child_node) = tree.get(LayoutNodeId::new(child_index)) else { continue; };
+        let Some(child_node) = tree.get(LayoutNodeId::new(child_index)) else {
+            continue;
+        };
         let Some(child_dom_id) = child_node.dom_node_id else {
             continue;
         };
@@ -1325,7 +1443,10 @@ fn process_layout_children<T: ParsedFontTrait>(
             // Non-inline children are treated as atomic inline-level boxes
             // (e.g., inline-block, images, floats)
             // Their intrinsic size must have been calculated in the bottom-up pass
-            let intrinsic_sizes = tree.warm(LayoutNodeId::new(child_index)).and_then(|w| w.intrinsic_sizes).unwrap_or_default();
+            let intrinsic_sizes = tree
+                .warm(LayoutNodeId::new(child_index))
+                .and_then(|w| w.intrinsic_sizes)
+                .unwrap_or_default();
 
             // CSS 2.2 § 10.3.9: For inline-block elements with explicit CSS width/height,
             // use the CSS-defined values instead of intrinsic sizes.
@@ -1376,7 +1497,9 @@ fn process_layout_children<T: ParsedFontTrait>(
                 MultiValue::Exact(LayoutHeight::MinContent) => intrinsic_sizes.max_content_height,
                 // is equivalent to automatic size
                 MultiValue::Exact(LayoutHeight::MaxContent) => intrinsic_sizes.max_content_height,
-                MultiValue::Exact(LayoutHeight::FitContent(_)) => intrinsic_sizes.max_content_height,
+                MultiValue::Exact(LayoutHeight::FitContent(_)) => {
+                    intrinsic_sizes.max_content_height
+                }
                 _ => intrinsic_sizes.max_content_height,
             };
 
@@ -1395,7 +1518,10 @@ fn process_layout_children<T: ParsedFontTrait>(
                 fill: None,
                 stroke: None,
                 baseline_offset: used_height,
-                alignment: crate::solver3::getters::get_vertical_align_for_node(ctx.styled_dom, child_dom_id),
+                alignment: crate::solver3::getters::get_vertical_align_for_node(
+                    ctx.styled_dom,
+                    child_dom_id,
+                ),
                 source_node_id: Some(child_dom_id),
             }));
         }
@@ -1492,7 +1618,8 @@ fn auto_block_inline_size_definite_or_max_content(
     }
 }
 
-#[allow(clippy::match_same_arms)] // enum/value mapping/dispatch table: one arm per input variant (or cross-type bindings that can't merge)
+#[allow(clippy::match_same_arms)]
+// enum/value mapping/dispatch table: one arm per input variant (or cross-type bindings that can't merge)
 #[allow(clippy::too_many_lines, clippy::cognitive_complexity)] // large but cohesive: single-purpose layout/render/parse routine (one branch per case)
 /// # Errors
 ///
@@ -1557,15 +1684,13 @@ pub fn calculate_used_size_for_node(
     // +spec:display-property:06e0b1 - form controls (non-image) treated as non-replaced
     // Determine if this element is a replaced element (images, virtual views)
     let node_data = &styled_dom.node_data.as_container()[id];
-    let is_replaced = matches!(node_data.get_node_type(), NodeType::Image(_))
-        || node_data.is_virtual_view_node();
+    let is_replaced =
+        matches!(node_data.get_node_type(), NodeType::Image(_)) || node_data.is_virtual_view_node();
 
     // +spec:width-calculation:79cdf8 - inline non-replaced: width property does not apply
     // +spec:width-calculation:972e86 - §10.3.1: width property does not apply to inline non-replaced elements
     // For inline non-replaced elements, override any explicit width to Auto.
-    let css_width = if display.unwrap_or_default() == LayoutDisplay::Inline
-        && !is_replaced
-    {
+    let css_width = if display.unwrap_or_default() == LayoutDisplay::Inline && !is_replaced {
         MultiValue::Exact(LayoutWidth::Auto)
     } else {
         css_width
@@ -1576,17 +1701,17 @@ pub fn calculate_used_size_for_node(
     // +spec:height-calculation:c03717 - height does not apply to inline non-replaced elements
     // CSS 2.2 §10.6.1 / CSS Inline 3 §6.4: height property does not apply to
     // inline, non-replaced elements. Override any explicit height to Auto.
-    let css_height = if display.unwrap_or_default() == LayoutDisplay::Inline
-        && !is_replaced
-    {
+    let css_height = if display.unwrap_or_default() == LayoutDisplay::Inline && !is_replaced {
         MultiValue::Exact(LayoutHeight::Auto)
     } else {
         css_height
     };
 
     // Remember if width/height were auto before consuming them
-    let width_is_auto = css_width.is_auto() || matches!(&css_width, MultiValue::Exact(LayoutWidth::Auto));
-    let height_is_auto = css_height.is_auto() || matches!(&css_height, MultiValue::Exact(LayoutHeight::Auto));
+    let width_is_auto =
+        css_width.is_auto() || matches!(&css_width, MultiValue::Exact(LayoutWidth::Auto));
+    let height_is_auto =
+        css_height.is_auto() || matches!(&css_height, MultiValue::Exact(LayoutHeight::Auto));
 
     // +spec:intrinsic-sizing:9e1c9d - non-quantitative values (auto, min-content, max-content) are not influenced by box-sizing
     let width_is_quantitative = matches!(
@@ -1595,7 +1720,9 @@ pub fn calculate_used_size_for_node(
     );
     let height_is_quantitative = matches!(
         &css_height,
-        MultiValue::Exact(LayoutHeight::Px(_) | LayoutHeight::FitContent(_) | LayoutHeight::Calc(_))
+        MultiValue::Exact(
+            LayoutHeight::Px(_) | LayoutHeight::FitContent(_) | LayoutHeight::Calc(_)
+        )
     );
 
     // +spec:width-calculation:50d67a - automatic sizing concepts (width/height auto resolution)
@@ -1625,7 +1752,9 @@ pub fn calculate_used_size_for_node(
                 intrinsic.max_content_width
             }
             // +spec:intrinsic-sizing:560697 - shrink-to-fit = clamp(min-content, stretch-fit, max-content)
-            else if get_float(styled_dom, id, node_state).unwrap_or(LayoutFloat::None) != LayoutFloat::None {
+            else if get_float(styled_dom, id, node_state).unwrap_or(LayoutFloat::None)
+                != LayoutFloat::None
+            {
                 // +spec:width-calculation:8d7047 - shrink-to-fit width per CSS2.1§10.3.5
                 // +spec:width-calculation:0bb038 - shrink-to-fit for floating non-replaced elements (§10.3.5)
                 // shrink-to-fit = min(max(preferred minimum width, available width), preferred width)
@@ -1643,9 +1772,11 @@ pub fn calculate_used_size_for_node(
                     .max(0.0);
                 let preferred_minimum = intrinsic.min_content_width;
                 let preferred = intrinsic.max_content_width;
-                preferred_minimum.max(available_width).min(preferred).max(0.0)
-            }
-            else if matches!(position, LayoutPosition::Absolute | LayoutPosition::Fixed) {
+                preferred_minimum
+                    .max(available_width)
+                    .min(preferred)
+                    .max(0.0)
+            } else if matches!(position, LayoutPosition::Absolute | LayoutPosition::Fixed) {
                 // +spec:intrinsic-sizing:12a531 - abspos auto size = fit-content (shrink-to-fit)
                 // +spec:width-calculation:0bb038 - shrink-to-fit width for abs-pos non-replaced elements
                 // §10.3.7: abs-pos elements with auto width use shrink-to-fit
@@ -1662,97 +1793,110 @@ pub fn calculate_used_size_for_node(
                     .max(0.0);
                 let preferred_minimum = intrinsic.min_content_width;
                 let preferred = intrinsic.max_content_width;
-                preferred_minimum.max(available_width).min(preferred).max(0.0)
+                preferred_minimum
+                    .max(available_width)
+                    .min(preferred)
+                    .max(0.0)
             } else {
-            // +spec:width-calculation:472065 - orthogonal flow auto inline size: if this block
-            // container establishes an orthogonal flow (child writing mode axis differs from
-            // parent), its auto inline size should use the parent's block-axis size as available
-            // space, falling back to the initial containing block size. Currently not implemented;
-            // auto width always resolves against the containing block's width.
-            // 'auto' width resolution depends on the display type.
-            match display.unwrap_or_default() {
-                LayoutDisplay::Block
-                | LayoutDisplay::FlowRoot
-                | LayoutDisplay::ListItem
-                | LayoutDisplay::Flex
-                | LayoutDisplay::Grid => {
-                    // +spec:box-model:503ea3 - margin + border + padding + width = containing block width
-                    // +spec:box-model:5ed651 - stretch fit: size minus margins (auto=0), border, padding, floored at 0
-                    // +spec:box-model:33b951 - stretch-fit inline size: available space minus margins/border/padding, floored at zero
-                    // +spec:box-model:30b4d0 - stretch fit: available size minus margins (auto as zero), border, padding, floored at zero
-                    // +spec:width-calculation:e2c8f6 - auto width for non-replaced blocks in normal flow per CSS2.1§10.3.3
-                    // For block-level non-replaced elements,
-                    // 'auto' width fills the containing block (minus margins, borders, padding).
-                    // CSS 2.2 §10.3.3: width = containing_block_width - margin_left -
-                    // margin_right - border_left - border_right - padding_left - padding_right
-                    // +spec:width-calculation:aef2da - auto width: other auto values become 0, width follows from constraint equality
-                    // M12.7: compute in a small #[inline(never)] helper with by-ref/out-ptr
-                    // args. calc_used_size is a ~6KB fn (38 maxnum, heavy SROA); the remill
-                    // lift spills + diverges the available_width copyload feeding `.max`
-                    // (a marker read sees 800, the maxnum's copyload reads 0 → width 0). A
-                    // small fn has clean register allocation; out-ptr avoids the f32-return
-                    // mis-lift. cb/bp are already &-refs (GP-pointer args lift cleanly).
-                    // M12.7: compute the auto-width in a small f32-RETURNING helper.
-                    // Inline-in-calc reads cb.width back 0 (huge-fn lift divergence); the
-                    // out-ptr helper's readback was opt-forwarded to init 0. The f32
-                    // return comes back in D0 as the call's SSA result (opt can't forward
-                    // the init over it), and with D8-D15 preserved across calc's later
-                    // calls the value survives to the return.
-                    auto_block_inline_size_definite_or_max_content(
-                        containing_block_size,
-                        box_props,
-                        intrinsic.max_content_width,
-                    )
-                }
-                LayoutDisplay::InlineBlock | LayoutDisplay::InlineGrid | LayoutDisplay::InlineFlex => {
-                    // +spec:width-calculation:c01de8 - inline-block auto width uses shrink-to-fit (§10.3.9)
-                    // shrink-to-fit = min(max(preferred_minimum, available), preferred)
-                    let available_width = (containing_block_size.width
-                        - box_props.margin.left
-                        - box_props.margin.right
-                        - box_props.border.left
-                        - box_props.border.right
-                        - box_props.padding.left
-                        - box_props.padding.right)
-                        .max(0.0);
-                    let preferred_minimum = intrinsic.min_content_width;
-                    let preferred = intrinsic.max_content_width;
-                    preferred_minimum.max(available_width).min(preferred).max(0.0)
-                }
-                LayoutDisplay::Inline => {
-                    // For inline elements, 'auto' width is the intrinsic/max-content width
-                    intrinsic.max_content_width
-                }
-                LayoutDisplay::Table | LayoutDisplay::InlineTable => intrinsic.max_content_width,
-                // Table cells: during intrinsic measurement, intrinsic sizes
-                // aren't known yet (0). Use containing block width so content
-                // can expand and be measured. The table layout algorithm sets
-                // the final cell width from computed column widths.
-                LayoutDisplay::TableCell => {
-                    if intrinsic.max_content_width > 0.0 {
-                        intrinsic.max_content_width
-                    } else {
-                        (containing_block_size.width
+                // +spec:width-calculation:472065 - orthogonal flow auto inline size: if this block
+                // container establishes an orthogonal flow (child writing mode axis differs from
+                // parent), its auto inline size should use the parent's block-axis size as available
+                // space, falling back to the initial containing block size. Currently not implemented;
+                // auto width always resolves against the containing block's width.
+                // 'auto' width resolution depends on the display type.
+                match display.unwrap_or_default() {
+                    LayoutDisplay::Block
+                    | LayoutDisplay::FlowRoot
+                    | LayoutDisplay::ListItem
+                    | LayoutDisplay::Flex
+                    | LayoutDisplay::Grid => {
+                        // +spec:box-model:503ea3 - margin + border + padding + width = containing block width
+                        // +spec:box-model:5ed651 - stretch fit: size minus margins (auto=0), border, padding, floored at 0
+                        // +spec:box-model:33b951 - stretch-fit inline size: available space minus margins/border/padding, floored at zero
+                        // +spec:box-model:30b4d0 - stretch fit: available size minus margins (auto as zero), border, padding, floored at zero
+                        // +spec:width-calculation:e2c8f6 - auto width for non-replaced blocks in normal flow per CSS2.1§10.3.3
+                        // For block-level non-replaced elements,
+                        // 'auto' width fills the containing block (minus margins, borders, padding).
+                        // CSS 2.2 §10.3.3: width = containing_block_width - margin_left -
+                        // margin_right - border_left - border_right - padding_left - padding_right
+                        // +spec:width-calculation:aef2da - auto width: other auto values become 0, width follows from constraint equality
+                        // M12.7: compute in a small #[inline(never)] helper with by-ref/out-ptr
+                        // args. calc_used_size is a ~6KB fn (38 maxnum, heavy SROA); the remill
+                        // lift spills + diverges the available_width copyload feeding `.max`
+                        // (a marker read sees 800, the maxnum's copyload reads 0 → width 0). A
+                        // small fn has clean register allocation; out-ptr avoids the f32-return
+                        // mis-lift. cb/bp are already &-refs (GP-pointer args lift cleanly).
+                        // M12.7: compute the auto-width in a small f32-RETURNING helper.
+                        // Inline-in-calc reads cb.width back 0 (huge-fn lift divergence); the
+                        // out-ptr helper's readback was opt-forwarded to init 0. The f32
+                        // return comes back in D0 as the call's SSA result (opt can't forward
+                        // the init over it), and with D8-D15 preserved across calc's later
+                        // calls the value survives to the return.
+                        auto_block_inline_size_definite_or_max_content(
+                            containing_block_size,
+                            box_props,
+                            intrinsic.max_content_width,
+                        )
+                    }
+                    LayoutDisplay::InlineBlock
+                    | LayoutDisplay::InlineGrid
+                    | LayoutDisplay::InlineFlex => {
+                        // +spec:width-calculation:c01de8 - inline-block auto width uses shrink-to-fit (§10.3.9)
+                        // shrink-to-fit = min(max(preferred_minimum, available), preferred)
+                        let available_width = (containing_block_size.width
                             - box_props.margin.left
                             - box_props.margin.right
                             - box_props.border.left
                             - box_props.border.right
                             - box_props.padding.left
                             - box_props.padding.right)
+                            .max(0.0);
+                        let preferred_minimum = intrinsic.min_content_width;
+                        let preferred = intrinsic.max_content_width;
+                        preferred_minimum
+                            .max(available_width)
+                            .min(preferred)
                             .max(0.0)
                     }
+                    LayoutDisplay::Inline => {
+                        // For inline elements, 'auto' width is the intrinsic/max-content width
+                        intrinsic.max_content_width
+                    }
+                    LayoutDisplay::Table | LayoutDisplay::InlineTable => {
+                        intrinsic.max_content_width
+                    }
+                    // Table cells: during intrinsic measurement, intrinsic sizes
+                    // aren't known yet (0). Use containing block width so content
+                    // can expand and be measured. The table layout algorithm sets
+                    // the final cell width from computed column widths.
+                    LayoutDisplay::TableCell => {
+                        if intrinsic.max_content_width > 0.0 {
+                            intrinsic.max_content_width
+                        } else {
+                            (containing_block_size.width
+                                - box_props.margin.left
+                                - box_props.margin.right
+                                - box_props.border.left
+                                - box_props.border.right
+                                - box_props.padding.left
+                                - box_props.padding.right)
+                                .max(0.0)
+                        }
+                    }
+                    // Other display types use intrinsic sizing
+                    _ => intrinsic.max_content_width,
                 }
-                // Other display types use intrinsic sizing
-                _ => intrinsic.max_content_width,
-            }
             }
         }
         LayoutWidth::Px(px) => {
             let em = get_element_font_size(styled_dom, id, node_state);
             let rem = super::getters::get_root_font_size(styled_dom, node_state);
             let pixels_opt = super::calc::resolve_pixel_value_no_percent_with_viewport(
-                &px, em, rem,
-                viewport_size.width, viewport_size.height,
+                &px,
+                em,
+                rem,
+                viewport_size.width,
+                viewport_size.height,
             );
 
             pixels_opt.unwrap_or_else(|| {
@@ -1778,16 +1922,24 @@ pub fn calculate_used_size_for_node(
             let em = get_element_font_size(styled_dom, id, node_state);
             let rem = super::getters::get_root_font_size(styled_dom, node_state);
             let arg = super::calc::resolve_pixel_value_with_viewport(
-                &px, containing_block_size.width, em, rem,
-                viewport_size.width, viewport_size.height,
+                &px,
+                containing_block_size.width,
+                em,
+                rem,
+                viewport_size.width,
+                viewport_size.height,
             );
-            intrinsic.max_content_width.min(intrinsic.min_content_width.max(arg))
+            intrinsic
+                .max_content_width
+                .min(intrinsic.min_content_width.max(arg))
         }
         LayoutWidth::Calc(items) => {
             use azul_css::props::basic::pixel::DEFAULT_FONT_SIZE;
             let em = get_element_font_size(styled_dom, id, node_state);
             let calc_ctx = super::calc::CalcResolveContext {
-                items, em_size: em, rem_size: DEFAULT_FONT_SIZE,
+                items,
+                em_size: em,
+                rem_size: DEFAULT_FONT_SIZE,
             };
             super::calc::evaluate_calc(&calc_ctx, containing_block_size.width)
         }
@@ -1848,28 +2000,30 @@ pub fn calculate_used_size_for_node(
             // CHILDREN resolve against the real box during their own layout instead of
             // collapsing against a 0 placeholder. (Root cause of the slippy-map
             // VirtualView blank-bounds bug: its container fills via abs inset:0.)
-            let abs_stretch_fit = if matches!(
-                position,
-                LayoutPosition::Absolute | LayoutPosition::Fixed
-            ) && !is_replaced
-            {
-                let off = crate::solver3::positioning::resolve_position_offsets(
-                    styled_dom, dom_id, *containing_block_size, *viewport_size,
-                );
-                match (off.top, off.bottom) {
-                    (Some(t), Some(b)) => Some(
-                        (containing_block_size.height
-                            - t
-                            - b
-                            - box_props.margin.top
-                            - box_props.margin.bottom)
-                            .max(0.0),
-                    ),
-                    _ => None,
-                }
-            } else {
-                None
-            };
+            let abs_stretch_fit =
+                if matches!(position, LayoutPosition::Absolute | LayoutPosition::Fixed)
+                    && !is_replaced
+                {
+                    let off = crate::solver3::positioning::resolve_position_offsets(
+                        styled_dom,
+                        dom_id,
+                        *containing_block_size,
+                        *viewport_size,
+                    );
+                    match (off.top, off.bottom) {
+                        (Some(t), Some(b)) => Some(
+                            (containing_block_size.height
+                                - t
+                                - b
+                                - box_props.margin.top
+                                - box_props.margin.bottom)
+                                .max(0.0),
+                        ),
+                        _ => None,
+                    }
+                } else {
+                    None
+                };
             match abs_stretch_fit {
                 Some(h) => h,
                 // §10.6.2: auto height for a replaced element (image / VirtualView)
@@ -1895,8 +2049,11 @@ pub fn calculate_used_size_for_node(
             let em = get_element_font_size(styled_dom, id, node_state);
             let rem = super::getters::get_root_font_size(styled_dom, node_state);
             let pixels_opt = super::calc::resolve_pixel_value_no_percent_with_viewport(
-                &px, em, rem,
-                viewport_size.width, viewport_size.height,
+                &px,
+                em,
+                rem,
+                viewport_size.width,
+                viewport_size.height,
             );
 
             // +spec:height-calculation:37bc8c - percentage heights resolve against definite containing block height
@@ -1922,8 +2079,12 @@ pub fn calculate_used_size_for_node(
             let em = get_element_font_size(styled_dom, id, node_state);
             let rem = super::getters::get_root_font_size(styled_dom, node_state);
             let arg = super::calc::resolve_pixel_value_with_viewport(
-                &px, containing_block_size.height, em, rem,
-                viewport_size.width, viewport_size.height,
+                &px,
+                containing_block_size.height,
+                em,
+                rem,
+                viewport_size.width,
+                viewport_size.height,
             );
             let auto_height = intrinsic.max_content_height;
             auto_height.min(auto_height.max(arg))
@@ -1932,7 +2093,9 @@ pub fn calculate_used_size_for_node(
             use azul_css::props::basic::pixel::DEFAULT_FONT_SIZE;
             let em = get_element_font_size(styled_dom, id, node_state);
             let calc_ctx = super::calc::CalcResolveContext {
-                items, em_size: em, rem_size: DEFAULT_FONT_SIZE,
+                items,
+                em_size: em,
+                rem_size: DEFAULT_FONT_SIZE,
             };
             super::calc::evaluate_calc(&calc_ctx, containing_block_size.height)
         }
@@ -1960,7 +2123,8 @@ pub fn calculate_used_size_for_node(
             _ => None,
         };
 
-        intrinsic_ratio.map_or((resolved_width, resolved_height), |ratio| if height_is_auto && !has_intrinsic_width && has_intrinsic_height {
+        intrinsic_ratio.map_or((resolved_width, resolved_height), |ratio| {
+            if height_is_auto && !has_intrinsic_width && has_intrinsic_height {
                 // §6.2 case: both auto, no intrinsic width, has intrinsic height + ratio
                 // → width = used height × ratio
                 (resolved_height * ratio, resolved_height)
@@ -1982,7 +2146,8 @@ pub fn calculate_used_size_for_node(
                 (block_width, block_width / ratio)
             } else {
                 (resolved_width, resolved_height)
-            })
+            }
+        })
     } else {
         (resolved_width, resolved_height)
     };
@@ -1998,7 +2163,11 @@ pub fn calculate_used_size_for_node(
     } else if let MultiValue::Exact(azul_css::props::style::effects::StyleAspectRatio::Ratio(ar)) =
         crate::solver3::getters::get_aspect_ratio_property(styled_dom, id, node_state)
     {
-        let ratio = if ar.height == 0 { 0.0 } else { ar.width as f32 / ar.height as f32 };
+        let ratio = if ar.height == 0 {
+            0.0
+        } else {
+            ar.width as f32 / ar.height as f32
+        };
         if ratio > 0.0 && height_is_auto && !width_is_auto {
             (resolved_width, resolved_width / ratio)
         } else if ratio > 0.0 && width_is_auto && !height_is_auto {
@@ -2175,14 +2344,14 @@ fn apply_constraint_violation_table(
     styled_dom: &StyledDom,
     id: NodeId,
     node_state: &StyledNodeState,
-    w: f32,  // tentative width (ignoring min/max)
-    h: f32,  // tentative height (ignoring min/max)
+    w: f32, // tentative width (ignoring min/max)
+    h: f32, // tentative height (ignoring min/max)
     containing_block_width: f32,
     containing_block_height: f32,
     box_props: &BoxProps,
 ) -> (f32, f32) {
     use crate::solver3::getters::{
-        get_css_min_width, get_css_max_width, get_css_min_height, get_css_max_height, MultiValue,
+        get_css_max_height, get_css_max_width, get_css_min_height, get_css_min_width, MultiValue,
     };
 
     // Resolve em against the element's OWN font-size and rem against the root
@@ -2196,7 +2365,10 @@ fn apply_constraint_violation_table(
     // +spec:positioning:c0af55 - automatic minimum size of abspos box is always zero (default 0.0)
     // Resolve min-width (default 0)
     let min_w = match get_css_min_width(styled_dom, id, node_state) {
-        MultiValue::Exact(mw) => resolve_px_with_box_model(&mw.inner, containing_block_width, box_props, true, em, rem).unwrap_or(0.0),
+        MultiValue::Exact(mw) => {
+            resolve_px_with_box_model(&mw.inner, containing_block_width, box_props, true, em, rem)
+                .unwrap_or(0.0)
+        }
         _ => 0.0,
     };
 
@@ -2206,7 +2378,15 @@ fn apply_constraint_violation_table(
             if mw.inner.number.get() >= core::f32::MAX - 1.0 {
                 f32::MAX
             } else {
-                resolve_px_with_box_model(&mw.inner, containing_block_width, box_props, true, em, rem).unwrap_or(f32::MAX)
+                resolve_px_with_box_model(
+                    &mw.inner,
+                    containing_block_width,
+                    box_props,
+                    true,
+                    em,
+                    rem,
+                )
+                .unwrap_or(f32::MAX)
             }
         }
         _ => f32::MAX,
@@ -2214,7 +2394,15 @@ fn apply_constraint_violation_table(
 
     // Resolve min-height (default 0)
     let min_h = match get_css_min_height(styled_dom, id, node_state) {
-        MultiValue::Exact(mh) => resolve_px_with_box_model(&mh.inner, containing_block_height, box_props, false, em, rem).unwrap_or(0.0),
+        MultiValue::Exact(mh) => resolve_px_with_box_model(
+            &mh.inner,
+            containing_block_height,
+            box_props,
+            false,
+            em,
+            rem,
+        )
+        .unwrap_or(0.0),
         _ => 0.0,
     };
 
@@ -2224,7 +2412,15 @@ fn apply_constraint_violation_table(
             if mh.inner.number.get() >= core::f32::MAX - 1.0 {
                 f32::MAX
             } else {
-                resolve_px_with_box_model(&mh.inner, containing_block_height, box_props, false, em, rem).unwrap_or(f32::MAX)
+                resolve_px_with_box_model(
+                    &mh.inner,
+                    containing_block_height,
+                    box_props,
+                    false,
+                    em,
+                    rem,
+                )
+                .unwrap_or(f32::MAX)
             }
         }
         _ => f32::MAX,
@@ -2250,24 +2446,16 @@ fn apply_constraint_violation_table(
         (false, false, false, false) => (w, h),
 
         // Row 2: w > max-width only
-        (true, false, false, false) => {
-            (max_w, (max_w * h / w).max(min_h))
-        }
+        (true, false, false, false) => (max_w, (max_w * h / w).max(min_h)),
 
         // Row 3: w < min-width only
-        (false, true, false, false) => {
-            (min_w, (min_w * h / w).min(max_h))
-        }
+        (false, true, false, false) => (min_w, (min_w * h / w).min(max_h)),
 
         // Row 4: h > max-height only
-        (false, false, true, false) => {
-            ((max_h * w / h).max(min_w), max_h)
-        }
+        (false, false, true, false) => ((max_h * w / h).max(min_w), max_h),
 
         // Row 5: h < min-height only
-        (false, false, false, true) => {
-            ((min_h * w / h).min(max_w), min_h)
-        }
+        (false, false, false, true) => ((min_h * w / h).min(max_w), min_h),
 
         // Row 6+7: (w > max-width) and (h > max-height)
         (true, false, true, false) => {
@@ -2323,7 +2511,10 @@ fn apply_width_constraints(
     // +spec:display-property:0c55e5 - auto min-width resolves to 0 for CSS2 display types
     // Resolve min-width (default is 0)
     let min_width = match get_css_min_width(styled_dom, id, node_state) {
-        MultiValue::Exact(mw) => resolve_px_with_box_model(&mw.inner, containing_block_width, box_props, true, em, rem).unwrap_or(0.0),
+        MultiValue::Exact(mw) => {
+            resolve_px_with_box_model(&mw.inner, containing_block_width, box_props, true, em, rem)
+                .unwrap_or(0.0)
+        }
         _ => 0.0,
     };
 
@@ -2333,7 +2524,14 @@ fn apply_width_constraints(
             if mw.inner.number.get() >= core::f32::MAX - 1.0 {
                 None
             } else {
-                resolve_px_with_box_model(&mw.inner, containing_block_width, box_props, true, em, rem)
+                resolve_px_with_box_model(
+                    &mw.inner,
+                    containing_block_width,
+                    box_props,
+                    true,
+                    em,
+                    rem,
+                )
             }
         }
         _ => None,
@@ -2370,7 +2568,15 @@ fn apply_height_constraints(
     // for backwards-compat with CSS2 display types (block, inline, inline-block, table)
     // Resolve min-height (default is 0)
     let min_height = match get_css_min_height(styled_dom, id, node_state) {
-        MultiValue::Exact(mh) => resolve_px_with_box_model(&mh.inner, containing_block_height, box_props, false, em, rem).unwrap_or(0.0),
+        MultiValue::Exact(mh) => resolve_px_with_box_model(
+            &mh.inner,
+            containing_block_height,
+            box_props,
+            false,
+            em,
+            rem,
+        )
+        .unwrap_or(0.0),
         _ => 0.0,
     };
 
@@ -2380,7 +2586,14 @@ fn apply_height_constraints(
             if mh.inner.number.get() >= core::f32::MAX - 1.0 {
                 None
             } else {
-                resolve_px_with_box_model(&mh.inner, containing_block_height, box_props, false, em, rem)
+                resolve_px_with_box_model(
+                    &mh.inner,
+                    containing_block_height,
+                    box_props,
+                    false,
+                    em,
+                    rem,
+                )
             }
         }
         _ => None,
@@ -2396,11 +2609,10 @@ fn apply_height_constraints(
     result.max(min_height)
 }
 
-#[must_use] pub fn extract_text_from_node(styled_dom: &StyledDom, node_id: NodeId) -> Option<String> {
+#[must_use]
+pub fn extract_text_from_node(styled_dom: &StyledDom, node_id: NodeId) -> Option<String> {
     match &styled_dom.node_data.as_container()[node_id].get_node_type() {
-        NodeType::Text(text_data) => {
-            Some(text_data.as_str().to_string())
-        }
+        NodeType::Text(text_data) => Some(text_data.as_str().to_string()),
         _ => None,
     }
 }
@@ -2513,7 +2725,7 @@ mod autotest_generated {
 
         fn ctx(&mut self) -> LayoutContext<'_, FontRef> {
             LayoutContext {
-            reflowed_ifcs: BTreeSet::new(),
+                reflowed_ifcs: BTreeSet::new(),
                 style_cache: Default::default(),
                 scrollbar_style_cache: core::cell::RefCell::new(HashMap::new()),
                 styled_dom: &self.styled_dom,
@@ -2614,7 +2826,10 @@ mod autotest_generated {
             (-1e30, 1e30),
         );
         assert_eq!(plain, 400.0);
-        assert_eq!(poisoned, 400.0, "box-model args must not leak into the result");
+        assert_eq!(
+            poisoned, 400.0,
+            "box-model args must not leak into the result"
+        );
     }
 
     #[test]
@@ -2788,11 +3003,20 @@ mod autotest_generated {
         // extremes are clamped at construction — nothing infinite or NaN can
         // reach the sizing math through a `PixelValue`.
         let bp = zero_props();
-        for raw in [f32::MAX, f32::MIN, f32::INFINITY, f32::NEG_INFINITY, f32::NAN] {
+        for raw in [
+            f32::MAX,
+            f32::MIN,
+            f32::INFINITY,
+            f32::NEG_INFINITY,
+            f32::NAN,
+        ] {
             let px = PixelValue::px(raw);
             let r = resolve_px_with_box_model(&px, 800.0, &bp, true, 16.0, 16.0)
                 .expect("px metric always resolves to Some");
-            assert!(r.is_finite(), "non-finite length from PixelValue::px({raw})");
+            assert!(
+                r.is_finite(),
+                "non-finite length from PixelValue::px({raw})"
+            );
         }
         assert_eq!(
             resolve_px_with_box_model(&PixelValue::px(f32::NAN), 800.0, &bp, true, 16.0, 16.0),
@@ -2820,7 +3044,10 @@ mod autotest_generated {
         // A zero-width containing block is exactly the boundary case.
         assert_eq!(auto_block_inline_size(&size(0.0, 0.0), &zero_props()), 0.0);
         // A negative containing block never yields a negative inline size.
-        assert_eq!(auto_block_inline_size(&size(-800.0, 0.0), &zero_props()), 0.0);
+        assert_eq!(
+            auto_block_inline_size(&size(-800.0, 0.0), &zero_props()),
+            0.0
+        );
     }
 
     #[test]
@@ -2850,7 +3077,10 @@ mod autotest_generated {
             &props(10.0, 2.0, 5.0),
             420.0,
         );
-        assert_eq!(r, 420.0, "auto under a max-content constraint is max-content");
+        assert_eq!(
+            r, 420.0,
+            "auto under a max-content constraint is max-content"
+        );
     }
 
     #[test]
@@ -3024,7 +3254,10 @@ mod autotest_generated {
         let r = calc.calculate_intrinsic_recursive(&mut tree, 0, false);
         let sizes = r.expect("a stray child index must be skipped, not fatal");
         assert!(sizes.min_content_width.is_finite());
-        assert!(tree.warm(LayoutNodeId::new(0)).and_then(|w| w.intrinsic_sizes).is_some());
+        assert!(tree
+            .warm(LayoutNodeId::new(0))
+            .and_then(|w| w.intrinsic_sizes)
+            .is_some());
     }
 
     #[test]
@@ -3051,7 +3284,10 @@ mod autotest_generated {
         assert_eq!(sizes.min_content_height, 33.0);
         assert_eq!(sizes.max_content_height, 44.0);
         // Children were never visited, so their warm slots stay empty.
-        assert!(tree.warm(LayoutNodeId::new(1)).and_then(|w| w.intrinsic_sizes).is_none());
+        assert!(tree
+            .warm(LayoutNodeId::new(1))
+            .and_then(|w| w.intrinsic_sizes)
+            .is_none());
     }
 
     // ==================================================================
@@ -3085,7 +3321,10 @@ mod autotest_generated {
         let mut text_cache = LayoutCache::new();
         let calc = IntrinsicSizeCalculator::new(&mut ctx, &mut text_cache);
 
-        let children = [(1usize, isz(10.0, 20.0, 5.0, 6.0)), (2usize, isz(30.0, 40.0, 7.0, 8.0))];
+        let children = [
+            (1usize, isz(10.0, 20.0, 5.0, 6.0)),
+            (2usize, isz(30.0, 40.0, 7.0, 8.0)),
+        ];
         let r = calc
             .calculate_block_intrinsic_sizes(&tree, 0, &children)
             .expect("valid tree");
@@ -3178,7 +3417,10 @@ mod autotest_generated {
         let mut text_cache = LayoutCache::new();
         let calc = IntrinsicSizeCalculator::new(&mut ctx, &mut text_cache);
 
-        let children = [(1usize, isz(10.0, 20.0, 5.0, 6.0)), (2usize, isz(30.0, 40.0, 7.0, 8.0))];
+        let children = [
+            (1usize, isz(10.0, 20.0, 5.0, 6.0)),
+            (2usize, isz(30.0, 40.0, 7.0, 8.0)),
+        ];
         let r = calc
             .calculate_flex_intrinsic_sizes(&tree, 0, &children)
             .expect("valid tree");
@@ -3264,7 +3506,10 @@ mod autotest_generated {
         let mut calc = IntrinsicSizeCalculator::new(&mut ctx, &mut text_cache);
 
         // Cell intrinsics keyed by the *cell* indices (the aggregation path).
-        let cells = [(2usize, isz(30.0, 50.0, 10.0, 20.0)), (3usize, isz(40.0, 60.0, 10.0, 15.0))];
+        let cells = [
+            (2usize, isz(30.0, 50.0, 10.0, 20.0)),
+            (3usize, isz(40.0, 60.0, 10.0, 15.0)),
+        ];
         let r = calc.calculate_table_intrinsic_sizes(&tree, 0, &cells);
         assert_eq!(r.min_content_width, 70.0, "sum of per-column minima");
         assert_eq!(r.max_content_width, 110.0, "sum of per-column maxima");
@@ -3307,7 +3552,8 @@ mod autotest_generated {
         let mut text_cache = LayoutCache::new();
         let mut calc = IntrinsicSizeCalculator::new(&mut ctx, &mut text_cache);
 
-        let r = calc.calculate_table_intrinsic_sizes(&tree, 0, &[(1usize, isz(9.0, 9.0, 9.0, 9.0))]);
+        let r =
+            calc.calculate_table_intrinsic_sizes(&tree, 0, &[(1usize, isz(9.0, 9.0, 9.0, 9.0))]);
         assert_eq!(r.min_content_width, 0.0);
         assert_eq!(r.max_content_width, 0.0);
         assert_eq!(r.min_content_height, 0.0);
@@ -3418,7 +3664,9 @@ mod autotest_generated {
 
         calculate_intrinsic_sizes(&mut ctx, &mut tree, &mut text_cache, &dirty)
             .expect("stale dirty ids must be ignored, not fatal");
-        let root = tree.warm(LayoutNodeId::new(tree.root)).and_then(|w| w.intrinsic_sizes);
+        let root = tree
+            .warm(LayoutNodeId::new(tree.root))
+            .and_then(|w| w.intrinsic_sizes);
         assert!(root.is_some(), "the root is still measured");
     }
 
@@ -3432,10 +3680,16 @@ mod autotest_generated {
 
         calculate_intrinsic_sizes(&mut ctx, &mut tree, &mut text_cache, &dirty).expect("pass 1");
         let a = layout_index(&tree, NodeId::new(2));
-        let first = tree.warm(LayoutNodeId::new(a)).and_then(|w| w.intrinsic_sizes).expect("measured");
+        let first = tree
+            .warm(LayoutNodeId::new(a))
+            .and_then(|w| w.intrinsic_sizes)
+            .expect("measured");
 
         calculate_intrinsic_sizes(&mut ctx, &mut tree, &mut text_cache, &dirty).expect("pass 2");
-        let second = tree.warm(LayoutNodeId::new(a)).and_then(|w| w.intrinsic_sizes).expect("measured");
+        let second = tree
+            .warm(LayoutNodeId::new(a))
+            .and_then(|w| w.intrinsic_sizes)
+            .expect("measured");
 
         assert_eq!(first.min_content_width, second.min_content_width);
         assert_eq!(first.max_content_width, second.max_content_width);
@@ -3449,7 +3703,9 @@ mod autotest_generated {
 
     fn text_dom(text: &str) -> StyledDom {
         styled(
-            Dom::create_body().with_child(div_class("p").with_child(Dom::create_text_do_not_use_without_block_level_wrapper(text))),
+            Dom::create_body().with_child(div_class("p").with_child(
+                Dom::create_text_do_not_use_without_block_level_wrapper(text),
+            )),
             ".p { display: block; }",
         )
     }
@@ -3473,7 +3729,8 @@ mod autotest_generated {
             .get(&text_dom)
             .and_then(|v| v.first())
             .copied()
-            .unwrap_or_else(|| LayoutNodeId::new(layout_index(tree, block_dom))).index()
+            .unwrap_or_else(|| LayoutNodeId::new(layout_index(tree, block_dom)))
+            .index()
     }
 
     #[test]
@@ -3502,7 +3759,10 @@ mod autotest_generated {
         let text = collected_text(&items);
         assert!(text.contains('\u{301}'), "combining acute survived");
         assert!(text.contains("مرحبا"), "RTL run survived");
-        assert!(text.contains("👨\u{200d}👩\u{200d}👧"), "ZWJ sequence survived");
+        assert!(
+            text.contains("👨\u{200d}👩\u{200d}👧"),
+            "ZWJ sequence survived"
+        );
     }
 
     #[test]
@@ -3560,7 +3820,10 @@ mod autotest_generated {
     fn subtree_contains_text_sees_the_node_itself_and_its_descendants() {
         let dom = text_dom("hi");
         // body(0) > .p(1) > text(2)
-        assert!(subtree_contains_text(&dom, NodeId::new(2)), "the text node itself");
+        assert!(
+            subtree_contains_text(&dom, NodeId::new(2)),
+            "the text node itself"
+        );
         assert!(subtree_contains_text(&dom, NodeId::new(1)), "its parent");
         assert!(subtree_contains_text(&dom, NodeId::new(0)), "the root");
     }
@@ -3580,7 +3843,9 @@ mod autotest_generated {
     fn subtree_contains_text_walks_a_deeply_nested_subtree() {
         // The recursion is unbounded in depth — 200 levels must not blow up.
         const DEPTH: usize = 200;
-        let mut inner = Dom::create_div().with_child(Dom::create_text_do_not_use_without_block_level_wrapper("deep"));
+        let mut inner = Dom::create_div().with_child(
+            Dom::create_text_do_not_use_without_block_level_wrapper("deep"),
+        );
         for _ in 0..DEPTH {
             inner = Dom::create_div().with_child(inner);
         }
@@ -3682,25 +3947,12 @@ mod autotest_generated {
     const ROW10: NodeId = NodeId::new(11);
 
     fn node_state(dom: &StyledDom, id: NodeId) -> StyledNodeState {
-        dom.styled_nodes.as_container()[id]
-            .styled_node_state
+        dom.styled_nodes.as_container()[id].styled_node_state
     }
 
-    fn used_size(
-        dom: &StyledDom,
-        id: NodeId,
-        cb: LogicalSize,
-        bp: &BoxProps,
-    ) -> LogicalSize {
-        calculate_used_size_for_node(
-            dom,
-            Some(id),
-            &cb,
-            IntrinsicSizes::default(),
-            bp,
-            &VIEWPORT,
-        )
-        .expect("used size")
+    fn used_size(dom: &StyledDom, id: NodeId, cb: LogicalSize, bp: &BoxProps) -> LogicalSize {
+        calculate_used_size_for_node(dom, Some(id), &cb, IntrinsicSizes::default(), bp, &VIEWPORT)
+            .expect("used size")
     }
 
     #[test]
@@ -3709,15 +3961,17 @@ mod autotest_generated {
         let cb = size(800.0, 600.0);
         let bp = zero_props();
 
-        let r = calculate_used_size_for_node(&dom, None, &cb, isz(0.0, 0.0, 0.0, 42.0), &bp, &VIEWPORT)
-            .expect("anonymous box");
+        let r =
+            calculate_used_size_for_node(&dom, None, &cb, isz(0.0, 0.0, 0.0, 42.0), &bp, &VIEWPORT)
+                .expect("anonymous box");
         assert_eq!(r.width, 800.0);
         assert_eq!(r.height, 42.0);
 
         // A non-positive content height means "auto" — resolved later from the
         // laid-out children, so 0.0 (not the negative value) is stored now.
-        let r = calculate_used_size_for_node(&dom, None, &cb, isz(0.0, 0.0, 0.0, -5.0), &bp, &VIEWPORT)
-            .expect("anonymous box");
+        let r =
+            calculate_used_size_for_node(&dom, None, &cb, isz(0.0, 0.0, 0.0, -5.0), &bp, &VIEWPORT)
+                .expect("anonymous box");
         assert_eq!(r.height, 0.0);
     }
 
@@ -3756,7 +4010,10 @@ mod autotest_generated {
         ] {
             let r = used_size(&dom, PCT, cb, &bp);
             assert!(!r.width.is_nan() && !r.height.is_nan(), "NaN for cb={cb:?}");
-            assert!(r.width >= 0.0 && r.height >= 0.0, "negative size for cb={cb:?}");
+            assert!(
+                r.width >= 0.0 && r.height >= 0.0,
+                "negative size for cb={cb:?}"
+            );
         }
         // An infinite CB is a MEASUREMENT constraint, not a length: a
         // percentage against it behaves as auto (max-content), never as an
@@ -3798,7 +4055,9 @@ mod autotest_generated {
         // compositor layer, and a ~900 GB allocation.
         let dom = constraints_dom();
         let bp = zero_props();
-        for id in [PLAIN, PCT, CLAMPED, MAXED, PCTMIN, BBOX, AUTOBLOCK, VWMIN, EM, HCLAMPED, ROW10] {
+        for id in [
+            PLAIN, PCT, CLAMPED, MAXED, PCTMIN, BBOX, AUTOBLOCK, VWMIN, EM, HCLAMPED, ROW10,
+        ] {
             let r = used_size(&dom, id, size(f32::INFINITY, f32::INFINITY), &bp);
             assert!(
                 r.width.is_finite() && r.height.is_finite(),
@@ -3878,8 +4137,16 @@ mod autotest_generated {
     #[test]
     fn width_constraints_clamp_then_let_min_win_over_max() {
         let dom = constraints_dom();
-        assert_eq!(width_constrained(&dom, MAXED, 300.0, 800.0), 100.0, "max clamps");
-        assert_eq!(width_constrained(&dom, MAXED, 50.0, 800.0), 50.0, "below max: untouched");
+        assert_eq!(
+            width_constrained(&dom, MAXED, 300.0, 800.0),
+            100.0,
+            "max clamps"
+        );
+        assert_eq!(
+            width_constrained(&dom, MAXED, 50.0, 800.0),
+            50.0,
+            "below max: untouched"
+        );
         assert_eq!(
             width_constrained(&dom, CLAMPED, 300.0, 800.0),
             200.0,
@@ -3926,7 +4193,10 @@ mod autotest_generated {
         // No max-width → +inf survives (a definite size is never produced from
         // an infinite one, but the function must not panic or wrap).
         assert!(width_constrained(&dom, PLAIN, f32::INFINITY, 800.0).is_infinite());
-        assert_eq!(width_constrained(&dom, CLAMPED, f32::NEG_INFINITY, 800.0), 200.0);
+        assert_eq!(
+            width_constrained(&dom, CLAMPED, f32::NEG_INFINITY, 800.0),
+            200.0
+        );
     }
 
     #[test]
@@ -4008,7 +4278,11 @@ mod autotest_generated {
         assert_eq!(cvt(&dom, MAXED, 0.0, 100.0), (0.0, 100.0));
         assert_eq!(cvt(&dom, MAXED, 200.0, 0.0), (100.0, 0.0));
         assert_eq!(cvt(&dom, MAXED, 0.0, 0.0), (0.0, 0.0));
-        assert_eq!(cvt(&dom, MAXED, -50.0, -50.0), (0.0, 0.0), "negatives clamp up to 0");
+        assert_eq!(
+            cvt(&dom, MAXED, -50.0, -50.0),
+            (0.0, 0.0),
+            "negatives clamp up to 0"
+        );
     }
 
     #[test]

--- a/layout/src/widgets/map.rs
+++ b/layout/src/widgets/map.rs
@@ -38,9 +38,7 @@
 
 use alloc::collections::btree_map::BTreeMap;
 
-use azul_core::callbacks::{
-    VirtualViewCallback, VirtualViewCallbackInfo, VirtualViewReturn,
-};
+use azul_core::callbacks::{VirtualViewCallback, VirtualViewCallbackInfo, VirtualViewReturn};
 use azul_core::dom::{DatasetMergeCallbackType, Dom, OptionDom};
 use azul_core::refany::{OptionRefAny, RefAny};
 use azul_css::dynamic_selector::CssPropertyWithConditionsVec;
@@ -185,13 +183,43 @@ impl MapTileStyle {
     pub const fn look(self, scheme: MapColorScheme) -> MapTheme {
         let dark = matches!(scheme, MapColorScheme::Dark);
         match self {
-            Self::Standard => if dark { MapTheme::Dark } else { MapTheme::Positron },
+            Self::Standard => {
+                if dark {
+                    MapTheme::Dark
+                } else {
+                    MapTheme::Positron
+                }
+            }
             // Bright and Liberty are light-only designs; their dark counterpart
             // is Dark Matter, the same pairing MapLibre's demo styles use.
-            Self::Bright => if dark { MapTheme::Dark } else { MapTheme::Bright },
-            Self::Liberty => if dark { MapTheme::Dark } else { MapTheme::Liberty },
-            Self::Google => if dark { MapTheme::GoogleNight } else { MapTheme::GoogleLight },
-            Self::Apple => if dark { MapTheme::AppleDark } else { MapTheme::AppleLight },
+            Self::Bright => {
+                if dark {
+                    MapTheme::Dark
+                } else {
+                    MapTheme::Bright
+                }
+            }
+            Self::Liberty => {
+                if dark {
+                    MapTheme::Dark
+                } else {
+                    MapTheme::Liberty
+                }
+            }
+            Self::Google => {
+                if dark {
+                    MapTheme::GoogleNight
+                } else {
+                    MapTheme::GoogleLight
+                }
+            }
+            Self::Apple => {
+                if dark {
+                    MapTheme::AppleDark
+                } else {
+                    MapTheme::AppleLight
+                }
+            }
             Self::Custom => MapTheme::Custom,
         }
     }
@@ -235,8 +263,11 @@ impl MapTheme {
     #[must_use]
     pub const fn pinned_scheme(self) -> Option<MapColorScheme> {
         match self {
-            Self::Positron | Self::Bright | Self::Liberty
-            | Self::GoogleLight | Self::AppleLight => Some(MapColorScheme::Light),
+            Self::Positron
+            | Self::Bright
+            | Self::Liberty
+            | Self::GoogleLight
+            | Self::AppleLight => Some(MapColorScheme::Light),
             Self::Dark | Self::GoogleNight | Self::AppleDark => Some(MapColorScheme::Dark),
             Self::System | Self::Custom => None,
         }
@@ -341,7 +372,11 @@ impl MapTileLayer {
     #[must_use]
     pub fn with_theme(mut self, theme: MapTheme) -> Self {
         self.theme = theme;
-        for t in [theme, theme.resolve(azul_core::window::WindowTheme::LightMode), theme.resolve(azul_core::window::WindowTheme::DarkMode)] {
+        for t in [
+            theme,
+            theme.resolve(azul_core::window::WindowTheme::LightMode),
+            theme.resolve(azul_core::window::WindowTheme::DarkMode),
+        ] {
             let credit = t.credit_str();
             if !credit.is_empty() && !self.attribution.as_str().contains(credit) {
                 let mut s = self.attribution.as_str().to_string();
@@ -455,7 +490,8 @@ pub struct MapWidget {
 }
 
 impl MapWidget {
-    #[must_use] pub fn create(layer: MapTileLayer) -> Self {
+    #[must_use]
+    pub fn create(layer: MapTileLayer) -> Self {
         Self {
             layer,
             viewport: MapViewport::default(),
@@ -465,14 +501,16 @@ impl MapWidget {
         }
     }
 
-    #[must_use] pub const fn with_viewport(mut self, viewport: MapViewport) -> Self {
+    #[must_use]
+    pub const fn with_viewport(mut self, viewport: MapViewport) -> Self {
         self.viewport = viewport;
         self
     }
 
     /// Pick a look for the tile layer (see [`MapTheme`]); `System` follows
     /// the window's light / dark theme.
-    #[must_use] pub fn with_theme(mut self, theme: MapTheme) -> Self {
+    #[must_use]
+    pub fn with_theme(mut self, theme: MapTheme) -> Self {
         self.layer = self.layer.with_theme(theme);
         self
     }
@@ -480,19 +518,22 @@ impl MapWidget {
     /// Tilt the camera: 0 looks straight down, [`MAX_PITCH_DEG`] is the
     /// steepest 3D view (clamped). Rendered as a perspective transform on
     /// the tile canvas; right-drag vertically changes it at runtime.
-    #[must_use] pub fn with_pitch(mut self, pitch_deg: f32) -> Self {
+    #[must_use]
+    pub fn with_pitch(mut self, pitch_deg: f32) -> Self {
         self.viewport.pitch_deg = clamp_pitch(pitch_deg);
         self
     }
 
     /// Rotate the map (clockwise degrees, normalised to `-180..180`).
     /// Right-drag horizontally or a rotate gesture changes it at runtime.
-    #[must_use] pub const fn with_bearing(mut self, bearing_deg: f32) -> Self {
+    #[must_use]
+    pub const fn with_bearing(mut self, bearing_deg: f32) -> Self {
         self.viewport.bearing_deg = normalize_bearing(bearing_deg);
         self
     }
 
-    #[must_use] pub fn with_container_style(mut self, css: CssPropertyWithConditionsVec) -> Self {
+    #[must_use]
+    pub fn with_container_style(mut self, css: CssPropertyWithConditionsVec) -> Self {
         self.container_style = css;
         self
     }
@@ -551,7 +592,8 @@ impl MapWidget {
     /// [`px_at_latlon`](Self::px_at_latlon). Exposed so apps don't reimplement
     /// the projection (e.g. to drop a pin where the user tapped).
     #[allow(clippy::suboptimal_flops)] // mul_add not guaranteed faster/available without target +fma; keep explicit a*b+c
-    #[must_use] pub fn latlon_at_px(
+    #[must_use]
+    pub fn latlon_at_px(
         viewport: MapViewport,
         px: azul_core::geom::LogicalPosition,
         container: azul_core::geom::LogicalSize,
@@ -572,7 +614,8 @@ impl MapWidget {
     /// container pixels at `viewport`.
     #[allow(clippy::suboptimal_flops)] // mul_add not guaranteed faster/available without target +fma; keep explicit a*b+c
     #[allow(clippy::cast_possible_truncation)] // bounded layout/render numeric cast
-    #[must_use] pub fn px_at_latlon(
+    #[must_use]
+    pub fn px_at_latlon(
         viewport: MapViewport,
         coord: MapLatLon,
         container: azul_core::geom::LogicalSize,
@@ -606,7 +649,8 @@ impl MapWidget {
     /// `azul_dll::unified::map::map_widget_dom`, which calls `dom_with_fetch`
     /// with the built-in worker. It used to route here, which is why the map
     /// panned but never painted a tile on every desktop platform.
-    #[must_use] pub fn dom(self) -> Dom {
+    #[must_use]
+    pub fn dom(self) -> Dom {
         self.build_dom(None)
     }
 
@@ -618,7 +662,8 @@ impl MapWidget {
     /// `azul_dll::desktop::extra::map::tile_fetch_worker`; wrap it in a
     /// `ThreadCallback` to pass it here. See the recipe in
     /// `MOBILE_SESSION_LOG.md`.
-    #[must_use] pub fn dom_with_fetch(self, cb: crate::thread::ThreadCallback) -> Dom {
+    #[must_use]
+    pub fn dom_with_fetch(self, cb: crate::thread::ThreadCallback) -> Dom {
         self.build_dom(Some(cb))
     }
 
@@ -844,7 +889,8 @@ pub struct MapTileCache {
 }
 
 impl MapTileCache {
-    #[must_use] pub const fn new(layer: MapTileLayer, viewport: MapViewport) -> Self {
+    #[must_use]
+    pub const fn new(layer: MapTileLayer, viewport: MapViewport) -> Self {
         let active_theme = layer.theme;
         Self {
             layer,
@@ -892,7 +938,10 @@ impl MapTileCache {
     /// The key `tile` occupies at the look the cache is currently showing.
     #[must_use]
     pub fn key_at_current_look(&self, tile: MapTileId) -> TileStyleKey {
-        TileStyleKey { tile, theme: self.current_look() }
+        TileStyleKey {
+            tile,
+            theme: self.current_look(),
+        }
     }
 
     /// Insert / replace `tile`'s entry at the current look.
@@ -929,16 +978,19 @@ impl MapTileCache {
     /// when the colour scheme flips — the previous look keeps painting until the
     /// restyle lands, and the restyle needs no network.
     #[must_use]
-    pub fn best_available_svg(&self, tile: MapTileId, want: MapTheme) -> Option<(MapTheme, AzString)> {
-        if let Some(TileEntry::Ready { svg }) = self.tiles.get(&TileStyleKey { tile, theme: want }) {
+    pub fn best_available_svg(
+        &self,
+        tile: MapTileId,
+        want: MapTheme,
+    ) -> Option<(MapTheme, AzString)> {
+        if let Some(TileEntry::Ready { svg }) = self.tiles.get(&TileStyleKey { tile, theme: want })
+        {
             return Some((want, svg.clone()));
         }
-        self.tiles
-            .iter()
-            .find_map(|(k, e)| match e {
-                TileEntry::Ready { svg } if k.tile == tile => Some((k.theme, svg.clone())),
-                _ => None,
-            })
+        self.tiles.iter().find_map(|(k, e)| match e {
+            TileEntry::Ready { svg } if k.tile == tile => Some((k.theme, svg.clone())),
+            _ => None,
+        })
     }
 
     /// Bound the tile cache by evicting tiles far from the current viewport.
@@ -971,7 +1023,11 @@ impl MapTileCache {
         let active = self.active_theme;
         let score = |k: &TileStyleKey| {
             tile_viewport_score(&self.viewport, &self.layer, k.tile)
-                + if k.theme == active { 0.0 } else { OTHER_LOOK_PENALTY }
+                + if k.theme == active {
+                    0.0
+                } else {
+                    OTHER_LOOK_PENALTY
+                }
         };
 
         let mut evictable: Vec<(f64, TileStyleKey)> = self
@@ -1189,10 +1245,10 @@ extern "C" fn merge_map_tile_cache(mut new_data: RefAny, mut old_data: RefAny) -
 // ────────── Pan + zoom callbacks ─────────────────────────────────────
 
 use crate::callbacks::CallbackInfo;
-use azul_core::callbacks::Update;
-use azul_core::callbacks::TimerCallbackReturn;
-use azul_core::task::{Duration, SystemTimeDiff, TerminateTimer, TimerId};
 use crate::timer::{Timer, TimerCallback, TimerCallbackInfo};
+use azul_core::callbacks::TimerCallbackReturn;
+use azul_core::callbacks::Update;
+use azul_core::task::{Duration, SystemTimeDiff, TerminateTimer, TimerId};
 
 // --- User hook: on_viewport_changed (backreference DI, FFI-exposed) ---
 
@@ -1237,9 +1293,7 @@ fn invoke_viewport_changed(
     viewport: MapViewport,
 ) -> Update {
     match hook {
-        OptionMapViewportChanged::Some(h) => {
-            (h.callback.cb)(h.refany.clone(), *info, viewport)
-        }
+        OptionMapViewportChanged::Some(h) => (h.callback.cb)(h.refany.clone(), *info, viewport),
         OptionMapViewportChanged::None => Update::DoNothing,
     }
 }
@@ -1486,7 +1540,9 @@ extern "C" fn map_on_pointer_up(mut data: RefAny, mut info: CallbackInfo) -> Upd
     let container = info
         .get_hit_node_rect()
         .map_or(azul_core::geom::LogicalSize::new(0.0, 0.0), |r| r.size);
-    let (press, viewport, hook) = data.downcast_mut::<MapTileCache>().map_or_else(|| (None, MapViewport::default(), OptionMapPinTap::None), |mut cache| {
+    let (press, viewport, hook) = data.downcast_mut::<MapTileCache>().map_or_else(
+        || (None, MapViewport::default(), OptionMapPinTap::None),
+        |mut cache| {
             let out = (cache.press_origin, cache.viewport, cache.on_pin_tap.clone());
             cache.drag_anchor = None;
             cache.pinch_anchor = None;
@@ -1494,7 +1550,8 @@ extern "C" fn map_on_pointer_up(mut data: RefAny, mut info: CallbackInfo) -> Upd
             // a pointer leaving the canvas ends a camera drag too
             cache.tilt_anchor = None;
             out
-        });
+        },
+    );
     // A press + release at ~the same point (no pan/pinch) is a tap: project it
     // to lat/lon and fire the user's on_pin_tap hook — and carry its answer
     // out, so a hook that drops a pin with `RefreshDom` sees the pin now, not
@@ -1531,7 +1588,9 @@ extern "C" fn map_on_scroll(mut data: RefAny, mut info: CallbackInfo) -> Update 
     // the scroll-physics input queue (which only feeds scrollable nodes).
     let dy: f32 = {
         let hn = info.get_hit_node();
-        hn.node.into_crate_internal().map_or(0.0, |nid| info.get_scroll_delta(hn.dom, nid).map_or(0.0, |d| d.y))
+        hn.node.into_crate_internal().map_or(0.0, |nid| {
+            info.get_scroll_delta(hn.dom, nid).map_or(0.0, |d| d.y)
+        })
     };
     #[cfg(feature = "std")]
     if std::env::var("AZ_MAP_DEBUG").is_ok() {
@@ -1562,7 +1621,10 @@ extern "C" fn map_on_scroll(mut data: RefAny, mut info: CallbackInfo) -> Update 
         for t in map_visible_tiles(&vp, bounds, &layer) {
             cache
                 .tiles
-                .entry(TileStyleKey { tile: t, theme: look })
+                .entry(TileStyleKey {
+                    tile: t,
+                    theme: look,
+                })
                 .or_insert(TileEntry::Pending);
         }
         (vp, cache.on_viewport_changed.clone())
@@ -1590,8 +1652,10 @@ fn wheel_zoom_step(dy_px: f32) -> f32 {
     if !dy_px.is_finite() {
         return 0.0;
     }
-    (dy_px / WHEEL_PX_PER_ZOOM_LEVEL)
-        .clamp(-MAX_ZOOM_STEP_PER_WHEEL_EVENT, MAX_ZOOM_STEP_PER_WHEEL_EVENT)
+    (dy_px / WHEEL_PX_PER_ZOOM_LEVEL).clamp(
+        -MAX_ZOOM_STEP_PER_WHEEL_EVENT,
+        MAX_ZOOM_STEP_PER_WHEEL_EVENT,
+    )
 }
 
 fn wrap_lon(lon: f64) -> f64 {
@@ -1645,7 +1709,11 @@ pub const fn normalize_bearing(bearing_deg: f32) -> f32 {
 /// away (`MapLibre`'s pitch), `rotate` applies the bearing; all about the
 /// canvas centre.
 #[must_use]
-pub fn camera_transform_css(viewport: &MapViewport, width_px: f32, height_px: f32) -> Option<String> {
+pub fn camera_transform_css(
+    viewport: &MapViewport,
+    width_px: f32,
+    height_px: f32,
+) -> Option<String> {
     let pitch = clamp_pitch(viewport.pitch_deg);
     let bearing = normalize_bearing(viewport.bearing_deg);
     if pitch.abs() < 0.01 && bearing.abs() < 0.01 {
@@ -1686,8 +1754,7 @@ fn lon_to_tile_x(lon_deg: f64, tile_count: f64) -> f64 {
 /// Latitude (deg) → fractional tile-y at the given `tile_count`.
 fn lat_to_tile_y(lat_deg: f64, tile_count: f64) -> f64 {
     let lat_rad = lat_deg.to_radians();
-    let mercator =
-        (1.0 - (lat_rad.tan() + 1.0 / lat_rad.cos()).ln() / core::f64::consts::PI) / 2.0;
+    let mercator = (1.0 - (lat_rad.tan() + 1.0 / lat_rad.cos()).ln() / core::f64::consts::PI) / 2.0;
     mercator * tile_count
 }
 
@@ -1748,7 +1815,8 @@ fn pan_viewport(
 // (`str_to_dom_unstyled` → `SvgNodeData::Path`) only produces a clip mask, so it
 // cannot paint the feature colours — hence the tiles rendered grey.
 #[cfg(all(feature = "xml", feature = "cpurender"))]
-#[must_use] pub fn svg_string_to_dom(svg: &str) -> Option<Dom> {
+#[must_use]
+pub fn svg_string_to_dom(svg: &str) -> Option<Dom> {
     let img = crate::cpurender::render_svg_to_imageref(svg.as_bytes(), 256, 256).ok()?;
     Some(
         Dom::create_image(img)
@@ -1897,7 +1965,10 @@ fn spawn_pending_tile_fetches(data: &mut RefAny, info: &mut CallbackInfo) {
             cache.tiles.remove(&k);
             cache
                 .tiles
-                .entry(TileStyleKey { tile: k.tile, theme: look })
+                .entry(TileStyleKey {
+                    tile: k.tile,
+                    theme: look,
+                })
                 .or_insert(TileEntry::Pending);
         }
 
@@ -2013,7 +2084,8 @@ fn build_tile_url(template: &str, tile: MapTileId) -> String {
 /// `MapTileCache` the widget reads); `incoming` is the `TileReadyMsg`
 /// the worker sent. Stamps the tile `Ready` (or `Failed`) and asks for
 /// a relayout so the `VirtualView` renders the new content.
-#[must_use] pub extern "C" fn map_tile_writeback(
+#[must_use]
+pub extern "C" fn map_tile_writeback(
     mut cache_dataset: RefAny,
     mut incoming: RefAny,
     mut info: CallbackInfo,
@@ -2027,7 +2099,13 @@ fn build_tile_url(template: &str, tile: MapTileId) -> String {
         }
         return Update::DoNothing;
     };
-    let msg = (m.tile, m.svg.clone(), m.error.clone(), m.theme, m.bytes.clone());
+    let msg = (
+        m.tile,
+        m.svg.clone(),
+        m.error.clone(),
+        m.theme,
+        m.bytes.clone(),
+    );
     drop(m);
     {
         let Some(mut cache) = cache_dataset.downcast_mut::<MapTileCache>() else {
@@ -2056,7 +2134,10 @@ fn build_tile_url(template: &str, tile: MapTileId) -> String {
         // widget has moved on from is still correct data for that look, so it is
         // kept, not thrown away and re-fetched. If the user flips back it paints
         // instantly; until then it serves as the fallback for its own tile.
-        let key = TileStyleKey { tile: msg.0, theme: msg.3 };
+        let key = TileStyleKey {
+            tile: msg.0,
+            theme: msg.3,
+        };
         let ok = msg.2.as_str().is_empty();
         let svg_len = msg.1.as_str().len();
         if ok {
@@ -2151,19 +2232,29 @@ fn map_visible_tiles(
     bounds: azul_core::geom::LogicalSize,
     layer: &MapTileLayer,
 ) -> Vec<MapTileId> {
-    let z_int =
-        (viewport.zoom.floor() as i32).clamp(i32::from(layer.min_zoom), i32::from(layer.max_zoom)) as u8;
+    let z_int = (viewport.zoom.floor() as i32)
+        .clamp(i32::from(layer.min_zoom), i32::from(layer.max_zoom)) as u8;
     let tile_count = 1u32 << u32::from(z_int);
     let frac_zoom = viewport.zoom - f32::from(z_int);
     let zoom_scale = 2.0_f32.powf(frac_zoom);
     let centre_x = lon_to_tile_x(viewport.centre_lon_deg, f64::from(tile_count)) as f32;
     let centre_y = lat_to_tile_y(viewport.centre_lat_deg, f64::from(tile_count)) as f32;
-    let (x_min, x_max, y_min, y_max) =
-        visible_tile_range(centre_x, centre_y, bounds.width, bounds.height, zoom_scale, tile_count);
+    let (x_min, x_max, y_min, y_max) = visible_tile_range(
+        centre_x,
+        centre_y,
+        bounds.width,
+        bounds.height,
+        zoom_scale,
+        tile_count,
+    );
     let mut tiles = Vec::new();
     for x in x_min..=x_max {
         for y in y_min..=y_max {
-            tiles.push(MapTileId { z: z_int, x: wrap_tile_x(x, tile_count), y: y as u32 });
+            tiles.push(MapTileId {
+                z: z_int,
+                x: wrap_tile_x(x, tile_count),
+                y: y as u32,
+            });
         }
     }
     tiles
@@ -2172,12 +2263,13 @@ fn map_visible_tiles(
 // ────────── VirtualView callback — visible-tile rendering ─────────────
 
 #[allow(clippy::suboptimal_flops)] // mul_add not guaranteed faster/available without target +fma; keep explicit a*b+c
-#[allow(clippy::cast_possible_truncation, clippy::cast_precision_loss, clippy::cast_sign_loss)] // bounded layout/render numeric cast
+#[allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_precision_loss,
+    clippy::cast_sign_loss
+)] // bounded layout/render numeric cast
 #[allow(clippy::too_many_lines)] // large but cohesive: single-purpose layout/render/parse routine (one branch per case)
-extern "C" fn map_widget_render(
-    data: RefAny,
-    info: VirtualViewCallbackInfo,
-) -> VirtualViewReturn {
+extern "C" fn map_widget_render(data: RefAny, info: VirtualViewCallbackInfo) -> VirtualViewReturn {
     enum TileDisplay {
         Glyph(&'static str),
         Svg(AzString),
@@ -2198,8 +2290,14 @@ extern "C" fn map_widget_render(
         }
         return VirtualViewReturn {
             dom: OptionDom::None,
-            materialized: azul_core::geom::LogicalRect::new(azul_core::geom::LogicalPosition::zero(), bounds_logical),
-            virtual_rect: azul_core::geom::LogicalRect::new(azul_core::geom::LogicalPosition::zero(), bounds_logical),
+            materialized: azul_core::geom::LogicalRect::new(
+                azul_core::geom::LogicalPosition::zero(),
+                bounds_logical,
+            ),
+            virtual_rect: azul_core::geom::LogicalRect::new(
+                azul_core::geom::LogicalPosition::zero(),
+                bounds_logical,
+            ),
         };
     }
 
@@ -2217,8 +2315,14 @@ extern "C" fn map_widget_render(
         None => {
             return VirtualViewReturn {
                 dom: OptionDom::None,
-                materialized: azul_core::geom::LogicalRect::new(azul_core::geom::LogicalPosition::zero(), bounds_logical),
-                virtual_rect: azul_core::geom::LogicalRect::new(azul_core::geom::LogicalPosition::zero(), bounds_logical),
+                materialized: azul_core::geom::LogicalRect::new(
+                    azul_core::geom::LogicalPosition::zero(),
+                    bounds_logical,
+                ),
+                virtual_rect: azul_core::geom::LogicalRect::new(
+                    azul_core::geom::LogicalPosition::zero(),
+                    bounds_logical,
+                ),
             };
         }
     };
@@ -2226,8 +2330,7 @@ extern "C" fn map_widget_render(
     // Round the requested fractional zoom down to the nearest integer
     // tile zoom the layer supports.
     let z_int = (viewport.zoom.floor() as i32)
-        .clamp(i32::from(layer.min_zoom), i32::from(layer.max_zoom))
-        as u8;
+        .clamp(i32::from(layer.min_zoom), i32::from(layer.max_zoom)) as u8;
     let tile_count = 1u32 << u32::from(z_int);
     let frac_zoom = viewport.zoom - f32::from(z_int);
     let zoom_scale = 2.0_f32.powf(frac_zoom);
@@ -2277,7 +2380,10 @@ extern "C" fn map_widget_render(
                 };
                 cache
                     .tiles
-                    .entry(TileStyleKey { tile: id, theme: look })
+                    .entry(TileStyleKey {
+                        tile: id,
+                        theme: look,
+                    })
                     .or_insert(TileEntry::Pending);
             }
         }
@@ -2293,27 +2399,30 @@ extern "C" fn map_widget_render(
     // placeholders. Only a tile with NO decoded look at all shows a glyph
     // (`…` Pending / `⟳` Fetching / `✗` Failed), which keeps the fetch path
     // observable.
-    let states: BTreeMap<MapTileId, TileDisplay> = data
-        .downcast_ref::<MapTileCache>()
-        .map_or_else(BTreeMap::new, |c| {
-            let mut out = BTreeMap::new();
-            for k in c.tiles.keys() {
-                if out.contains_key(&k.tile) {
-                    continue;
-                }
-                let disp = if let Some((_, svg)) = c.best_available_svg(k.tile, look) {
-                    TileDisplay::Svg(svg)
-                } else {
-                    match c.tiles.get(&TileStyleKey { tile: k.tile, theme: look }) {
-                        Some(TileEntry::Fetching) => TileDisplay::Glyph("⟳"),
-                        Some(TileEntry::Failed { .. }) => TileDisplay::Glyph("✗"),
-                        _ => TileDisplay::Glyph("…"),
+    let states: BTreeMap<MapTileId, TileDisplay> =
+        data.downcast_ref::<MapTileCache>()
+            .map_or_else(BTreeMap::new, |c| {
+                let mut out = BTreeMap::new();
+                for k in c.tiles.keys() {
+                    if out.contains_key(&k.tile) {
+                        continue;
                     }
-                };
-                out.insert(k.tile, disp);
-            }
-            out
-        });
+                    let disp = if let Some((_, svg)) = c.best_available_svg(k.tile, look) {
+                        TileDisplay::Svg(svg)
+                    } else {
+                        match c.tiles.get(&TileStyleKey {
+                            tile: k.tile,
+                            theme: look,
+                        }) {
+                            Some(TileEntry::Fetching) => TileDisplay::Glyph("⟳"),
+                            Some(TileEntry::Failed { .. }) => TileDisplay::Glyph("✗"),
+                            _ => TileDisplay::Glyph("…"),
+                        }
+                    };
+                    out.insert(k.tile, disp);
+                }
+                out
+            });
 
     // Build the visible-tile grid. Each tile div is GPU-translated
     // into its screen position; the (CSS-driven) `transform` keeps
@@ -2515,8 +2624,14 @@ extern "C" fn map_widget_render(
 
     VirtualViewReturn {
         dom: OptionDom::Some(grid),
-        materialized: azul_core::geom::LogicalRect::new(azul_core::geom::LogicalPosition::zero(), bounds_logical),
-        virtual_rect: azul_core::geom::LogicalRect::new(azul_core::geom::LogicalPosition::zero(), bounds_logical),
+        materialized: azul_core::geom::LogicalRect::new(
+            azul_core::geom::LogicalPosition::zero(),
+            bounds_logical,
+        ),
+        virtual_rect: azul_core::geom::LogicalRect::new(
+            azul_core::geom::LogicalPosition::zero(),
+            bounds_logical,
+        ),
     }
 }
 
@@ -2536,7 +2651,11 @@ mod camera_tests {
     fn the_flat_view_has_no_transform_and_no_overscan() {
         assert_eq!(camera_transform_css(&vp(0.0, 0.0), 800.0, 600.0), None);
         assert_eq!(camera_overscan(&vp(0.0, 0.0), 800.0, 600.0), (1.0, 1.0));
-        assert_eq!(camera_transform_css(&vp(0.001, -0.001), 800.0, 600.0), None, "sub-0.01deg is flat");
+        assert_eq!(
+            camera_transform_css(&vp(0.001, -0.001), 800.0, 600.0),
+            None,
+            "sub-0.01deg is flat"
+        );
     }
 
     #[test]
@@ -2547,7 +2666,9 @@ mod camera_tests {
         assert!(css.contains("rotate(30.00deg)"), "{css}");
         assert!(css.contains("transform-origin: 50% 50%"), "{css}");
         // the widget API clamps and normalises
-        let w = MapWidget::create(MapTileLayer::default()).with_pitch(95.0).with_bearing(370.0);
+        let w = MapWidget::create(MapTileLayer::default())
+            .with_pitch(95.0)
+            .with_bearing(370.0);
         assert_eq!(w.viewport.pitch_deg, MAX_PITCH_DEG);
         assert!((w.viewport.bearing_deg - 10.0).abs() < 1e-4);
         assert_eq!(clamp_pitch(f32::NAN), 0.0);
@@ -2561,9 +2682,15 @@ mod camera_tests {
         assert!((h - 2.0).abs() < 1e-4, "max pitch doubles the rows: {h}");
         assert!(w > 1.0 && w < 2.0, "{w}");
         let (w, h) = camera_overscan(&vp(0.0, 90.0), 800.0, 600.0);
-        assert!((w - 600.0 / 800.0).abs() < 1e-4 && (h - 800.0 / 600.0).abs() < 1e-4, "a 90deg turn swaps the sides: {w} {h}");
+        assert!(
+            (w - 600.0 / 800.0).abs() < 1e-4 && (h - 800.0 / 600.0).abs() < 1e-4,
+            "a 90deg turn swaps the sides: {w} {h}"
+        );
         let (w, h) = camera_overscan(&vp(0.0, 45.0), 800.0, 800.0);
-        assert!((w - core::f32::consts::SQRT_2).abs() < 1e-3 && (h - core::f32::consts::SQRT_2).abs() < 1e-3);
+        assert!(
+            (w - core::f32::consts::SQRT_2).abs() < 1e-3
+                && (h - core::f32::consts::SQRT_2).abs() < 1e-3
+        );
     }
 
     #[test]
@@ -2589,10 +2716,19 @@ mod theme_tests {
     fn system_follows_the_window_theme_and_presets_resolve_to_themselves() {
         let light = MapTheme::System.resolve(WindowTheme::LightMode);
         let dark = MapTheme::System.resolve(WindowTheme::DarkMode);
-        assert!(!light.is_dark_look() && dark.is_dark_look(), "{light:?} / {dark:?}");
+        assert!(
+            !light.is_dark_look() && dark.is_dark_look(),
+            "{light:?} / {dark:?}"
+        );
         assert_ne!(light, MapTheme::System);
         assert!(!light.sheet().is_empty() && !dark.sheet().is_empty());
-        for preset in [MapTheme::Positron, MapTheme::Dark, MapTheme::GoogleNight, MapTheme::AppleLight, MapTheme::Custom] {
+        for preset in [
+            MapTheme::Positron,
+            MapTheme::Dark,
+            MapTheme::GoogleNight,
+            MapTheme::AppleLight,
+            MapTheme::Custom,
+        ] {
             assert_eq!(preset.resolve(WindowTheme::DarkMode), preset);
             assert_eq!(preset.resolve(WindowTheme::LightMode), preset);
         }
@@ -2603,7 +2739,10 @@ mod theme_tests {
     #[test]
     fn a_custom_sheet_wins_over_a_preset_and_with_theme_credits_the_design() {
         let layer = MapTileLayer::default().with_theme(MapTheme::Positron);
-        assert_eq!(layer.effective_style_css(MapTheme::Positron).as_str(), super::super::map_themes::POSITRON);
+        assert_eq!(
+            layer.effective_style_css(MapTheme::Positron).as_str(),
+            super::super::map_themes::POSITRON
+        );
         assert!(
             layer.attribution.as_str().contains("CC BY 4.0"),
             "the CC BY design credit must reach the attribution: {}",
@@ -2615,13 +2754,24 @@ mod theme_tests {
 
         let mut custom = MapTileLayer::default().with_theme(MapTheme::Dark);
         custom.style_css = AzString::from("water { fill: #123456; }");
-        assert_eq!(custom.effective_style_css(MapTheme::Dark).as_str(), "water { fill: #123456; }");
+        assert_eq!(
+            custom.effective_style_css(MapTheme::Dark).as_str(),
+            "water { fill: #123456; }"
+        );
         // authored looks carry no third-party credit
-        assert!(MapTheme::AppleLight.credit_str().is_empty() && MapTheme::GoogleLight.credit_str().is_empty());
-        assert_eq!(MapTheme::Positron.credit().as_str(), MapTheme::Positron.credit_str());
+        assert!(
+            MapTheme::AppleLight.credit_str().is_empty()
+                && MapTheme::GoogleLight.credit_str().is_empty()
+        );
+        assert_eq!(
+            MapTheme::Positron.credit().as_str(),
+            MapTheme::Positron.credit_str()
+        );
         // System credits BOTH resolutions' designs where they have one
         let sys = MapTileLayer::default().with_theme(MapTheme::System);
-        let l = MapTheme::System.resolve(WindowTheme::LightMode).credit_str();
+        let l = MapTheme::System
+            .resolve(WindowTheme::LightMode)
+            .credit_str();
         let d = MapTheme::System.resolve(WindowTheme::DarkMode).credit_str();
         assert!(l.is_empty() || sys.attribution.as_str().contains(l));
         assert!(d.is_empty() || sys.attribution.as_str().contains(d));
@@ -2633,7 +2783,10 @@ mod theme_tests {
         let id = MapTileId { z: 1, x: 0, y: 0 };
         let look_a = cache.key_at_current_look(id);
         cache.mark_tile_ready(look_a, AzString::from("<svg/>"));
-        assert!(!cache.set_active_theme(cache.active_theme), "same look: nothing to do");
+        assert!(
+            !cache.set_active_theme(cache.active_theme),
+            "same look: nothing to do"
+        );
         assert!(matches!(cache.tiles[&look_a], TileEntry::Ready { .. }));
         assert!(cache.set_active_theme(MapTheme::Dark));
         // A look change RE-KEYS the lookup; it must never invalidate geometry
@@ -2644,7 +2797,10 @@ mod theme_tests {
             "a look change must not discard a decoded tile"
         );
         assert_eq!(cache.active_theme, MapTheme::Dark);
-        assert_eq!(cache.layer.effective_style_css(cache.active_theme).as_str(), super::super::map_themes::DARK);
+        assert_eq!(
+            cache.layer.effective_style_css(cache.active_theme).as_str(),
+            super::super::map_themes::DARK
+        );
     }
 }
 
@@ -2675,7 +2831,11 @@ mod tests {
 
     #[test]
     fn build_tile_url_substitutes_zxy() {
-        let tile = MapTileId { z: 11, x: 327, y: 791 };
+        let tile = MapTileId {
+            z: 11,
+            x: 327,
+            y: 791,
+        };
         assert_eq!(
             build_tile_url("https://t.example/{z}/{x}/{y}.pbf", tile),
             "https://t.example/11/327/791.pbf"
@@ -2740,8 +2900,14 @@ mod tests {
         for lat in [37.7749, -33.8688, 0.0] {
             let (_, down) = pan_viewport(lat, 0.0, 4.0, 0.0, 128.0);
             let (_, up) = pan_viewport(lat, 0.0, 4.0, 0.0, -128.0);
-            assert!(down > lat, "content dragged down must reveal the north: {lat} → {down}");
-            assert!(up < lat, "content dragged up must reveal the south: {lat} → {up}");
+            assert!(
+                down > lat,
+                "content dragged down must reveal the north: {lat} → {down}"
+            );
+            assert!(
+                up < lat,
+                "content dragged up must reveal the south: {lat} → {up}"
+            );
         }
     }
 
@@ -2766,8 +2932,14 @@ mod tests {
         let events: Vec<f32> = (0..40).map(|i| if i < 20 { 8.0 } else { 2.0 }).collect();
         let total: f32 = events.iter().map(|d| wheel_zoom_step(*d)).sum();
         // The old signum() * 0.5 charged 40 × 0.5 = 20 levels — past any cap.
-        assert!(total < 3.0, "a flick must stay within a couple of levels, got {total}");
-        assert!(total > 0.5, "a flick must still zoom noticeably, got {total}");
+        assert!(
+            total < 3.0,
+            "a flick must stay within a couple of levels, got {total}"
+        );
+        assert!(
+            total > 0.5,
+            "a flick must still zoom noticeably, got {total}"
+        );
     }
 
     #[test]
@@ -2801,15 +2973,29 @@ mod tests {
             .map(|k| k.tile)
             .collect();
         assert_eq!(order.len(), 17, "{order:?}");
-        assert_eq!(order[0], MapTileId { z: 2, x: 2, y: 2 }, "the tile under the centre first");
+        assert_eq!(
+            order[0],
+            MapTileId { z: 2, x: 2, y: 2 },
+            "the tile under the centre first"
+        );
         let ring: std::collections::BTreeSet<MapTileId> = order[..9].iter().copied().collect();
         for x in 1..=3 {
             for y in 1..=3 {
-                assert!(ring.contains(&MapTileId { z: 2, x, y }), "3×3 ring before the edge: {order:?}");
+                assert!(
+                    ring.contains(&MapTileId { z: 2, x, y }),
+                    "3×3 ring before the edge: {order:?}"
+                );
             }
         }
-        assert_eq!(*order.last().unwrap(), MapTileId { z: 1, x: 0, y: 0 }, "another zoom's leftover last");
-        assert!(!order.contains(&MapTileId { z: 2, x: 9, y: 9 }), "in-flight tiles are not pending");
+        assert_eq!(
+            *order.last().unwrap(),
+            MapTileId { z: 1, x: 0, y: 0 },
+            "another zoom's leftover last"
+        );
+        assert!(
+            !order.contains(&MapTileId { z: 2, x: 9, y: 9 }),
+            "in-flight tiles are not pending"
+        );
     }
 
     #[test]
@@ -2889,7 +3075,12 @@ mod tests {
         worker_handle
             .downcast_mut::<MapTileCache>()
             .unwrap()
-            .insert_tile(tile, TileEntry::Ready { svg: AzString::from("<svg/>") });
+            .insert_tile(
+                tile,
+                TileEntry::Ready {
+                    svg: AzString::from("<svg/>"),
+                },
+            );
 
         // ...and it IS visible through the merged cache (shared storage). With the
         // old copy-merge this assertion failed — the tile was stranded.
@@ -2914,15 +3105,23 @@ mod tests {
         let mut old_cache = MapTileCache::new(MapTileLayer::default(), viewport_at(5.0));
         old_cache.viewport.zoom = 7.0; // internal state from previous frames
         let tile = MapTileId { z: 2, x: 1, y: 1 };
-        old_cache.insert_tile(tile, TileEntry::Ready { svg: "<svg/>".into() });
+        old_cache.insert_tile(
+            tile,
+            TileEntry::Ready {
+                svg: "<svg/>".into(),
+            },
+        );
 
         let new_cache = MapTileCache::new(MapTileLayer::default(), viewport_at(2.0));
 
-        let mut merged =
-            merge_map_tile_cache(RefAny::new(new_cache), RefAny::new(old_cache));
+        let mut merged = merge_map_tile_cache(RefAny::new(new_cache), RefAny::new(old_cache));
         let g = merged.downcast_ref::<MapTileCache>().unwrap();
         // The build's viewport wins…
-        approx(f64::from(g.viewport.zoom), f64::from(viewport_at(2.0).zoom), 1e-6);
+        approx(
+            f64::from(g.viewport.zoom),
+            f64::from(viewport_at(2.0).zoom),
+            1e-6,
+        );
         // …while the fetched tiles survive in the same allocation.
         assert!(
             g.tile_entry(tile).is_some(),
@@ -2985,8 +3184,14 @@ mod tests {
         // …but x is unclamped so the world wraps: a west-edge viewport over-scans
         // into negative columns and an east-edge one past tile_count-1; both wrap
         // back into 0..tile_count via wrap_tile_x.
-        assert!(x0 < 0, "west-edge viewport should over-scan into wrapped columns");
-        assert!(x1 > 15, "east-edge viewport should over-scan into wrapped columns");
+        assert!(
+            x0 < 0,
+            "west-edge viewport should over-scan into wrapped columns"
+        );
+        assert!(
+            x1 > 15,
+            "east-edge viewport should over-scan into wrapped columns"
+        );
         assert_eq!(wrap_tile_x(x0, 16), x0.rem_euclid(16) as u32);
         assert_eq!(wrap_tile_x(x1, 16), x1.rem_euclid(16) as u32);
     }
@@ -3017,21 +3222,38 @@ mod tests {
         // the 192 cap — plus a near Pending tile and a near Ready tile.
         for x in 0..20u32 {
             for y in 0..20u32 {
-                cache
-                    .insert_tile(MapTileId { z: 4, x, y }, TileEntry::Ready { svg: AzString::from("<svg/>") });
+                cache.insert_tile(
+                    MapTileId { z: 4, x, y },
+                    TileEntry::Ready {
+                        svg: AzString::from("<svg/>"),
+                    },
+                );
             }
         }
         // A near, in-flight tile (must NEVER be evicted).
         cache.insert_tile(MapTileId { z: 4, x: 8, y: 8 }, TileEntry::Pending);
         // A near, ready tile (should survive — low distance score).
-        cache.insert_tile(MapTileId { z: 4, x: 9, y: 8 }, TileEntry::Ready { svg: AzString::from("<svg/>") });
+        cache.insert_tile(
+            MapTileId { z: 4, x: 9, y: 8 },
+            TileEntry::Ready {
+                svg: AzString::from("<svg/>"),
+            },
+        );
         // A very far ready tile (should be evicted first).
-        cache.insert_tile(MapTileId { z: 4, x: 0, y: 0 }, TileEntry::Ready { svg: AzString::from("<svg/>") });
+        cache.insert_tile(
+            MapTileId { z: 4, x: 0, y: 0 },
+            TileEntry::Ready {
+                svg: AzString::from("<svg/>"),
+            },
+        );
 
         assert!(cache.tiles.len() > 192, "precondition: over the cap");
         cache.prune_distant_tiles();
 
-        assert!(cache.tiles.len() <= 192, "cache must be bounded after prune");
+        assert!(
+            cache.tiles.len() <= 192,
+            "cache must be bounded after prune"
+        );
         // In-flight tile survives.
         assert!(matches!(
             cache.tile_entry(MapTileId { z: 4, x: 8, y: 8 }),
@@ -3046,8 +3268,12 @@ mod tests {
     fn prune_is_noop_under_cap() {
         let mut cache = test_cache();
         for x in 0..4u32 {
-            cache
-                .insert_tile(MapTileId { z: 4, x, y: 8 }, TileEntry::Ready { svg: AzString::from("<svg/>") });
+            cache.insert_tile(
+                MapTileId { z: 4, x, y: 8 },
+                TileEntry::Ready {
+                    svg: AzString::from("<svg/>"),
+                },
+            );
         }
         cache.prune_distant_tiles();
         assert_eq!(cache.tiles.len(), 4, "under the cap → nothing evicted");
@@ -3182,10 +3408,8 @@ mod autotest_generated {
         let previous_window_state: Option<FullWindowState> = None;
         let current_window_state = FullWindowState::default();
         let gl_context = OptionGlContextPtr::None;
-        let scroll_states: BTreeMap<
-            DomId,
-            BTreeMap<NodeHierarchyItemId, ScrollPosition>,
-        > = BTreeMap::new();
+        let scroll_states: BTreeMap<DomId, BTreeMap<NodeHierarchyItemId, ScrollPosition>> =
+            BTreeMap::new();
         let window_handle = RawWindowHandle::Unsupported;
         let system_callbacks = ExternalSystemCallbacks::rust_internal();
 
@@ -3516,11 +3740,8 @@ mod autotest_generated {
     fn latlon_at_px_centre_pixel_is_the_viewport_centre() {
         let viewport = view(51.5074, -0.1278, 11.0);
         let container = LogicalSize::new(800.0, 600.0);
-        let coord = MapWidget::latlon_at_px(
-            viewport,
-            LogicalPosition::new(400.0, 300.0),
-            container,
-        );
+        let coord =
+            MapWidget::latlon_at_px(viewport, LogicalPosition::new(400.0, 300.0), container);
         close(coord.lat_deg, 51.5074, 1e-9);
         close(coord.lon_deg, -0.1278, 1e-9);
     }
@@ -3624,7 +3845,11 @@ mod autotest_generated {
             container,
         );
         assert!(p.x.is_finite(), "x should stay finite, got {}", p.x);
-        assert!(!p.y.is_nan(), "y must be a number or an infinity, got {}", p.y);
+        assert!(
+            !p.y.is_nan(),
+            "y must be a number or an infinity, got {}",
+            p.y
+        );
     }
 
     #[test]
@@ -3660,8 +3885,7 @@ mod autotest_generated {
 
     #[test]
     fn visible_tile_range_infinite_dimensions_saturate_the_same_way() {
-        let (x0, x1, y0, y1) =
-            visible_tile_range(8.0, 8.0, f32::INFINITY, f32::INFINITY, 1.0, 16);
+        let (x0, x1, y0, y1) = visible_tile_range(8.0, 8.0, f32::INFINITY, f32::INFINITY, 1.0, 16);
         assert_eq!((x0, x1), (i32::MIN, i32::MAX));
         assert_eq!((y0, y1), (0, 15));
     }
@@ -3779,7 +4003,10 @@ mod autotest_generated {
     fn map_visible_tiles_zero_bounds_still_covers_the_centre() {
         let layer = MapTileLayer::default();
         let tiles = map_visible_tiles(&view(0.0, 0.0, 2.0), LogicalSize::new(0.0, 0.0), &layer);
-        assert!(!tiles.is_empty(), "the one-tile margin must survive 0x0 bounds");
+        assert!(
+            !tiles.is_empty(),
+            "the one-tile margin must survive 0x0 bounds"
+        );
         for t in &tiles {
             assert_eq!(t.z, 2);
             assert!(t.x < 4 && t.y < 4, "tile {t:?} escaped the z2 grid");
@@ -3842,9 +4069,8 @@ mod autotest_generated {
                     let viewport = view(lat, lon, zoom);
                     let tiles =
                         map_visible_tiles(&viewport, LogicalSize::new(800.0, 600.0), &layer);
-                    let expected_z = (zoom.floor() as i32)
-                        .clamp(i32::from(min_zoom), i32::from(max_zoom))
-                        as u8;
+                    let expected_z =
+                        (zoom.floor() as i32).clamp(i32::from(min_zoom), i32::from(max_zoom)) as u8;
                     let tile_count = 1u32 << u32::from(expected_z);
                     for t in &tiles {
                         assert_eq!(t.z, expected_z, "zoom {zoom} produced z {}", t.z);
@@ -3912,14 +4138,20 @@ mod autotest_generated {
 
     #[test]
     fn with_viewport_stores_extreme_values_verbatim() {
-        let widget = MapWidget::create(MapTileLayer::default())
-            .with_viewport(view(1.0e300, -1.0e300, f32::MAX));
+        let widget = MapWidget::create(MapTileLayer::default()).with_viewport(view(
+            1.0e300,
+            -1.0e300,
+            f32::MAX,
+        ));
         assert_eq!(widget.viewport.centre_lat_deg, 1.0e300);
         assert_eq!(widget.viewport.centre_lon_deg, -1.0e300);
         assert_eq!(widget.viewport.zoom, f32::MAX);
 
-        let widget = MapWidget::create(MapTileLayer::default())
-            .with_viewport(view(f64::NAN, f64::INFINITY, f32::NEG_INFINITY));
+        let widget = MapWidget::create(MapTileLayer::default()).with_viewport(view(
+            f64::NAN,
+            f64::INFINITY,
+            f32::NEG_INFINITY,
+        ));
         assert!(widget.viewport.centre_lat_deg.is_nan());
         assert!(widget.viewport.centre_lon_deg.is_infinite());
         assert!(widget.viewport.zoom.is_infinite());
@@ -3989,8 +4221,10 @@ mod autotest_generated {
 
     #[test]
     fn with_on_pin_tap_installs_and_replaces_the_hook() {
-        let mut widget = MapWidget::create(MapTileLayer::default())
-            .with_on_pin_tap(RefAny::new(HookLog::default()), record_pin as MapPinTapCallbackType);
+        let mut widget = MapWidget::create(MapTileLayer::default()).with_on_pin_tap(
+            RefAny::new(HookLog::default()),
+            record_pin as MapPinTapCallbackType,
+        );
         assert!(matches!(widget.on_pin_tap, OptionMapPinTap::Some(_)));
         widget.set_on_pin_tap(
             RefAny::new(HookLog::default()),
@@ -4118,11 +4352,20 @@ mod autotest_generated {
         let tile = MapTileId { z: 4, x: 8, y: 8 };
         let key = cache.key_at_current_look(tile);
         cache.mark_tile_ready(key, AzString::from("<svg/>"));
-        assert!(matches!(cache.tile_entry(tile), Some(TileEntry::Ready { .. })));
+        assert!(matches!(
+            cache.tile_entry(tile),
+            Some(TileEntry::Ready { .. })
+        ));
         cache.mark_tile_failed(key, AzString::from("boom"));
-        assert!(matches!(cache.tile_entry(tile), Some(TileEntry::Failed { .. })));
+        assert!(matches!(
+            cache.tile_entry(tile),
+            Some(TileEntry::Failed { .. })
+        ));
         cache.mark_tile_ready(key, AzString::from(""));
-        assert!(matches!(cache.tile_entry(tile), Some(TileEntry::Ready { .. })));
+        assert!(matches!(
+            cache.tile_entry(tile),
+            Some(TileEntry::Ready { .. })
+        ));
         assert_eq!(cache.tiles.len(), 1, "the same id must not duplicate");
     }
 
@@ -4166,7 +4409,12 @@ mod autotest_generated {
                 y: 0,
             },
         ] {
-            cache.insert_tile(tile, TileEntry::Failed { error: AzString::from("e") });
+            cache.insert_tile(
+                tile,
+                TileEntry::Failed {
+                    error: AzString::from("e"),
+                },
+            );
         }
         assert_eq!(cache.tiles.len(), 3);
     }
@@ -4178,8 +4426,12 @@ mod autotest_generated {
     fn fill_ready_grid(cache: &mut MapTileCache, z: u8, side: u32) {
         for x in 0..side {
             for y in 0..side {
-                cache
-                    .insert_tile(MapTileId { z, x, y }, TileEntry::Ready { svg: AzString::from("<svg/>") });
+                cache.insert_tile(
+                    MapTileId { z, x, y },
+                    TileEntry::Ready {
+                        svg: AzString::from("<svg/>"),
+                    },
+                );
             }
         }
     }
@@ -4225,7 +4477,11 @@ mod autotest_generated {
             let mut cache = MapTileCache::new(layer_zoom(0, 19), view(0.0, 0.0, zoom));
             fill_ready_grid(&mut cache, 4, 16);
             cache.prune_distant_tiles();
-            assert_eq!(cache.tiles.len(), 192, "zoom {zoom} must still bound the cache");
+            assert_eq!(
+                cache.tiles.len(),
+                192,
+                "zoom {zoom} must still bound the cache"
+            );
         }
     }
 
@@ -4251,9 +4507,17 @@ mod autotest_generated {
         // tile (the score adds 10_000 per zoom level of mismatch).
         let mut cache = cache_at(0.0, 0.0, 4.0);
         fill_ready_grid(&mut cache, 4, 16);
-        let wrong_zoom = MapTileId { z: 9, x: 256, y: 256 };
-        cache
-            .insert_tile(wrong_zoom, TileEntry::Ready { svg: AzString::from("<svg/>") });
+        let wrong_zoom = MapTileId {
+            z: 9,
+            x: 256,
+            y: 256,
+        };
+        cache.insert_tile(
+            wrong_zoom,
+            TileEntry::Ready {
+                svg: AzString::from("<svg/>"),
+            },
+        );
         let near = MapTileId { z: 4, x: 8, y: 8 };
         cache.prune_distant_tiles();
         assert!(cache.tiles.len() <= 192);
@@ -4261,7 +4525,10 @@ mod autotest_generated {
             cache.tile_entry(wrong_zoom).is_none(),
             "a zoom-mismatched tile must be evicted before same-zoom neighbours"
         );
-        assert!(cache.tile_entry(near).is_some(), "the centre tile must survive");
+        assert!(
+            cache.tile_entry(near).is_some(),
+            "the centre tile must survive"
+        );
     }
 
     // ==================================================================
@@ -4272,10 +4539,18 @@ mod autotest_generated {
     fn merge_with_a_wrong_typed_new_dataset_returns_the_old_one_intact() {
         let mut old_cache = cache_at(0.0, 0.0, 5.0);
         let tile = MapTileId { z: 5, x: 1, y: 1 };
-        old_cache.insert_tile(tile, TileEntry::Ready { svg: AzString::from("<svg/>") });
+        old_cache.insert_tile(
+            tile,
+            TileEntry::Ready {
+                svg: AzString::from("<svg/>"),
+            },
+        );
         let mut merged = merge_map_tile_cache(RefAny::new(0u32), RefAny::new(old_cache));
         let cache = merged.downcast_ref::<MapTileCache>().expect("old cache");
-        assert_eq!(cache.viewport.zoom, 5.0, "no adoption from a bogus new dataset");
+        assert_eq!(
+            cache.viewport.zoom, 5.0,
+            "no adoption from a bogus new dataset"
+        );
         assert!(cache.tile_entry(tile).is_some());
     }
 
@@ -4346,7 +4621,10 @@ mod autotest_generated {
     fn build_tile_url_without_placeholders_is_the_identity() {
         let tile = MapTileId { z: 1, x: 2, y: 3 };
         assert_eq!(build_tile_url("", tile), "");
-        assert_eq!(build_tile_url("https://t.example/fixed", tile), "https://t.example/fixed");
+        assert_eq!(
+            build_tile_url("https://t.example/fixed", tile),
+            "https://t.example/fixed"
+        );
         // Unknown placeholders are left verbatim, not eaten.
         assert_eq!(build_tile_url("{q}/{Z}/{ x }", tile), "{q}/{Z}/{ x }");
     }
@@ -4545,7 +4823,14 @@ mod autotest_generated {
     #[cfg(not(feature = "xml"))]
     #[test]
     fn svg_stub_returns_none_for_every_input() {
-        for input in ["", "   ", "<svg/>", "<svg><g/></svg>", "\u{1F600}", "<<<>>>"] {
+        for input in [
+            "",
+            "   ",
+            "<svg/>",
+            "<svg><g/></svg>",
+            "\u{1F600}",
+            "<<<>>>",
+        ] {
             assert!(svg_string_to_dom(input).is_none());
         }
         let long = "a".repeat(1_000_000);
@@ -4573,7 +4858,8 @@ mod autotest_generated {
             callback: (record_viewport as MapViewportChangedCallbackType).into(),
         });
         let viewport = view(f64::NAN, f64::INFINITY, f32::NAN);
-        let (update, _) = with_callback_info(|info| invoke_viewport_changed(&hook, &info, viewport));
+        let (update, _) =
+            with_callback_info(|info| invoke_viewport_changed(&hook, &info, viewport));
         assert_eq!(update, Update::DoNothing);
         assert_eq!(hook_log(&mut log), (1, 0));
     }
@@ -4593,11 +4879,17 @@ mod autotest_generated {
     fn finish_viewport_change_returns_the_hooks_update_and_rerenders_only_without_a_rebuild() {
         // No hook: the handler owes the in-place VirtualView re-render itself.
         let (update, changes) = with_callback_info(|mut info| {
-            finish_viewport_change(&OptionMapViewportChanged::None, &mut info, view(1.0, 2.0, 3.0))
+            finish_viewport_change(
+                &OptionMapViewportChanged::None,
+                &mut info,
+                view(1.0, 2.0, 3.0),
+            )
         });
         assert_eq!(update, Update::DoNothing);
         assert!(
-            changes.iter().any(|c| matches!(c, CallbackChange::UpdateAllVirtualViews)),
+            changes
+                .iter()
+                .any(|c| matches!(c, CallbackChange::UpdateAllVirtualViews)),
             "without a rebuild the view must be re-rendered in place: {changes:?}"
         );
 
@@ -4607,10 +4899,13 @@ mod autotest_generated {
             refany: log.clone(),
             callback: (record_viewport as MapViewportChangedCallbackType).into(),
         });
-        let (update, changes) =
-            with_callback_info(|mut info| finish_viewport_change(&hook, &mut info, view(1.0, 2.0, 3.0)));
+        let (update, changes) = with_callback_info(|mut info| {
+            finish_viewport_change(&hook, &mut info, view(1.0, 2.0, 3.0))
+        });
         assert_eq!(update, Update::DoNothing);
-        assert!(changes.iter().any(|c| matches!(c, CallbackChange::UpdateAllVirtualViews)));
+        assert!(changes
+            .iter()
+            .any(|c| matches!(c, CallbackChange::UpdateAllVirtualViews)));
         assert_eq!(hook_log(&mut log), (1, 0));
 
         // A hook that asks for RefreshDom: the handler RETURNS it (the bug:
@@ -4621,11 +4916,18 @@ mod autotest_generated {
             refany: log.clone(),
             callback: (record_viewport_and_refresh as MapViewportChangedCallbackType).into(),
         });
-        let (update, changes) =
-            with_callback_info(|mut info| finish_viewport_change(&hook, &mut info, view(1.0, 2.0, 3.0)));
-        assert_eq!(update, Update::RefreshDom, "the user's Update must come out of the handler");
+        let (update, changes) = with_callback_info(|mut info| {
+            finish_viewport_change(&hook, &mut info, view(1.0, 2.0, 3.0))
+        });
+        assert_eq!(
+            update,
+            Update::RefreshDom,
+            "the user's Update must come out of the handler"
+        );
         assert!(
-            !changes.iter().any(|c| matches!(c, CallbackChange::UpdateAllVirtualViews)),
+            !changes
+                .iter()
+                .any(|c| matches!(c, CallbackChange::UpdateAllVirtualViews)),
             "a rebuild already re-invokes the view; rendering it twice is waste: {changes:?}"
         );
         assert_eq!(hook_log(&mut log), (1, 0));
@@ -4674,8 +4976,7 @@ mod autotest_generated {
     #[test]
     fn pointer_down_without_a_cursor_is_a_no_op() {
         let mut dataset = RefAny::new(cache_at(0.0, 0.0, 4.0));
-        let (update, _) =
-            with_callback_info(|info| map_on_pointer_down(dataset.clone(), info));
+        let (update, _) = with_callback_info(|info| map_on_pointer_down(dataset.clone(), info));
         assert_eq!(update, Update::DoNothing);
         let cache = dataset.downcast_ref::<MapTileCache>().expect("cache");
         assert!(cache.drag_anchor.is_none());
@@ -4894,7 +5195,10 @@ mod autotest_generated {
         assert!(changes.is_empty(), "no worker → no threads queued");
         let cache = dataset.downcast_ref::<MapTileCache>().expect("cache");
         assert!(
-            cache.tiles.values().all(|e| matches!(e, TileEntry::Pending)),
+            cache
+                .tiles
+                .values()
+                .all(|e| matches!(e, TileEntry::Pending)),
             "tiles must stay Pending so the placeholder grid renders"
         );
     }
@@ -4934,7 +5238,11 @@ mod autotest_generated {
             let mut info = info;
             spawn_pending_tile_fetches(&mut dataset.clone(), &mut info);
         });
-        assert_eq!(count_states(&mut dataset), (16, 4), "one call spawns at most 16");
+        assert_eq!(
+            count_states(&mut dataset),
+            (16, 4),
+            "one call spawns at most 16"
+        );
         assert_eq!(
             changes
                 .iter()
@@ -4974,16 +5282,18 @@ mod autotest_generated {
             error: AzString::from(""),
             bytes: azul_css::U8Vec::from_vec(Vec::new()),
         });
-        let (update, changes) = with_callback_info(|info| {
-            map_tile_writeback(dataset.clone(), ok.clone(), info)
-        });
+        let (update, changes) =
+            with_callback_info(|info| map_tile_writeback(dataset.clone(), ok.clone(), info));
         assert_eq!(update, Update::DoNothing);
         assert!(changes
             .iter()
             .any(|c| matches!(c, CallbackChange::UpdateAllVirtualViews)));
         {
             let cache = dataset.downcast_ref::<MapTileCache>().expect("cache");
-            assert!(matches!(cache.tile_entry(tile), Some(TileEntry::Ready { .. })));
+            assert!(matches!(
+                cache.tile_entry(tile),
+                Some(TileEntry::Ready { .. })
+            ));
         }
 
         let failed = RefAny::new(TileReadyMsg {
@@ -4993,12 +5303,14 @@ mod autotest_generated {
             error: AzString::from("404"),
             bytes: azul_css::U8Vec::from_vec(Vec::new()),
         });
-        let (update, _) = with_callback_info(|info| {
-            map_tile_writeback(dataset.clone(), failed.clone(), info)
-        });
+        let (update, _) =
+            with_callback_info(|info| map_tile_writeback(dataset.clone(), failed.clone(), info));
         assert_eq!(update, Update::DoNothing);
         let cache = dataset.downcast_ref::<MapTileCache>().expect("cache");
-        assert!(matches!(cache.tile_entry(tile), Some(TileEntry::Failed { .. })));
+        assert!(matches!(
+            cache.tile_entry(tile),
+            Some(TileEntry::Failed { .. })
+        ));
     }
 
     #[test]
@@ -5026,11 +5338,13 @@ mod autotest_generated {
     #[test]
     fn tile_writeback_with_a_wrong_typed_message_is_a_no_op() {
         let mut dataset = RefAny::new(cache_at(0.0, 0.0, 4.0));
-        let (update, changes) = with_callback_info(|info| {
-            map_tile_writeback(dataset.clone(), RefAny::new(0u32), info)
-        });
+        let (update, changes) =
+            with_callback_info(|info| map_tile_writeback(dataset.clone(), RefAny::new(0u32), info));
         assert_eq!(update, Update::DoNothing);
-        assert!(changes.is_empty(), "a bogus message must not force a re-render");
+        assert!(
+            changes.is_empty(),
+            "a bogus message must not force a re-render"
+        );
         let cache = dataset.downcast_ref::<MapTileCache>().expect("cache");
         assert!(cache.tiles.is_empty());
     }
@@ -5044,9 +5358,8 @@ mod autotest_generated {
             error: AzString::from(""),
             bytes: azul_css::U8Vec::from_vec(Vec::new()),
         });
-        let (update, changes) = with_callback_info(|info| {
-            map_tile_writeback(RefAny::new(9u64), msg.clone(), info)
-        });
+        let (update, changes) =
+            with_callback_info(|info| map_tile_writeback(RefAny::new(9u64), msg.clone(), info));
         assert_eq!(update, Update::DoNothing);
         assert!(changes.is_empty());
     }
@@ -5150,9 +5463,7 @@ mod autotest_generated {
             TileStyleKey { tile, theme: dark },
             AzString::from("<svg id='d'/>"),
         );
-        let (got, svg) = cache
-            .best_available_svg(tile, dark)
-            .expect("exact hit");
+        let (got, svg) = cache.best_available_svg(tile, dark).expect("exact hit");
         assert_eq!(got, dark);
         assert_eq!(svg.as_str(), "<svg id='d'/>");
     }
@@ -5183,7 +5494,10 @@ mod autotest_generated {
         let cache = dataset.downcast_ref::<MapTileCache>().expect("cache");
         assert!(
             matches!(
-                cache.tiles.get(&TileStyleKey { tile, theme: arrived_for }),
+                cache.tiles.get(&TileStyleKey {
+                    tile,
+                    theme: arrived_for
+                }),
                 Some(TileEntry::Ready { .. })
             ),
             "a result for a look the widget has since left is still correct data \
@@ -5205,7 +5519,10 @@ mod autotest_generated {
             .insert(tile, azul_css::U8Vec::from_vec(Vec::from([9u8])));
         for scheme in [MapColorScheme::Light, MapColorScheme::Dark] {
             cache.mark_tile_ready(
-                TileStyleKey { tile, theme: MapTileStyle::Google.look(scheme) },
+                TileStyleKey {
+                    tile,
+                    theme: MapTileStyle::Google.look(scheme),
+                },
                 AzString::from("<svg/>"),
             );
         }
@@ -5265,8 +5582,7 @@ mod autotest_generated {
             (f32::INFINITY, 600.0),
             (800.0, f32::NEG_INFINITY),
         ] {
-            let ret =
-                with_virtual_view_info(w, h, |info| map_widget_render(dataset.clone(), info));
+            let ret = with_virtual_view_info(w, h, |info| map_widget_render(dataset.clone(), info));
             assert!(
                 rendered_child_count(&ret).is_none(),
                 "bounds {w}x{h} must render nothing until layout settles"
@@ -5277,8 +5593,9 @@ mod autotest_generated {
     #[test]
     fn render_with_a_wrong_typed_dataset_emits_no_dom() {
         let dataset = RefAny::new(0u32);
-        let ret =
-            with_virtual_view_info(800.0, 600.0, |info| map_widget_render(dataset.clone(), info));
+        let ret = with_virtual_view_info(800.0, 600.0, |info| {
+            map_widget_render(dataset.clone(), info)
+        });
         assert!(rendered_child_count(&ret).is_none());
     }
 
@@ -5290,8 +5607,9 @@ mod autotest_generated {
             LogicalSize::new(800.0, 600.0),
             &layer_zoom(0, 19),
         );
-        let ret =
-            with_virtual_view_info(800.0, 600.0, |info| map_widget_render(dataset.clone(), info));
+        let ret = with_virtual_view_info(800.0, 600.0, |info| {
+            map_widget_render(dataset.clone(), info)
+        });
         assert_eq!(
             rendered_child_count(&ret),
             Some(expected.len()),
@@ -5309,13 +5627,17 @@ mod autotest_generated {
     #[test]
     fn render_reports_the_bounds_back_as_the_scroll_size() {
         let dataset = RefAny::new(cache_at(0.0, 0.0, 2.0));
-        let ret =
-            with_virtual_view_info(640.0, 480.0, |info| map_widget_render(dataset.clone(), info));
+        let ret = with_virtual_view_info(640.0, 480.0, |info| {
+            map_widget_render(dataset.clone(), info)
+        });
         assert_eq!(ret.materialized.size.width, 640.0);
         assert_eq!(ret.materialized.size.height, 480.0);
         assert_eq!(ret.virtual_rect.size.width, 640.0);
         assert_eq!(ret.virtual_rect.size.height, 480.0);
-        assert_eq!((ret.materialized.origin.x, ret.materialized.origin.y), (0.0, 0.0));
+        assert_eq!(
+            (ret.materialized.origin.x, ret.materialized.origin.y),
+            (0.0, 0.0)
+        );
         assert_eq!(
             (ret.virtual_rect.origin.x, ret.virtual_rect.origin.y),
             (0.0, 0.0)
@@ -5332,11 +5654,17 @@ mod autotest_generated {
             LogicalSize::new(512.0, 512.0),
             &layer_zoom(0, 19),
         ) {
-            cache.insert_tile(tile, TileEntry::Ready { svg: AzString::from("not xml at all <<<") });
+            cache.insert_tile(
+                tile,
+                TileEntry::Ready {
+                    svg: AzString::from("not xml at all <<<"),
+                },
+            );
         }
         let dataset = RefAny::new(cache);
-        let ret =
-            with_virtual_view_info(512.0, 512.0, |info| map_widget_render(dataset.clone(), info));
+        let ret = with_virtual_view_info(512.0, 512.0, |info| {
+            map_widget_render(dataset.clone(), info)
+        });
         assert!(
             rendered_child_count(&ret).is_some_and(|n| n > 0),
             "garbage tiles still render their placeholder"
@@ -5357,14 +5685,22 @@ mod autotest_generated {
                 1 => cache.insert_tile(*tile, TileEntry::Fetching),
                 2 => cache.insert_tile(
                     *tile,
-                    TileEntry::Failed { error: AzString::from("\u{1F600} failed") },
+                    TileEntry::Failed {
+                        error: AzString::from("\u{1F600} failed"),
+                    },
                 ),
-                _ => cache.insert_tile(*tile, TileEntry::Ready { svg: AzString::from("") }),
+                _ => cache.insert_tile(
+                    *tile,
+                    TileEntry::Ready {
+                        svg: AzString::from(""),
+                    },
+                ),
             }
         }
         let dataset = RefAny::new(cache);
-        let ret =
-            with_virtual_view_info(512.0, 512.0, |info| map_widget_render(dataset.clone(), info));
+        let ret = with_virtual_view_info(512.0, 512.0, |info| {
+            map_widget_render(dataset.clone(), info)
+        });
         assert_eq!(rendered_child_count(&ret), Some(tiles.len()));
     }
 
@@ -5390,10 +5726,12 @@ mod autotest_generated {
     #[test]
     fn render_is_stable_across_repeated_invocations() {
         let dataset = RefAny::new(cache_at(48.1372, 11.5756, 5.0));
-        let first =
-            with_virtual_view_info(800.0, 600.0, |info| map_widget_render(dataset.clone(), info));
-        let second =
-            with_virtual_view_info(800.0, 600.0, |info| map_widget_render(dataset.clone(), info));
+        let first = with_virtual_view_info(800.0, 600.0, |info| {
+            map_widget_render(dataset.clone(), info)
+        });
+        let second = with_virtual_view_info(800.0, 600.0, |info| {
+            map_widget_render(dataset.clone(), info)
+        });
         assert_eq!(rendered_child_count(&first), rendered_child_count(&second));
     }
 }

--- a/layout/src/widgets/map.rs
+++ b/layout/src/widgets/map.rs
@@ -127,7 +127,137 @@ pub enum MapTheme {
     Custom,
 }
 
+/// The LIGHT/DARK half of a map look — the axis the CASCADE owns.
+///
+/// This is deliberately not a `MapTheme` variant. Every cartography style has
+/// both a light and a dark rendering, and which one to show is the same
+/// question `@media (prefers-color-scheme: dark)` already answers for every
+/// other node in the tree. The widget must not answer it a second time, with
+/// its own platform rules, against its own copy of the theme.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub enum MapColorScheme {
+    #[default]
+    Light,
+    Dark,
+}
+
+impl MapColorScheme {
+    /// The scheme the CASCADE is resolving against — `SystemStyle::theme` is
+    /// literally what `DynamicSelectorContext::from_system_style` turns into
+    /// the `ThemeCondition` that `prefers-color-scheme` matches on
+    /// (`css/src/dynamic_selector.rs`). Reading it here means the map and the
+    /// stylesheet cannot disagree about what "dark" means.
+    #[must_use]
+    pub const fn from_system_theme(theme: azul_css::system::Theme) -> Self {
+        match theme {
+            azul_css::system::Theme::Dark => Self::Dark,
+            _ => Self::Light,
+        }
+    }
+}
+
+/// The CARTOGRAPHY half of a map look — the axis the APP owns.
+///
+/// "Which map am I looking at" (OSM-ish, Google-like, Apple-like) is a product
+/// decision and belongs to the widget's caller. It is orthogonal to light/dark:
+/// each of these has both.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub enum MapTileStyle {
+    /// CARTO Positron / Dark Matter via `OpenFreeMap`.
+    #[default]
+    Standard,
+    /// OSM Bright (light only; pairs with Dark Matter).
+    Bright,
+    /// OSM Liberty (light only; pairs with Dark Matter).
+    Liberty,
+    /// Google-Maps-like.
+    Google,
+    /// Apple-Maps-like.
+    Apple,
+    /// The caller's own `MapTileLayer::style_css`.
+    Custom,
+}
+
+impl MapTileStyle {
+    /// This cartography rendered for `scheme`. THE join of the two axes: the
+    /// only place a (style, scheme) pair becomes one concrete sheet.
+    #[must_use]
+    pub const fn look(self, scheme: MapColorScheme) -> MapTheme {
+        let dark = matches!(scheme, MapColorScheme::Dark);
+        match self {
+            Self::Standard => if dark { MapTheme::Dark } else { MapTheme::Positron },
+            // Bright and Liberty are light-only designs; their dark counterpart
+            // is Dark Matter, the same pairing MapLibre's demo styles use.
+            Self::Bright => if dark { MapTheme::Dark } else { MapTheme::Bright },
+            Self::Liberty => if dark { MapTheme::Dark } else { MapTheme::Liberty },
+            Self::Google => if dark { MapTheme::GoogleNight } else { MapTheme::GoogleLight },
+            Self::Apple => if dark { MapTheme::AppleDark } else { MapTheme::AppleLight },
+            Self::Custom => MapTheme::Custom,
+        }
+    }
+
+    /// The platform's familiar cartography. A FAMILY choice, not a light/dark
+    /// one — picking Apple-like maps on Apple platforms is a product decision
+    /// that has nothing to do with the colour scheme, which is why this `cfg!`
+    /// is legitimate where the old `resolve()`'s light/dark `cfg!` was not.
+    #[must_use]
+    pub const fn platform_default() -> Self {
+        if cfg!(any(target_os = "macos", target_os = "ios")) {
+            Self::Apple
+        } else if cfg!(target_os = "android") {
+            Self::Google
+        } else {
+            Self::Standard
+        }
+    }
+}
+
 impl MapTheme {
+    /// Which cartography this look belongs to (the app-owned axis).
+    #[must_use]
+    pub const fn style(self) -> MapTileStyle {
+        match self {
+            Self::Positron | Self::Dark => MapTileStyle::Standard,
+            Self::Bright => MapTileStyle::Bright,
+            Self::Liberty => MapTileStyle::Liberty,
+            Self::GoogleLight | Self::GoogleNight => MapTileStyle::Google,
+            Self::AppleLight | Self::AppleDark => MapTileStyle::Apple,
+            Self::Custom => MapTileStyle::Custom,
+            Self::System => MapTileStyle::platform_default(),
+        }
+    }
+
+    /// The scheme this look PINS, or `None` when it defers to the cascade.
+    ///
+    /// Only `System` defers. Naming a light or dark preset explicitly is an app
+    /// overriding the cascade on purpose, and an explicit override wins — the
+    /// same contract as writing a colour directly on a node.
+    #[must_use]
+    pub const fn pinned_scheme(self) -> Option<MapColorScheme> {
+        match self {
+            Self::Positron | Self::Bright | Self::Liberty
+            | Self::GoogleLight | Self::AppleLight => Some(MapColorScheme::Light),
+            Self::Dark | Self::GoogleNight | Self::AppleDark => Some(MapColorScheme::Dark),
+            Self::System | Self::Custom => None,
+        }
+    }
+
+    /// This look as it should be rendered when the cascade says `scheme`.
+    ///
+    /// Replaces `resolve(window_theme)` as the widget's internal entry point:
+    /// the light/dark input is the CASCADE's, and the platform `cfg!` that
+    /// remains only picks the cartography family.
+    #[must_use]
+    pub const fn for_scheme(self, scheme: MapColorScheme) -> Self {
+        match self.pinned_scheme() {
+            Some(_) => self,
+            None => match self {
+                Self::Custom => Self::Custom,
+                _ => self.style().look(scheme),
+            },
+        }
+    }
+
     /// The `MapCSS` sheet of a preset; empty for `Custom` and the unresolved
     /// `System` (resolve it with [`Self::resolve`] first).
     #[must_use]
@@ -162,22 +292,20 @@ impl MapTheme {
 
     /// `System` resolved against the window's theme; every other preset
     /// is its own resolution.
+    /// COMPATIBILITY entry point, kept because it is public API. Internals use
+    /// [`Self::for_scheme`] with the scheme the CASCADE resolved instead: the
+    /// window theme and the cascade's `prefers-color-scheme` are fed from two
+    /// different places (`FullWindowState::theme` vs `SystemStyle::theme`) and
+    /// on macOS only the former is refreshed on a theme flip, so resolving off
+    /// the window theme makes the map disagree with its own stylesheet.
     #[must_use]
     pub fn resolve(self, window_theme: azul_core::window::WindowTheme) -> Self {
-        use azul_core::window::WindowTheme;
-        if self != Self::System {
-            return self;
-        }
-        let dark = matches!(window_theme, WindowTheme::DarkMode);
-        if cfg!(any(target_os = "macos", target_os = "ios")) {
-            if dark { Self::AppleDark } else { Self::AppleLight }
-        } else if cfg!(target_os = "android") {
-            if dark { Self::GoogleNight } else { Self::GoogleLight }
-        } else if dark {
-            Self::Dark
+        let scheme = if matches!(window_theme, azul_core::window::WindowTheme::DarkMode) {
+            MapColorScheme::Dark
         } else {
-            Self::Positron
-        }
+            MapColorScheme::Light
+        };
+        self.for_scheme(scheme)
     }
 
     /// The credit line a preset's licence asks for (CC BY 4.0 for the
@@ -606,15 +734,59 @@ impl MapWidget {
 
 // ────────── Tile cache (dataset RefAny payload) ───────────────────────
 
+/// What a cached tile IS: these coordinates, styled for that look.
+///
+/// The look is part of the KEY, not a stamp the cache checks and invalidates
+/// on. Two looks of one tile are two entries that coexist, so switching look
+/// (a light/dark flip, an app changing cartography) RE-KEYS the lookup and the
+/// other variant stays cached — instantly available if the user flips back, and
+/// usable as a fallback while the new one styles.
+///
+/// The old cache keyed on `MapTileId` alone and kept a single `decoded_theme`
+/// beside it. Any disagreement between the two threw decoded tiles away and
+/// re-fetched them, so a look that was not yet settled on the first frame cost
+/// a second network round-trip for every visible tile.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct TileStyleKey {
+    pub tile: MapTileId,
+    pub theme: MapTheme,
+}
+
+// Ordered by hand rather than derived: `MapTheme` is an api.json type whose
+// derive list is generated, and widening it just to key a private map would be
+// drift. A fieldless `#[repr(C)]` enum casts to its discriminant, which is all
+// the ordering needs — it only has to be total and stable so the `BTreeMap`
+// iterates deterministically for the debug log and the e2e snapshots.
+impl PartialOrd for TileStyleKey {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+impl Ord for TileStyleKey {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        self.tile
+            .cmp(&other.tile)
+            .then_with(|| (self.theme as u8).cmp(&(other.theme as u8)))
+    }
+}
+
 #[derive(Debug)]
 pub struct MapTileCache {
     pub layer: MapTileLayer,
     pub viewport: MapViewport,
-    /// `Ready(svg)` once the tile has been fetched + decoded;
-    /// `Pending` while queued, `Fetching` while a worker thread is
+    /// `Ready(svg)` once the tile has been fetched + styled for THIS key's
+    /// look; `Pending` while queued, `Fetching` while a worker thread is
     /// in flight; absent otherwise. `BTreeMap` for deterministic
     /// iteration so the debug log + e2e snapshots are stable.
-    pub tiles: BTreeMap<MapTileId, TileEntry>,
+    pub tiles: BTreeMap<TileStyleKey, TileEntry>,
+    /// The tile's raw MVT payload, keyed by coordinates ALONE because the bytes
+    /// do not depend on the look — the same features are styled differently.
+    ///
+    /// This is what makes a look change free of network traffic: a restyle is
+    /// handed these bytes and performs no HTTP request at all. A tile is
+    /// therefore fetched at most once per session no matter how often the
+    /// cascade's light/dark answer changes.
+    pub tile_bytes: BTreeMap<MapTileId, azul_css::U8Vec>,
     /// Worker thread entry point that fetches + decodes one tile.
     /// Supplied by `MapWidget::dom_with_fetch` (the caller, usually
     /// `azul_dll`'s map-tiles glue, provides this because the MVT
@@ -647,12 +819,25 @@ pub struct MapTileCache {
     /// Pixel position of the last right-button press while a camera drag
     /// (tilt / rotate) is in flight; `None` between drags.
     pub tilt_anchor: Option<azul_core::geom::LogicalPosition>,
-    /// The RESOLVED theme the cached tiles were decoded with (see
-    /// [`MapTheme::resolve`]). The render callback compares it with the
-    /// window's current theme every frame; a mismatch re-queues every tile
-    /// (the decode happens on the fetch worker with the sheet of record)
-    /// and drops in-flight results decoded with the old sheet.
-    pub decoded_theme: MapTheme,
+    /// A MEMO of the look the last render resolved — nothing more.
+    ///
+    /// The render decides the look from the style available at render time and
+    /// writes it here purely so the spawn/sweep callbacks (which have no render
+    /// info) know which key to fill. It is deliberately NOT a validity stamp:
+    /// changing it invalidates nothing and discards nothing, because the look
+    /// is part of every tile's key.
+    pub active_theme: MapTheme,
+    /// The light/dark answer THE CASCADE gave, recorded by whichever callback
+    /// last had a `CallbackInfo` (mount, the 250 ms sweep, any pointer event).
+    ///
+    /// `SystemStyle::theme` is the exact input `prefers-color-scheme` matches
+    /// on, so the map and the app's stylesheet always agree. It is `None` until
+    /// the first such callback runs — the very first VirtualView render happens
+    /// before mount, and rather than invent an answer there it renders the
+    /// layer's own look and lets the sweep correct it. Getting that first guess
+    /// wrong is now free: it re-keys, it does not invalidate, and no tile is
+    /// fetched twice.
+    pub cascade_scheme: Option<MapColorScheme>,
     /// The user's `on_pin_tap` hook, copied from the builder so pointer-up can
     /// fire it. Carried across relayout.
     pub on_pin_tap: OptionMapPinTap,
@@ -660,48 +845,100 @@ pub struct MapTileCache {
 
 impl MapTileCache {
     #[must_use] pub const fn new(layer: MapTileLayer, viewport: MapViewport) -> Self {
-        let decoded_theme = layer.theme;
+        let active_theme = layer.theme;
         Self {
             layer,
             viewport,
             tiles: BTreeMap::new(),
+            tile_bytes: BTreeMap::new(),
             fetch_callback: None,
             drag_anchor: None,
             pinch_anchor: None,
             press_origin: None,
             tilt_anchor: None,
-            decoded_theme,
+            active_theme,
+            cascade_scheme: None,
             on_viewport_changed: OptionMapViewportChanged::None,
             on_pin_tap: OptionMapPinTap::None,
         }
     }
 
-    /// Adopt a newly resolved theme: every decoded tile goes back to
-    /// `Pending` so the fetch worker re-decodes it with the new sheet.
-    /// `true` when something changed.
-    pub fn adopt_theme(&mut self, resolved: MapTheme) -> bool {
-        if self.decoded_theme == resolved {
-            return false;
+    /// The look to render right now: the layer's choice of cartography, taken
+    /// to the cascade's light/dark. An explicitly pinned preset wins.
+    #[must_use]
+    pub fn current_look(&self) -> MapTheme {
+        match self.cascade_scheme {
+            Some(scheme) => self.layer.theme.for_scheme(scheme),
+            // Nothing has told us what the cascade says yet (pre-mount). Use the
+            // layer's own look; the sweep re-keys within 250 ms, for free.
+            None => self.layer.theme,
         }
-        self.decoded_theme = resolved;
-        for entry in self.tiles.values_mut() {
-            if matches!(entry, TileEntry::Ready { .. } | TileEntry::Failed { .. }) {
-                *entry = TileEntry::Pending;
-            }
-        }
-        true
+    }
+
+    /// Record the look the renderer resolved. Returns `true` when it moved.
+    ///
+    /// This USED to be `adopt_theme`, and it used to push every decoded tile
+    /// back to `Pending` so the worker would re-fetch and re-decode it. That
+    /// was the conflation: a look is not a reason to throw away geometry. The
+    /// look now selects a key, so a change here costs nothing — the tiles for
+    /// the new look are styled from bytes already in `tile_bytes`, and the
+    /// tiles for the old look stay cached.
+    pub fn set_active_theme(&mut self, resolved: MapTheme) -> bool {
+        let changed = self.active_theme != resolved;
+        self.active_theme = resolved;
+        changed
+    }
+
+    /// The key `tile` occupies at the look the cache is currently showing.
+    #[must_use]
+    pub fn key_at_current_look(&self, tile: MapTileId) -> TileStyleKey {
+        TileStyleKey { tile, theme: self.current_look() }
+    }
+
+    /// Insert / replace `tile`'s entry at the current look.
+    pub fn insert_tile(&mut self, tile: MapTileId, entry: TileEntry) {
+        let k = self.key_at_current_look(tile);
+        self.tiles.insert(k, entry);
+    }
+
+    /// `tile`'s entry at the current look, if the cache holds one.
+    #[must_use]
+    pub fn tile_entry(&self, tile: MapTileId) -> Option<&TileEntry> {
+        self.tiles.get(&self.key_at_current_look(tile))
     }
 
     /// Worker-thread → main-thread write path. Set the decoded SVG for
-    /// a tile (called from `map_tile_writeback`). Stamps `Ready`.
-    pub fn mark_tile_ready(&mut self, tile: MapTileId, svg: AzString) {
-        self.tiles.insert(tile, TileEntry::Ready { svg });
+    /// a tile AT THE LOOK IT WAS STYLED FOR (called from
+    /// `map_tile_writeback`). Stamps `Ready`.
+    pub fn mark_tile_ready(&mut self, key: TileStyleKey, svg: AzString) {
+        self.tiles.insert(key, TileEntry::Ready { svg });
     }
 
     /// Mark a tile's fetch as failed so the grid doesn't re-spawn it
     /// every frame.
-    pub fn mark_tile_failed(&mut self, tile: MapTileId, error: AzString) {
-        self.tiles.insert(tile, TileEntry::Failed { error });
+    pub fn mark_tile_failed(&mut self, key: TileStyleKey, error: AzString) {
+        self.tiles.insert(key, TileEntry::Failed { error });
+    }
+
+    /// The best SVG the cache can show for `tile` right now, preferring
+    /// `want` — the depth in "fix the fallback in depth".
+    ///
+    /// An exact hit is used as-is. Otherwise ANY other look of the same tile is
+    /// returned: real cartography in the wrong palette beats a grey placeholder,
+    /// and it is already in memory. This is what removes the flash of empty grid
+    /// when the colour scheme flips — the previous look keeps painting until the
+    /// restyle lands, and the restyle needs no network.
+    #[must_use]
+    pub fn best_available_svg(&self, tile: MapTileId, want: MapTheme) -> Option<(MapTheme, AzString)> {
+        if let Some(TileEntry::Ready { svg }) = self.tiles.get(&TileStyleKey { tile, theme: want }) {
+            return Some((want, svg.clone()));
+        }
+        self.tiles
+            .iter()
+            .find_map(|(k, e)| match e {
+                TileEntry::Ready { svg } if k.tile == tile => Some((k.theme, svg.clone())),
+                _ => None,
+            })
     }
 
     /// Bound the tile cache by evicting tiles far from the current viewport.
@@ -724,24 +961,60 @@ impl MapTileCache {
         }
 
         // Higher score = farther from what the user sees = evict sooner.
-        let score = |id: &MapTileId| tile_viewport_score(&self.viewport, &self.layer, *id);
+        //
+        // An entry for a look we are NOT showing is the first thing to go: it is
+        // a stand-in for a flip that has already happened, not what the user is
+        // looking at. Without this penalty the budget below is a budget on
+        // (tile, look) PAIRS, so while two looks are live the number of distinct
+        // tiles the cache can hold would silently halve.
+        const OTHER_LOOK_PENALTY: f64 = 1.0e9;
+        let active = self.active_theme;
+        let score = |k: &TileStyleKey| {
+            tile_viewport_score(&self.viewport, &self.layer, k.tile)
+                + if k.theme == active { 0.0 } else { OTHER_LOOK_PENALTY }
+        };
 
-        let mut evictable: Vec<(f64, MapTileId)> = self
+        let mut evictable: Vec<(f64, TileStyleKey)> = self
             .tiles
             .iter()
             .filter(|(_, e)| !matches!(e, TileEntry::Pending | TileEntry::Fetching))
-            .map(|(id, _)| (score(id), *id))
+            .map(|(k, _)| (score(k), *k))
             .collect();
         // Farthest first.
         evictable.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(core::cmp::Ordering::Equal));
 
         let mut to_remove = self.tiles.len().saturating_sub(MAX_CACHED_TILES);
-        for (_, id) in evictable {
+        for (_, k) in evictable {
             if to_remove == 0 {
                 break;
             }
-            self.tiles.remove(&id);
+            self.tiles.remove(&k);
             to_remove -= 1;
+        }
+
+        // The byte cache is bounded by the same policy, but SEPARATELY: it is
+        // keyed by coordinates, so one entry backs every look of a tile. Keep
+        // bytes for any tile that still has a styled entry (a restyle must not
+        // have to re-fetch), and drop the rest farthest-first.
+        let live: alloc::collections::BTreeSet<MapTileId> =
+            self.tiles.keys().map(|k| k.tile).collect();
+        if self.tile_bytes.len() > MAX_CACHED_TILES {
+            let mut byte_evictable: Vec<(f64, MapTileId)> = self
+                .tile_bytes
+                .keys()
+                .filter(|t| !live.contains(t))
+                .map(|t| (tile_viewport_score(&self.viewport, &self.layer, *t), *t))
+                .collect();
+            byte_evictable
+                .sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(core::cmp::Ordering::Equal));
+            let mut drop_n = self.tile_bytes.len().saturating_sub(MAX_CACHED_TILES);
+            for (_, t) in byte_evictable {
+                if drop_n == 0 {
+                    break;
+                }
+                self.tile_bytes.remove(&t);
+                drop_n -= 1;
+            }
         }
     }
 
@@ -756,12 +1029,12 @@ impl MapTileCache {
     /// [`tile_viewport_score`] puts the tile under the user's eyes first and
     /// the margin and stale zooms last, with nothing cancelled or lost.
     #[must_use]
-    pub fn pending_tiles_nearest_first(&self) -> Vec<MapTileId> {
-        let mut pending: Vec<(f64, MapTileId)> = self
+    pub fn pending_tiles_nearest_first(&self) -> Vec<TileStyleKey> {
+        let mut pending: Vec<(f64, TileStyleKey)> = self
             .tiles
             .iter()
             .filter(|(_, e)| matches!(e, TileEntry::Pending))
-            .map(|(id, _)| (tile_viewport_score(&self.viewport, &self.layer, *id), *id))
+            .map(|(k, _)| (tile_viewport_score(&self.viewport, &self.layer, k.tile), *k))
             .collect();
         // Nearest first; the `(z, x, y)` key order breaks exact ties so the
         // result is deterministic.
@@ -770,7 +1043,7 @@ impl MapTileCache {
                 .unwrap_or(core::cmp::Ordering::Equal)
                 .then_with(|| a.1.cmp(&b.1))
         });
-        pending.into_iter().map(|(_, id)| id).collect()
+        pending.into_iter().map(|(_, k)| k).collect()
     }
 }
 
@@ -827,12 +1100,18 @@ pub struct TileFetchInit {
     pub tile: MapTileId,
     pub url: AzString,
     /// The `MapCSS` to decode with: `MapTileLayer::effective_style_css` for
-    /// the resolved theme (empty = the built-in palette).
+    /// the look being styled (empty = the built-in palette).
     pub style_css: AzString,
-    /// The resolved theme `style_css` belongs to — echoed back in
-    /// `TileReadyMsg` so a result decoded for a theme the widget has since
-    /// left is dropped instead of painted.
+    /// The look `style_css` belongs to — echoed back in `TileReadyMsg` so the
+    /// result is filed under the key it was actually styled for.
     pub theme: MapTheme,
+    /// The tile's MVT payload when the cache already holds it.
+    ///
+    /// Non-empty turns this job into a pure RESTYLE: the worker decodes and
+    /// styles these bytes and issues NO network request. This is what makes a
+    /// colour-scheme flip cost zero fetches — the geometry is already here, only
+    /// the palette changed.
+    pub bytes: azul_css::U8Vec,
 }
 
 /// Worker-thread output, sent back via `ThreadWriteBackMsg`. The
@@ -848,6 +1127,10 @@ pub struct TileReadyMsg {
     pub error: AzString,
     /// The theme the SVG was decoded for (from `TileFetchInit::theme`).
     pub theme: MapTheme,
+    /// The MVT payload the worker downloaded, handed back so the main thread
+    /// can cache it and never fetch this tile again. Empty when the worker was
+    /// given bytes to begin with (a restyle) — there is nothing new to store.
+    pub bytes: azul_css::U8Vec,
 }
 
 // ────────── Merge callback — cache survives relayout ─────────────────
@@ -888,17 +1171,15 @@ extern "C" fn merge_map_tile_cache(mut new_data: RefAny, mut old_data: RefAny) -
                 old_g.fetch_callback.clone_from(&new_g.fetch_callback);
             }
             old_g.viewport = new_g.viewport;
-            let theme_changed = old_g.layer.theme != new_g.layer.theme
-                || old_g.layer.style_css != new_g.layer.style_css;
+            // Adopt the app's layer verbatim. There is nothing to invalidate: if
+            // the app switched cartography, the next render simply looks up a
+            // different key, and the tiles for the previous look stay cached (so
+            // switching back is instant, and they serve as the fallback until
+            // the new look styles). This block used to force `decoded_theme` to
+            // a sentinel so `adopt_theme` would push every decoded tile back to
+            // `Pending` — a rebuild that re-declared the SAME layer therefore
+            // threw away and re-fetched the whole viewport.
             old_g.layer = new_g.layer.clone();
-            if theme_changed {
-                // The app picked another look (or another custom sheet):
-                // the decoded tiles are the OLD look. Re-queue them; the
-                // render resolves `System` against the window next frame.
-                let resolved = new_g.layer.theme;
-                old_g.decoded_theme = MapTheme::Custom; // force adopt
-                old_g.adopt_theme(resolved);
-            }
             old_g.on_viewport_changed = new_g.on_viewport_changed.clone();
         }
     }
@@ -1277,8 +1558,12 @@ extern "C" fn map_on_scroll(mut data: RefAny, mut info: CallbackInfo) -> Update 
         cache.viewport.zoom = (cache.viewport.zoom + dz).clamp(min, max);
         let vp = cache.viewport;
         let layer = cache.layer.clone();
+        let look = cache.current_look();
         for t in map_visible_tiles(&vp, bounds, &layer) {
-            cache.tiles.entry(t).or_insert(TileEntry::Pending);
+            cache
+                .tiles
+                .entry(TileStyleKey { tile: t, theme: look })
+                .or_insert(TileEntry::Pending);
         }
         (vp, cache.on_viewport_changed.clone())
     };
@@ -1548,6 +1833,14 @@ fn spawn_pending_tile_fetches(data: &mut RefAny, info: &mut CallbackInfo) {
     // Per-call spawn cap — bounds the burst on a big viewport jump.
     const MAX_SPAWN_PER_CALL: usize = 16;
 
+    // THE CASCADE'S ANSWER, taken here because this is the earliest point the
+    // widget has a `CallbackInfo` (mount, the 250 ms sweep, every pointer
+    // event all funnel through here). `SystemStyle::theme` is the same value
+    // `DynamicSelectorContext::from_system_style` feeds to
+    // `prefers-color-scheme`, so the tiles and the app's stylesheet resolve
+    // light/dark from one source instead of two.
+    let scheme = MapColorScheme::from_system_theme(info.get_system_style().theme);
+
     // Collect the work first (URL build + state flip) under one borrow,
     // then spawn outside it so we don't hold the cache lock across
     // `info.add_thread`.
@@ -1577,24 +1870,67 @@ fn spawn_pending_tile_fetches(data: &mut RefAny, info: &mut CallbackInfo) {
             }
             return; // no worker wired — leave tiles Pending (placeholder grid)
         }
+        cache.cascade_scheme = Some(scheme);
+        let look = cache.current_look();
+        cache.set_active_theme(look);
+        // A tile that is merely QUEUED for a look we have since left is RE-KEYED
+        // to the look we now want — not dropped, and never fetched for the look
+        // nobody is going to look at. `Pending` means "wanted, nothing done
+        // yet"; what is wanted has not changed, only which sheet to style it
+        // with, so moving the key preserves the request and costs no request.
+        //
+        // Dropping them instead strands the FIRST render's queue on every cold
+        // start: that render runs before any callback exists, so it keys at the
+        // layer's own look — `System`, which is never equal to the look `System`
+        // resolves to — and the whole viewport would have to be re-queued by the
+        // next render before anything could be fetched.
+        //
+        // `Fetching` / `Ready` / `Failed` are never touched here: those hold real
+        // work, and each is already filed under the look it belongs to.
+        let stale: Vec<TileStyleKey> = cache
+            .tiles
+            .iter()
+            .filter(|(k, e)| matches!(e, TileEntry::Pending) && k.theme != look)
+            .map(|(k, _)| *k)
+            .collect();
+        for k in stale {
+            cache.tiles.remove(&k);
+            cache
+                .tiles
+                .entry(TileStyleKey { tile: k.tile, theme: look })
+                .or_insert(TileEntry::Pending);
+        }
+
         let template = cache.layer.url_template.as_str().to_string();
-        let theme = cache.decoded_theme;
-        let style_css = cache.layer.effective_style_css(theme);
         // Centre-out: the tiles under the user's eyes first, the off-screen
         // margin and other-zoom leftovers last (see `pending_tiles_nearest_first`).
-        let pending: Vec<MapTileId> = cache
+        let pending: Vec<TileStyleKey> = cache
             .pending_tiles_nearest_first()
             .into_iter()
             .take(MAX_SPAWN_PER_CALL)
             .collect();
-        for tile in pending {
-            let url = build_tile_url(&template, tile);
-            cache.tiles.insert(tile, TileEntry::Fetching);
+        for key in pending {
+            let url = build_tile_url(&template, key.tile);
+            // Each job is styled for the look ITS KEY asks for, not for one
+            // cache-wide "current" look. A sweep can therefore legitimately
+            // carry jobs for two different looks at once (the new one being
+            // filled in, an old one still queued) and neither invalidates the
+            // other.
+            let style_css = cache.layer.effective_style_css(key.theme);
+            // Bytes already in hand => restyle, no network. This is the whole
+            // point of the split cache: geometry is fetched once per tile, ever.
+            let bytes = cache
+                .tile_bytes
+                .get(&key.tile)
+                .cloned()
+                .unwrap_or_else(|| azul_css::U8Vec::from_vec(Vec::new()));
+            cache.tiles.insert(key, TileEntry::Fetching);
             to_spawn.push(TileFetchInit {
-                tile,
+                tile: key.tile,
                 url: AzString::from(url),
-                style_css: style_css.clone(),
-                theme,
+                style_css,
+                theme: key.theme,
+                bytes,
             });
         }
         // Now that the current view's tiles are queued (Fetching, so eviction
@@ -1691,7 +2027,7 @@ fn build_tile_url(template: &str, tile: MapTileId) -> String {
         }
         return Update::DoNothing;
     };
-    let msg = (m.tile, m.svg.clone(), m.error.clone(), m.theme);
+    let msg = (m.tile, m.svg.clone(), m.error.clone(), m.theme, m.bytes.clone());
     drop(m);
     {
         let Some(mut cache) = cache_dataset.downcast_mut::<MapTileCache>() else {
@@ -1707,24 +2043,47 @@ fn build_tile_url(template: &str, tile: MapTileId) -> String {
             }
             return Update::DoNothing;
         };
+        // Cache the geometry FIRST and unconditionally. Whatever happens to the
+        // styled result, these bytes mean this tile never has to be downloaded
+        // again — including for a look nobody has asked for yet.
+        let fetched_bytes = msg.4.as_ref().len();
+        if fetched_bytes != 0 {
+            cache.tile_bytes.insert(msg.0, msg.4);
+        }
+
+        // File the result under the look it was STYLED FOR. There is no
+        // "arrived for the wrong theme" case any more: a result for a look the
+        // widget has moved on from is still correct data for that look, so it is
+        // kept, not thrown away and re-fetched. If the user flips back it paints
+        // instantly; until then it serves as the fallback for its own tile.
+        let key = TileStyleKey { tile: msg.0, theme: msg.3 };
+        let ok = msg.2.as_str().is_empty();
+        let svg_len = msg.1.as_str().len();
+        if ok {
+            cache.mark_tile_ready(key, msg.1);
+        } else {
+            cache.mark_tile_failed(key, msg.2.clone());
+        }
+
+        // Logged AFTER the decision, reporting the decision. The old line
+        // printed `ok=true` from "the error string is empty" BEFORE the theme
+        // check that then discarded the tile — so a tile about to be thrown
+        // away and re-fetched logged as a success. A log line that lies is
+        // worse than no log line.
         #[cfg(feature = "std")]
         if std::env::var("AZ_MAP_DEBUG").is_ok() {
             eprintln!(
-                "[map] writeback tile=({},{},{}) ok={} svg_len={} err={:?}",
-                msg.0.z, msg.0.x, msg.0.y,
-                msg.2.as_str().is_empty(), msg.1.as_str().len(), msg.2.as_str()
+                "[map] writeback tile=({},{},{}) theme={:?} stored={} svg_len={} \
+                 bytes_cached={} err={:?}",
+                msg.0.z,
+                msg.0.x,
+                msg.0.y,
+                msg.3,
+                if ok { "Ready" } else { "Failed" },
+                svg_len,
+                fetched_bytes,
+                msg.2.as_str()
             );
-        }
-        if msg.3 != cache.decoded_theme {
-            // Decoded with the sheet of a theme the widget has since left
-            // (the window flipped light/dark mid-fetch): painting it would
-            // mix palettes. Back to Pending; the next sweep refetches it
-            // with the sheet of record.
-            cache.tiles.insert(msg.0, TileEntry::Pending);
-        } else if msg.2.as_str().is_empty() {
-            cache.mark_tile_ready(msg.0, msg.1);
-        } else {
-            cache.mark_tile_failed(msg.0, msg.2);
         }
     } // drop the cache borrow before touching `info`
 
@@ -1844,15 +2203,16 @@ extern "C" fn map_widget_render(
         };
     }
 
-    let (layer, viewport) = match data.downcast_mut::<MapTileCache>() {
+    let (layer, viewport, look) = match data.downcast_mut::<MapTileCache>() {
         Some(mut c) => {
-            // THE THEME FOLLOWS THE WINDOW: `System` resolves against the
-            // window's light / dark theme here, every frame, so an OS theme
-            // flip re-decodes the visible tiles with the other palette (no
-            // rebuild, no app code). A preset resolves to itself.
-            let resolved = c.layer.theme.resolve(info.window_theme);
-            c.adopt_theme(resolved);
-            (c.layer.clone(), c.viewport)
+            // THE CASCADE OWNS LIGHT/DARK. The look is the layer's cartography
+            // taken to the scheme recorded from `SystemStyle::theme` — the same
+            // value `prefers-color-scheme` matches on — not a resolution this
+            // callback performs against `info.window_theme`. Nothing is
+            // invalidated here: the look only selects which key to read.
+            let look = c.current_look();
+            c.set_active_theme(look);
+            (c.layer.clone(), c.viewport, look)
         }
         None => {
             return VirtualViewReturn {
@@ -1915,31 +2275,44 @@ extern "C" fn map_widget_render(
                     x: wrap_tile_x(x, tile_count),
                     y: y as u32,
                 };
-                cache.tiles.entry(id).or_insert(TileEntry::Pending);
+                cache
+                    .tiles
+                    .entry(TileStyleKey { tile: id, theme: look })
+                    .or_insert(TileEntry::Pending);
             }
         }
     }
 
-    // Snapshot the per-tile state under a short borrow, then drop it
-    // before building DOM. `Ready` tiles carry their decoded SVG so the
-    // render loop can parse it into a DOM child; the rest carry a glyph
-    // (`…` Pending / `⟳` Fetching / `✗` Failed) so the fetch path stays
+    // Snapshot what to DISPLAY per visible tile, under a short borrow, then
+    // drop it before building DOM.
+    //
+    // Display is a lookup, not the cache state: `best_available_svg` prefers
+    // the current look and otherwise takes any look already decoded for that
+    // tile. So while a scheme change re-styles, the previous palette keeps
+    // painting real cartography instead of the grid falling back to grey
+    // placeholders. Only a tile with NO decoded look at all shows a glyph
+    // (`…` Pending / `⟳` Fetching / `✗` Failed), which keeps the fetch path
     // observable.
     let states: BTreeMap<MapTileId, TileDisplay> = data
         .downcast_ref::<MapTileCache>()
         .map_or_else(BTreeMap::new, |c| {
-            c.tiles
-                .iter()
-                .map(|(id, e)| {
-                    let disp = match e {
-                        TileEntry::Pending => TileDisplay::Glyph("…"),
-                        TileEntry::Fetching => TileDisplay::Glyph("⟳"),
-                        TileEntry::Ready { svg } => TileDisplay::Svg(svg.clone()),
-                        TileEntry::Failed { .. } => TileDisplay::Glyph("✗"),
-                    };
-                    (*id, disp)
-                })
-                .collect()
+            let mut out = BTreeMap::new();
+            for k in c.tiles.keys() {
+                if out.contains_key(&k.tile) {
+                    continue;
+                }
+                let disp = if let Some((_, svg)) = c.best_available_svg(k.tile, look) {
+                    TileDisplay::Svg(svg)
+                } else {
+                    match c.tiles.get(&TileStyleKey { tile: k.tile, theme: look }) {
+                        Some(TileEntry::Fetching) => TileDisplay::Glyph("⟳"),
+                        Some(TileEntry::Failed { .. }) => TileDisplay::Glyph("✗"),
+                        _ => TileDisplay::Glyph("…"),
+                    }
+                };
+                out.insert(k.tile, disp);
+            }
+            out
         });
 
     // Build the visible-tile grid. Each tile div is GPU-translated
@@ -2255,16 +2628,23 @@ mod theme_tests {
     }
 
     #[test]
-    fn adopting_another_theme_requeues_decoded_tiles_and_the_fetch_carries_the_sheet() {
+    fn changing_the_look_re_keys_the_cache_and_keeps_the_decoded_tile() {
         let mut cache = MapTileCache::new(MapTileLayer::default(), MapViewport::default());
         let id = MapTileId { z: 1, x: 0, y: 0 };
-        cache.mark_tile_ready(id, AzString::from("<svg/>"));
-        assert!(!cache.adopt_theme(cache.decoded_theme), "same theme: nothing to do");
-        assert!(matches!(cache.tiles[&id], TileEntry::Ready { .. }));
-        assert!(cache.adopt_theme(MapTheme::Dark));
-        assert!(matches!(cache.tiles[&id], TileEntry::Pending), "a decoded tile is re-queued for the new look");
-        assert_eq!(cache.decoded_theme, MapTheme::Dark);
-        assert_eq!(cache.layer.effective_style_css(cache.decoded_theme).as_str(), super::super::map_themes::DARK);
+        let look_a = cache.key_at_current_look(id);
+        cache.mark_tile_ready(look_a, AzString::from("<svg/>"));
+        assert!(!cache.set_active_theme(cache.active_theme), "same look: nothing to do");
+        assert!(matches!(cache.tiles[&look_a], TileEntry::Ready { .. }));
+        assert!(cache.set_active_theme(MapTheme::Dark));
+        // A look change RE-KEYS the lookup; it must never invalidate geometry
+        // that is already decoded. Look A's tile stays Ready and instantly
+        // available if the user flips back.
+        assert!(
+            matches!(cache.tiles[&look_a], TileEntry::Ready { .. }),
+            "a look change must not discard a decoded tile"
+        );
+        assert_eq!(cache.active_theme, MapTheme::Dark);
+        assert_eq!(cache.layer.effective_style_css(cache.active_theme).as_str(), super::super::map_themes::DARK);
     }
 }
 
@@ -2404,16 +2784,22 @@ mod tests {
         let mut cache = MapTileCache::new(layer, viewport);
         for x in 0..4 {
             for y in 0..4 {
-                cache.tiles.insert(MapTileId { z: 2, x, y }, TileEntry::Pending);
+                cache.insert_tile(MapTileId { z: 2, x, y }, TileEntry::Pending);
             }
         }
         // A leftover from the previous zoom, which the (z, x, y) key order
         // used to fetch FIRST.
-        cache.tiles.insert(MapTileId { z: 1, x: 0, y: 0 }, TileEntry::Pending);
+        cache.insert_tile(MapTileId { z: 1, x: 0, y: 0 }, TileEntry::Pending);
         // Tiles already in flight / ready are not re-queued.
-        cache.tiles.insert(MapTileId { z: 2, x: 9, y: 9 }, TileEntry::Fetching);
+        cache.insert_tile(MapTileId { z: 2, x: 9, y: 9 }, TileEntry::Fetching);
 
-        let order = cache.pending_tiles_nearest_first();
+        // The queue is keyed by (tile, look); this test is about the ORDER the
+        // coordinates come out in, so drop the (single, uniform) look here.
+        let order: Vec<MapTileId> = cache
+            .pending_tiles_nearest_first()
+            .into_iter()
+            .map(|k| k.tile)
+            .collect();
         assert_eq!(order.len(), 17, "{order:?}");
         assert_eq!(order[0], MapTileId { z: 2, x: 2, y: 2 }, "the tile under the centre first");
         let ring: std::collections::BTreeSet<MapTileId> = order[..9].iter().copied().collect();
@@ -2503,13 +2889,13 @@ mod tests {
         worker_handle
             .downcast_mut::<MapTileCache>()
             .unwrap()
-            .mark_tile_ready(tile, AzString::from("<svg/>"));
+            .insert_tile(tile, TileEntry::Ready { svg: AzString::from("<svg/>") });
 
         // ...and it IS visible through the merged cache (shared storage). With the
         // old copy-merge this assertion failed — the tile was stranded.
         let g = merged.downcast_ref::<MapTileCache>().unwrap();
         assert!(
-            g.tiles.contains_key(&tile),
+            g.tile_entry(tile).is_some(),
             "a worker writeback after relayout must reach the rendered cache"
         );
     }
@@ -2528,7 +2914,7 @@ mod tests {
         let mut old_cache = MapTileCache::new(MapTileLayer::default(), viewport_at(5.0));
         old_cache.viewport.zoom = 7.0; // internal state from previous frames
         let tile = MapTileId { z: 2, x: 1, y: 1 };
-        old_cache.tiles.insert(tile, TileEntry::Ready { svg: "<svg/>".into() });
+        old_cache.insert_tile(tile, TileEntry::Ready { svg: "<svg/>".into() });
 
         let new_cache = MapTileCache::new(MapTileLayer::default(), viewport_at(2.0));
 
@@ -2539,7 +2925,7 @@ mod tests {
         approx(f64::from(g.viewport.zoom), f64::from(viewport_at(2.0).zoom), 1e-6);
         // …while the fetched tiles survive in the same allocation.
         assert!(
-            g.tiles.contains_key(&tile),
+            g.tile_entry(tile).is_some(),
             "fetched tiles must survive the merge (workers write into this cache)"
         );
     }
@@ -2632,16 +3018,15 @@ mod tests {
         for x in 0..20u32 {
             for y in 0..20u32 {
                 cache
-                    .tiles
-                    .insert(MapTileId { z: 4, x, y }, TileEntry::Ready { svg: AzString::from("<svg/>") });
+                    .insert_tile(MapTileId { z: 4, x, y }, TileEntry::Ready { svg: AzString::from("<svg/>") });
             }
         }
         // A near, in-flight tile (must NEVER be evicted).
-        cache.tiles.insert(MapTileId { z: 4, x: 8, y: 8 }, TileEntry::Pending);
+        cache.insert_tile(MapTileId { z: 4, x: 8, y: 8 }, TileEntry::Pending);
         // A near, ready tile (should survive — low distance score).
-        cache.tiles.insert(MapTileId { z: 4, x: 9, y: 8 }, TileEntry::Ready { svg: AzString::from("<svg/>") });
+        cache.insert_tile(MapTileId { z: 4, x: 9, y: 8 }, TileEntry::Ready { svg: AzString::from("<svg/>") });
         // A very far ready tile (should be evicted first).
-        cache.tiles.insert(MapTileId { z: 4, x: 0, y: 0 }, TileEntry::Ready { svg: AzString::from("<svg/>") });
+        cache.insert_tile(MapTileId { z: 4, x: 0, y: 0 }, TileEntry::Ready { svg: AzString::from("<svg/>") });
 
         assert!(cache.tiles.len() > 192, "precondition: over the cap");
         cache.prune_distant_tiles();
@@ -2649,12 +3034,12 @@ mod tests {
         assert!(cache.tiles.len() <= 192, "cache must be bounded after prune");
         // In-flight tile survives.
         assert!(matches!(
-            cache.tiles.get(&MapTileId { z: 4, x: 8, y: 8 }),
+            cache.tile_entry(MapTileId { z: 4, x: 8, y: 8 }),
             Some(TileEntry::Pending)
         ));
         // Near tile survives; the corner tile is gone.
-        assert!(cache.tiles.contains_key(&MapTileId { z: 4, x: 9, y: 8 }));
-        assert!(!cache.tiles.contains_key(&MapTileId { z: 4, x: 0, y: 0 }));
+        assert!(cache.tile_entry(MapTileId { z: 4, x: 9, y: 8 }).is_some());
+        assert!(cache.tile_entry(MapTileId { z: 4, x: 0, y: 0 }).is_none());
     }
 
     #[test]
@@ -2662,8 +3047,7 @@ mod tests {
         let mut cache = test_cache();
         for x in 0..4u32 {
             cache
-                .tiles
-                .insert(MapTileId { z: 4, x, y: 8 }, TileEntry::Ready { svg: AzString::from("<svg/>") });
+                .insert_tile(MapTileId { z: 4, x, y: 8 }, TileEntry::Ready { svg: AzString::from("<svg/>") });
         }
         cache.prune_distant_tiles();
         assert_eq!(cache.tiles.len(), 4, "under the cap → nothing evicted");
@@ -3732,12 +4116,13 @@ mod autotest_generated {
     fn mark_tile_ready_and_failed_overwrite_each_other() {
         let mut cache = cache_at(0.0, 0.0, 4.0);
         let tile = MapTileId { z: 4, x: 8, y: 8 };
-        cache.mark_tile_ready(tile, AzString::from("<svg/>"));
-        assert!(matches!(cache.tiles.get(&tile), Some(TileEntry::Ready { .. })));
-        cache.mark_tile_failed(tile, AzString::from("boom"));
-        assert!(matches!(cache.tiles.get(&tile), Some(TileEntry::Failed { .. })));
-        cache.mark_tile_ready(tile, AzString::from(""));
-        assert!(matches!(cache.tiles.get(&tile), Some(TileEntry::Ready { .. })));
+        let key = cache.key_at_current_look(tile);
+        cache.mark_tile_ready(key, AzString::from("<svg/>"));
+        assert!(matches!(cache.tile_entry(tile), Some(TileEntry::Ready { .. })));
+        cache.mark_tile_failed(key, AzString::from("boom"));
+        assert!(matches!(cache.tile_entry(tile), Some(TileEntry::Failed { .. })));
+        cache.mark_tile_ready(key, AzString::from(""));
+        assert!(matches!(cache.tile_entry(tile), Some(TileEntry::Ready { .. })));
         assert_eq!(cache.tiles.len(), 1, "the same id must not duplicate");
     }
 
@@ -3751,13 +4136,13 @@ mod autotest_generated {
             AzString::from("x".repeat(1_000_000)),
         ];
         for (i, svg) in payloads.into_iter().enumerate() {
-            cache.mark_tile_ready(
+            cache.insert_tile(
                 MapTileId {
                     z: 4,
                     x: i as u32,
                     y: 0,
                 },
-                svg,
+                TileEntry::Ready { svg },
             );
         }
         assert_eq!(cache.tiles.len(), 4);
@@ -3781,7 +4166,7 @@ mod autotest_generated {
                 y: 0,
             },
         ] {
-            cache.mark_tile_failed(tile, AzString::from("e"));
+            cache.insert_tile(tile, TileEntry::Failed { error: AzString::from("e") });
         }
         assert_eq!(cache.tiles.len(), 3);
     }
@@ -3794,8 +4179,7 @@ mod autotest_generated {
         for x in 0..side {
             for y in 0..side {
                 cache
-                    .tiles
-                    .insert(MapTileId { z, x, y }, TileEntry::Ready { svg: AzString::from("<svg/>") });
+                    .insert_tile(MapTileId { z, x, y }, TileEntry::Ready { svg: AzString::from("<svg/>") });
             }
         }
     }
@@ -3805,7 +4189,7 @@ mod autotest_generated {
         let mut cache = cache_at(0.0, 0.0, 4.0);
         for x in 0..16u32 {
             for y in 0..16u32 {
-                cache.tiles.insert(
+                cache.insert_tile(
                     MapTileId { z: 4, x, y },
                     if (x + y) % 2 == 0 {
                         TileEntry::Pending
@@ -3851,11 +4235,11 @@ mod autotest_generated {
         fill_ready_grid(&mut cache, 4, 16);
         cache.prune_distant_tiles();
         let first = cache.tiles.len();
-        let survivors: Vec<MapTileId> = cache.tiles.keys().copied().collect();
+        let survivors: Vec<MapTileId> = cache.tiles.keys().map(|k| k.tile).collect();
         cache.prune_distant_tiles();
         assert_eq!(cache.tiles.len(), first);
         assert_eq!(
-            cache.tiles.keys().copied().collect::<Vec<_>>(),
+            cache.tiles.keys().map(|k| k.tile).collect::<Vec<_>>(),
             survivors,
             "a second prune under the cap must change nothing"
         );
@@ -3869,16 +4253,15 @@ mod autotest_generated {
         fill_ready_grid(&mut cache, 4, 16);
         let wrong_zoom = MapTileId { z: 9, x: 256, y: 256 };
         cache
-            .tiles
-            .insert(wrong_zoom, TileEntry::Ready { svg: AzString::from("<svg/>") });
+            .insert_tile(wrong_zoom, TileEntry::Ready { svg: AzString::from("<svg/>") });
         let near = MapTileId { z: 4, x: 8, y: 8 };
         cache.prune_distant_tiles();
         assert!(cache.tiles.len() <= 192);
         assert!(
-            !cache.tiles.contains_key(&wrong_zoom),
+            cache.tile_entry(wrong_zoom).is_none(),
             "a zoom-mismatched tile must be evicted before same-zoom neighbours"
         );
-        assert!(cache.tiles.contains_key(&near), "the centre tile must survive");
+        assert!(cache.tile_entry(near).is_some(), "the centre tile must survive");
     }
 
     // ==================================================================
@@ -3889,11 +4272,11 @@ mod autotest_generated {
     fn merge_with_a_wrong_typed_new_dataset_returns_the_old_one_intact() {
         let mut old_cache = cache_at(0.0, 0.0, 5.0);
         let tile = MapTileId { z: 5, x: 1, y: 1 };
-        old_cache.mark_tile_ready(tile, AzString::from("<svg/>"));
+        old_cache.insert_tile(tile, TileEntry::Ready { svg: AzString::from("<svg/>") });
         let mut merged = merge_map_tile_cache(RefAny::new(0u32), RefAny::new(old_cache));
         let cache = merged.downcast_ref::<MapTileCache>().expect("old cache");
         assert_eq!(cache.viewport.zoom, 5.0, "no adoption from a bogus new dataset");
-        assert!(cache.tiles.contains_key(&tile));
+        assert!(cache.tile_entry(tile).is_some());
     }
 
     #[test]
@@ -4501,7 +4884,7 @@ mod autotest_generated {
     fn spawn_pending_tile_fetches_is_a_no_op_without_a_worker() {
         let mut cache = cache_at(0.0, 0.0, 4.0);
         for x in 0..4u32 {
-            cache.tiles.insert(MapTileId { z: 4, x, y: 8 }, TileEntry::Pending);
+            cache.insert_tile(MapTileId { z: 4, x, y: 8 }, TileEntry::Pending);
         }
         let mut dataset = RefAny::new(cache);
         let (_, changes) = with_callback_info(|info| {
@@ -4520,8 +4903,13 @@ mod autotest_generated {
     fn spawn_pending_tile_fetches_caps_the_burst_at_sixteen() {
         let mut cache = cache_at(0.0, 0.0, 4.0);
         cache.fetch_callback = Some(ThreadCallback::new(noop_worker));
+        // Queue at the look the spawn pass will resolve. The harness's
+        // `SystemStyle::default()` is a light theme, and the spawn dequeues
+        // `Pending` jobs left over from a look the widget has moved on from —
+        // this test is about the burst CAP, not about that re-keying.
+        cache.cascade_scheme = Some(MapColorScheme::Light);
         for x in 0..20u32 {
-            cache.tiles.insert(MapTileId { z: 4, x, y: 8 }, TileEntry::Pending);
+            cache.insert_tile(MapTileId { z: 4, x, y: 8 }, TileEntry::Pending);
         }
         let mut dataset = RefAny::new(cache);
 
@@ -4584,6 +4972,7 @@ mod autotest_generated {
             tile,
             svg: AzString::from("<svg/>"),
             error: AzString::from(""),
+            bytes: azul_css::U8Vec::from_vec(Vec::new()),
         });
         let (update, changes) = with_callback_info(|info| {
             map_tile_writeback(dataset.clone(), ok.clone(), info)
@@ -4594,7 +4983,7 @@ mod autotest_generated {
             .any(|c| matches!(c, CallbackChange::UpdateAllVirtualViews)));
         {
             let cache = dataset.downcast_ref::<MapTileCache>().expect("cache");
-            assert!(matches!(cache.tiles.get(&tile), Some(TileEntry::Ready { .. })));
+            assert!(matches!(cache.tile_entry(tile), Some(TileEntry::Ready { .. })));
         }
 
         let failed = RefAny::new(TileReadyMsg {
@@ -4602,13 +4991,14 @@ mod autotest_generated {
             tile,
             svg: AzString::from(""),
             error: AzString::from("404"),
+            bytes: azul_css::U8Vec::from_vec(Vec::new()),
         });
         let (update, _) = with_callback_info(|info| {
             map_tile_writeback(dataset.clone(), failed.clone(), info)
         });
         assert_eq!(update, Update::DoNothing);
         let cache = dataset.downcast_ref::<MapTileCache>().expect("cache");
-        assert!(matches!(cache.tiles.get(&tile), Some(TileEntry::Failed { .. })));
+        assert!(matches!(cache.tile_entry(tile), Some(TileEntry::Failed { .. })));
     }
 
     #[test]
@@ -4624,12 +5014,13 @@ mod autotest_generated {
             tile,
             svg: AzString::from("<svg/>".repeat(50_000)),
             error: AzString::from(""),
+            bytes: azul_css::U8Vec::from_vec(Vec::new()),
         });
         let (update, _) =
             with_callback_info(|info| map_tile_writeback(dataset.clone(), msg.clone(), info));
         assert_eq!(update, Update::DoNothing);
         let cache = dataset.downcast_ref::<MapTileCache>().expect("cache");
-        assert!(cache.tiles.contains_key(&tile));
+        assert!(cache.tile_entry(tile).is_some());
     }
 
     #[test]
@@ -4651,12 +5042,179 @@ mod autotest_generated {
             tile: MapTileId { z: 1, x: 0, y: 0 },
             svg: AzString::from("<svg/>"),
             error: AzString::from(""),
+            bytes: azul_css::U8Vec::from_vec(Vec::new()),
         });
         let (update, changes) = with_callback_info(|info| {
             map_tile_writeback(RefAny::new(9u64), msg.clone(), info)
         });
         assert_eq!(update, Update::DoNothing);
         assert!(changes.is_empty());
+    }
+
+    // ── The two axes: cartography (the app's) vs light/dark (the cascade's) ──
+
+    #[test]
+    fn a_look_is_a_cartography_taken_to_a_colour_scheme_and_every_style_has_both() {
+        // The property that makes (style, scheme) a real product rather than
+        // ten ad-hoc enum variants: every cartography renders in either scheme,
+        // and the look you get back says which scheme it is.
+        for style in [
+            MapTileStyle::Standard,
+            MapTileStyle::Bright,
+            MapTileStyle::Liberty,
+            MapTileStyle::Google,
+            MapTileStyle::Apple,
+        ] {
+            for scheme in [MapColorScheme::Light, MapColorScheme::Dark] {
+                let look = style.look(scheme);
+                assert_eq!(
+                    look.pinned_scheme(),
+                    Some(scheme),
+                    "{style:?} in {scheme:?} must render as {scheme:?}"
+                );
+                assert!(
+                    !look.stylesheet().as_str().is_empty(),
+                    "{style:?} in {scheme:?} must have a sheet to decode with"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn only_system_defers_to_the_cascade_and_an_explicit_preset_overrides_it() {
+        // `System` is the only look with no opinion of its own — the cascade
+        // fills the scheme in. Everything else is an app deliberately
+        // overriding the cascade, and an explicit override has to win.
+        assert_eq!(MapTheme::System.pinned_scheme(), None);
+        assert_eq!(
+            MapTheme::System.for_scheme(MapColorScheme::Dark),
+            MapTileStyle::platform_default().look(MapColorScheme::Dark),
+        );
+        assert_eq!(
+            MapTheme::AppleLight.for_scheme(MapColorScheme::Dark),
+            MapTheme::AppleLight,
+            "an app that asked for the light Apple look keeps it in dark mode"
+        );
+        assert_eq!(
+            MapTheme::Dark.for_scheme(MapColorScheme::Light),
+            MapTheme::Dark
+        );
+    }
+
+    #[test]
+    fn a_colour_scheme_flip_re_keys_the_cache_and_discards_no_decoded_tile() {
+        // THE REGRESSION. This used to push every decoded tile back to
+        // `Pending`, so a colour scheme that settled one frame late cost a
+        // second download of the entire viewport.
+        let tile = MapTileId { z: 2, x: 1, y: 1 };
+        let mut cache = cache_at(0.0, 0.0, 2.0);
+        let light = MapTileStyle::Apple.look(MapColorScheme::Light);
+        let dark = MapTileStyle::Apple.look(MapColorScheme::Dark);
+
+        cache.mark_tile_ready(
+            TileStyleKey { tile, theme: light },
+            AzString::from("<svg id='l'/>"),
+        );
+        assert!(cache.set_active_theme(dark), "the look moved");
+
+        assert!(
+            matches!(
+                cache.tiles.get(&TileStyleKey { tile, theme: light }),
+                Some(TileEntry::Ready { .. })
+            ),
+            "the light tile is still correct data for the light look and must \
+             survive the flip — re-key, never invalidate"
+        );
+        assert_eq!(cache.active_theme, dark);
+    }
+
+    #[test]
+    fn an_unstyled_look_falls_back_to_a_decoded_one_instead_of_a_grey_placeholder() {
+        let tile = MapTileId { z: 2, x: 1, y: 1 };
+        let mut cache = cache_at(0.0, 0.0, 2.0);
+        let light = MapTileStyle::Apple.look(MapColorScheme::Light);
+        let dark = MapTileStyle::Apple.look(MapColorScheme::Dark);
+        cache.mark_tile_ready(
+            TileStyleKey { tile, theme: light },
+            AzString::from("<svg id='l'/>"),
+        );
+
+        let (got, svg) = cache
+            .best_available_svg(tile, dark)
+            .expect("the light tile must stand in while the dark one styles");
+        assert_eq!(got, light, "real cartography beats a grey box");
+        assert_eq!(svg.as_str(), "<svg id='l'/>");
+
+        // An exact hit always wins over the stand-in.
+        cache.mark_tile_ready(
+            TileStyleKey { tile, theme: dark },
+            AzString::from("<svg id='d'/>"),
+        );
+        let (got, svg) = cache
+            .best_available_svg(tile, dark)
+            .expect("exact hit");
+        assert_eq!(got, dark);
+        assert_eq!(svg.as_str(), "<svg id='d'/>");
+    }
+
+    #[test]
+    fn the_writeback_files_a_tile_under_its_own_look_and_caches_the_payload() {
+        // The old writeback compared the arriving theme against the cache's
+        // single `decoded_theme` and, on a mismatch, threw the decoded tile
+        // away and re-queued it — the second fetch of every tile. And it logged
+        // `ok=true` on the way past, before the check that discarded it.
+        let tile = MapTileId { z: 4, x: 1, y: 2 };
+        let mut dataset = RefAny::new(cache_at(0.0, 0.0, 4.0));
+        let arrived_for = MapTileStyle::Apple.look(MapColorScheme::Dark);
+        {
+            let mut c = dataset.downcast_mut::<MapTileCache>().expect("cache");
+            c.set_active_theme(MapTileStyle::Apple.look(MapColorScheme::Light));
+        }
+
+        let msg = RefAny::new(TileReadyMsg {
+            tile,
+            svg: AzString::from("<svg/>"),
+            error: AzString::from(""),
+            theme: arrived_for,
+            bytes: azul_css::U8Vec::from_vec(Vec::from([1u8, 2, 3])),
+        });
+        let _ = with_callback_info(|info| map_tile_writeback(dataset.clone(), msg.clone(), info));
+
+        let cache = dataset.downcast_ref::<MapTileCache>().expect("cache");
+        assert!(
+            matches!(
+                cache.tiles.get(&TileStyleKey { tile, theme: arrived_for }),
+                Some(TileEntry::Ready { .. })
+            ),
+            "a result for a look the widget has since left is still correct data \
+             for that look: it must be filed, not re-queued"
+        );
+        assert_eq!(
+            cache.tile_bytes.get(&tile).map(|b| b.as_ref().to_vec()),
+            Some(Vec::from([1u8, 2, 3])),
+            "the payload must be cached so no look ever re-downloads this tile"
+        );
+    }
+
+    #[test]
+    fn the_byte_cache_is_keyed_by_coordinates_so_every_look_shares_one_download() {
+        let tile = MapTileId { z: 2, x: 1, y: 1 };
+        let mut cache = cache_at(0.0, 0.0, 2.0);
+        cache
+            .tile_bytes
+            .insert(tile, azul_css::U8Vec::from_vec(Vec::from([9u8])));
+        for scheme in [MapColorScheme::Light, MapColorScheme::Dark] {
+            cache.mark_tile_ready(
+                TileStyleKey { tile, theme: MapTileStyle::Google.look(scheme) },
+                AzString::from("<svg/>"),
+            );
+        }
+        assert_eq!(cache.tiles.len(), 2, "two looks are two styled entries");
+        assert_eq!(
+            cache.tile_bytes.len(),
+            1,
+            "but the geometry behind them is downloaded exactly once"
+        );
     }
 
     #[test]
@@ -4742,7 +5300,7 @@ mod autotest_generated {
         let cache = dataset.downcast_ref::<MapTileCache>().expect("cache");
         for tile in &expected {
             assert!(
-                matches!(cache.tiles.get(tile), Some(TileEntry::Pending)),
+                matches!(cache.tile_entry(*tile), Some(TileEntry::Pending)),
                 "tile {tile:?} must be queued by the render pass"
             );
         }
@@ -4774,7 +5332,7 @@ mod autotest_generated {
             LogicalSize::new(512.0, 512.0),
             &layer_zoom(0, 19),
         ) {
-            cache.mark_tile_ready(tile, AzString::from("not xml at all <<<"));
+            cache.insert_tile(tile, TileEntry::Ready { svg: AzString::from("not xml at all <<<") });
         }
         let dataset = RefAny::new(cache);
         let ret =
@@ -4795,14 +5353,13 @@ mod autotest_generated {
         );
         for (i, tile) in tiles.iter().enumerate() {
             match i % 4 {
-                0 => {
-                    cache.tiles.insert(*tile, TileEntry::Pending);
-                }
-                1 => {
-                    cache.tiles.insert(*tile, TileEntry::Fetching);
-                }
-                2 => cache.mark_tile_failed(*tile, AzString::from("\u{1F600} failed")),
-                _ => cache.mark_tile_ready(*tile, AzString::from("")),
+                0 => cache.insert_tile(*tile, TileEntry::Pending),
+                1 => cache.insert_tile(*tile, TileEntry::Fetching),
+                2 => cache.insert_tile(
+                    *tile,
+                    TileEntry::Failed { error: AzString::from("\u{1F600} failed") },
+                ),
+                _ => cache.insert_tile(*tile, TileEntry::Ready { svg: AzString::from("") }),
             }
         }
         let dataset = RefAny::new(cache);

--- a/layout/src/window.rs
+++ b/layout/src/window.rs
@@ -12690,8 +12690,35 @@ impl LayoutWindow {
             return empty;
         }
 
-        // Get the current inline content from cache
-        let content = self.get_text_before_textinput(dom_id, node_id);
+        // The buffer this edit splices into.
+        //
+        // `text3::edit::insert_text` writes into `content[cursor.source_run]`,
+        // so an editable with NO text at all — a brand-new document, an empty
+        // `<p>`, a field the user just cleared — has no run 0 to write into:
+        // the splice found nothing, returned the content unchanged, and the
+        // FIRST character typed into it was silently dropped. It happened on
+        // every shape (a flat `div[contenteditable]` as much as the
+        // `container > p` the text widgets and AzWriter use), and it looked
+        // like a dead window — the caret blinked in a document that could not
+        // be started.
+        //
+        // Seed ONE empty run so there is something to splice into, carrying
+        // the node's own text style: the first character has to be the size
+        // and font the block is styled at, not `StyleProperties::default()`.
+        // `source_node_id` stays `None` — no Text node produced this run, and
+        // `reshape_text_node` routes the result by IFC, not by that id.
+        //
+        // Only the INSERT path needs it: `delete_selection` on an empty
+        // editable is correctly a no-op.
+        let mut content = self.get_text_before_textinput(dom_id, node_id);
+        if content.is_empty() {
+            content = vec![InlineContent::Text(StyledRun {
+                text: Arc::from(""),
+                style: self.get_text_style_for_node(dom_id, node_id),
+                logical_start_byte: 0,
+                source_node_id: None,
+            })];
+        }
 
         // Get current cursor/selection — prefer non-empty MultiCursorState, fall back to legacy
         let mc_selections = self.text_edit_manager.multi_cursor.as_ref()

--- a/layout/src/window.rs
+++ b/layout/src/window.rs
@@ -14606,6 +14606,45 @@ impl LayoutWindow {
         ))
     }
 
+    /// The one caret position an EMPTY editable line owns.
+    ///
+    /// `layout_ifc` keeps a strut line box for an IFC root with no inline
+    /// content when it is (inside) a `contenteditable` host, precisely so a
+    /// caret can stand there. But `UnifiedLayout::hittest_cursor` answers
+    /// `None` for a layout with no clusters — there is no glyph to measure
+    /// against — so a click on that line found nothing, and
+    /// `process_mouse_click_for_selection` fell through to its "the press hit
+    /// no selectable text" branch. A brand-new document is made of exactly one
+    /// such line, so it could not be clicked into at all.
+    ///
+    /// There is no ambiguity to resolve on an empty line: the caret goes at
+    /// offset 0, leading. Returns `None` for anything that HAS clusters (the
+    /// real hit test answers those) and for non-editable empty IFCs (an empty
+    /// `<div>` is not something you put a caret in).
+    fn empty_editing_host_caret(
+        styled_dom: &StyledDom,
+        ifc_root_node_id: NodeId,
+        layout: &UnifiedLayout,
+    ) -> Option<TextCursor> {
+        if layout
+            .items
+            .iter()
+            .any(|item| matches!(item.item, ShapedItem::Cluster(_)))
+        {
+            return None;
+        }
+        if !solver3::getters::is_node_contenteditable_inherited(styled_dom, ifc_root_node_id) {
+            return None;
+        }
+        Some(TextCursor {
+            cluster_id: GraphemeClusterId {
+                source_run: 0,
+                start_byte_in_run: 0,
+            },
+            affinity: CursorAffinity::Leading,
+        })
+    }
+
     /// Process mouse click for text selection.
     ///
     /// This method handles:
@@ -14750,7 +14789,14 @@ impl LayoutWindow {
                     };
 
                     // Hit-test the cursor in this text layout
-                    if let Some(cursor) = layout.hittest_point(local_pos) {
+                    let hit_cursor = layout.hittest_point(local_pos).or_else(|| {
+                        Self::empty_editing_host_caret(
+                            &layout_result.styled_dom,
+                            ifc_root_node_id,
+                            layout.as_ref(),
+                        )
+                    });
+                    if let Some(cursor) = hit_cursor {
                         // Store selection with IFC root NodeId, not the hit text node
                         found_selection = Some((*dom_id, ifc_root_node_id, SelectionRange {
                             start: cursor,
@@ -14837,7 +14883,14 @@ impl LayoutWindow {
                     let layout = Self::materialized_inline_layout(cached_layout);
 
                     // Hit-test the cursor in this text layout
-                    if let Some(cursor) = layout.hittest_point(local_pos) {
+                    let hit_cursor = layout.hittest_point(local_pos).or_else(|| {
+                        Self::empty_editing_host_caret(
+                            &layout_result.styled_dom,
+                            node_id,
+                            layout.as_ref(),
+                        )
+                    });
+                    if let Some(cursor) = hit_cursor {
                         found_selection = Some((*dom_id, node_id, SelectionRange {
                             start: cursor,
                             end: cursor,

--- a/layout/src/window.rs
+++ b/layout/src/window.rs
@@ -28,8 +28,7 @@ use std::{
 };
 
 use azul_core::{
-    resources::UpdateImageType,
-    callbacks::{FocusTarget, HidpiAdjustedBounds, VirtualViewCallbackReason, Update},
+    callbacks::{FocusTarget, HidpiAdjustedBounds, Update, VirtualViewCallbackReason},
     dom::{
         AccessibilityAction, AttributeType, Dom, DomId, DomIdVec, DomNodeId, NodeId, NodeType, On,
     },
@@ -39,6 +38,7 @@ use azul_core::{
     gpu::{GpuScrollbarOpacityEvent, GpuValueCache},
     hit_test::{DocumentId, ScrollPosition, ScrollbarHitId},
     refany::{OptionRefAny, RefAny},
+    resources::UpdateImageType,
     resources::{
         Epoch, FontKey, GlTextureCache, IdNamespace, ImageCache, ImageMask, ImageRef, ImageRefHash,
         OpacityKey, RendererResources,
@@ -75,14 +75,10 @@ use rust_fontconfig::FcFontCache;
 #[cfg(feature = "icu")]
 use crate::icu::IcuLocalizerHandle;
 use crate::{
-    callbacks::{
-        Callback, ExternalSystemCallbacks, MenuCallback,
-    },
+    callbacks::{Callback, ExternalSystemCallbacks, MenuCallback},
     managers::{
-        gpu_state::GpuStateManager,
-        selection::ClipboardExtract,
+        gpu_state::GpuStateManager, scroll_state::ScrollManager, selection::ClipboardExtract,
         virtual_view::VirtualViewManager,
-        scroll_state::ScrollManager,
     },
     solver3::{
         self, cache::LayoutCache as Solver3LayoutCache, display_list::DisplayList,
@@ -90,8 +86,8 @@ use crate::{
     },
     text3::{
         cache::{
-            FontManager, FontSelector, FontStyle, InlineContent, TextShapingCache as TextLayoutCache,
-            LayoutError, ShapedItem, StyleProperties, StyledRun, UnifiedConstraints,
+            FontManager, FontSelector, FontStyle, InlineContent, LayoutError, ShapedItem,
+            StyleProperties, StyledRun, TextShapingCache as TextLayoutCache, UnifiedConstraints,
             UnifiedLayout,
         },
         default::PathLoader,
@@ -196,7 +192,8 @@ extern "C" fn cursor_blink_timer_destructor(_: RefAny) {
 /// The callback returns:
 /// - `TerminateTimer::Continue` + `Update::RefreshDom` if cursor toggled
 /// - `TerminateTimer::Terminate` if focus is no longer on a contenteditable element
-#[must_use] pub extern "C" fn cursor_blink_timer_callback(
+#[must_use]
+pub extern "C" fn cursor_blink_timer_callback(
     _data: RefAny,
     mut info: crate::timer::TimerCallbackInfo,
 ) -> azul_core::callbacks::TimerCallbackReturn {
@@ -275,7 +272,8 @@ pub struct TweenTimerData {
 /// also regenerates the display list, which is what advances the tween via
 /// `LayoutWindow::apply_text_tweens`). When the tween state goes idle the
 /// callback terminates the timer.
-#[must_use] pub extern "C" fn caret_tween_timer_callback(
+#[must_use]
+pub extern "C" fn caret_tween_timer_callback(
     mut data: RefAny,
     mut info: crate::timer::TimerCallbackInfo,
 ) -> azul_core::callbacks::TimerCallbackReturn {
@@ -313,7 +311,8 @@ pub struct TweenTimerData {
 /// Movement to a different node (or any hover loss) removes and re-adds the
 /// timer from the platform layer, so the callback itself never needs to
 /// reschedule.
-#[must_use] pub extern "C" fn tooltip_delay_timer_callback(
+#[must_use]
+pub extern "C" fn tooltip_delay_timer_callback(
     _data: RefAny,
     mut info: crate::timer::TimerCallbackInfo,
 ) -> azul_core::callbacks::TimerCallbackReturn {
@@ -758,7 +757,7 @@ const fn memory_walk_coverage_is_exhaustive(w: &LayoutWindow) {
         // that is exactly the mistake `layout_results` represented.
         e2e_mount: _,
         #[cfg(feature = "e2e-server")]
-        e2e_scratch: _,
+            e2e_scratch: _,
         skip_gpu_sync: _,
         frame_report: _,
         frame_report_reset_request: _,
@@ -791,7 +790,7 @@ const fn memory_walk_coverage_is_exhaustive(w: &LayoutWindow) {
         // the tree; walked nowhere, listed so the destructure stays total.
         last_dom_fingerprints: _,
         #[cfg(feature = "pdf")]
-        fragmentation_context: _,
+            fragmentation_context: _,
         image_cache: _,
         content_overlay: _,
         content_journal: _,
@@ -859,7 +858,7 @@ const fn memory_walk_coverage_is_exhaustive(w: &LayoutWindow) {
         resize_watch: _,
         resize_watch_dpi: _,
         #[cfg(feature = "icu")]
-        icu_localizer: _,
+            icu_localizer: _,
     } = w;
 }
 
@@ -878,13 +877,11 @@ pub use crate::managers::text_input::PendingTextEdit;
 
 /// Cached text layout constraints for a node
 /// These are the layout parameters that were used to shape the text
-#[derive(Debug, Clone)]
-#[derive(Default)]
+#[derive(Debug, Clone, Default)]
 pub struct TextConstraintsCache {
     /// Map from (`dom_id`, `node_id`) to their layout constraints
     pub constraints: BTreeMap<(DomId, NodeId), UnifiedConstraints>,
 }
-
 
 /// A text node that has been edited since the last full layout.
 /// This allows us to perform lightweight relayout without rebuilding the entire DOM.
@@ -988,8 +985,6 @@ const NESTED_DOM_HOST_WALK_LIMIT: usize = 32;
 /// small; the bound only stops a malformed hierarchy from spinning.
 const IFC_CANDIDATE_SCAN_LIMIT: usize = 4096;
 
-
-
 #[allow(clippy::struct_excessive_bools)]
 /// A tear-off drag of an inline-docked `<transient-window>`, running in
 /// the PARENT window (the panel has no window of its own to drag).
@@ -1089,10 +1084,7 @@ pub struct LayoutWindow {
     /// This is the bridge, and it is deliberately rebuilt rather than migrated:
     /// after a rebuild the old `NodeIds` are meaningless, so a stale entry here
     /// would write a transform onto whatever unrelated node inherited the slot.
-    pub anim_key_to_node: BTreeMap<
-        azul_core::animation::AnimKey,
-        NodeId,
-    >,
+    pub anim_key_to_node: BTreeMap<azul_core::animation::AnimKey, NodeId>,
     /// Diff-triggered `animation` transitions in flight (ROOT dom). See
     /// [`CssTransition`] for the governing semantics.
     pub css_transitions: Vec<CssTransition>,
@@ -1649,7 +1641,8 @@ impl LayoutWindow {
     /// font the parent can — its parsed system faces AND its embedded (icon)
     /// fonts — instead of rebuilding an empty manager and rendering the macOS
     /// last-resort "tofu" face for text and icons.
-    #[must_use] pub fn from_font_manager(font_manager: FontManager<FontRef>) -> Self {
+    #[must_use]
+    pub fn from_font_manager(font_manager: FontManager<FontRef>) -> Self {
         Self {
             pending_css_dirty: None,
             e2e_mount: E2eMountOverride::default(),
@@ -1677,18 +1670,18 @@ impl LayoutWindow {
             layout_cache: Solver3LayoutCache {
                 tree: None,
                 resize_only_hint: false,
-            last_reconcile_was_skipped: false,
-            last_reconcile_structure_preserved: false,
-            last_build_was_patched: false,
-            last_patch_damage: None,
-            build_seq: 0,
-            last_full_build_seq: 0,
-            patch_damage_log: Vec::new(),
-            last_dynamic_context: None,
-            previous_sizes: Vec::new(),
-            dom_diff_clean: None,
-            last_fingerprint_skips: 0,
-            last_patch_move: None,
+                last_reconcile_was_skipped: false,
+                last_reconcile_structure_preserved: false,
+                last_build_was_patched: false,
+                last_patch_damage: None,
+                build_seq: 0,
+                last_full_build_seq: 0,
+                patch_damage_log: Vec::new(),
+                last_dynamic_context: None,
+                previous_sizes: Vec::new(),
+                dom_diff_clean: None,
+                last_fingerprint_skips: 0,
+                last_patch_move: None,
                 calculated_positions: Vec::new(),
                 viewport: None,
                 scroll_ids: HashMap::new(),
@@ -1700,9 +1693,9 @@ impl LayoutWindow {
                 cached_display_list: None,
                 prev_dom_ptr: 0,
                 prev_viewport: LogicalRect::zero(),
-            last_reconcile_reused: 0,
-            last_reconcile_fresh: 0,
-            last_intrinsic_dirty: 0,
+                last_reconcile_reused: 0,
+                last_reconcile_fresh: 0,
+                last_intrinsic_dirty: 0,
             },
             text_cache: TextLayoutCache::new(),
             font_manager,
@@ -1795,7 +1788,9 @@ impl LayoutWindow {
     /// # Errors
     ///
     /// Returns a `LayoutError` if the layout window cannot be initialized.
-    pub fn from_font_context(ctx: &crate::text3::cache::FontContext) -> Result<Self, solver3::LayoutError> {
+    pub fn from_font_context(
+        ctx: &crate::text3::cache::FontContext,
+    ) -> Result<Self, solver3::LayoutError> {
         let fm = ctx.to_font_manager();
         let fc_cache = fm.fc_cache.clone();
         let parsed_fonts = fm.parsed_fonts.clone();
@@ -2132,7 +2127,8 @@ impl LayoutWindow {
     /// notification that replaces app-side polling). The shared dispatcher
     /// includes it in event determination and calls
     /// [`Self::mark_document_edit_notified`] afterwards.
-    #[must_use] pub fn document_edit_event_provider(
+    #[must_use]
+    pub fn document_edit_event_provider(
         &self,
     ) -> crate::event_determination::DocumentEditEventProvider {
         crate::event_determination::DocumentEditEventProvider {
@@ -2222,19 +2218,23 @@ impl LayoutWindow {
         // `white-space`: when newlines are preserved, `"\n"` is the native
         // line separator and Enter inserts one instead of splitting blocks.
         let host_preserves_newlines = self.layout_results.get(&focus.dom).is_some_and(|lr| {
-            use azul_css::props::style::StyleWhiteSpace;
             use crate::solver3::getters::{get_white_space_property, MultiValue};
-            lr.styled_dom.styled_nodes.as_container().get(host).is_some_and(|n| {
-                matches!(
-                    get_white_space_property(&lr.styled_dom, host, &n.styled_node_state),
-                    MultiValue::Exact(
-                        StyleWhiteSpace::Pre
-                            | StyleWhiteSpace::PreWrap
-                            | StyleWhiteSpace::BreakSpaces
-                            | StyleWhiteSpace::PreLine
+            use azul_css::props::style::StyleWhiteSpace;
+            lr.styled_dom
+                .styled_nodes
+                .as_container()
+                .get(host)
+                .is_some_and(|n| {
+                    matches!(
+                        get_white_space_property(&lr.styled_dom, host, &n.styled_node_state),
+                        MultiValue::Exact(
+                            StyleWhiteSpace::Pre
+                                | StyleWhiteSpace::PreWrap
+                                | StyleWhiteSpace::BreakSpaces
+                                | StyleWhiteSpace::PreLine
+                        )
                     )
-                )
-            })
+                })
         });
 
         // Caret at block start / end, judged against the CURRENT effective
@@ -2242,30 +2242,32 @@ impl LayoutWindow {
         // on multi-run content: a caret we cannot prove at the boundary keeps
         // Backspace/Delete on the plain per-IFC text path — safe fallback.
         let (at_start, at_end) =
-            self.text_edit_manager.get_primary_cursor().map_or((false, false), |cursor| {
-                let content = self.get_text_before_textinput(focus.dom, node_id);
-                let at_start = cursor.cluster_id.source_run == 0
-                    && cursor.cluster_id.start_byte_in_run == 0;
-                let last_text = content.iter().enumerate().rev().find_map(|(i, c)| {
-                    if let InlineContent::Text(run) = c {
-                        Some((
-                            u32::try_from(i).unwrap_or(u32::MAX),
-                            u32::try_from(run.text.len()).unwrap_or(u32::MAX),
-                        ))
-                    } else {
-                        None
-                    }
+            self.text_edit_manager
+                .get_primary_cursor()
+                .map_or((false, false), |cursor| {
+                    let content = self.get_text_before_textinput(focus.dom, node_id);
+                    let at_start = cursor.cluster_id.source_run == 0
+                        && cursor.cluster_id.start_byte_in_run == 0;
+                    let last_text = content.iter().enumerate().rev().find_map(|(i, c)| {
+                        if let InlineContent::Text(run) = c {
+                            Some((
+                                u32::try_from(i).unwrap_or(u32::MAX),
+                                u32::try_from(run.text.len()).unwrap_or(u32::MAX),
+                            ))
+                        } else {
+                            None
+                        }
+                    });
+                    let at_end = match last_text {
+                        Some((last_run, last_len)) => {
+                            cursor.cluster_id.source_run >= last_run
+                                && cursor.cluster_id.start_byte_in_run >= last_len
+                        }
+                        // No text at all: the caret is at both boundaries.
+                        None => true,
+                    };
+                    (at_start, at_end)
                 });
-                let at_end = match last_text {
-                    Some((last_run, last_len)) => {
-                        cursor.cluster_id.source_run >= last_run
-                            && cursor.cluster_id.start_byte_in_run >= last_len
-                    }
-                    // No text at all: the caret is at both boundaries.
-                    None => true,
-                };
-                (at_start, at_end)
-            });
 
         Some(crate::default_actions::EditingQueryState {
             is_contenteditable: true,
@@ -2315,9 +2317,7 @@ impl LayoutWindow {
                 .dom_to_layout
                 .get(&host_node)
                 .and_then(|indices| indices.first().copied())
-                .and_then(|idx| {
-                    solver3::pos_get(&parent_result.calculated_positions, idx.index())
-                });
+                .and_then(|idx| solver3::pos_get(&parent_result.calculated_positions, idx.index()));
             if let Some(host_pos) = host_pos {
                 let content = self.virtual_view_content_offset(parent_dom, host_node);
                 total.x += host_pos.x + content.x;
@@ -2329,11 +2329,7 @@ impl LayoutWindow {
         total
     }
 
-    pub fn virtual_view_content_offset(
-        &self,
-        dom_id: DomId,
-        node_id: NodeId,
-    ) -> LogicalPosition {
+    pub fn virtual_view_content_offset(&self, dom_id: DomId, node_id: NodeId) -> LogicalPosition {
         let window_origin = self
             .virtual_view_manager
             .materialized_window_origin(dom_id, node_id)
@@ -2388,10 +2384,15 @@ impl LayoutWindow {
         let hierarchy = lr.styled_dom.node_hierarchy.as_container();
         let mut current = Some(node_id);
         while let Some(nid) = current {
-            if node_data.get(nid).is_some_and(azul_core::dom::NodeData::is_contenteditable) {
+            if node_data
+                .get(nid)
+                .is_some_and(azul_core::dom::NodeData::is_contenteditable)
+            {
                 return Some(nid);
             }
-            current = hierarchy.get(nid).and_then(azul_core::styled_dom::NodeHierarchyItem::parent_id);
+            current = hierarchy
+                .get(nid)
+                .and_then(azul_core::styled_dom::NodeHierarchyItem::parent_id);
         }
         None
     }
@@ -2432,9 +2433,12 @@ impl LayoutWindow {
         };
         self.undo_redo_manager
             .store_content_snapshot(changeset_id, pre_content, post_content);
-        self.undo_redo_manager.record_operation(changeset, pre_state);
+        self.undo_redo_manager
+            .record_operation(changeset, pre_state);
         if matches!(notify, TextEditNotify::QueueInput) {
-            self.text_edit_manager.pending_edit_notifications.push(target);
+            self.text_edit_manager
+                .pending_edit_notifications
+                .push(target);
         }
         changeset_id
     }
@@ -2498,10 +2502,7 @@ impl LayoutWindow {
                 let at = self.caret_node_position(target.dom, node_id)?;
                 (
                     *target,
-                    DocumentOperation::SplitNode(DocOpSplitNode {
-                        node: *target,
-                        at,
-                    }),
+                    DocumentOperation::SplitNode(DocOpSplitNode { node: *target, at }),
                 )
             }
             DefaultAction::MergeWithPrevious { target } => {
@@ -2540,12 +2541,7 @@ impl LayoutWindow {
         };
 
         let resume = self.compute_edit_resume_point(target, &operation)?;
-        let changeset = DocumentChangeset::new(
-            target,
-            operation,
-            resume,
-            Instant::now(),
-        );
+        let changeset = DocumentChangeset::new(target, operation, resume, Instant::now());
 
         // The preview materializes inside record_document_edit — the shared
         // chokepoint, so app-recorded changesets preview identically.
@@ -2580,7 +2576,10 @@ impl LayoutWindow {
         // Walk the caret's node up to the DIRECT child of `node`.
         let mut direct_child = caret_node;
         if direct_child != node_id {
-            while let Some(parent) = hierarchy.get(direct_child).and_then(azul_core::styled_dom::NodeHierarchyItem::parent_id) {
+            while let Some(parent) = hierarchy
+                .get(direct_child)
+                .and_then(azul_core::styled_dom::NodeHierarchyItem::parent_id)
+            {
                 if parent == node_id {
                     break;
                 }
@@ -2594,10 +2593,14 @@ impl LayoutWindow {
 
         // Index of that direct child among ALL children.
         let mut index: u32 = 0;
-        let mut sib = hierarchy.get(direct_child).and_then(azul_core::styled_dom::NodeHierarchyItem::previous_sibling_id);
+        let mut sib = hierarchy
+            .get(direct_child)
+            .and_then(azul_core::styled_dom::NodeHierarchyItem::previous_sibling_id);
         while let Some(sn) = sib {
             index += 1;
-            sib = hierarchy.get(sn).and_then(azul_core::styled_dom::NodeHierarchyItem::previous_sibling_id);
+            sib = hierarchy
+                .get(sn)
+                .and_then(azul_core::styled_dom::NodeHierarchyItem::previous_sibling_id);
         }
 
         // Only a TEXT child carries a byte offset; anything else is a
@@ -2635,7 +2638,9 @@ impl LayoutWindow {
         while let Some(c) = child {
             count += 1;
             last_child = Some(c);
-            child = hierarchy.get(c).and_then(azul_core::styled_dom::NodeHierarchyItem::next_sibling_id);
+            child = hierarchy
+                .get(c)
+                .and_then(azul_core::styled_dom::NodeHierarchyItem::next_sibling_id);
         }
         let last_text_len = last_child.and_then(|c| {
             node_data.get(c).and_then(|n| match n.get_node_type() {
@@ -2652,11 +2657,7 @@ impl LayoutWindow {
     /// The end-of-text cursor of an IFC root: the byte AFTER the last text
     /// run's content (overlay-aware — sees uncommitted edits). `None` when
     /// the node has no text runs.
-    fn node_text_end_cursor(
-        &self,
-        dom_id: DomId,
-        node_id: NodeId,
-    ) -> Option<TextCursor> {
+    fn node_text_end_cursor(&self, dom_id: DomId, node_id: NodeId) -> Option<TextCursor> {
         // The LAYOUT knows the real grapheme clusters: end = Trailing on the
         // final cluster. A byte-length synthetic cursor (one past the last
         // cluster start) resolves to NOTHING in get_selection_rects and the
@@ -2733,32 +2734,53 @@ impl LayoutWindow {
         // A cross-block selection contributes exactly ONE range per node; the
         // list carrier exists for the multi-cursor sessions of the other path.
         let mut affected = BTreeMap::new();
-        affected.insert(first, vec![SelectionRange { start: first_cursor, end: first_end }]);
+        affected.insert(
+            first,
+            vec![SelectionRange {
+                start: first_cursor,
+                end: first_end,
+            }],
+        );
         for &m in &middles {
             // Text-less middles (images, rules) contribute a zero-width range
             // at their start: they are INSIDE the selection (deleted by
             // delete_cross_block_selection) but have no text to highlight.
-            let end = self.node_text_end_cursor(dom_id, m).unwrap_or_else(|| node_start(m));
-            affected.insert(m, vec![SelectionRange { start: node_start(m), end }]);
+            let end = self
+                .node_text_end_cursor(dom_id, m)
+                .unwrap_or_else(|| node_start(m));
+            affected.insert(
+                m,
+                vec![SelectionRange {
+                    start: node_start(m),
+                    end,
+                }],
+            );
         }
-        affected.insert(last, vec![SelectionRange { start: node_start(last), end: last_cursor }]);
+        affected.insert(
+            last,
+            vec![SelectionRange {
+                start: node_start(last),
+                end: last_cursor,
+            }],
+        );
 
-        self.text_edit_manager.set_cross_block_selection(TextSelection {
-            dom_id,
-            anchor: SelectionAnchor {
-                ifc_root_node_id: anchor_node,
-                cursor: anchor_cursor,
-                char_bounds: LogicalRect::zero(),
-                mouse_position: LogicalPosition::zero(),
-            },
-            focus: SelectionFocus {
-                ifc_root_node_id: focus_node,
-                cursor: focus_cursor,
-                mouse_position: LogicalPosition::zero(),
-            },
-            affected_nodes: affected,
-            is_forward,
-        });
+        self.text_edit_manager
+            .set_cross_block_selection(TextSelection {
+                dom_id,
+                anchor: SelectionAnchor {
+                    ifc_root_node_id: anchor_node,
+                    cursor: anchor_cursor,
+                    char_bounds: LogicalRect::zero(),
+                    mouse_position: LogicalPosition::zero(),
+                },
+                focus: SelectionFocus {
+                    ifc_root_node_id: focus_node,
+                    cursor: focus_cursor,
+                    mouse_position: LogicalPosition::zero(),
+                },
+                affected_nodes: affected,
+                is_forward,
+            });
         true
     }
 
@@ -2818,7 +2840,11 @@ impl LayoutWindow {
         use crate::text3::edit::cursor_byte_offset_in_run;
         let cut_run = first_range.start.cluster_id.source_run;
         let mut first_kept = String::new();
-        for (i, c) in self.get_text_before_textinput(dom_id, first).iter().enumerate() {
+        for (i, c) in self
+            .get_text_before_textinput(dom_id, first)
+            .iter()
+            .enumerate()
+        {
             let i = u32::try_from(i).unwrap_or(u32::MAX);
             if let InlineContent::Text(run) = c {
                 match i.cmp(&cut_run) {
@@ -2837,7 +2863,11 @@ impl LayoutWindow {
         // Text kept from the LAST block: everything after the range end.
         let cut_run = last_range.end.cluster_id.source_run;
         let mut last_kept = String::new();
-        for (i, c) in self.get_text_before_textinput(dom_id, last).iter().enumerate() {
+        for (i, c) in self
+            .get_text_before_textinput(dom_id, last)
+            .iter()
+            .enumerate()
+        {
             let i = u32::try_from(i).unwrap_or(u32::MAX);
             if let InlineContent::Text(run) = c {
                 match i.cmp(&cut_run) {
@@ -2852,12 +2882,9 @@ impl LayoutWindow {
             }
         }
 
-        let join_byte =
-            u32::try_from(first_kept.len() + insert.len()).unwrap_or(u32::MAX);
+        let join_byte = u32::try_from(first_kept.len() + insert.len()).unwrap_or(u32::MAX);
         let merged_text = {
-            let mut t = String::with_capacity(
-                first_kept.len() + insert.len() + last_kept.len(),
-            );
+            let mut t = String::with_capacity(first_kept.len() + insert.len() + last_kept.len());
             t.push_str(&first_kept);
             t.push_str(insert);
             t.push_str(&last_kept);
@@ -3019,8 +3046,7 @@ impl LayoutWindow {
             // First real sibling found: eligible iff its computed display is
             // a flow block. Anything else (inline, table, flex, grid,
             // display:none…) stops the merge — do NOT jump over it.
-            let MultiValue::Exact(display) = get_display_property(&lr.styled_dom, Some(sib))
-            else {
+            let MultiValue::Exact(display) = get_display_property(&lr.styled_dom, Some(sib)) else {
                 return None;
             };
             return match display {
@@ -3054,7 +3080,11 @@ impl LayoutWindow {
         let hierarchy_c = lr.styled_dom.node_hierarchy.as_container();
         let anchor = self
             .find_contenteditable_host(target.dom, node_id)
-            .or_else(|| hierarchy_c.get(node_id).and_then(azul_core::styled_dom::NodeHierarchyItem::parent_id))
+            .or_else(|| {
+                hierarchy_c
+                    .get(node_id)
+                    .and_then(azul_core::styled_dom::NodeHierarchyItem::parent_id)
+            })
             .unwrap_or(node_id);
         let node_data = lr.styled_dom.node_data.as_ref();
         let hierarchy = lr.styled_dom.node_hierarchy.as_ref();
@@ -3065,13 +3095,20 @@ impl LayoutWindow {
         let mut current = node_id;
         while current != anchor {
             let mut index: u32 = 0;
-            let mut sib = hierarchy_c.get(current).and_then(azul_core::styled_dom::NodeHierarchyItem::previous_sibling_id);
+            let mut sib = hierarchy_c
+                .get(current)
+                .and_then(azul_core::styled_dom::NodeHierarchyItem::previous_sibling_id);
             while let Some(sn) = sib {
                 index += 1;
-                sib = hierarchy_c.get(sn).and_then(azul_core::styled_dom::NodeHierarchyItem::previous_sibling_id);
+                sib = hierarchy_c
+                    .get(sn)
+                    .and_then(azul_core::styled_dom::NodeHierarchyItem::previous_sibling_id);
             }
             path_rev.push(index);
-            match hierarchy_c.get(current).and_then(azul_core::styled_dom::NodeHierarchyItem::parent_id) {
+            match hierarchy_c
+                .get(current)
+                .and_then(azul_core::styled_dom::NodeHierarchyItem::parent_id)
+            {
                 Some(p) => current = p,
                 None => break,
             }
@@ -3107,9 +3144,7 @@ impl LayoutWindow {
             DocumentOperation::RemoveChildren(r) => NodePosition::before_child(r.start),
             DocumentOperation::ReplaceChildren(r) => NodePosition::before_child(r.start),
             DocumentOperation::WrapRange(w) => w.start,
-            DocumentOperation::UnwrapRange(u) => {
-                NodePosition::before_child(u.at.child_index)
-            }
+            DocumentOperation::UnwrapRange(u) => NodePosition::before_child(u.at.child_index),
         };
 
         Some(EditResumePoint {
@@ -3126,7 +3161,11 @@ impl LayoutWindow {
     /// `layout_and_generate_display_list`), and returns true iff the ids
     /// matched.
     pub fn mark_document_edit_applied(&mut self, id: u64) -> bool {
-        if self.pending_document_edit.as_ref().is_some_and(|c| c.id == id) {
+        if self
+            .pending_document_edit
+            .as_ref()
+            .is_some_and(|c| c.id == id)
+        {
             if let Some(edit) = self.pending_document_edit.take() {
                 self.pending_caret_restore = Some(edit.resume);
             }
@@ -3157,10 +3196,7 @@ impl LayoutWindow {
         id: u64,
         inverse: crate::managers::changeset::DocumentOperation,
     ) -> bool {
-        let Some(edit) = self
-            .pending_document_edit
-            .take_if(|c| c.id == id)
-        else {
+        let Some(edit) = self.pending_document_edit.take_if(|c| c.id == id) else {
             return false;
         };
         self.pending_caret_restore = Some(edit.resume.clone());
@@ -3176,7 +3212,8 @@ impl LayoutWindow {
             Some(StructuralAckKind::Undo) => {}
             // The ack of a REDO re-record: back onto undo WITHOUT clearing redo.
             Some(StructuralAckKind::Redo) => {
-                self.undo_redo_manager.push_structural_undo_after_redo(entry);
+                self.undo_redo_manager
+                    .push_structural_undo_after_redo(entry);
             }
             // A fresh user edit.
             None => self.undo_redo_manager.push_structural(entry),
@@ -3227,7 +3264,8 @@ impl LayoutWindow {
             Instant::now(),
         );
         let id = self.record_document_edit(changeset);
-        self.undo_redo_manager.push_structural_undo_after_redo(entry);
+        self.undo_redo_manager
+            .push_structural_undo_after_redo(entry);
         self.structural_history_suppression = Some(StructuralAckKind::Redo);
         Some(id)
     }
@@ -3261,15 +3299,11 @@ impl LayoutWindow {
             }
             (Op::InsertChildren(_), Op::RemoveChildren(r)) => NodePosition::before_child(r.start),
             (Op::RemoveChildren(_), Op::InsertChildren(i)) => NodePosition::before_child(i.index),
-            (Op::ReplaceChildren(_), Op::ReplaceChildren(r)) => {
-                NodePosition::before_child(r.start)
-            }
+            (Op::ReplaceChildren(_), Op::ReplaceChildren(r)) => NodePosition::before_child(r.start),
             (Op::WrapRange(w), Op::UnwrapRange(_)) => {
                 NodePosition::before_child(w.start.child_index)
             }
-            (Op::UnwrapRange(u), Op::WrapRange(_)) => {
-                NodePosition::before_child(u.at.child_index)
-            }
+            (Op::UnwrapRange(u), Op::WrapRange(_)) => NodePosition::before_child(u.at.child_index),
             _ => return None,
         };
         Some(EditResumePoint {
@@ -3312,7 +3346,9 @@ impl LayoutWindow {
                     return Some(c);
                 }
                 i += 1;
-                child = hierarchy.get(c).and_then(azul_core::styled_dom::NodeHierarchyItem::next_sibling_id);
+                child = hierarchy
+                    .get(c)
+                    .and_then(azul_core::styled_dom::NodeHierarchyItem::next_sibling_id);
             }
             None
         };
@@ -3320,7 +3356,9 @@ impl LayoutWindow {
         // Walk the child-index path; any miss falls back to the anchor.
         let mut target = anchor;
         for &idx in resume.node_path.as_ref() {
-            if let Some(c) = nth_child(target, idx) { target = c } else {
+            if let Some(c) = nth_child(target, idx) {
+                target = c
+            } else {
                 target = anchor;
                 break;
             }
@@ -3447,7 +3485,9 @@ impl LayoutWindow {
                     {
                         out.push(c);
                     }
-                    child = hierarchy.get(c).and_then(azul_core::styled_dom::NodeHierarchyItem::next_sibling_id);
+                    child = hierarchy
+                        .get(c)
+                        .and_then(azul_core::styled_dom::NodeHierarchyItem::next_sibling_id);
                 }
             }
             out
@@ -3539,7 +3579,11 @@ impl LayoutWindow {
     /// Style + lay `styled_dom` out against `available` on fresh scratch
     /// caches — nothing of the window's live layout state is touched. The
     /// returned cache holds the tree and positions for the caller to read.
-    fn scratch_layout(&self, styled_dom: &StyledDom, available: LogicalSize) -> Option<Solver3LayoutCache> {
+    fn scratch_layout(
+        &self,
+        styled_dom: &StyledDom,
+        available: LogicalSize,
+    ) -> Option<Solver3LayoutCache> {
         let mut scratch_cache = Solver3LayoutCache {
             tree: None,
             resize_only_hint: false,
@@ -3672,10 +3716,11 @@ impl LayoutWindow {
     ) -> Option<crate::transient::OpenTransientWindow> {
         let closed = self.transient_windows.dismiss(source_node)?;
         self.layout_results.remove(&closed.content_dom);
-        self.pending_transient_diff.merge(crate::transient::TransientDiff {
-            closed: vec![closed.content_dom],
-            ..Default::default()
-        });
+        self.pending_transient_diff
+            .merge(crate::transient::TransientDiff {
+                closed: vec![closed.content_dom],
+                ..Default::default()
+            });
         let now = {
             #[cfg(feature = "std")]
             {
@@ -3686,12 +3731,13 @@ impl LayoutWindow {
                 azul_core::task::Instant::Tick(azul_core::task::SystemTick { tick_counter: 0 })
             }
         };
-        self.pending_lifecycle_events.push(azul_core::diff::create_dismiss_event(
-            source_node,
-            DomId::ROOT_ID,
-            &now,
-            closed.placement.anchor_rect,
-        ));
+        self.pending_lifecycle_events
+            .push(azul_core::diff::create_dismiss_event(
+                source_node,
+                DomId::ROOT_ID,
+                &now,
+                closed.placement.anchor_rect,
+            ));
         Some(closed)
     }
 
@@ -3715,7 +3761,10 @@ impl LayoutWindow {
         let mut current = Some(node);
         for _ in 0..256 {
             let n = current?;
-            if matches!(nodes.get(n).map(azul_core::dom::NodeData::get_node_type), Some(NodeType::TransientWindow(_))) {
+            if matches!(
+                nodes.get(n).map(azul_core::dom::NodeData::get_node_type),
+                Some(NodeType::TransientWindow(_))
+            ) {
                 let inline = self
                     .transient_windows
                     .open_windows()
@@ -3723,7 +3772,9 @@ impl LayoutWindow {
                     .any(|w| w.source_node == n && w.is_inline());
                 return inline.then_some(n);
             }
-            current = hierarchy.get(n).and_then(azul_core::styled_dom::NodeHierarchyItem::parent_id);
+            current = hierarchy
+                .get(n)
+                .and_then(azul_core::styled_dom::NodeHierarchyItem::parent_id);
         }
         None
     }
@@ -3757,7 +3808,12 @@ impl LayoutWindow {
         // event): it is a drag proxy, not an app-facing tear-off — the app
         // hears one event on release (`end_inline_tear`).
         self.transient_windows.set_content_size(panel, rect.size);
-        self.inline_tear = Some(InlineTear { node: panel, press, origin, was_zone });
+        self.inline_tear = Some(InlineTear {
+            node: panel,
+            press,
+            origin,
+            was_zone,
+        });
         self.apply_transient_drop_inner(panel, crate::transient::TearDrop::TearOff(origin), false)
     }
 
@@ -3766,7 +3822,10 @@ impl LayoutWindow {
     /// this into the proxy window's mailbox each move (the parent owns the
     /// gesture, so it drives the child). `None` if no inline tear is active.
     #[must_use]
-    pub fn inline_tear_origin_at(&self, cursor: LogicalPosition) -> Option<(NodeId, LogicalPosition)> {
+    pub fn inline_tear_origin_at(
+        &self,
+        cursor: LogicalPosition,
+    ) -> Option<(NodeId, LogicalPosition)> {
         let tear = self.inline_tear?;
         Some((
             tear.node,
@@ -3795,7 +3854,8 @@ impl LayoutWindow {
             dom: DomId::ROOT_ID,
             node: NodeHierarchyItemId::from_crate_internal(Some(tear.node)),
         }) {
-            self.transient_windows.set_content_size(tear.node, rect.size);
+            self.transient_windows
+                .set_content_size(tear.node, rect.size);
         }
         // Apply the drop SILENTLY (the proxy tear on drag-start was silent too),
         // then fire ONE lifecycle event for the NET change from the pre-drag
@@ -3843,13 +3903,14 @@ impl LayoutWindow {
                 azul_core::task::Instant::Tick(azul_core::task::SystemTick { tick_counter: 0 })
             }
         };
-        self.pending_lifecycle_events.push(azul_core::diff::create_tearoff_event(
-            node,
-            DomId::ROOT_ID,
-            &now,
-            torn,
-            bounds,
-        ));
+        self.pending_lifecycle_events
+            .push(azul_core::diff::create_tearoff_event(
+                node,
+                DomId::ROOT_ID,
+                &now,
+                torn,
+                bounds,
+            ));
     }
 
     /// The user's tear-off drag of the window at `source_node` ended with the
@@ -3878,7 +3939,9 @@ impl LayoutWindow {
         cursor: LogicalPosition,
         emit: bool,
     ) -> bool {
-        use crate::transient::{decide_drop, nodes_matching_selector, tearoff_zone_selector, TearDrop};
+        use crate::transient::{
+            decide_drop, nodes_matching_selector, tearoff_zone_selector, TearDrop,
+        };
         let Some(open) = self
             .transient_windows
             .open_windows()
@@ -3891,28 +3954,33 @@ impl LayoutWindow {
         // Zones: the nodes matching the window's `tearoff-zone` selector,
         // hit-tested by their viewport rects; the innermost (last in
         // document order) one under the pointer wins.
-        let zones: Vec<(NodeId, LogicalRect)> = if open.placement.tearoff == azul_core::transient::TransientTearoff::Zone {
-            let root = self.layout_results.get(&DomId::ROOT_ID);
-            let selector = root.and_then(|r| tearoff_zone_selector(&r.styled_dom, source_node));
-            match (root, selector) {
-                (Some(r), Some(sel)) => nodes_matching_selector(&r.styled_dom, &sel)
-                    .into_iter()
-                    .filter(|n| *n != source_node)
-                    .filter_map(|n| {
-                        let rect = self.get_node_rect_in_viewport(DomNodeId {
-                            dom: DomId::ROOT_ID,
-                            node: NodeHierarchyItemId::from_crate_internal(Some(n)),
-                        })?;
-                        Some((n, rect))
-                    })
-                    .collect(),
-                _ => Vec::new(),
-            }
-        } else {
-            Vec::new()
-        };
+        let zones: Vec<(NodeId, LogicalRect)> =
+            if open.placement.tearoff == azul_core::transient::TransientTearoff::Zone {
+                let root = self.layout_results.get(&DomId::ROOT_ID);
+                let selector = root.and_then(|r| tearoff_zone_selector(&r.styled_dom, source_node));
+                match (root, selector) {
+                    (Some(r), Some(sel)) => nodes_matching_selector(&r.styled_dom, &sel)
+                        .into_iter()
+                        .filter(|n| *n != source_node)
+                        .filter_map(|n| {
+                            let rect = self.get_node_rect_in_viewport(DomNodeId {
+                                dom: DomId::ROOT_ID,
+                                node: NodeHierarchyItemId::from_crate_internal(Some(n)),
+                            })?;
+                            Some((n, rect))
+                        })
+                        .collect(),
+                    _ => Vec::new(),
+                }
+            } else {
+                Vec::new()
+            };
         let drop = decide_drop(cursor, open.placement.anchor_rect, window_origin, |p| {
-            zones.iter().rev().find(|(_, r)| r.contains(p)).map(|(n, _)| *n)
+            zones
+                .iter()
+                .rev()
+                .find(|(_, r)| r.contains(p))
+                .map(|(n, _)| *n)
         });
         self.apply_transient_drop_inner(source_node, drop, emit)
     }
@@ -3939,7 +4007,11 @@ impl LayoutWindow {
         self.apply_transient_drop(source_node, drop)
     }
 
-    fn apply_transient_drop(&mut self, source_node: NodeId, drop: crate::transient::TearDrop) -> bool {
+    fn apply_transient_drop(
+        &mut self,
+        source_node: NodeId,
+        drop: crate::transient::TearDrop,
+    ) -> bool {
         self.apply_transient_drop_inner(source_node, drop, true)
     }
 
@@ -3995,17 +4067,22 @@ impl LayoutWindow {
                     azul_core::task::Instant::Tick(azul_core::task::SystemTick { tick_counter: 0 })
                 }
             };
-            self.pending_lifecycle_events.push(azul_core::diff::create_tearoff_event(
-                source_node,
-                DomId::ROOT_ID,
-                &now,
-                w.torn.is_some(),
-                bounds,
-            ));
+            self.pending_lifecycle_events
+                .push(azul_core::diff::create_tearoff_event(
+                    source_node,
+                    DomId::ROOT_ID,
+                    &now,
+                    w.torn.is_some(),
+                    bounds,
+                ));
         }
         // A re-anchor (a zone) or a move of a torn window changes placement
         // without changing kind: the next reconcile re-places it.
-        changed || matches!(drop, crate::transient::TearDrop::DockOnto(_) | crate::transient::TearDrop::TearOff(_))
+        changed
+            || matches!(
+                drop,
+                crate::transient::TearDrop::DockOnto(_) | crate::transient::TearDrop::TearOff(_)
+            )
     }
 
     /// Measure the content of the `<transient-window>` at `source_node` for
@@ -4158,7 +4235,10 @@ impl LayoutWindow {
         };
 
         // Get the platform from system_style, falling back to compile-time detection
-        let platform = self.system_style.as_ref().map_or_else(azul_css::system::Platform::current, |s| s.platform.clone());
+        let platform = self
+            .system_style
+            .as_ref()
+            .map_or_else(azul_css::system::Platform::current, |s| s.platform.clone());
 
         // Font Resolution And Loading
         // This must happen BEFORE layout_document() is called
@@ -4240,7 +4320,8 @@ impl LayoutWindow {
             if font_requirements_unchanged {
                 if let Some(msgs) = debug_messages.as_mut() {
                     msgs.push(LayoutDebugMessage::info(
-                        "[FontLoading] Font requirements unchanged, skipping resolution (cached)".to_string(),
+                        "[FontLoading] Font requirements unchanged, skipping resolution (cached)"
+                            .to_string(),
                     ));
                 }
             } else {
@@ -4254,7 +4335,9 @@ impl LayoutWindow {
                 // so the reverse map accumulates across DOMs.
                 if let Some(cc) = styled_dom.css_property_cache.ptr.compact_cache.as_ref() {
                     for (k, v) in &cc.font_hash_to_families {
-                        self.font_manager.font_hash_to_families.insert(*k, v.clone());
+                        self.font_manager
+                            .font_hash_to_families
+                            .insert(*k, v.clone());
                     }
                 }
 
@@ -4269,11 +4352,16 @@ impl LayoutWindow {
                 let mut chains = {
                     let _p = crate::probe::Probe::span("font_chain_resolve");
                     collect_and_resolve_font_chains_with_registration(
-                        &styled_dom, &self.font_manager.fc_cache, &self.font_manager, &platform,
+                        &styled_dom,
+                        &self.font_manager.fc_cache,
+                        &self.font_manager,
+                        &platform,
                     )
                 };
                 // [g80] localize where font_chain_cache drops to 0: chains right after collect_and_resolve.
-                unsafe { crate::az_mark(0x60770_u32, chains.chains.len() as u32); }
+                unsafe {
+                    crate::az_mark(0x60770_u32, chains.chains.len() as u32);
+                }
                 // WEB-LIFT last resort (the DEFINITIVE spot — the layout's own `chains` that
                 // feed load_missing_for_chains below): the lifted font-query path can leave a
                 // chain with NO fonts even when a fallback IS registered (generic→OS-name +
@@ -4282,19 +4370,25 @@ impl LayoutWindow {
                 // Done here (azul-layout), NOT rust-fontconfig (which re-codegens the fragile
                 // with_memory_fonts into a trapping shape).
                 for chain in chains.chains.values_mut() {
-                    let total = chain.css_fallbacks.iter().map(|g| g.fonts.len()).sum::<usize>()
+                    let total = chain
+                        .css_fallbacks
+                        .iter()
+                        .map(|g| g.fonts.len())
+                        .sum::<usize>()
                         + chain.unicode_fallbacks.len();
                     if total == 0 {
                         // `list()` deep-copies the ENTIRE font database to read one
-                            // entry; see `first_font_in_cache` in solver3::getters.
-                            let __first = {
-                                let mut f = None;
-                                self.font_manager.fc_cache.for_each_pattern(|p, id| {
-                                    if f.is_none() { f = Some((p.clone(), *id)); }
-                                });
-                                f
-                            };
-                            if let Some((pattern, id)) = __first.as_ref() {
+                        // entry; see `first_font_in_cache` in solver3::getters.
+                        let __first = {
+                            let mut f = None;
+                            self.font_manager.fc_cache.for_each_pattern(|p, id| {
+                                if f.is_none() {
+                                    f = Some((p.clone(), *id));
+                                }
+                            });
+                            f
+                        };
+                        if let Some((pattern, id)) = __first.as_ref() {
                             chain.unicode_fallbacks.push(rust_fontconfig::FontMatch {
                                 id: *id,
                                 unicode_ranges: pattern.unicode_ranges.clone(),
@@ -4304,7 +4398,9 @@ impl LayoutWindow {
                     }
                 }
                 // [g80] chains after the window.rs last-resort loop (values_mut path).
-                unsafe { crate::az_mark(0x60774_u32, chains.chains.len() as u32); }
+                unsafe {
+                    crate::az_mark(0x60774_u32, chains.chains.len() as u32);
+                }
                 // [az-web-lift 2026-06-05] REMOVED a WASM-ONLY diagnostic probe that computed
                 // nchains/total_fonts/nreg here purely to write debug markers. Its
                 // `chains.chains.values().map(|c| …).sum()` closure-iterator chain (and/or the
@@ -4335,10 +4431,10 @@ impl LayoutWindow {
                 crate::probe::sample_peak_rss("rss:before_font_load");
                 let failed = {
                     let _p = crate::probe::Probe::span("font_load_missing");
-                    self.font_manager.load_missing_for_chains(
-                        &chains,
-                        |bytes, index| loader.load_font_shared(bytes, index),
-                    )
+                    self.font_manager
+                        .load_missing_for_chains(&chains, |bytes, index| {
+                            loader.load_font_shared(bytes, index)
+                        })
                 };
                 crate::probe::sample_peak_rss("rss:after_font_load");
                 if let Some(msgs) = debug_messages.as_mut() {
@@ -4363,13 +4459,9 @@ impl LayoutWindow {
                 // the keep-set describes just the DOM being laid out, and evicting
                 // on it could drop a sibling DOM's font between its layout and its
                 // raster.
-                let single_dom = self
-                    .layout_results
-                    .keys()
-                    .all(|d| *d == dom_id);
+                let single_dom = self.layout_results.keys().all(|d| *d == dom_id);
                 if single_dom {
-                    let keep_ids =
-                        solver3::getters::collect_font_ids_from_chains(&chains);
+                    let keep_ids = solver3::getters::collect_font_ids_from_chains(&chains);
                     // The family-hash keep-set comes from the compact style
                     // cache — which a runtime CSS patch legitimately DROPS
                     // (`restyle_user_property` invalidates it so the next
@@ -4413,13 +4505,18 @@ impl LayoutWindow {
                 // an identical DOM skips the resolver entirely).
                 let fc_chains = chains.into_fontconfig_chains();
                 // [g80] fc_chains after into_fontconfig_chains (the BTreeMap rebuild) — does it drop them?
-                unsafe { crate::az_mark(0x60778_u32, fc_chains.len() as u32); }
-                self.font_manager.set_font_chain_cache_with_sig(
-                    fc_chains,
-                    font_stacks_sig,
-                );
+                unsafe {
+                    crate::az_mark(0x60778_u32, fc_chains.len() as u32);
+                }
+                self.font_manager
+                    .set_font_chain_cache_with_sig(fc_chains, font_stacks_sig);
                 // [g80] font_chain_cache right after set (does set_font_chain_cache_with_sig persist it?).
-                unsafe { crate::az_mark(0x6077C_u32, (self.font_manager.font_chain_cache.len() as u32)); }
+                unsafe {
+                    crate::az_mark(
+                        0x6077C_u32,
+                        (self.font_manager.font_chain_cache.len() as u32),
+                    );
+                }
             }
         }
         let scroll_offsets = self.scroll_manager.get_scroll_states_for_dom(dom_id);
@@ -4499,9 +4596,11 @@ impl LayoutWindow {
         // pass eats it, and only for the DOM it was computed against.
         let css_dirty_for_this_pass: Vec<(NodeId, azul_css::props::property::RelayoutScope)> =
             match &self.pending_css_dirty {
-                Some((d, _)) if *d == dom_id => {
-                    self.pending_css_dirty.take().map(|(_, v)| v).unwrap_or_default()
-                }
+                Some((d, _)) if *d == dom_id => self
+                    .pending_css_dirty
+                    .take()
+                    .map(|(_, v)| v)
+                    .unwrap_or_default(),
                 _ => Vec::new(),
             };
 
@@ -4625,8 +4724,7 @@ impl LayoutWindow {
             // single-threaded (it runs inside layout) and a mutex would only
             // add a way for the instrumentation to deadlock the thing it
             // measures.
-            static MEM_FRAME: core::sync::atomic::AtomicU64 =
-                core::sync::atomic::AtomicU64::new(0);
+            static MEM_FRAME: core::sync::atomic::AtomicU64 = core::sync::atomic::AtomicU64::new(0);
             static PREV_WALKED_KIB: core::sync::atomic::AtomicU64 =
                 core::sync::atomic::AtomicU64::new(0);
             static PREV_RSS_KIB: core::sync::atomic::AtomicU64 =
@@ -4636,31 +4734,87 @@ impl LayoutWindow {
             eprintln!("[MEM] ================ frame {mem_frame} ================");
 
             let sr = styled_dom.memory_report();
-            eprintln!("[MEM] StyledDom ({} nodes) total={} KiB", sr.node_count, sr.total_bytes() / 1024);
-            eprintln!("[MEM]   node_hierarchy    {:>7} KiB", sr.node_hierarchy_bytes / 1024);
-            eprintln!("[MEM]   node_data         {:>7} KiB", sr.node_data_bytes / 1024);
-            eprintln!("[MEM]   styled_nodes      {:>7} KiB", sr.styled_nodes_bytes / 1024);
-            eprintln!("[MEM]   cascade_info      {:>7} KiB", sr.cascade_info_bytes / 1024);
-            eprintln!("[MEM]   tag_ids           {:>7} KiB", sr.tag_ids_bytes / 1024);
-            eprintln!("[MEM]   non_leaf_nodes    {:>7} KiB", sr.non_leaf_nodes_bytes / 1024);
+            eprintln!(
+                "[MEM] StyledDom ({} nodes) total={} KiB",
+                sr.node_count,
+                sr.total_bytes() / 1024
+            );
+            eprintln!(
+                "[MEM]   node_hierarchy    {:>7} KiB",
+                sr.node_hierarchy_bytes / 1024
+            );
+            eprintln!(
+                "[MEM]   node_data         {:>7} KiB",
+                sr.node_data_bytes / 1024
+            );
+            eprintln!(
+                "[MEM]   styled_nodes      {:>7} KiB",
+                sr.styled_nodes_bytes / 1024
+            );
+            eprintln!(
+                "[MEM]   cascade_info      {:>7} KiB",
+                sr.cascade_info_bytes / 1024
+            );
+            eprintln!(
+                "[MEM]   tag_ids           {:>7} KiB",
+                sr.tag_ids_bytes / 1024
+            );
+            eprintln!(
+                "[MEM]   non_leaf_nodes    {:>7} KiB",
+                sr.non_leaf_nodes_bytes / 1024
+            );
             let bd = &sr.css_property_cache;
-            eprintln!("[MEM]   CssPropertyCache  {:>7} KiB", bd.total_bytes() / 1024);
-            eprintln!("[MEM]     cascaded_props   {:>6} KiB", bd.cascaded_props_bytes / 1024);
-            eprintln!("[MEM]     css_props        {:>6} KiB", bd.css_props_bytes / 1024);
-            eprintln!("[MEM]   computed_values   {:>7} KiB", bd.computed_values_bytes / 1024);
-            eprintln!("[MEM]   user_overridden   {:>7} KiB", bd.user_overridden_bytes / 1024);
-            eprintln!("[MEM]   global_css_props  {:>7} KiB", bd.global_css_props_bytes / 1024);
-            eprintln!("[MEM]   compact_cache     {:>7} KiB", bd.compact_cache_bytes / 1024);
-            eprintln!("[MEM]   resolved_font_sz  {:>7} KiB", bd.resolved_font_sizes_bytes / 1024);
+            eprintln!(
+                "[MEM]   CssPropertyCache  {:>7} KiB",
+                bd.total_bytes() / 1024
+            );
+            eprintln!(
+                "[MEM]     cascaded_props   {:>6} KiB",
+                bd.cascaded_props_bytes / 1024
+            );
+            eprintln!(
+                "[MEM]     css_props        {:>6} KiB",
+                bd.css_props_bytes / 1024
+            );
+            eprintln!(
+                "[MEM]   computed_values   {:>7} KiB",
+                bd.computed_values_bytes / 1024
+            );
+            eprintln!(
+                "[MEM]   user_overridden   {:>7} KiB",
+                bd.user_overridden_bytes / 1024
+            );
+            eprintln!(
+                "[MEM]   global_css_props  {:>7} KiB",
+                bd.global_css_props_bytes / 1024
+            );
+            eprintln!(
+                "[MEM]   compact_cache     {:>7} KiB",
+                bd.compact_cache_bytes / 1024
+            );
+            eprintln!(
+                "[MEM]   resolved_font_sz  {:>7} KiB",
+                bd.resolved_font_sizes_bytes / 1024
+            );
 
             // solver3 LayoutCache breakdown
             let sc = self.layout_cache.memory_report();
-            eprintln!("[MEM] Solver3 LayoutCache total={} KiB", sc.total_bytes() / 1024);
+            eprintln!(
+                "[MEM] Solver3 LayoutCache total={} KiB",
+                sc.total_bytes() / 1024
+            );
             if let Some(tr) = &sc.tree_report {
-                eprintln!("[MEM]   LayoutTree        {:>7} KiB  ({} nodes)", sc.tree_bytes / 1024, tr.node_count);
+                eprintln!(
+                    "[MEM]   LayoutTree        {:>7} KiB  ({} nodes)",
+                    sc.tree_bytes / 1024,
+                    tr.node_count
+                );
                 eprintln!("[MEM]     hot              {:>6} KiB", tr.hot_bytes / 1024);
                 eprintln!("[MEM]     warm             {:>6} KiB", tr.warm_bytes / 1024);
-                eprintln!("[MEM]     warm.inline      {:>6} KiB  (shaped text in CachedInlineLayout)", tr.warm_inline_layout_bytes / 1024);
+                eprintln!(
+                    "[MEM]     warm.inline      {:>6} KiB  (shaped text in CachedInlineLayout)",
+                    tr.warm_inline_layout_bytes / 1024
+                );
                 // The paint-run derivation retained at store time (#25).
                 if tr.glyph_run_count > 0 {
                     eprintln!(
@@ -4704,17 +4858,44 @@ impl LayoutWindow {
                         size_of::<crate::text3::cache::ShapedGlyph>(),
                     );
                 }
-                eprintln!("[MEM]     warm.taffy       {:>6} KiB", tr.warm_taffy_cache_bytes / 1024);
+                eprintln!(
+                    "[MEM]     warm.taffy       {:>6} KiB",
+                    tr.warm_taffy_cache_bytes / 1024
+                );
                 eprintln!("[MEM]     cold             {:>6} KiB", tr.cold_bytes / 1024);
-                eprintln!("[MEM]     children_arena   {:>6} KiB", tr.children_arena_bytes / 1024);
-                eprintln!("[MEM]     dom_to_layout    {:>6} KiB", tr.dom_to_layout_bytes / 1024);
+                eprintln!(
+                    "[MEM]     children_arena   {:>6} KiB",
+                    tr.children_arena_bytes / 1024
+                );
+                eprintln!(
+                    "[MEM]     dom_to_layout    {:>6} KiB",
+                    tr.dom_to_layout_bytes / 1024
+                );
             }
-            eprintln!("[MEM]   cache_map         {:>7} KiB  (Taffy-style 9+1 slots per node)", sc.cache_map_bytes / 1024);
-            eprintln!("[MEM]   calculated_pos    {:>7} KiB", sc.calculated_positions_bytes / 1024);
-            eprintln!("[MEM]   previous_pos      {:>7} KiB", sc.previous_positions_bytes / 1024);
-            eprintln!("[MEM]   float_cache       {:>7} KiB", sc.float_cache_bytes / 1024);
-            eprintln!("[MEM]   counters          {:>7} KiB", sc.counters_bytes / 1024);
-            eprintln!("[MEM]   scroll_ids        {:>7} KiB", sc.scroll_ids_bytes / 1024);
+            eprintln!(
+                "[MEM]   cache_map         {:>7} KiB  (Taffy-style 9+1 slots per node)",
+                sc.cache_map_bytes / 1024
+            );
+            eprintln!(
+                "[MEM]   calculated_pos    {:>7} KiB",
+                sc.calculated_positions_bytes / 1024
+            );
+            eprintln!(
+                "[MEM]   previous_pos      {:>7} KiB",
+                sc.previous_positions_bytes / 1024
+            );
+            eprintln!(
+                "[MEM]   float_cache       {:>7} KiB",
+                sc.float_cache_bytes / 1024
+            );
+            eprintln!(
+                "[MEM]   counters          {:>7} KiB",
+                sc.counters_bytes / 1024
+            );
+            eprintln!(
+                "[MEM]   scroll_ids        {:>7} KiB",
+                sc.scroll_ids_bytes / 1024
+            );
             eprintln!(
                 "[MEM]   cached_display    {:>7} KiB  ({} items x {} B/slot + {} Text glyph instances — offset copies of glyph_runs)",
                 sc.cached_display_list_bytes / 1024,
@@ -4725,17 +4906,51 @@ impl LayoutWindow {
 
             // text shaping cache breakdown
             let tc = self.text_cache.memory_report();
-            eprintln!("[MEM] TextShapingCache total={} KiB", tc.total_bytes() / 1024);
-            eprintln!("[MEM]   logical_items     {:>7} KiB  ({} entries)", tc.logical_items_bytes / 1024, tc.logical_items_entries);
-            eprintln!("[MEM]   visual_items      {:>7} KiB  ({} entries)", tc.visual_items_bytes / 1024, tc.visual_items_entries);
-            eprintln!("[MEM]   shaped_items      {:>7} KiB  ({} entries)", tc.shaped_items_bytes / 1024, tc.shaped_items_entries);
-            eprintln!("[MEM]     glyph_bytes     {:>7} KiB", tc.shaped_glyph_bytes / 1024);
-            eprintln!("[MEM]     cluster_text    {:>7} KiB", tc.shaped_cluster_text_bytes / 1024);
-            eprintln!("[MEM]   per_item_shaped   {:>7} KiB  ({} entries)", tc.per_item_shaped_bytes / 1024, tc.per_item_shaped_entries);
-            eprintln!("[MEM]     composition: {} atoms / {} segments / {} detail glyphs",
-                tc.per_item_atoms, tc.per_item_segments, tc.per_item_detail_glyphs);
-            eprintln!("[MEM]   map_overhead      {:>7} KiB  (HashMap tables + Arc headers; ESTIMATE)", tc.map_overhead_bytes / 1024);
-            eprintln!("[MEM]   style_arcs        {:>7} KiB  ({} distinct Arc<StyleProperties>)", tc.style_arc_bytes / 1024, tc.distinct_style_arcs);
+            eprintln!(
+                "[MEM] TextShapingCache total={} KiB",
+                tc.total_bytes() / 1024
+            );
+            eprintln!(
+                "[MEM]   logical_items     {:>7} KiB  ({} entries)",
+                tc.logical_items_bytes / 1024,
+                tc.logical_items_entries
+            );
+            eprintln!(
+                "[MEM]   visual_items      {:>7} KiB  ({} entries)",
+                tc.visual_items_bytes / 1024,
+                tc.visual_items_entries
+            );
+            eprintln!(
+                "[MEM]   shaped_items      {:>7} KiB  ({} entries)",
+                tc.shaped_items_bytes / 1024,
+                tc.shaped_items_entries
+            );
+            eprintln!(
+                "[MEM]     glyph_bytes     {:>7} KiB",
+                tc.shaped_glyph_bytes / 1024
+            );
+            eprintln!(
+                "[MEM]     cluster_text    {:>7} KiB",
+                tc.shaped_cluster_text_bytes / 1024
+            );
+            eprintln!(
+                "[MEM]   per_item_shaped   {:>7} KiB  ({} entries)",
+                tc.per_item_shaped_bytes / 1024,
+                tc.per_item_shaped_entries
+            );
+            eprintln!(
+                "[MEM]     composition: {} atoms / {} segments / {} detail glyphs",
+                tc.per_item_atoms, tc.per_item_segments, tc.per_item_detail_glyphs
+            );
+            eprintln!(
+                "[MEM]   map_overhead      {:>7} KiB  (HashMap tables + Arc headers; ESTIMATE)",
+                tc.map_overhead_bytes / 1024
+            );
+            eprintln!(
+                "[MEM]   style_arcs        {:>7} KiB  ({} distinct Arc<StyleProperties>)",
+                tc.style_arc_bytes / 1024,
+                tc.distinct_style_arcs
+            );
             // Printed unconditionally, INCLUDING when zero. A shared-Arc
             // correction that only appears when non-zero is indistinguishable
             // from a walk that stopped deduplicating, and this figure exists
@@ -4746,7 +4961,10 @@ impl LayoutWindow {
                 tc.shared_bytes_avoided / 1024,
             );
             if tc.combined_block_glyph_bytes > 0 {
-                eprintln!("[MEM]   combined_block    {:>7} KiB  (tate-chu-yoko glyphs)", tc.combined_block_glyph_bytes / 1024);
+                eprintln!(
+                    "[MEM]   combined_block    {:>7} KiB  (tate-chu-yoko glyphs)",
+                    tc.combined_block_glyph_bytes / 1024
+                );
             }
             if let Some(bpc) = tc.bytes_per_cluster() {
                 // THIS CACHE ONLY. The same text is ALSO retained per layout
@@ -4755,15 +4973,24 @@ impl LayoutWindow {
                 // line alone understates it roughly twofold. Both are printed;
                 // the combined figure is the one to compare externally.
                 let warm_per_cluster = if tc.cluster_count > 0 {
-                    sc.tree_report.as_ref().map_or(0, |t| t.warm_inline_layout_bytes) / tc.cluster_count
+                    sc.tree_report
+                        .as_ref()
+                        .map_or(0, |t| t.warm_inline_layout_bytes)
+                        / tc.cluster_count
                 } else {
                     0
                 };
-                eprintln!("[MEM]   -> {} clusters; {} B/cluster in THIS cache, {} B/cluster in",
-                    tc.cluster_count, bpc, warm_per_cluster);
-                eprintln!("[MEM]      warm.inline = {} B/cluster retained TOTAL for shaped text",
-                    bpc + warm_per_cluster);
-                eprintln!("[MEM]      (Gecko retains ~6 B/char; the same text is held TWICE here —");
+                eprintln!(
+                    "[MEM]   -> {} clusters; {} B/cluster in THIS cache, {} B/cluster in",
+                    tc.cluster_count, bpc, warm_per_cluster
+                );
+                eprintln!(
+                    "[MEM]      warm.inline = {} B/cluster retained TOTAL for shaped text",
+                    bpc + warm_per_cluster
+                );
+                eprintln!(
+                    "[MEM]      (Gecko retains ~6 B/char; the same text is held TWICE here —"
+                );
                 eprintln!("[MEM]       once by measure_intrinsic_widths, once by layout_flow.)");
             }
 
@@ -4777,7 +5004,9 @@ impl LayoutWindow {
             // that was really 4.7%, and a "peak above settled" effect that did
             // not exist. Both units are printed above so a comparison cannot
             // pick the wrong one by accident.
-            eprintln!("[MEM] NOTE units: this report and smaps are KiB (1024); heaptrack is MB (1000).");
+            eprintln!(
+                "[MEM] NOTE units: this report and smaps are KiB (1024); heaptrack is MB (1000)."
+            );
             // COVERAGE. What this walk does NOT reach, so nobody reads the
             // grand total as the process's memory:
             eprintln!("[MEM] NOT COVERED by the walk above: framebuffers/pixmaps, font files +");
@@ -4803,23 +5032,39 @@ impl LayoutWindow {
                 eprintln!("[MEM] === RSS CENSUS (all KiB; smaps prints \"kB\" but means KiB) ===");
                 let row = |label: &str, kib: u64| {
                     if kib > 0 {
-                        eprintln!("[MEM]   {label:<22} {:>8} KiB  {:>6.1} MiB", kib, kib as f64 / 1024.0);
+                        eprintln!(
+                            "[MEM]   {label:<22} {:>8} KiB  {:>6.1} MiB",
+                            kib,
+                            kib as f64 / 1024.0
+                        );
                     }
                 };
                 row("[heap]", m.heap_kib);
                 row("[anon] (incl. pixmaps)", m.anon_kib);
                 row("binary", m.binary_kib);
-                eprintln!("[MEM]   {:<22} {:>8} KiB  {:>6.1} MiB  ({} mappings)",
-                    "shared libraries", m.shared_libs_kib, m.shared_libs_kib as f64 / 1024.0,
-                    m.shared_lib_mappings);
-                eprintln!("[MEM]   {:<22} {:>8} KiB  {:>6.1} MiB  ({} mappings, mostly untouched)",
-                    "font files (mmap)", m.font_files_kib, m.font_files_kib as f64 / 1024.0,
-                    m.font_mappings);
+                eprintln!(
+                    "[MEM]   {:<22} {:>8} KiB  {:>6.1} MiB  ({} mappings)",
+                    "shared libraries",
+                    m.shared_libs_kib,
+                    m.shared_libs_kib as f64 / 1024.0,
+                    m.shared_lib_mappings
+                );
+                eprintln!(
+                    "[MEM]   {:<22} {:>8} KiB  {:>6.1} MiB  ({} mappings, mostly untouched)",
+                    "font files (mmap)",
+                    m.font_files_kib,
+                    m.font_files_kib as f64 / 1024.0,
+                    m.font_mappings
+                );
                 row("framebuffer (memfd)", m.framebuffer_kib);
                 row("stacks/vdso", m.stacks_kib);
                 row("other", m.other_kib);
-                eprintln!("[MEM]   {:<22} {:>8} KiB  {:>6.1} MiB", "TOTAL RSS",
-                    m.total_kib, m.total_kib as f64 / 1024.0);
+                eprintln!(
+                    "[MEM]   {:<22} {:>8} KiB  {:>6.1} MiB",
+                    "TOTAL RSS",
+                    m.total_kib,
+                    m.total_kib as f64 / 1024.0
+                );
                 // The census must be exhaustive; if it is not, say so rather
                 // than letting a silent shortfall look like attributed memory.
                 let missed = m.total_kib.saturating_sub(m.categorised_kib());
@@ -4829,9 +5074,15 @@ impl LayoutWindow {
                 // THE HEADLINE RATIO, with both sides in the same unit.
                 let walked_kib = (grand_total / 1024) as u64;
                 if m.total_kib > 0 {
-                    eprintln!("[MEM] the object walk reaches {:.1}% of RSS ({} of {} KiB).",
-                        100.0 * walked_kib as f64 / m.total_kib as f64, walked_kib, m.total_kib);
-                    eprintln!("[MEM] The remainder is NOT missing — it is the categories above that");
+                    eprintln!(
+                        "[MEM] the object walk reaches {:.1}% of RSS ({} of {} KiB).",
+                        100.0 * walked_kib as f64 / m.total_kib as f64,
+                        walked_kib,
+                        m.total_kib
+                    );
+                    eprintln!(
+                        "[MEM] The remainder is NOT missing — it is the categories above that"
+                    );
                     eprintln!("[MEM] the engine does not own..");
                 }
                 // ALLOCATOR. The census above says where RSS is; it cannot say
@@ -4846,13 +5097,23 @@ impl LayoutWindow {
                         mb(a.live_bytes));
                     eprintln!("[MEM]   freed, still held      {:>8.1} MiB  ({:.0}% of arena) <- CHURN, not data",
                         mb(a.free_in_arena_bytes), a.fragmentation_pct());
-                    eprintln!("[MEM]   arena                  {:>8.1} MiB", mb(a.arena_bytes));
-                    eprintln!("[MEM]   releasable by trim     {:>8.1} MiB", mb(a.releasable_bytes));
+                    eprintln!(
+                        "[MEM]   arena                  {:>8.1} MiB",
+                        mb(a.arena_bytes)
+                    );
+                    eprintln!(
+                        "[MEM]   releasable by trim     {:>8.1} MiB",
+                        mb(a.releasable_bytes)
+                    );
                     eprintln!("[MEM]   mmapped (hblkhd)       {:>8.1} MiB  <- lands in [anon], NOT [heap]",
                         mb(a.mmapped_bytes));
                 } else {
-                    eprintln!("[MEM] ALLOCATOR: mallinfo2 unavailable (musl / glibc < 2.33 / macOS).");
-                    eprintln!("[MEM]   Saying so rather than printing zeros — a zero here would read");
+                    eprintln!(
+                        "[MEM] ALLOCATOR: mallinfo2 unavailable (musl / glibc < 2.33 / macOS)."
+                    );
+                    eprintln!(
+                        "[MEM]   Saying so rather than printing zeros — a zero here would read"
+                    );
                     eprintln!("[MEM]   as \"no memory held\", the worst possible wrong answer.");
                 }
 
@@ -4867,8 +5128,12 @@ impl LayoutWindow {
                         let diff = now as i64 - was as i64;
                         format!("{diff:+} KiB ({:+.1} MiB)", diff as f64 / 1024.0)
                     };
-                    eprintln!("[MEM] delta vs frame {}: engine-walked {} | RSS {}",
-                        mem_frame - 1, d(walked_kib, prev_walk), d(m.total_kib, prev_rss));
+                    eprintln!(
+                        "[MEM] delta vs frame {}: engine-walked {} | RSS {}",
+                        mem_frame - 1,
+                        d(walked_kib, prev_walk),
+                        d(m.total_kib, prev_rss)
+                    );
                     // A SINGLE frame growing proves nothing: laying out a
                     // NEW document legitimately allocates, and a host that
                     // renders many documents in one process (the reftest
@@ -4891,10 +5156,16 @@ impl LayoutWindow {
                         0
                     };
                     if run >= RUN_TO_WARN {
-                        eprintln!("[MEM] !! RSS grew >{GROWTH_KIB} KiB for {run} CONSECUTIVE layouts.");
+                        eprintln!(
+                            "[MEM] !! RSS grew >{GROWTH_KIB} KiB for {run} CONSECUTIVE layouts."
+                        );
                         eprintln!("[MEM] !! Sustained growth is the shape a leak or an unbounded");
-                        eprintln!("[MEM] !! cache makes. One growing frame is normal (new content);");
-                        eprintln!("[MEM] !! {run} in a row is not. A single snapshot cannot show this.");
+                        eprintln!(
+                            "[MEM] !! cache makes. One growing frame is normal (new content);"
+                        );
+                        eprintln!(
+                            "[MEM] !! {run} in a row is not. A single snapshot cannot show this."
+                        );
                     }
                 }
             }
@@ -4917,9 +5188,11 @@ impl LayoutWindow {
                 eprintln!("[MEM] accounted / rss = {:.1}% (layout_cache walk only) — the gap is allocator overhead + unreturned transient pages + fonts/images + misc",
                     grand_total as f64 * 100.0 / (rss as f64).max(1.0));
                 if lr > 0 {
-                    eprintln!("[MEM]   incl. layout_results ({:.1} MiB, previous frame) = {:.1}%",
+                    eprintln!(
+                        "[MEM]   incl. layout_results ({:.1} MiB, previous frame) = {:.1}%",
                         lr as f64 / 1_048_576.0,
-                        (grand_total as u64 + lr) as f64 * 100.0 / (rss as f64).max(1.0));
+                        (grand_total as u64 + lr) as f64 * 100.0 / (rss as f64).max(1.0)
+                    );
                 } else {
                     eprintln!("[MEM]   layout_results not yet measured this run — the ratio above is a FLOOR.");
                 }
@@ -4978,13 +5251,17 @@ impl LayoutWindow {
                                 ScrollbarHitId::VerticalThumb(_, nid) => {
                                     if !gpu_cache.transform_keys.contains_key(nid) {
                                         gpu_cache.transform_keys.insert(*nid, transform_key);
-                                        gpu_cache.current_transform_values.insert(*nid, info.thumb_initial_transform);
+                                        gpu_cache
+                                            .current_transform_values
+                                            .insert(*nid, info.thumb_initial_transform);
                                     }
                                 }
                                 ScrollbarHitId::HorizontalThumb(_, nid) => {
                                     if !gpu_cache.h_transform_keys.contains_key(nid) {
                                         gpu_cache.h_transform_keys.insert(*nid, transform_key);
-                                        gpu_cache.h_current_transform_values.insert(*nid, info.thumb_initial_transform);
+                                        gpu_cache
+                                            .h_current_transform_values
+                                            .insert(*nid, info.thumb_initial_transform);
                                     }
                                 }
                                 _ => {}
@@ -5001,7 +5278,9 @@ impl LayoutWindow {
                         //   Always       → 1.0 (legacy scrollbar, always visible)
                         //   WhenScrolling → 0.0 (overlay scrollbar, hidden until scroll)
                         //   Auto         → 0.0 (same as WhenScrolling)
-                        let initial_opacity = if info.visibility == azul_css::props::style::scrollbar::ScrollbarVisibilityMode::Always {
+                        let initial_opacity = if info.visibility
+                            == azul_css::props::style::scrollbar::ScrollbarVisibilityMode::Always
+                        {
                             1.0
                         } else {
                             0.0
@@ -5010,16 +5289,24 @@ impl LayoutWindow {
                             match hit_id {
                                 ScrollbarHitId::VerticalThumb(_, nid) => {
                                     let key = (dom_id, *nid);
-                                    if let std::collections::hash_map::Entry::Vacant(e) = gpu_cache.scrollbar_v_opacity_keys.entry(key) {
+                                    if let std::collections::hash_map::Entry::Vacant(e) =
+                                        gpu_cache.scrollbar_v_opacity_keys.entry(key)
+                                    {
                                         e.insert(opacity_key);
-                                        gpu_cache.scrollbar_v_opacity_values.insert(key, initial_opacity);
+                                        gpu_cache
+                                            .scrollbar_v_opacity_values
+                                            .insert(key, initial_opacity);
                                     }
                                 }
                                 ScrollbarHitId::HorizontalThumb(_, nid) => {
                                     let key = (dom_id, *nid);
-                                    if let std::collections::hash_map::Entry::Vacant(e) = gpu_cache.scrollbar_h_opacity_keys.entry(key) {
+                                    if let std::collections::hash_map::Entry::Vacant(e) =
+                                        gpu_cache.scrollbar_h_opacity_keys.entry(key)
+                                    {
                                         e.insert(opacity_key);
-                                        gpu_cache.scrollbar_h_opacity_values.insert(key, initial_opacity);
+                                        gpu_cache
+                                            .scrollbar_h_opacity_values
+                                            .insert(key, initial_opacity);
                                     }
                                 }
                                 _ => {}
@@ -5036,11 +5323,27 @@ impl LayoutWindow {
 
         // Scan for VirtualViews *after* the initial layout pass
         // Pass styled_dom directly — layout_results isn't populated yet at this point
-        let vviews = Self::scan_for_virtual_views(&styled_dom, &tree, &self.layout_cache.calculated_positions);
+        let vviews = Self::scan_for_virtual_views(
+            &styled_dom,
+            &tree,
+            &self.layout_cache.calculated_positions,
+        );
 
         if std::env::var("AZ_MAP_DEBUG").is_ok() {
-            eprintln!("[vview] scan found {} VirtualView node(s): {:?}", vviews.len(),
-                vviews.iter().map(|(n, b)| (n.index(), b.origin.x, b.origin.y, b.size.width, b.size.height)).collect::<Vec<_>>());
+            eprintln!(
+                "[vview] scan found {} VirtualView node(s): {:?}",
+                vviews.len(),
+                vviews
+                    .iter()
+                    .map(|(n, b)| (
+                        n.index(),
+                        b.origin.x,
+                        b.origin.y,
+                        b.size.width,
+                        b.size.height
+                    ))
+                    .collect::<Vec<_>>()
+            );
         }
 
         for (node_id, bounds) in vviews {
@@ -5088,8 +5391,7 @@ impl LayoutWindow {
                                 child_dom_id,
                                 bounds: *placeholder_bounds,
                                 clip_rect: *placeholder_clip,
-                                content_offset: self
-                                    .virtual_view_content_offset(dom_id, node_id),
+                                content_offset: self.virtual_view_content_offset(dom_id, node_id),
                             };
                             replaced = true;
                             break;
@@ -5187,11 +5489,9 @@ impl LayoutWindow {
                 // rss_census(), not current_rss_bytes(): the latter is behind
                 // `#[cfg(feature = "probe")]` and this path must report in any
                 // build where the trim itself runs.
-                let rss_mib = crate::probe::rss_census()
-                    .map_or(0.0, |c| c.total_kib as f64 / 1024.0);
-                eprintln!(
-                    "[MEM] malloc_trim: released={released:?}  rss now {rss_mib:.1} MiB"
-                );
+                let rss_mib =
+                    crate::probe::rss_census().map_or(0.0, |c| c.total_kib as f64 / 1024.0);
+                eprintln!("[MEM] malloc_trim: released={released:?}  rss now {rss_mib:.1} MiB");
             }
         }
 
@@ -5293,11 +5593,7 @@ impl LayoutWindow {
         let mut moved = false;
         for (dom_id, layout_result) in layout_results {
             moved |= !gpu_state_manager
-                .update_scrollbar_transforms(
-                    *dom_id,
-                    scroll_manager,
-                    &layout_result.layout_tree,
-                )
+                .update_scrollbar_transforms(*dom_id, scroll_manager, &layout_result.layout_tree)
                 .is_empty();
         }
         moved
@@ -5343,7 +5639,10 @@ impl LayoutWindow {
         let mut focus_h = std::collections::hash_map::DefaultHasher::new();
         if let Some(f) = self.focus_manager.get_focused_node() {
             f.dom.inner.hash(&mut focus_h);
-            f.node.into_crate_internal().map(|n| n.index()).hash(&mut focus_h);
+            f.node
+                .into_crate_internal()
+                .map(|n| n.index())
+                .hash(&mut focus_h);
         }
 
         let mut sel_h = std::collections::hash_map::DefaultHasher::new();
@@ -5383,10 +5682,18 @@ impl LayoutWindow {
         // node anchor is captured up front; whether it counts is decided by
         // the resulting tier below.
         let pagination_anchor: Option<(DomId, NodeId)> = match &change {
-            ContentChange::Image { dom_id, node_id, .. }
-            | ContentChange::ImageCallbackResult { dom_id, node_id, .. }
-            | ContentChange::NodeCss { dom_id, node_id, .. }
-            | ContentChange::ImageMask { dom_id, node_id, .. } => Some((*dom_id, *node_id)),
+            ContentChange::Image {
+                dom_id, node_id, ..
+            }
+            | ContentChange::ImageCallbackResult {
+                dom_id, node_id, ..
+            }
+            | ContentChange::NodeCss {
+                dom_id, node_id, ..
+            }
+            | ContentChange::ImageMask {
+                dom_id, node_id, ..
+            } => Some((*dom_id, *node_id)),
             ContentChange::ImageById { .. } => None,
         };
         let is_image_by_id = matches!(&change, ContentChange::ImageById { .. });
@@ -5423,8 +5730,7 @@ impl LayoutWindow {
                         tier: ContentDirtyTier::Unchanged,
                     };
                 }
-                layout_result.styled_dom.node_data.as_container_mut()[node_id]
-                    .set_clip_mask(mask);
+                layout_result.styled_dom.node_data.as_container_mut()[node_id].set_clip_mask(mask);
                 self.regenerate_display_list_for_dom(dom_id);
                 ContentChangeResult {
                     tier: ContentDirtyTier::RebuildDisplayList,
@@ -5599,7 +5905,9 @@ impl LayoutWindow {
         image: &ImageRef,
         from_callback: bool,
     ) -> crate::overlay::ContentChangeResult {
-        use crate::overlay::{AppliedChange, ContentChangeResult, ContentDirtyTier, ResolvedContent};
+        use crate::overlay::{
+            AppliedChange, ContentChangeResult, ContentDirtyTier, ResolvedContent,
+        };
 
         // Current EFFECTIVE image (overlay → DOM). Unknown DOM: no-op.
         let Some(lr) = self.layout_results.get(&dom_id) else {
@@ -5638,7 +5946,8 @@ impl LayoutWindow {
             }
         };
 
-        self.content_overlay.set_image(dom_id, node_id, image.clone());
+        self.content_overlay
+            .set_image(dom_id, node_id, image.clone());
         self.content_journal.record(AppliedChange::Image {
             dom_id,
             node_id,
@@ -5652,8 +5961,7 @@ impl LayoutWindow {
                 // geometry, only the ImageRef changes. The backend's DL diff
                 // sees the identity change and damages exactly those bounds.
                 if let Some(lr) = self.layout_results.get_mut(&dom_id) {
-                    Arc::make_mut(&mut lr.display_list)
-                        .patch_node_image(node_id, image);
+                    Arc::make_mut(&mut lr.display_list).patch_node_image(node_id, image);
                 }
             }
             ContentDirtyTier::Relayout => {
@@ -5741,7 +6049,8 @@ impl LayoutWindow {
             );
             let produced = match image_ref.get_data() {
                 DecodedImage::Callback(core_callback) if core_callback.callback.cb != 0 => {
-                    let cb = crate::callbacks::RenderImageCallback::from_core(&core_callback.callback);
+                    let cb =
+                        crate::callbacks::RenderImageCallback::from_core(&core_callback.callback);
                     let refany = core_callback.refany.clone();
                     std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| (cb.cb)(refany, info)))
                         .ok()
@@ -5829,9 +6138,9 @@ impl LayoutWindow {
             float_cache: HashMap::new(),
             cache_map: solver3::cache::LayoutCacheMap::default(),
             previous_positions: Vec::new(),
-                cached_display_list: None,
-                prev_dom_ptr: 0,
-                prev_viewport: LogicalRect::zero(),
+            cached_display_list: None,
+            prev_dom_ptr: 0,
+            prev_viewport: LogicalRect::zero(),
             last_reconcile_reused: 0,
             last_reconcile_fresh: 0,
             last_intrinsic_dirty: 0,
@@ -5896,8 +6205,14 @@ impl LayoutWindow {
         debug_messages: &mut Option<Vec<LayoutDebugMessage>>,
     ) -> Option<DomId> {
         self.invoke_virtual_view_callback_with_dom(
-            parent_dom_id, node_id, bounds, None,
-            window_state, renderer_resources, system_callbacks, debug_messages,
+            parent_dom_id,
+            node_id,
+            bounds,
+            None,
+            window_state,
+            renderer_resources,
+            system_callbacks,
+            debug_messages,
         )
     }
 
@@ -5935,7 +6250,9 @@ impl LayoutWindow {
             }
             let node_data_container = layout_result.styled_dom.node_data.as_container();
             let node_data = node_data_container.get(node_id)?;
-            if let Some(vv) = node_data.get_virtual_view_node_ref() { vv.clone() } else {
+            if let Some(vv) = node_data.get_virtual_view_node_ref() {
+                vv.clone()
+            } else {
                 if let Some(msgs) = debug_messages {
                     msgs.push(LayoutDebugMessage::info(format!(
                         "Node is NOT VirtualView, type = {:?}",
@@ -5947,7 +6264,9 @@ impl LayoutWindow {
         };
 
         if let Some(msgs) = debug_messages {
-            msgs.push(LayoutDebugMessage::info("Node is VirtualView type".to_string()));
+            msgs.push(LayoutDebugMessage::info(
+                "Node is VirtualView type".to_string(),
+            ));
         }
 
         // Call the actual implementation with all necessary data
@@ -6088,7 +6407,7 @@ impl LayoutWindow {
             azul_core::dom::OptionDom::Some(dom) => {
                 // Convert Dom → StyledDom (single deferred cascade pass)
                 StyledDom::create_from_dom(dom)
-            },
+            }
             azul_core::dom::OptionDom::None => {
                 // If the callback returns None, it's an optimization hint.
                 if reason == VirtualViewCallbackReason::InitialRender {
@@ -6178,7 +6497,9 @@ impl LayoutWindow {
         // Use dom_to_layout mapping since layout tree indices differ from DOM indices
         let layout_indices = layout_result.layout_tree.dom_to_layout.get(&nid)?;
         let layout_index = *layout_indices.first()?;
-        let position = layout_result.calculated_positions.get(layout_index.index())?;
+        let position = layout_result
+            .calculated_positions
+            .get(layout_index.index())?;
         Some(*position)
     }
 
@@ -6195,7 +6516,10 @@ impl LayoutWindow {
 
         // Look up tag_id from the authoritative tag_ids_to_node_ids mapping
         let nid_encoded = NodeHierarchyItemId::from_crate_internal(Some(nid));
-        let tag_id = layout_result.styled_dom.tag_ids_to_node_ids.iter()
+        let tag_id = layout_result
+            .styled_dom
+            .tag_ids_to_node_ids
+            .iter()
             .find(|m| m.node_id == nid_encoded)?
             .tag_id
             .inner;
@@ -6463,9 +6787,7 @@ impl LayoutWindow {
     /// scroll-ancestor walk needs the hops one at a time, because it collects
     /// containers in each dom on the way up.
     #[must_use]
-    pub fn nested_dom_hops(
-        &self,
-    ) -> BTreeMap<DomId, (DomId, NodeId, LogicalPosition)> {
+    pub fn nested_dom_hops(&self) -> BTreeMap<DomId, (DomId, NodeId, LogicalPosition)> {
         let mut hops = BTreeMap::new();
         for (parent_dom, host_node) in self.virtual_view_manager.all_view_keys() {
             let Some(nested) = self
@@ -6482,9 +6804,7 @@ impl LayoutWindow {
                 .dom_to_layout
                 .get(&host_node)
                 .and_then(|indices| indices.first().copied())
-                .and_then(|idx| {
-                    solver3::pos_get(&parent_result.calculated_positions, idx.index())
-                });
+                .and_then(|idx| solver3::pos_get(&parent_result.calculated_positions, idx.index()));
             let Some(host_pos) = host_pos else { continue };
             let content = self.virtual_view_content_offset(parent_dom, host_node);
             hops.insert(
@@ -6657,7 +6977,8 @@ impl LayoutWindow {
     ///
     /// `RefAny` data = [`TweenTimerData`] sharing `tween.tick_flag`, so the
     /// callback self-terminates the tick after both tweens finish.
-    #[must_use] pub fn create_caret_tween_timer(&self) -> Timer {
+    #[must_use]
+    pub fn create_caret_tween_timer(&self) -> Timer {
         use crate::timer::{Timer, TimerCallback};
         use azul_core::refany::RefAny;
 
@@ -6672,9 +6993,7 @@ impl LayoutWindow {
             run_count: 0,
             last_run: azul_core::task::OptionInstant::None,
             delay: azul_core::task::OptionDuration::None,
-            interval: azul_core::task::OptionDuration::Some(
-                Duration::from_millis(16),
-            ),
+            interval: azul_core::task::OptionDuration::Some(Duration::from_millis(16)),
             timeout: azul_core::task::OptionDuration::None,
             callback: TimerCallback::create(caret_tween_timer_callback),
         }
@@ -6683,7 +7002,8 @@ impl LayoutWindow {
     /// The system-animation configuration this window runs with: the
     /// per-window override if set (tests), else the app-global one
     /// installed by `App::create`.
-    #[must_use] pub fn effective_system_animations(&self) -> &azul_core::resources::SystemAnimations {
+    #[must_use]
+    pub fn effective_system_animations(&self) -> &azul_core::resources::SystemAnimations {
         self.system_animations_override
             .as_ref()
             .unwrap_or_else(|| global_system_animations())
@@ -6964,8 +7284,7 @@ impl LayoutWindow {
                     }
                     None => current.clone(),
                 };
-                for ((&item_i, r), c) in sel_idx.iter().zip(rendered.iter()).zip(current.iter())
-                {
+                for ((&item_i, r), c) in sel_idx.iter().zip(rendered.iter()).zip(current.iter()) {
                     if r != c {
                         sel_patch.push((item_i, *r));
                     }
@@ -6994,13 +7313,11 @@ impl LayoutWindow {
                     None => {
                         if let Some(last) = tween.last_focus_ring {
                             if last != current {
-                                tween.focus_ring = Some(
-                                    CaretTweenTrack {
-                                        from: last,
-                                        to: current,
-                                        start: now.clone(),
-                                    },
-                                );
+                                tween.focus_ring = Some(CaretTweenTrack {
+                                    from: last,
+                                    to: current,
+                                    start: now.clone(),
+                                });
                             }
                         }
                     }
@@ -7049,11 +7366,11 @@ impl LayoutWindow {
                 // The ring is a plain Border item APPENDED to the list —
                 // no new item kind, every renderer already draws it. Word
                 // accent blue, 2px solid, subtly rounded.
-                use azul_css::props::basic::PixelValue;
-                use azul_css::css::CssPropertyValue;
                 use crate::solver3::display_list::{
                     DisplayListItem, StyleBorderColors, StyleBorderStyles, StyleBorderWidths,
                 };
+                use azul_css::css::CssPropertyValue;
+                use azul_css::props::basic::PixelValue;
                 let accent = azul_css::props::basic::ColorU {
                     r: 43,
                     g: 87,
@@ -7090,19 +7407,13 @@ impl LayoutWindow {
                             azul_css::props::style::StyleBorderTopColor { inner: accent },
                         )),
                         right: Some(CssPropertyValue::Exact(
-                            azul_css::props::style::StyleBorderRightColor {
-                                inner: accent,
-                            },
+                            azul_css::props::style::StyleBorderRightColor { inner: accent },
                         )),
                         bottom: Some(CssPropertyValue::Exact(
-                            azul_css::props::style::StyleBorderBottomColor {
-                                inner: accent,
-                            },
+                            azul_css::props::style::StyleBorderBottomColor { inner: accent },
                         )),
                         left: Some(CssPropertyValue::Exact(
-                            azul_css::props::style::StyleBorderLeftColor {
-                                inner: accent,
-                            },
+                            azul_css::props::style::StyleBorderLeftColor { inner: accent },
                         )),
                     },
                     styles: StyleBorderStyles {
@@ -7110,19 +7421,13 @@ impl LayoutWindow {
                             azul_css::props::style::StyleBorderTopStyle { inner: solid },
                         )),
                         right: Some(CssPropertyValue::Exact(
-                            azul_css::props::style::StyleBorderRightStyle {
-                                inner: solid,
-                            },
+                            azul_css::props::style::StyleBorderRightStyle { inner: solid },
                         )),
                         bottom: Some(CssPropertyValue::Exact(
-                            azul_css::props::style::StyleBorderBottomStyle {
-                                inner: solid,
-                            },
+                            azul_css::props::style::StyleBorderBottomStyle { inner: solid },
                         )),
                         left: Some(CssPropertyValue::Exact(
-                            azul_css::props::style::StyleBorderLeftStyle {
-                                inner: solid,
-                            },
+                            azul_css::props::style::StyleBorderLeftStyle { inner: solid },
                         )),
                     },
                     border_radius: azul_css::props::style::border_radius::StyleBorderRadius {
@@ -7145,9 +7450,9 @@ impl LayoutWindow {
     /// looks up the currently-hovered node's `title` / `alt` / `aria-label`
     /// attribute and emits a `ShowTooltip` `CallbackChange`, then terminates.
     pub fn create_tooltip_delay_timer(&self, hover_time_ms: u32) -> Timer {
-        use azul_core::task::{Duration, SystemTimeDiff};
         use crate::timer::{Timer, TimerCallback};
         use azul_core::refany::RefAny;
+        use azul_core::task::{Duration, SystemTimeDiff};
 
         Timer {
             refany: RefAny::new(()),
@@ -7300,11 +7605,7 @@ impl LayoutWindow {
                     .styled_dom
                     .css_property_cache
                     .ptr
-                    .get_caret_animation_duration(
-                        node_data,
-                        &node_id,
-                        &StyledNodeState::default(),
-                    )
+                    .get_caret_animation_duration(node_data, &node_id, &StyledNodeState::default())
                     .and_then(|d| d.get_property().copied())
             })
             .map(|d| Duration::from(d.inner));
@@ -7323,7 +7624,11 @@ impl LayoutWindow {
         // interval for the same reason the CSS zero is not taken literally — a
         // real suppression path (blink timer off, caret forced visible) would be
         // better than a very long period.
-        match self.system_style.as_ref().map(|s| s.input.caret_blink_rate_ms) {
+        match self
+            .system_style
+            .as_ref()
+            .map(|s| s.input.caret_blink_rate_ms)
+        {
             None => CURSOR_BLINK_INTERVAL,
             Some(0 | u32::MAX) => Duration::from_millis(u64::from(u32::MAX)),
             Some(ms) => Duration::from_millis(u64::from(ms)),
@@ -7387,7 +7692,6 @@ impl LayoutWindow {
         let timer_was_active = self.text_edit_manager.blink.is_blink_timer_active();
 
         if let Some((dom_id, container_node_id, text_node_id)) = contenteditable_info {
-
             // W3C "flag and defer" pattern:
             // Set flag for cursor initialization AFTER layout pass
             self.focus_manager.set_pending_contenteditable_focus(
@@ -7564,7 +7868,8 @@ impl LayoutWindow {
         }
         let target = self.focus_manager.take_deferred_focus_target()?;
         let current_focus = self.focus_manager.get_focused_node().copied();
-        let Ok(resolved) = resolve_focus_target(&target, &self.layout_results, current_focus) else {
+        let Ok(resolved) = resolve_focus_target(&target, &self.layout_results, current_focus)
+        else {
             return None;
         };
         // A target that STILL matches nothing is a genuine "no such focusable"
@@ -7649,7 +7954,9 @@ impl LayoutWindow {
         }
 
         // Now we can safely get the text layout (layout pass has completed)
-        let text_layout = self.get_inline_layout_for_node(pending.dom_id, pending.text_node_id).cloned();
+        let text_layout = self
+            .get_inline_layout_for_node(pending.dom_id, pending.text_node_id)
+            .cloned();
 
         // Initialize cursor at end of text
         // Get the last cluster cursor from text layout
@@ -7659,16 +7966,18 @@ impl LayoutWindow {
         let dense_cursor = self
             .get_dense_for_node(pending.dom_id, pending.text_node_id)
             .and_then(|d| d.last_cluster_cursor());
-        let sparse_cursor = text_layout.as_ref()
-            .and_then(|layout| {
-                layout.items.iter().rev()
-                    .find_map(|item| if let ShapedItem::Cluster(c) = &item.item {
-                        Some(TextCursor {
-                            cluster_id: c.source_cluster_id,
-                            affinity: CursorAffinity::Trailing,
-                        })
-                    } else { None })
-            });
+        let sparse_cursor = text_layout.as_ref().and_then(|layout| {
+            layout.items.iter().rev().find_map(|item| {
+                if let ShapedItem::Cluster(c) = &item.item {
+                    Some(TextCursor {
+                        cluster_id: c.source_cluster_id,
+                        affinity: CursorAffinity::Trailing,
+                    })
+                } else {
+                    None
+                }
+            })
+        });
         if std::env::var("AZ_DENSE_TEXT").as_deref() == Ok("verify") {
             if let (Some(d), Some(s)) = (&dense_cursor, &sparse_cursor) {
                 assert_eq!(d, s, "d4 verify: last-cluster cursor diverged");
@@ -7682,7 +7991,11 @@ impl LayoutWindow {
         // it properly. Bounded by `MAX_PENDING_FOCUS_RETRIES` so a node that
         // never gains an inline layout still gets its (0,0) fallback.
         let node_has_layout = self.layout_results.get(&pending.dom_id).is_some_and(|lr| {
-            if lr.layout_tree.dom_to_layout.contains_key(&pending.text_node_id) {
+            if lr
+                .layout_tree
+                .dom_to_layout
+                .contains_key(&pending.text_node_id)
+            {
                 return true;
             }
             // An EMPTY text node generates no box (it is filtered out of the
@@ -7714,11 +8027,13 @@ impl LayoutWindow {
             return false;
         }
 
-        let cursor = dense_cursor.or(sparse_cursor)
-            .unwrap_or(TextCursor {
-                cluster_id: GraphemeClusterId { source_run: 0, start_byte_in_run: 0 },
-                affinity: CursorAffinity::Trailing,
-            });
+        let cursor = dense_cursor.or(sparse_cursor).unwrap_or(TextCursor {
+            cluster_id: GraphemeClusterId {
+                source_run: 0,
+                start_byte_in_run: 0,
+            },
+            affinity: CursorAffinity::Trailing,
+        });
         if std::env::var_os("AZ_FOCUS_DEBUG").is_some() {
             eprintln!(
                 "[finalize_pending_focus] editing initialized: node {:?} cursor {:?} (had_layout={})",
@@ -7732,8 +8047,12 @@ impl LayoutWindow {
             node: NodeHierarchyItemId::from_crate_internal(Some(pending.text_node_id)),
         });
         self.text_edit_manager.enter_focus_scope(scope);
-        self.text_edit_manager
-            .initialize_editing(cursor, pending.dom_id, pending.text_node_id, ce_key);
+        self.text_edit_manager.initialize_editing(
+            cursor,
+            pending.dom_id,
+            pending.text_node_id,
+            ce_key,
+        );
         true
     }
 
@@ -7755,7 +8074,9 @@ impl LayoutWindow {
         let layout_result = self.layout_results.get(&dom_id)?;
         let layout_indices = layout_result.layout_tree.dom_to_layout.get(&node_id)?;
         let layout_index = *layout_indices.first()?;
-        layout_result.layout_tree.get_dense_for_node(layout_index.index())
+        layout_result
+            .layout_tree
+            .get_dense_for_node(layout_index.index())
     }
 
     pub fn get_inline_layout_for_node(
@@ -7769,7 +8090,9 @@ impl LayoutWindow {
         let layout_index = *layout_indices.first()?;
 
         // Use the centralized LayoutTree method that handles IFC membership
-        layout_result.layout_tree.get_inline_layout_for_node(layout_index.index())
+        layout_result
+            .layout_tree
+            .get_inline_layout_for_node(layout_index.index())
     }
 
     /// (d6f) Dense-first step resolution: the dense dispatcher when the
@@ -7881,7 +8204,7 @@ impl LayoutWindow {
         target: DomNodeId,
         op: &azul_core::events::SelectionOp,
     ) -> bool {
-        use azul_core::events::{SelectionMode, SelectionStep, SelectionDirection};
+        use azul_core::events::{SelectionDirection, SelectionMode, SelectionStep};
 
         let dom_id = target.dom;
         let Some(node_id) = target.node.into_crate_internal() else {
@@ -7923,7 +8246,13 @@ impl LayoutWindow {
                 if let Some(ref mut mc) = self.text_edit_manager.multi_cursor {
                     for _ in 0..op.repeat.max(1) {
                         mc.move_all_cursors_with(extend, collapse, |c| {
-                            Self::resolve_step_with(dense.as_deref(), &layout, c, op.direction, op.step)
+                            Self::resolve_step_with(
+                                dense.as_deref(),
+                                &layout,
+                                c,
+                                op.direction,
+                                op.step,
+                            )
                         });
                     }
                 }
@@ -7936,7 +8265,13 @@ impl LayoutWindow {
                     if let Some(ref mut mc) = self.text_edit_manager.multi_cursor {
                         for _ in 0..op.repeat.max(1) {
                             mc.move_all_cursors(true, |c| {
-                                Self::resolve_step_with(dense.as_deref(), &layout, c, op.direction, op.step)
+                                Self::resolve_step_with(
+                                    dense.as_deref(),
+                                    &layout,
+                                    c,
+                                    op.direction,
+                                    op.step,
+                                )
                             });
                         }
                     }
@@ -8272,8 +8607,10 @@ impl LayoutWindow {
         // Only SUBTREE ROOTS animate. A descendant of an entering node is drawn
         // inside its ancestor's transform, so animating it as well would apply
         // the effect twice and cost a GPU key per node in the subtree.
-        let is_root = |id: NodeId, hier: &[azul_core::styled_dom::NodeHierarchyItem],
-                       unmatched: &BTreeSet<NodeId>| -> bool {
+        let is_root = |id: NodeId,
+                       hier: &[azul_core::styled_dom::NodeHierarchyItem],
+                       unmatched: &BTreeSet<NodeId>|
+         -> bool {
             hier.get(id.index()).is_none_or(|item| {
                 // `parent` is a 1-based index with 0 meaning "no parent".
                 item.parent
@@ -8374,10 +8711,18 @@ impl LayoutWindow {
                 let mut worst = azul_css::props::property::RelayoutScope::None;
                 let mut changed_any = false;
                 for ty in azul_css::props::property::CssPropertyType::ALL {
-                    let before =
-                        old_cache.get_property(old_nd, &m.old_node_id, &old_state.styled_node_state, ty);
-                    let after =
-                        new_cache.get_property(new_nd, &m.new_node_id, &new_state.styled_node_state, ty);
+                    let before = old_cache.get_property(
+                        old_nd,
+                        &m.old_node_id,
+                        &old_state.styled_node_state,
+                        ty,
+                    );
+                    let after = new_cache.get_property(
+                        new_nd,
+                        &m.new_node_id,
+                        &new_state.styled_node_state,
+                        ty,
+                    );
                     if before != after {
                         changed_any = true;
                         // IFC membership is not known here; `false` is the
@@ -8399,8 +8744,7 @@ impl LayoutWindow {
                             // (`animation: width 1s, color 2s`): the LAST
                             // covering entry wins, web-cascade style.
                             let winner = anims.as_ref().iter().rev().find(|anim| {
-                                anim.name.as_str() == "all"
-                                    || anim.name.as_str() == ty.to_str()
+                                anim.name.as_str() == "all" || anim.name.as_str() == ty.to_str()
                             });
                             if let (Some(anim), false) = (winner, meta) {
                                 captured_transitions.push(CssTransition {
@@ -8500,7 +8844,9 @@ impl LayoutWindow {
                     }
                     // A node that never laid out has no rect to animate from
                     // — it disappears like an undeclared one.
-                    let Some(rect) = exit_rects.get(node) else { continue };
+                    let Some(rect) = exit_rects.get(node) else {
+                        continue;
+                    };
                     let named = old_node_data.get(node.index()).and_then(|nd| {
                         let st = old_result
                             .styled_dom
@@ -8513,8 +8859,7 @@ impl LayoutWindow {
                             &st.styled_node_state,
                             &azul_css::props::property::CssPropertyType::AnimationOut,
                         )?;
-                        let azul_css::props::property::CssProperty::AnimationOut(v) = prop
-                        else {
+                        let azul_css::props::property::CssProperty::AnimationOut(v) = prop else {
                             return None;
                         };
                         // A LIST of animations: the first entry whose name
@@ -8645,7 +8990,10 @@ impl LayoutWindow {
                 &pending.new_node_data,
                 &pending.new_hierarchy,
                 |old_id| pending.first_rects.get(&old_id).copied(),
-                |new_id| self.get_node_bounds(dom_id, new_id).map(layout_rect_to_logical),
+                |new_id| {
+                    self.get_node_bounds(dom_id, new_id)
+                        .map(layout_rect_to_logical)
+                },
             );
             azul_core::animation::seed_moves(
                 &mut self.animations,
@@ -8672,13 +9020,12 @@ impl LayoutWindow {
             // "structural hash is the same, another CSS diff comes in while
             // the animation is playing -> do NOT recreate the sidebar, but
             // in-flight change the zombie animation from -out to -in".
-            let mount_key = azul_core::animation::AnimKey(
-                azul_core::diff::calculate_reconciliation_key(
+            let mount_key =
+                azul_core::animation::AnimKey(azul_core::diff::calculate_reconciliation_key(
                     &pending.new_node_data,
                     &pending.new_hierarchy,
                     *node_id,
-                ),
-            );
+                ));
             let mut caught_track: Option<(TrackSample, AnimTrack)> = None;
             let mut caught_slide = false;
             for z in &mut self.zombies {
@@ -8751,14 +9098,13 @@ impl LayoutWindow {
                 // velocity preserved instead of minting a fresh enter.
                 self.anim_key_to_node.insert(mount_key, *node_id);
                 if let Some(anim) = self.animations.get_mut(mount_key) {
-                    let () = anim.retarget_presence(azul_core::animation::AnimClass::Enter, 0.0, 0.0);
+                    let () =
+                        anim.retarget_presence(azul_core::animation::AnimClass::Enter, 0.0, 0.0);
                 } else {
                     self.animations.start_enter(
                         mount_key,
                         (0.0, 0.0),
-                        azul_core::animation::Interp::Spring(
-                            azul_core::animation::Spring::SMOOTH,
-                        ),
+                        azul_core::animation::Interp::Spring(azul_core::animation::Spring::SMOOTH),
                     );
                 }
                 continue;
@@ -8912,10 +9258,9 @@ impl LayoutWindow {
             return false;
         }
         let now = Instant::now();
-        let dt = self
-            .last_anim_tick
-            .as_ref()
-            .map_or(1.0 / 60.0, |prev| now.duration_since(prev).as_millis_u64() as f32 / 1000.0);
+        let dt = self.last_anim_tick.as_ref().map_or(1.0 / 60.0, |prev| {
+            now.duration_since(prev).as_millis_u64() as f32 / 1000.0
+        });
         self.last_anim_tick = Some(now);
         self.tick_animations(dt)
     }
@@ -9026,8 +9371,7 @@ impl LayoutWindow {
         // so the driver escalates to an incremental relayout.
         if !self.css_transitions.is_empty() {
             let rects = transition_rects;
-            let mut dirty: Vec<(NodeId, azul_css::props::property::RelayoutScope)> =
-                Vec::new();
+            let mut dirty: Vec<(NodeId, azul_css::props::property::RelayoutScope)> = Vec::new();
             let mut needs_relayout = false;
             // (node, from-colour, to-colour, is_text) — executed after the
             // loop so the styled_dom borrow is released first.
@@ -9090,9 +9434,10 @@ impl LayoutWindow {
                         Some((from_c, to_c, is_text))
                     });
                     if let (true, Some((from_c, to_c, is_text))) = (patchable, colors) {
-                        result
-                            .styled_dom
-                            .set_user_property_override_fast(&tr.node, core::slice::from_ref(&over));
+                        result.styled_dom.set_user_property_override_fast(
+                            &tr.node,
+                            core::slice::from_ref(&over),
+                        );
                         if from_c != to_c {
                             patch_jobs.push((tr.node, from_c, to_c, is_text));
                             tr.last_color = Some(to_c);
@@ -9391,7 +9736,8 @@ impl LayoutWindow {
     /// display-list item references. Harmless for the offset map (an
     /// unreferenced id never matches a frame), but "an id exists" does NOT
     /// imply "a scroll frame exists".
-    #[must_use] pub fn compute_scroll_ids(
+    #[must_use]
+    pub fn compute_scroll_ids(
         layout_tree: &LayoutTree,
         styled_dom: &StyledDom,
     ) -> (HashMap<LayoutNodeId, u64>, HashMap<u64, NodeId>) {
@@ -9435,7 +9781,7 @@ impl LayoutWindow {
             // Generate stable scroll ID from node_data_fingerprint
             // Use a combined hash of the fingerprint fields to create a stable ID
             let scroll_id = {
-                use std::hash::{Hash, Hasher, DefaultHasher};
+                use std::hash::{DefaultHasher, Hash, Hasher};
                 let mut h = DefaultHasher::new();
                 if let Some(cold) = layout_tree.cold(LayoutNodeId::new(layout_idx)) {
                     cold.node_data_fingerprint.hash(&mut h);
@@ -9464,33 +9810,58 @@ impl LayoutWindow {
     /// returned the ROOT's node of the same index: asking for a popup's
     /// 240x160 child answered with the parent's swatch rect.
     #[allow(clippy::cast_possible_truncation)] // bounded layout/render numeric cast
-    pub fn get_node_layout_rect(
-        &self,
-        node_id: DomNodeId,
-    ) -> Option<LogicalRect> {
+    pub fn get_node_layout_rect(&self, node_id: DomNodeId) -> Option<LogicalRect> {
         let target_node_id = node_id.node.into_crate_internal();
         let (layout_tree, positions): (&LayoutTree, &solver3::PositionVec) =
             if node_id.dom == DomId::ROOT_ID {
-                (self.layout_cache.tree.as_ref()?, &self.layout_cache.calculated_positions)
+                (
+                    self.layout_cache.tree.as_ref()?,
+                    &self.layout_cache.calculated_positions,
+                )
             } else {
                 let lr = self.layout_results.get(&node_id.dom)?;
                 (&lr.layout_tree, &lr.calculated_positions)
             };
-        { let _ = (0xE5_000002u32 | ((layout_tree.nodes.len() as u32 & 0xff) << 8)); }
+        {
+            let _ = (0xE5_000002u32 | ((layout_tree.nodes.len() as u32 & 0xff) << 8));
+        }
 
         // Find the layout node index corresponding to this DOM node
-        let Some(layout_idx) = layout_tree.nodes.iter().position(|node| node.dom_node_id == target_node_id) else { { let _ = (0xE5_0000FFu32); } return None; };
-        { let _ = (0xE5_000003u32 | ((positions.len() as u32 & 0xfff) << 8)); }
+        let Some(layout_idx) = layout_tree
+            .nodes
+            .iter()
+            .position(|node| node.dom_node_id == target_node_id)
+        else {
+            {
+                let _ = (0xE5_0000FFu32);
+            }
+            return None;
+        };
+        {
+            let _ = (0xE5_000003u32 | ((positions.len() as u32 & 0xfff) << 8));
+        }
 
         // Get the calculated layout position (already in logical units)
-        let Some(calc_pos) = positions.get(layout_idx) else { { let _ = (0xE5_0000FEu32); } return None; };
+        let Some(calc_pos) = positions.get(layout_idx) else {
+            {
+                let _ = (0xE5_0000FEu32);
+            }
+            return None;
+        };
 
         // Get the layout node for size information
         let layout_node = layout_tree.nodes.get(layout_idx)?;
 
         // Get the used size (the actual laid-out size)
-        let Some(used_size) = layout_node.used_size else { { let _ = (0xE5_0000FDu32); } return None; };
-        { let _ = (0xE5_000004u32); }
+        let Some(used_size) = layout_node.used_size else {
+            {
+                let _ = (0xE5_0000FDu32);
+            }
+            return None;
+        };
+        {
+            let _ = (0xE5_000004u32);
+        }
 
         // `used_size` is LOGICAL already (the same value `get_node_size`
         // returns untouched). This used to divide it by the HiDPI factor, so
@@ -9563,7 +9934,11 @@ impl LayoutWindow {
                 &self.current_window_state.title,
                 self.current_window_state.size.dimensions,
                 self.focus_manager.get_focused_node().copied(),
-                self.current_window_state.size.get_hidpi_factor().inner.get(),
+                self.current_window_state
+                    .size
+                    .get_hidpi_factor()
+                    .inner
+                    .get(),
                 &dirty_text_overrides,
                 cursor_a11y_info,
             )
@@ -9622,7 +9997,8 @@ impl LayoutWindow {
         let dom_id = dom_node_id.dom;
 
         // Get current text content (from dirty overrides or StyledDom)
-        let text_content = if let Some(dirty) = self.content_overlay.text_for_node(dom_id, node_id) {
+        let text_content = if let Some(dirty) = self.content_overlay.text_for_node(dom_id, node_id)
+        {
             self.extract_text_from_inline_content(&dirty.content)
         } else {
             // Fall back to StyledDom text
@@ -9637,11 +10013,15 @@ impl LayoutWindow {
                 while let Some(child_id) = child {
                     if let Some(cd) = node_data.get(child_id.index()) {
                         if let NodeType::Text(t) = &cd.node_type {
-                            if !text.is_empty() { text.push(' '); }
+                            if !text.is_empty() {
+                                text.push(' ');
+                            }
                             text.push_str(t.as_str());
                         }
                     }
-                    if child_id.index() >= hierarchy.len() { break; }
+                    if child_id.index() >= hierarchy.len() {
+                        break;
+                    }
                     child = hierarchy[child_id.index()].next_sibling_id();
                 }
             }
@@ -9649,12 +10029,13 @@ impl LayoutWindow {
         };
 
         // Build the a11y node ID (same encoding as update_tree)
-        let a11y_node_id = accesskit::NodeId(
-            ((dom_id.inner as u64) << 32) | ((node_id.index() as u64) + 1),
-        );
+        let a11y_node_id =
+            accesskit::NodeId(((dom_id.inner as u64) << 32) | ((node_id.index() as u64) + 1));
 
         // Get the node data to determine role
-        let role = self.layout_results.get(&dom_id)
+        let role = self
+            .layout_results
+            .get(&dom_id)
             .and_then(|lr| lr.styled_dom.node_data.as_ref().get(node_id.index()))
             .map_or(accesskit::Role::GenericContainer, |nd| {
                 if nd.is_contenteditable() || matches!(nd.node_type, NodeType::TextArea) {
@@ -9686,13 +10067,12 @@ impl LayoutWindow {
                 ),
             };
 
-            let char_lengths: Vec<u8> = text_content.chars()
-                .map(|c| c.len_utf16() as u8)
-                .collect();
+            let char_lengths: Vec<u8> = text_content.chars().map(|c| c.len_utf16() as u8).collect();
             node.set_character_lengths(char_lengths.clone());
 
             let byte_to_char = |byte_off: usize| -> usize {
-                text_content.char_indices()
+                text_content
+                    .char_indices()
                     .take_while(|(b, _)| *b < byte_off)
                     .count()
                     .min(char_lengths.len())
@@ -9711,10 +10091,15 @@ impl LayoutWindow {
         }
 
         // Focus: use the current focused node or root
-        let focus = self.focus_manager.get_focused_node().copied()
+        let focus = self
+            .focus_manager
+            .get_focused_node()
+            .copied()
             .and_then(|dn| {
                 let idx = dn.node.into_crate_internal()?.index();
-                Some(accesskit::NodeId(((dn.dom.inner as u64) << 32) | ((idx as u64) + 1)))
+                Some(accesskit::NodeId(
+                    ((dn.dom.inner as u64) << 32) | ((idx as u64) + 1),
+                ))
             })
             .unwrap_or(self.a11y_manager.root_id);
 
@@ -9733,10 +10118,7 @@ impl LayoutWindow {
     /// holds the ROOT dom, and matched a bare `dom_node_id` with no `DomId`
     /// alongside it — so in a virtualized view the caret answered for whatever
     /// unrelated node happened to occupy the same index, or for nothing at all.
-    fn session_geometry_node(
-        &self,
-        node: DomNodeId,
-    ) -> Option<(&DomLayoutResult, LayoutNodeId)> {
+    fn session_geometry_node(&self, node: DomNodeId) -> Option<(&DomLayoutResult, LayoutNodeId)> {
         let node_id = node.node.into_crate_internal()?;
         let layout_result = self.layout_results.get(&node.dom)?;
         let tree = &layout_result.layout_tree;
@@ -9838,13 +10220,17 @@ impl LayoutWindow {
         let mc = self.text_edit_manager.multi_cursor.as_ref()?;
 
         // Collect Range selections
-        let ranges: Vec<_> = mc.selections.iter().filter_map(|s| {
-            if let Selection::Range(ref r) = s.selection {
-                Some(*r)
-            } else {
-                None
-            }
-        }).collect();
+        let ranges: Vec<_> = mc
+            .selections
+            .iter()
+            .filter_map(|s| {
+                if let Selection::Range(ref r) = s.selection {
+                    Some(*r)
+                } else {
+                    None
+                }
+            })
+            .collect();
 
         if ranges.is_empty() {
             return None;
@@ -9878,7 +10264,10 @@ impl LayoutWindow {
 
         Some(LogicalRect::new(
             LogicalPosition { x: min_x, y: min_y },
-            LogicalSize { width: max_x - min_x, height: max_y - min_y },
+            LogicalSize {
+                width: max_x - min_x,
+                height: max_y - min_y,
+            },
         ))
     }
 
@@ -9941,19 +10330,22 @@ impl LayoutWindow {
         // Extract the selected word text using byte offsets
         let start_byte = word_range.start.cluster_id.start_byte_in_run as usize;
         let end_byte = word_range.end.cluster_id.start_byte_in_run as usize;
-        let search_text = if word_range.start.cluster_id.source_run == word_range.end.cluster_id.source_run {
-            if let Some(InlineContent::Text(run)) = content.get(word_range.start.cluster_id.source_run as usize) {
-                if start_byte <= end_byte && end_byte <= run.text.len() {
-                    run.text[start_byte..end_byte].to_string()
+        let search_text =
+            if word_range.start.cluster_id.source_run == word_range.end.cluster_id.source_run {
+                if let Some(InlineContent::Text(run)) =
+                    content.get(word_range.start.cluster_id.source_run as usize)
+                {
+                    if start_byte <= end_byte && end_byte <= run.text.len() {
+                        run.text[start_byte..end_byte].to_string()
+                    } else {
+                        return false;
+                    }
                 } else {
                     return false;
                 }
             } else {
-                return false;
-            }
-        } else {
-            return false; // Multi-run selection search not yet supported
-        };
+                return false; // Multi-run selection search not yet supported
+            };
 
         if search_text.is_empty() {
             return false;
@@ -9961,11 +10353,10 @@ impl LayoutWindow {
 
         // Search forward from the end of the last selection
         let mc = self.text_edit_manager.multi_cursor.as_ref().unwrap();
-        let last_end_byte = mc.selections.last()
-            .map_or(0, |s| match &s.selection {
-                Selection::Range(r) => r.end.cluster_id.start_byte_in_run as usize,
-                Selection::Cursor(c) => c.cluster_id.start_byte_in_run as usize,
-            });
+        let last_end_byte = mc.selections.last().map_or(0, |s| match &s.selection {
+            Selection::Range(r) => r.end.cluster_id.start_byte_in_run as usize,
+            Selection::Cursor(c) => c.cluster_id.start_byte_in_run as usize,
+        });
 
         let search_run = word_range.start.cluster_id.source_run;
 
@@ -10142,10 +10533,7 @@ impl LayoutWindow {
     /// Find the nearest scrollable ancestor for a given node
     /// Returns (`DomId`, `NodeId`) of the scrollable container, or None if no scrollable ancestor
     /// exists
-    pub fn find_scrollable_ancestor(
-        &self,
-        node_id: DomNodeId,
-    ) -> Option<DomNodeId> {
+    pub fn find_scrollable_ancestor(&self, node_id: DomNodeId) -> Option<DomNodeId> {
         // The TARGET's own dom. This used to read `layout_cache.tree` — the
         // ROOT dom only — and then re-find each ancestor by bare arena index
         // while keying the scroll-state lookup by the target's `DomId`. For a
@@ -10268,7 +10656,8 @@ impl LayoutWindow {
             SelectionScrollType::Selection => {
                 // Compute bounding rect of all selection ranges via the text layout.
                 // Falls back to cursor rect if no ranges exist.
-                match self.calculate_selection_bounding_rect()
+                match self
+                    .calculate_selection_bounding_rect()
                     .or_else(|| self.get_focused_cursor_rect())
                 {
                     Some(rect) => rect,
@@ -10471,7 +10860,10 @@ impl LayoutWindow {
             .as_ref()
             .map(|mc| mc.node_id)
             .or(self.focus_manager.focused_node);
-        if anchor.and_then(|a| self.find_scrollable_ancestor(a)).is_none() {
+        if anchor
+            .and_then(|a| self.find_scrollable_ancestor(a))
+            .is_none()
+        {
             return false;
         }
         self.last_revealed_caret_rect = current;
@@ -10537,7 +10929,8 @@ pub struct LayoutResult {
 }
 
 impl LayoutResult {
-    #[must_use] pub const fn new(display_list: DisplayList, warnings: Vec<String>) -> Self {
+    #[must_use]
+    pub const fn new(display_list: DisplayList, warnings: Vec<String>) -> Self {
         Self {
             display_list,
             warnings,
@@ -10574,8 +10967,8 @@ impl LayoutWindow {
     ) -> Vec<crate::callbacks::CallbackChange> {
         use crate::callbacks::{CallbackInfo, CallbackInfoRefData};
 
-        let has_tracks = !self.live_tracks.is_empty()
-            || self.zombies.iter().any(|z| !z.tracks.is_empty());
+        let has_tracks =
+            !self.live_tracks.is_empty() || self.zombies.iter().any(|z| !z.tracks.is_empty());
         if !has_tracks || self.tracks_sampled_since_tick {
             return Vec::new();
         }
@@ -10665,7 +11058,9 @@ impl LayoutWindow {
             };
             for (zi, z) in self.zombies.iter().enumerate() {
                 for (node, tr) in &z.tracks {
-                    let Some(frozen) = z.rects.get(node) else { continue };
+                    let Some(frozen) = z.rects.get(node) else {
+                        continue;
+                    };
                     let (vx, vy) = z.velocities.get(node).copied().unwrap_or((0.0, 0.0));
                     let info = azul_core::resources::ZombieAnimInfo {
                         styled_dom: &raw const z.retained.styled_dom,
@@ -10686,7 +11081,9 @@ impl LayoutWindow {
                 }
             }
             for (node, tr) in &self.live_tracks {
-                let Some(r) = self.layout_results.get(&DomId::ROOT_ID) else { continue };
+                let Some(r) = self.layout_results.get(&DomId::ROOT_ID) else {
+                    continue;
+                };
                 let Some(rect) = self
                     .get_node_bounds(DomId::ROOT_ID, *node)
                     .map(layout_rect_to_logical)
@@ -10721,7 +11118,9 @@ impl LayoutWindow {
         } in sampled
         {
             if let Some(zi) = zombie_idx {
-                let Some(z) = self.zombies.get_mut(zi) else { continue };
+                let Some(z) = self.zombies.get_mut(zi) else {
+                    continue;
+                };
                 if let Some(tr) = z.tracks.get_mut(&node) {
                     tr.frames_run = tr.frames_run.saturating_add(1);
                 }
@@ -10761,8 +11160,7 @@ impl LayoutWindow {
                     drop(z.retained.styled_dom.restyle_user_property(&node, &props));
                     let dirty = [(
                         node,
-                        azul_css::props::property::CssPropertyType::Width
-                            .relayout_scope(false),
+                        azul_css::props::property::CssPropertyType::Width.relayout_scope(false),
                     )];
                     let external = ExternalSystemCallbacks::rust_internal();
                     let solved = solver3::layout_document(
@@ -10800,8 +11198,7 @@ impl LayoutWindow {
                                             idx,
                                         ),
                                     ) {
-                                        z.live_rects
-                                            .insert(node, LogicalRect::new(pos, size));
+                                        z.live_rects.insert(node, LogicalRect::new(pos, size));
                                     }
                                     break;
                                 }
@@ -10819,7 +11216,11 @@ impl LayoutWindow {
                 if let Some(tr) = self.live_tracks.get_mut(&node) {
                     tr.frames_run = tr.frames_run.saturating_add(1);
                 }
-                let cache = self.gpu_state_manager.caches.entry(DomId::ROOT_ID).or_default();
+                let cache = self
+                    .gpu_state_manager
+                    .caches
+                    .entry(DomId::ROOT_ID)
+                    .or_default();
                 let smp = sample;
                 cache
                     .anim_transform_keys
@@ -10835,7 +11236,11 @@ impl LayoutWindow {
                     .get_node_bounds(DomId::ROOT_ID, node)
                     .map(layout_rect_to_logical)
                     .map_or((0.0, 0.0), |r| (r.size.width / 2.0, r.size.height / 2.0));
-                let cache = self.gpu_state_manager.caches.entry(DomId::ROOT_ID).or_default();
+                let cache = self
+                    .gpu_state_manager
+                    .caches
+                    .entry(DomId::ROOT_ID)
+                    .or_default();
                 cache.anim_current_transform_values.insert(
                     node,
                     azul_core::transform::ComputedTransform3D {
@@ -10866,7 +11271,6 @@ impl LayoutWindow {
             .unwrap_or_default()
     }
 
-
     /// Runs a single timer, similar to `CallbacksOfHitTest.call()`
     ///
     /// NOTE: The timer has to be selected first by the calling code and verified
@@ -10892,7 +11296,7 @@ impl LayoutWindow {
         current_window_state: &FullWindowState,
         renderer_resources: &RendererResources,
     ) -> (Vec<crate::callbacks::CallbackChange>, Update) {
-        use crate::callbacks::{CallbackInfo, CallbackChange};
+        use crate::callbacks::{CallbackChange, CallbackInfo};
 
         // Dispatch span: until this existed, all 118 probe spans lived in
         // layout/font/render, so "is the *app's own* code slow" — a timer
@@ -10912,10 +11316,13 @@ impl LayoutWindow {
             .and_then(|t| t.node_id.into_option());
 
         if timer_exists {
-            let hit_dom_node = timer_node_id.map_or_else(|| DomNodeId {
+            let hit_dom_node = timer_node_id.map_or_else(
+                || DomNodeId {
                     dom: DomId::ROOT_ID,
                     node: NodeHierarchyItemId::from_crate_internal(None),
-                }, |s| s);
+                },
+                |s| s,
+            );
             let cursor_relative_to_item = OptionLogicalPosition::None;
             let cursor_in_viewport = OptionLogicalPosition::None;
 
@@ -10990,7 +11397,7 @@ impl LayoutWindow {
         use std::collections::BTreeSet;
 
         use crate::{
-            callbacks::{CallbackInfo, CallbackChange},
+            callbacks::{CallbackChange, CallbackInfo},
             thread::{OptionThreadReceiveMsg, ThreadReceiveMsg, ThreadWriteBackMsg},
         };
 
@@ -11021,95 +11428,97 @@ impl LayoutWindow {
             // is empty, and only retire a finished thread once it is.
             let mut ticked = false;
             loop {
-            let (msg, writeback_data_ptr, is_finished) = {
-                // Re-acquired every iteration: the borrow must end before the
-                // body below, which needs `self` for CallbackInfoRefData.
-                let Some(thread) = self.threads.get_mut(&thread_id) else {
-                    break;
-                };
-                let thread_inner = &mut *if let Ok(s) = thread.ptr.lock() { s } else {
-                    all_changes.push(CallbackChange::RemoveThread { thread_id });
-                    break;
-                };
-
-                if !ticked {
-                    let _ = thread_inner.sender_send(ThreadSendMsg::Tick);
-                    ticked = true;
-                }
-                let recv = thread_inner.receiver_try_recv();
-                let is_finished = thread_inner.is_finished();
-                let msg = match recv {
-                    // Queue empty: a finished worker has now delivered
-                    // everything it ever will, so it can be retired.
-                    OptionThreadReceiveMsg::None => {
-                        if is_finished {
-                            all_changes.push(CallbackChange::RemoveThread { thread_id });
-                        }
+                let (msg, writeback_data_ptr, is_finished) = {
+                    // Re-acquired every iteration: the borrow must end before the
+                    // body below, which needs `self` for CallbackInfoRefData.
+                    let Some(thread) = self.threads.get_mut(&thread_id) else {
                         break;
+                    };
+                    let thread_inner = &mut *if let Ok(s) = thread.ptr.lock() {
+                        s
+                    } else {
+                        all_changes.push(CallbackChange::RemoveThread { thread_id });
+                        break;
+                    };
+
+                    if !ticked {
+                        let _ = thread_inner.sender_send(ThreadSendMsg::Tick);
+                        ticked = true;
                     }
-                    OptionThreadReceiveMsg::Some(s) => s,
+                    let recv = thread_inner.receiver_try_recv();
+                    let is_finished = thread_inner.is_finished();
+                    let msg = match recv {
+                        // Queue empty: a finished worker has now delivered
+                        // everything it ever will, so it can be retired.
+                        OptionThreadReceiveMsg::None => {
+                            if is_finished {
+                                all_changes.push(CallbackChange::RemoveThread { thread_id });
+                            }
+                            break;
+                        }
+                        OptionThreadReceiveMsg::Some(s) => s,
+                    };
+
+                    let writeback_data_ptr: *mut RefAny = &raw mut thread_inner.writeback_data;
+
+                    (msg, writeback_data_ptr, is_finished)
+                };
+                let _ = is_finished;
+
+                let ThreadWriteBackMsg {
+                    refany: mut data_inner,
+                    callback,
+                } = match msg {
+                    ThreadReceiveMsg::Update(update_screen) => {
+                        update.max_self(update_screen);
+                        continue;
+                    }
+                    ThreadReceiveMsg::WriteBack(t) => t,
                 };
 
-                let writeback_data_ptr: *mut RefAny = &raw mut thread_inner.writeback_data;
+                let callback_changes = Arc::new(std::sync::Mutex::new(Vec::new()));
 
-                (msg, writeback_data_ptr, is_finished)
-            };
-            let _ = is_finished;
+                let ref_data = crate::callbacks::CallbackInfoRefData {
+                    layout_window: self,
+                    renderer_resources,
+                    previous_window_state,
+                    current_window_state,
+                    gl_context,
+                    current_scroll_manager: &current_scroll_states,
+                    current_window_handle,
+                    system_callbacks,
+                    system_style: system_style.clone(),
+                    monitors: self.monitors.clone(),
+                    #[cfg(feature = "icu")]
+                    icu_localizer: self.icu_localizer.clone(),
+                    ctx: callback.ctx.clone(),
+                };
 
-            let ThreadWriteBackMsg {
-                refany: mut data_inner,
-                callback,
-            } = match msg {
-                ThreadReceiveMsg::Update(update_screen) => {
-                    update.max_self(update_screen);
-                    continue;
-                }
-                ThreadReceiveMsg::WriteBack(t) => t,
-            };
+                let callback_info = CallbackInfo::new(
+                    &ref_data,
+                    &callback_changes,
+                    hit_dom_node,
+                    cursor_relative_to_item,
+                    cursor_in_viewport,
+                );
 
-            let callback_changes = Arc::new(std::sync::Mutex::new(Vec::new()));
+                // "is the app's own code slow": writeback callbacks carry a
+                // cb:<name> span, same as timers and event callbacks.
+                let cb_span = crate::probe::Probe::span_for_fn(callback.cb as usize);
+                let callback_update = (callback.cb)(
+                    unsafe { (*writeback_data_ptr).clone() },
+                    data_inner.clone(),
+                    callback_info,
+                );
+                drop(cb_span);
+                update.max_self(callback_update);
 
-            let ref_data = crate::callbacks::CallbackInfoRefData {
-                layout_window: self,
-                renderer_resources,
-                previous_window_state,
-                current_window_state,
-                gl_context,
-                current_scroll_manager: &current_scroll_states,
-                current_window_handle,
-                system_callbacks,
-                system_style: system_style.clone(),
-                monitors: self.monitors.clone(),
-                #[cfg(feature = "icu")]
-                icu_localizer: self.icu_localizer.clone(),
-                ctx: callback.ctx.clone(),
-            };
+                let collected_changes = callback_changes
+                    .lock()
+                    .map(|mut guard| core::mem::take(&mut *guard))
+                    .unwrap_or_default();
 
-            let callback_info = CallbackInfo::new(
-                &ref_data,
-                &callback_changes,
-                hit_dom_node,
-                cursor_relative_to_item,
-                cursor_in_viewport,
-            );
-
-            // "is the app's own code slow": writeback callbacks carry a
-            // cb:<name> span, same as timers and event callbacks.
-            let cb_span = crate::probe::Probe::span_for_fn(callback.cb as usize);
-            let callback_update = (callback.cb)(
-                unsafe { (*writeback_data_ptr).clone() },
-                data_inner.clone(),
-                callback_info,
-            );
-            drop(cb_span);
-            update.max_self(callback_update);
-
-            let collected_changes = callback_changes
-                .lock()
-                .map(|mut guard| core::mem::take(&mut *guard))
-                .unwrap_or_default();
-
-            all_changes.extend(collected_changes);
+                all_changes.extend(collected_changes);
             }
         }
 
@@ -11170,7 +11579,7 @@ impl LayoutWindow {
         current_window_state: &FullWindowState,
         renderer_resources: &RendererResources,
     ) -> (Vec<crate::callbacks::CallbackChange>, Update) {
-        use crate::callbacks::{CallbackInfo, CallbackChange};
+        use crate::callbacks::{CallbackChange, CallbackInfo};
 
         let current_scroll_states = self.get_nested_scroll_states(DomId::ROOT_ID);
 
@@ -11181,7 +11590,11 @@ impl LayoutWindow {
         // callback needing a node-local cursor (map pan/drag, custom hit
         // logic) silently bailed. Falls back to `None` when the node isn't in
         // the current hit test (e.g. non-pointer events).
-        let cursor_in_viewport = current_window_state.mouse_state.cursor_position.get_position().map_or(OptionLogicalPosition::None, OptionLogicalPosition::Some);
+        let cursor_in_viewport = current_window_state
+            .mouse_state
+            .cursor_position
+            .get_position()
+            .map_or(OptionLogicalPosition::None, OptionLogicalPosition::Some);
         let cursor_relative_to_item = match hit_dom_node.node.into_crate_internal() {
             Some(node_id) => self
                 .hover_manager
@@ -11287,7 +11700,8 @@ impl LayoutWindow {
     pub fn set_system_style(&mut self, system_style: Arc<azul_css::system::SystemStyle>) {
         #[cfg(feature = "icu")]
         {
-            self.icu_localizer = crate::icu::IcuLocalizerHandle::from_system_language(&system_style.language);
+            self.icu_localizer =
+                crate::icu::IcuLocalizerHandle::from_system_language(&system_style.language);
         }
         self.system_style = Some(system_style);
     }
@@ -11366,7 +11780,10 @@ mod tests {
         // Segment midpoint under linear timing.
         tr.t = 0.5;
         let mid = tr.sample().translate_x;
-        assert!((mid - 50.0).abs() < 0.01, "expected 50 at the midpoint, got {mid}");
+        assert!(
+            (mid - 50.0).abs() < 0.01,
+            "expected 50 at the midpoint, got {mid}"
+        );
         // Past the last stop: clamp again.
         tr.t = 1.0;
         assert_eq!(tr.sample().translate_x, 100.0);
@@ -11513,16 +11930,17 @@ mod tests {
     /// — momentum is motion, not a stored number.
     #[test]
     fn momentum_kick_creates_reads_and_moves() {
-        use azul_core::{dom::Dom, geom::LogicalSize, resources::RendererResources};
         use crate::xml::DomXmlExt;
+        use azul_core::{dom::Dom, geom::LogicalSize, resources::RendererResources};
 
         let fc = crate::font::loading::build_font_cache();
-        let Ok(mut window) = LayoutWindow::new(fc) else { return };
+        let Ok(mut window) = LayoutWindow::new(fc) else {
+            return;
+        };
         let rr = RendererResources::default();
         let sc = ExternalSystemCallbacks::rust_internal();
-        let styled_dom = Dom::from_xml_string(
-            "<html><body><div id=\"box\">content</div></body></html>",
-        );
+        let styled_dom =
+            Dom::from_xml_string("<html><body><div id=\"box\">content</div></body></html>");
         let mut ws = FullWindowState::default();
         ws.size.dimensions = LogicalSize::new(600.0, 400.0);
         let mut dbg = None;
@@ -11574,7 +11992,9 @@ mod tests {
         }
 
         let fc = crate::font::loading::build_font_cache();
-        let Ok(mut window) = LayoutWindow::new(fc) else { return };
+        let Ok(mut window) = LayoutWindow::new(fc) else {
+            return;
+        };
         let rr = RendererResources::default();
         let sc = ExternalSystemCallbacks::rust_internal();
 
@@ -11801,9 +12221,7 @@ mod tests {
             device: crate::managers::scroll_state::ScrollInputDevice::TestDriver,
         };
 
-        let should_start_timer = window
-            .scroll_manager
-            .record_scroll_input(scroll_input);
+        let should_start_timer = window.scroll_manager.record_scroll_input(scroll_input);
 
         // record_scroll_input should return true (timer was not running)
         assert!(should_start_timer);
@@ -11838,8 +12256,6 @@ mod tests {
         assert!(tick_result.needs_repaint);
     }
 
-
-
     #[test]
     fn test_gpu_cache_scrollbar_opacity_keys() {
         let fc_cache = FcFontCache::default();
@@ -11871,8 +12287,6 @@ mod tests {
             Some(&1.0)
         );
     }
-
-
 }
 
 // --- Cross-Paragraph Cursor Navigation API ---
@@ -12144,29 +12558,40 @@ impl LayoutWindow {
                         // NodeData has a direct `contenteditable: bool` field that should be
                         // checked in addition to the attribute for robustness
                         let is_contenteditable = styled_node.is_contenteditable()
-                            || styled_node.attributes().as_ref().iter().any(|attr| {
-                                matches!(attr, AttributeType::ContentEditable(_))
-                            });
+                            || styled_node
+                                .attributes()
+                                .as_ref()
+                                .iter()
+                                .any(|attr| matches!(attr, AttributeType::ContentEditable(_)));
 
                         if is_contenteditable {
                             // Get inline layout for cursor positioning
                             // Clone the Arc to avoid borrow conflict
-                            let inline_layout = self.get_inline_layout_for_node(dom_id, node_id).cloned();
+                            let inline_layout =
+                                self.get_inline_layout_for_node(dom_id, node_id).cloned();
                             if let Some(ref layout) = inline_layout {
                                 // (d4) Dense-first, sparse fallback — same
                                 // semantics as the finalize path.
                                 let cursor = self
                                     .get_dense_for_node(dom_id, node_id)
                                     .and_then(|d| d.last_cluster_cursor())
-                                    .or_else(|| layout.items.iter().rev()
-                                        .find_map(|item| if let ShapedItem::Cluster(c) = &item.item {
-                                            Some(TextCursor {
-                                                cluster_id: c.source_cluster_id,
-                                                affinity: CursorAffinity::Trailing,
-                                            })
-                                        } else { None }))
+                                    .or_else(|| {
+                                        layout.items.iter().rev().find_map(|item| {
+                                            if let ShapedItem::Cluster(c) = &item.item {
+                                                Some(TextCursor {
+                                                    cluster_id: c.source_cluster_id,
+                                                    affinity: CursorAffinity::Trailing,
+                                                })
+                                            } else {
+                                                None
+                                            }
+                                        })
+                                    })
                                     .unwrap_or(TextCursor {
-                                        cluster_id: GraphemeClusterId { source_run: 0, start_byte_in_run: 0 },
+                                        cluster_id: GraphemeClusterId {
+                                            source_run: 0,
+                                            start_byte_in_run: 0,
+                                        },
                                         affinity: CursorAffinity::Trailing,
                                     });
                                 let ce_key = self.contenteditable_session_key(dom_id, node_id);
@@ -12237,16 +12662,17 @@ impl LayoutWindow {
                     now,
                 );
             }
-            AccessibilityAction::ScrollLeft |
-            AccessibilityAction::ScrollRight |
-            AccessibilityAction::ScrollUp |
-            AccessibilityAction::ScrollDown => {
+            AccessibilityAction::ScrollLeft
+            | AccessibilityAction::ScrollRight
+            | AccessibilityAction::ScrollUp
+            | AccessibilityAction::ScrollDown => {
                 // Find the scrollable ancestor (or the node itself if scrollable)
                 let dom_node_id = DomNodeId {
                     dom: dom_id,
                     node: NodeHierarchyItemId::from_crate_internal(Some(node_id)),
                 };
-                let (scroll_dom, scroll_nid) = self.find_scrollable_ancestor(dom_node_id)
+                let (scroll_dom, scroll_nid) = self
+                    .find_scrollable_ancestor(dom_node_id)
                     .and_then(|a| Some((a.dom, a.node.into_crate_internal()?)))
                     .unwrap_or((dom_id, node_id));
 
@@ -12256,10 +12682,10 @@ impl LayoutWindow {
                 let vp_w = bounds.map_or(800.0, |b| b.size.width as f32);
 
                 let (dx, dy) = match action {
-                    AccessibilityAction::ScrollLeft  => (-vp_w * 0.75, 0.0),
-                    AccessibilityAction::ScrollRight => ( vp_w * 0.75, 0.0),
-                    AccessibilityAction::ScrollUp    => (0.0, -vp_h * 0.75),
-                    AccessibilityAction::ScrollDown  => (0.0,  vp_h * 0.75),
+                    AccessibilityAction::ScrollLeft => (-vp_w * 0.75, 0.0),
+                    AccessibilityAction::ScrollRight => (vp_w * 0.75, 0.0),
+                    AccessibilityAction::ScrollUp => (0.0, -vp_h * 0.75),
+                    AccessibilityAction::ScrollDown => (0.0, vp_h * 0.75),
                     _ => unreachable!(),
                 };
 
@@ -12357,20 +12783,25 @@ impl LayoutWindow {
                 if let Some(value_str) = current_value {
                     let parsed: Result<f64, _> = value_str.trim().parse();
 
-                    let new_value_str = parsed.map_or_else(|_| if is_increment {
-                            "1".to_string()
-                        } else {
-                            "-1".to_string()
-                        }, |num| {
-                        // Successfully parsed as number
-                        let new_num = if is_increment { num + 1.0 } else { num - 1.0 };
-                        // Format with same precision as input if possible
-                        if num.fract() == 0.0 {
-                            format!("{}", new_num as i64)
-                        } else {
-                            format!("{new_num}")
-                        }
-                    });
+                    let new_value_str = parsed.map_or_else(
+                        |_| {
+                            if is_increment {
+                                "1".to_string()
+                            } else {
+                                "-1".to_string()
+                            }
+                        },
+                        |num| {
+                            // Successfully parsed as number
+                            let new_num = if is_increment { num + 1.0 } else { num - 1.0 };
+                            // Format with same precision as input if possible
+                            if num.fract() == 0.0 {
+                                format!("{}", new_num as i64)
+                            } else {
+                                format!("{new_num}")
+                            }
+                        },
+                    );
 
                     // Record as text input (will fire On::TextInput callbacks)
                     let hierarchy_id = NodeHierarchyItemId::from_crate_internal(Some(node_id));
@@ -12466,12 +12897,16 @@ impl LayoutWindow {
                     // Return a synthetic right-click so the caller's event dispatcher
                     // triggers the normal context-menu code path (platform-specific).
                     let hierarchy_id = NodeHierarchyItemId::from_crate_internal(Some(node_id));
-                    let dom_node_id = DomNodeId { dom: dom_id, node: hierarchy_id };
+                    let dom_node_id = DomNodeId {
+                        dom: dom_id,
+                        node: hierarchy_id,
+                    };
                     affected_nodes.insert(
                         dom_node_id,
-                        (vec![EventFilter::Hover(
-                            HoverEventFilter::RightMouseDown,
-                        )], false),
+                        (
+                            vec![EventFilter::Hover(HoverEventFilter::RightMouseDown)],
+                            false,
+                        ),
                     );
                 }
             }
@@ -12520,17 +12955,21 @@ impl LayoutWindow {
                     let start_cursor = dense
                         .as_ref()
                         .and_then(|d| d.byte_offset_to_cursor(selection.selection_start as u32))
-                        .unwrap_or_else(|| Self::byte_offset_to_cursor(
-                            inline_layout.as_ref(),
-                            selection.selection_start as u32,
-                        ));
+                        .unwrap_or_else(|| {
+                            Self::byte_offset_to_cursor(
+                                inline_layout.as_ref(),
+                                selection.selection_start as u32,
+                            )
+                        });
                     let end_cursor = dense
                         .as_ref()
                         .and_then(|d| d.byte_offset_to_cursor(selection.selection_end as u32))
-                        .unwrap_or_else(|| Self::byte_offset_to_cursor(
-                            inline_layout.as_ref(),
-                            selection.selection_end as u32,
-                        ));
+                        .unwrap_or_else(|| {
+                            Self::byte_offset_to_cursor(
+                                inline_layout.as_ref(),
+                                selection.selection_end as u32,
+                            )
+                        });
 
                     {
                         let (start, end) = (start_cursor, end_cursor);
@@ -12659,19 +13098,22 @@ impl LayoutWindow {
             }
         }
 
-        TextChangesetResult { dirty_nodes, needs_relayout }
+        TextChangesetResult {
+            dirty_nodes,
+            needs_relayout,
+        }
     }
 
     /// One queued edit. The entry is ALREADY popped, so every early-out here
     /// simply skips it rather than clearing the queue behind the loop's back.
-    fn apply_one_text_changeset(
-        &mut self,
-        changeset: PendingTextEdit,
-    ) -> TextChangesetResult {
+    fn apply_one_text_changeset(&mut self, changeset: PendingTextEdit) -> TextChangesetResult {
         use crate::managers::changeset::{TextOpInsertText, TextOperation};
         use crate::text3::edit::{edit_text, TextEdit};
 
-        let empty = TextChangesetResult { dirty_nodes: Vec::new(), needs_relayout: false };
+        let empty = TextChangesetResult {
+            dirty_nodes: Vec::new(),
+            needs_relayout: false,
+        };
 
         let Some(node_id) = changeset.node.node.into_crate_internal() else {
             return empty;
@@ -12721,7 +13163,10 @@ impl LayoutWindow {
         }
 
         // Get current cursor/selection — prefer non-empty MultiCursorState, fall back to legacy
-        let mc_selections = self.text_edit_manager.multi_cursor.as_ref()
+        let mc_selections = self
+            .text_edit_manager
+            .multi_cursor
+            .as_ref()
             .map(azul_core::selection::MultiCursorState::to_selections)
             .unwrap_or_default();
         let current_selection = if !mc_selections.is_empty() {
@@ -12763,7 +13208,9 @@ impl LayoutWindow {
             #[cfg(feature = "std")]
             timestamp: Instant::now(),
             #[cfg(not(feature = "std"))]
-            timestamp: azul_core::task::Instant::Tick(azul_core::task::SystemTick { tick_counter: 0 }),
+            timestamp: azul_core::task::Instant::Tick(azul_core::task::SystemTick {
+                tick_counter: 0,
+            }),
         };
 
         // Apply the edit using text3::edit - this is a pure function
@@ -12796,7 +13243,9 @@ impl LayoutWindow {
         // Get the new cursor position after edit using the layout's cursor rect
         let new_cursor = self
             .get_focused_cursor_rect()
-            .map_or(CursorPosition::Uninitialized, |r| CursorPosition::InWindow(r.origin));
+            .map_or(CursorPosition::Uninitialized, |r| {
+                CursorPosition::InWindow(r.origin)
+            });
 
         let old_cursor_pos = old_cursor
             .as_ref()
@@ -12806,7 +13255,9 @@ impl LayoutWindow {
                 // This is acceptable for undo: the exact pre-edit position is
                 // approximated; what matters is restoring focus to the node.
                 self.get_focused_cursor_rect()
-                    .map_or(CursorPosition::Uninitialized, |r| CursorPosition::InWindow(r.origin))
+                    .map_or(CursorPosition::Uninitialized, |r| {
+                        CursorPosition::InWindow(r.origin)
+                    })
             });
 
         // The record pipeline's provider already dispatched this edit's Input
@@ -12836,17 +13287,16 @@ impl LayoutWindow {
 
         // Return nodes that need dirty marking
         let dirty_nodes = self.determine_dirty_text_nodes(dom_id, node_id);
-        TextChangesetResult { dirty_nodes, needs_relayout }
+        TextChangesetResult {
+            dirty_nodes,
+            needs_relayout,
+        }
     }
 
     /// Determine which nodes need to be marked dirty after a text edit
     ///
     /// Returns the edited node + its parent (if it exists)
-    fn determine_dirty_text_nodes(
-        &self,
-        dom_id: DomId,
-        node_id: NodeId,
-    ) -> Vec<DomNodeId> {
+    fn determine_dirty_text_nodes(&self, dom_id: DomId, node_id: NodeId) -> Vec<DomNodeId> {
         let Some(layout_result) = self.layout_results.get(&dom_id) else {
             return Vec::new();
         };
@@ -13056,11 +13506,7 @@ impl LayoutWindow {
     }
 
     /// Get the font style for a text node from CSS
-    fn get_text_style_for_node(
-        &self,
-        dom_id: DomId,
-        node_id: NodeId,
-    ) -> Arc<StyleProperties> {
+    fn get_text_style_for_node(&self, dom_id: DomId, node_id: NodeId) -> Arc<StyleProperties> {
         use alloc::sync::Arc;
 
         let Some(layout_result) = self.layout_results.get(&dom_id) else {
@@ -13319,7 +13765,9 @@ impl LayoutWindow {
             // contenteditable) — caret-owning block first, then document order.
             if found.is_none() {
                 for child_id in self.ifc_candidate_children(dom_id, node_id) {
-                    if let Some(child_indices) = layout_result.layout_tree.dom_to_layout.get(&child_id) {
+                    if let Some(child_indices) =
+                        layout_result.layout_tree.dom_to_layout.get(&child_id)
+                    {
                         for &idx in child_indices {
                             if let Some(w) = layout_result.layout_tree.warm(idx) {
                                 if let Some(ref cached) = w.inline_layout_result {
@@ -13329,7 +13777,9 @@ impl LayoutWindow {
                             }
                         }
                     }
-                    if found.is_some() { break; }
+                    if found.is_some() {
+                        break;
+                    }
                 }
             }
 
@@ -13363,8 +13813,10 @@ impl LayoutWindow {
                         if let Some(container_size) = container_node.used_size {
                             let bp = container_node.box_props.unpack();
                             let content_width = container_size.width
-                                - bp.padding.left - bp.padding.right
-                                - bp.border.left - bp.border.right;
+                                - bp.padding.left
+                                - bp.padding.right
+                                - bp.border.left
+                                - bp.border.right;
                             if content_width > 0.0 {
                                 constraints.available_width =
                                     crate::text3::cache::AvailableSpace::Definite(content_width);
@@ -13378,15 +13830,21 @@ impl LayoutWindow {
 
             // Fallback: walk up the IFC's ancestors in the layout tree
             if !found_width {
-                if let Some(parent_idx) = layout_result.layout_tree.get(LayoutNodeId::new(ifc_layout_index))
+                if let Some(parent_idx) = layout_result
+                    .layout_tree
+                    .get(LayoutNodeId::new(ifc_layout_index))
                     .and_then(|n| n.parent)
                 {
-                    if let Some(parent_node) = layout_result.layout_tree.get(LayoutNodeId::new(parent_idx)) {
+                    if let Some(parent_node) =
+                        layout_result.layout_tree.get(LayoutNodeId::new(parent_idx))
+                    {
                         if let Some(parent_size) = parent_node.used_size {
                             let bp = parent_node.box_props.unpack();
                             let content_width = parent_size.width
-                                - bp.padding.left - bp.padding.right
-                                - bp.border.left - bp.border.right;
+                                - bp.padding.left
+                                - bp.padding.right
+                                - bp.border.left
+                                - bp.border.right;
                             if content_width > 0.0 {
                                 constraints.available_width =
                                     crate::text3::cache::AvailableSpace::Definite(content_width);
@@ -13412,13 +13870,18 @@ impl LayoutWindow {
             .and_then(|w| w.inline_layout_result.as_ref())
             .cloned();
 
-        let new_layout = cached_snapshot.map_or_else(|| self.relayout_text_node_internal(&new_inline_content, &constraints), |cached| self.try_incremental_text_relayout(
-                &new_inline_content,
-                &constraints,
-                &cached,
-                node_id,
-            )
-            .map(|(layout, _skipped_fragment)| layout));
+        let new_layout = cached_snapshot.map_or_else(
+            || self.relayout_text_node_internal(&new_inline_content, &constraints),
+            |cached| {
+                self.try_incremental_text_relayout(
+                    &new_inline_content,
+                    &constraints,
+                    &cached,
+                    node_id,
+                )
+                .map(|(layout, _skipped_fragment)| layout)
+            },
+        );
 
         let Some(new_layout) = new_layout else {
             return;
@@ -13427,7 +13890,10 @@ impl LayoutWindow {
         // 4. Update the layout cache with the new layout
         // Use the ifc_layout_index we found earlier (correct layout tree index)
         if let Some(layout_result) = self.layout_results.get_mut(&dom_id) {
-            let old_size = layout_result.layout_tree.get(LayoutNodeId::new(ifc_layout_index)).and_then(|n| n.used_size);
+            let old_size = layout_result
+                .layout_tree
+                .get(LayoutNodeId::new(ifc_layout_index))
+                .and_then(|n| n.used_size);
             let new_bounds = new_layout.bounds();
             let new_size = Some(LogicalSize {
                 width: new_bounds.width,
@@ -13438,7 +13904,9 @@ impl LayoutWindow {
             if let (Some(old), Some(new)) = (old_size, new_size) {
                 if (old.height - new.height).abs() > 0.5 || (old.width - new.width).abs() > 0.5 {
                     // Mark that ancestor relayout is needed
-                    if let Some(dirty_node) = self.content_overlay.text_for_node_mut(dom_id, node_id) {
+                    if let Some(dirty_node) =
+                        self.content_overlay.text_for_node_mut(dom_id, node_id)
+                    {
                         dirty_node.needs_ancestor_relayout = true;
                     }
                 }
@@ -13459,13 +13927,17 @@ impl LayoutWindow {
             };
 
             // Update the inline layout result with the new layout but preserve constraints (warm data)
-            if let Some(warm_node) = layout_result.layout_tree.warm_mut(LayoutNodeId::new(ifc_layout_index)) {
-                warm_node.inline_layout_result = Some(Box::new(CachedInlineLayout::new_with_constraints(
-                    Arc::new(new_layout),
-                    constraints.available_width,
-                    false, // No floats in quick relayout
-                    constraints,
-                )));
+            if let Some(warm_node) = layout_result
+                .layout_tree
+                .warm_mut(LayoutNodeId::new(ifc_layout_index))
+            {
+                warm_node.inline_layout_result =
+                    Some(Box::new(CachedInlineLayout::new_with_constraints(
+                        Arc::new(new_layout),
+                        constraints.available_width,
+                        false, // No floats in quick relayout
+                        constraints,
+                    )));
                 warm_node.overflow_content_size = Some(content_extent);
             }
         }
@@ -13505,8 +13977,12 @@ impl LayoutWindow {
                         .layout_tree
                         .ancestor_chain(ifc_idx, Inclusivity::AncestorsOnly)
                     {
-                        let Some(pnode) = layout_result.layout_tree.get(idx) else { break };
-                        let Some(pdom) = pnode.dom_node_id else { continue };
+                        let Some(pnode) = layout_result.layout_tree.get(idx) else {
+                            break;
+                        };
+                        let Some(pdom) = pnode.dom_node_id else {
+                            continue;
+                        };
                         let st = layout_result
                             .styled_dom
                             .styled_nodes
@@ -13514,14 +13990,15 @@ impl LayoutWindow {
                             .get(pdom)
                             .map(|n| n.styled_node_state)
                             .unwrap_or_default();
-                        let scrolls = solver3::getters::get_overflow_x(
-                            &layout_result.styled_dom, pdom, &st,
-                        )
-                        .is_scroll()
-                            || solver3::getters::get_overflow_y(
-                                &layout_result.styled_dom, pdom, &st,
-                            )
-                            .is_scroll();
+                        let scrolls =
+                            solver3::getters::get_overflow_x(&layout_result.styled_dom, pdom, &st)
+                                .is_scroll()
+                                || solver3::getters::get_overflow_y(
+                                    &layout_result.styled_dom,
+                                    pdom,
+                                    &st,
+                                )
+                                .is_scroll();
                         if scrolls {
                             chain.push((pdom, extent));
                             break;
@@ -13674,12 +14151,22 @@ impl LayoutWindow {
         let Some(lr) = self.layout_results.get(&dom_id) else {
             return Vec::new();
         };
-        let patched: Vec<String> = lr.display_list.items.iter().map(|i| format!("{i:?}")).collect();
+        let patched: Vec<String> = lr
+            .display_list
+            .items
+            .iter()
+            .map(|i| format!("{i:?}"))
+            .collect();
         self.regenerate_display_list_for_dom(dom_id);
         let Some(lr) = self.layout_results.get(&dom_id) else {
             return Vec::new();
         };
-        let wholesale: Vec<String> = lr.display_list.items.iter().map(|i| format!("{i:?}")).collect();
+        let wholesale: Vec<String> = lr
+            .display_list
+            .items
+            .iter()
+            .map(|i| format!("{i:?}"))
+            .collect();
         // `AZ_PATCH_VERIFY_DUMP=<dir>`: write both lists in full, one item per
         // line, so a mismatch can be read side by side (the report below is
         // index-aligned and clipped, which is enough to SEE a drift but not
@@ -13692,7 +14179,10 @@ impl LayoutWindow {
                 // the verification it documents.
                 drop(std::fs::create_dir_all(&dir));
                 drop(std::fs::write(dir.join("patched.txt"), patched.join("\n")));
-                drop(std::fs::write(dir.join("wholesale.txt"), wholesale.join("\n")));
+                drop(std::fs::write(
+                    dir.join("wholesale.txt"),
+                    wholesale.join("\n"),
+                ));
             }
         }
         let mut out = Vec::new();
@@ -13726,10 +14216,7 @@ impl LayoutWindow {
     /// This method creates a temporary `LayoutContext` from the existing `LayoutWindow` state
     /// and calls `generate_display_list` on the already-computed layout tree and positions.
     pub fn regenerate_display_list_for_dom(&mut self, dom_id: DomId) {
-        use crate::solver3::{
-            display_list::generate_display_list,
-            LayoutContext,
-        };
+        use crate::solver3::{display_list::generate_display_list, LayoutContext};
 
         self.frame_report.dl_rebuilds = self.frame_report.dl_rebuilds.saturating_add(1);
 
@@ -13768,7 +14255,6 @@ impl LayoutWindow {
 
         // Get GPU cache for this DOM
         let gpu_cache = self.gpu_state_manager.get_or_create_cache(dom_id).clone();
-
 
         // Get cursor state for display list generation. A tween in flight
         // forces the caret solid (blinking is suppressed while animating).
@@ -13818,7 +14304,6 @@ impl LayoutWindow {
             self.id_namespace,
             dom_id,
         );
-
 
         // Restore the cache_map back to layout_cache
         self.layout_cache.cache_map = std::mem::take(&mut ctx.cache_map);
@@ -13916,8 +14401,7 @@ impl LayoutWindow {
                 #[cfg(feature = "a11y")]
                 self.update_a11y_tree_incremental();
             }
-            Err(_e) => {
-            }
+            Err(_e) => {}
         }
     }
 
@@ -13946,10 +14430,7 @@ impl LayoutWindow {
         &self,
         content: &[InlineContent],
         constraints: &UnifiedConstraints,
-    ) -> Option<(
-        Vec<crate::text3::cache::LogicalItem>,
-        Vec<ShapedItem>,
-    )> {
+    ) -> Option<(Vec<crate::text3::cache::LogicalItem>, Vec<ShapedItem>)> {
         use crate::text3::cache::{
             create_logical_items, reorder_logical_items, shape_visual_items, BidiDirection,
         };
@@ -13992,7 +14473,14 @@ impl LayoutWindow {
 
         let loaded_fonts = self.font_manager.get_loaded_fonts();
         let mut cursor = BreakCursor::new(shaped_items);
-        perform_fragment_layout(&mut cursor, logical_items, constraints, &mut None, &loaded_fonts).ok()
+        perform_fragment_layout(
+            &mut cursor,
+            logical_items,
+            constraints,
+            &mut None,
+            &loaded_fonts,
+        )
+        .ok()
     }
 
     /// Attempt an incremental IFC relayout for a text edit.
@@ -14088,7 +14576,9 @@ impl LayoutWindow {
                                 && sparse.line_index == li,
                             "d6g verify: positioned_cluster({i}) diverged: \
                              sparse ({}, {}, {}) vs dense ({x}, {y}, {li})",
-                            sparse.position.x, sparse.position.y, sparse.line_index,
+                            sparse.position.x,
+                            sparse.position.y,
+                            sparse.line_index,
                         );
                     }
                 }
@@ -14107,8 +14597,8 @@ impl LayoutWindow {
         edited_node_id: NodeId,
     ) -> Option<(UnifiedLayout, bool)> {
         use crate::text3::cache::{
-            try_incremental_relayout as decide_incremental,
-            IncrementalRelayoutResult, PositionedItem, ShapedItem,
+            try_incremental_relayout as decide_incremental, IncrementalRelayoutResult,
+            PositionedItem, ShapedItem,
         };
 
         let (logical_items, shaped_items) = self.shape_text_for_relayout(content, constraints)?;
@@ -14144,10 +14634,12 @@ impl LayoutWindow {
         if incremental_ok {
             let line_breaks = cached.line_breaks.as_ref().unwrap();
 
-            let old_advances: Vec<f32> =
-                cached.item_metrics.iter().map(|m| m.advance_width).collect();
-            let new_advances: Vec<f32> =
-                shaped_items.iter().map(|si| si.bounds().width).collect();
+            let old_advances: Vec<f32> = cached
+                .item_metrics
+                .iter()
+                .map(|m| m.advance_width)
+                .collect();
+            let new_advances: Vec<f32> = shaped_items.iter().map(|si| si.bounds().width).collect();
 
             // An item is dirty if its advance width changed OR it originates
             // from the edited DOM node. The latter is needed so GlyphSwap
@@ -14161,9 +14653,7 @@ impl LayoutWindow {
             }
             for (i, si) in shaped_items.iter().enumerate() {
                 if let ShapedItem::Cluster(c) = si {
-                    if c.source_node_id == Some(edited_node_id)
-                        && !dirty_indices.contains(&i)
-                    {
+                    if c.source_node_id == Some(edited_node_id) && !dirty_indices.contains(&i) {
                         dirty_indices.push(i);
                     }
                 }
@@ -14183,9 +14673,12 @@ impl LayoutWindow {
                         .into_iter()
                         .enumerate()
                         .map(|(i, new_shaped)| {
-                            let (position, line_index) =
-                                Self::cached_positioned_of(cached, i);
-                            PositionedItem { item: new_shaped, position, line_index }
+                            let (position, line_index) = Self::cached_positioned_of(cached, i);
+                            PositionedItem {
+                                item: new_shaped,
+                                position,
+                                line_index,
+                            }
                         })
                         .collect();
                     return Some((
@@ -14208,12 +14701,15 @@ impl LayoutWindow {
                         .into_iter()
                         .enumerate()
                         .map(|(i, new_shaped)| {
-                            let (mut position, line_index) =
-                                Self::cached_positioned_of(cached, i);
+                            let (mut position, line_index) = Self::cached_positioned_of(cached, i);
                             if i > affected_item && line_index == affected_line {
                                 position.x += delta;
                             }
-                            PositionedItem { item: new_shaped, position, line_index }
+                            PositionedItem {
+                                item: new_shaped,
+                                position,
+                                line_index,
+                            }
                         })
                         .collect();
                     return Some((
@@ -14234,17 +14730,14 @@ impl LayoutWindow {
         // Fall-back: run stage 4 (line breaking + positioning) with the
         // already-computed logical + shaped items. Still cheaper than the
         // plain full path because stages 1-3 aren't repeated.
-        let layout = self.fragment_layout_from_shaped(&logical_items, &shaped_items, constraints)?;
+        let layout =
+            self.fragment_layout_from_shaped(&logical_items, &shaped_items, constraints)?;
         Some((layout, false))
     }
 
     /// Helper to get node `used_size` for accessibility actions
     #[cfg(feature = "a11y")]
-    fn get_node_used_size_a11y(
-        &self,
-        dom_id: DomId,
-        node_id: NodeId,
-    ) -> Option<LogicalSize> {
+    fn get_node_used_size_a11y(&self, dom_id: DomId, node_id: NodeId) -> Option<LogicalSize> {
         let layout_result = self.layout_results.get(&dom_id)?;
         let layout_indices = layout_result.layout_tree.dom_to_layout.get(&node_id)?;
         let idx = *layout_indices.first()?;
@@ -14299,10 +14792,7 @@ impl LayoutWindow {
     /// A `TextCursor` positioned at the given byte offset, or None if the offset
     /// is out of bounds.
     #[allow(clippy::cast_possible_truncation)] // bounded layout/render numeric cast
-    fn byte_offset_to_cursor(
-        text_layout: &UnifiedLayout,
-        byte_offset: u32,
-    ) -> TextCursor {
+    fn byte_offset_to_cursor(text_layout: &UnifiedLayout, byte_offset: u32) -> TextCursor {
         // Handle offset 0 as special case (start of text)
         if byte_offset == 0 {
             // Find first cluster in items
@@ -14370,11 +14860,7 @@ impl LayoutWindow {
     ///
     /// This looks up the node in the layout tree and returns its inline layout result
     /// if it exists.
-    fn get_node_inline_layout(
-        &self,
-        dom_id: DomId,
-        node_id: NodeId,
-    ) -> Option<Arc<UnifiedLayout>> {
+    fn get_node_inline_layout(&self, dom_id: DomId, node_id: NodeId) -> Option<Arc<UnifiedLayout>> {
         // The tree of the REQUESTED dom. `layout_cache.tree` is the root dom's
         // only, so a bare `dom_node_id` match against it answered for an
         // unrelated node of the root DOM whenever `dom_id` named a virtualized
@@ -14563,7 +15049,10 @@ impl LayoutWindow {
     ) -> Option<LogicalPosition> {
         let border = solver3::pos_get(&layout_result.calculated_positions, layout_idx.index())?;
         let inset = layout_result.layout_tree.content_inset(layout_idx);
-        Some(LogicalPosition::new(border.x + inset.left, border.y + inset.top))
+        Some(LogicalPosition::new(
+            border.x + inset.left,
+            border.y + inset.top,
+        ))
     }
 
     /// [`Self::ifc_local_point_from`] when the node that was HIT is not the IFC
@@ -14597,9 +15086,12 @@ impl LayoutWindow {
             ));
         }
         let tree = &layout_result.layout_tree;
-        let hit_border = solver3::pos_get(&layout_result.calculated_positions, hit_layout_idx.index())?;
-        let root_border =
-            solver3::pos_get(&layout_result.calculated_positions, ifc_root_layout_idx.index())?;
+        let hit_border =
+            solver3::pos_get(&layout_result.calculated_positions, hit_layout_idx.index())?;
+        let root_border = solver3::pos_get(
+            &layout_result.calculated_positions,
+            ifc_root_layout_idx.index(),
+        )?;
         let rebased = hit_local
             .to_border_box_local(tree.content_inset(hit_layout_idx))
             .to_static_layout(hit_border)
@@ -14782,7 +15274,10 @@ impl LayoutWindow {
                 let get_dom_depth = |node_id: &NodeId| -> usize {
                     let mut depth = 0;
                     let mut current = *node_id;
-                    while let Some(parent) = node_hierarchy.get(current).and_then(azul_core::styled_dom::NodeHierarchyItem::parent_id) {
+                    while let Some(parent) = node_hierarchy
+                        .get(current)
+                        .and_then(azul_core::styled_dom::NodeHierarchyItem::parent_id)
+                    {
                         depth += 1;
                         current = parent;
                     }
@@ -14795,7 +15290,9 @@ impl LayoutWindow {
                     let depth_b = get_dom_depth(b_id);
                     // Higher depth = deeper in DOM = should come first
                     // Then sort by NodeId for deterministic order within same depth
-                    depth_b.cmp(&depth_a).then_with(|| a_id.index().cmp(&b_id.index()))
+                    depth_b
+                        .cmp(&depth_a)
+                        .then_with(|| a_id.index().cmp(&b_id.index()))
                 });
 
                 for (node_id, hit_item) in sorted_hits {
@@ -14805,7 +15302,10 @@ impl LayoutWindow {
                     }
 
                     // Find the layout node for this DOM node
-                    let layout_node_idx = tree.nodes.iter().position(|n| n.dom_node_id == Some(*node_id));
+                    let layout_node_idx = tree
+                        .nodes
+                        .iter()
+                        .position(|n| n.dom_node_id == Some(*node_id));
                     let Some(layout_node_idx) = layout_node_idx else {
                         continue;
                     };
@@ -14823,19 +15323,25 @@ impl LayoutWindow {
                             // This node IS an IFC root - use its own NodeId
                             (cached, *node_id, layout_node_idx)
                         } else if let Some(ref membership) = warm_node.ifc_membership {
-                        // This node participates in an IFC - get layout and NodeId from IFC root
-                        let root_idx = membership.ifc_root_layout_index;
-                        match tree.warm(LayoutNodeId::new(root_idx)) {
-                            Some(ifc_root_warm) => match (ifc_root_warm.inline_layout_result.as_ref(), tree.get(LayoutNodeId::new(root_idx)).and_then(|n| n.dom_node_id)) {
-                                (Some(cached), Some(root_dom_id)) => (cached, root_dom_id, root_idx),
-                                _ => continue,
-                            },
-                            None => continue,
-                        }
-                    } else {
-                        // No IFC involvement - not a text node
-                        continue;
-                    };
+                            // This node participates in an IFC - get layout and NodeId from IFC root
+                            let root_idx = membership.ifc_root_layout_index;
+                            match tree.warm(LayoutNodeId::new(root_idx)) {
+                                Some(ifc_root_warm) => match (
+                                    ifc_root_warm.inline_layout_result.as_ref(),
+                                    tree.get(LayoutNodeId::new(root_idx))
+                                        .and_then(|n| n.dom_node_id),
+                                ) {
+                                    (Some(cached), Some(root_dom_id)) => {
+                                        (cached, root_dom_id, root_idx)
+                                    }
+                                    _ => continue,
+                                },
+                                None => continue,
+                            }
+                        } else {
+                            // No IFC involvement - not a text node
+                            continue;
+                        };
 
                     // Under the default AZ_DENSE_TEXT=1, retire_sparse swaps
                     // `cached.layout` for a shared, permanently-EMPTY sentinel
@@ -14874,10 +15380,15 @@ impl LayoutWindow {
                     });
                     if let Some(cursor) = hit_cursor {
                         // Store selection with IFC root NodeId, not the hit text node
-                        found_selection = Some((*dom_id, ifc_root_node_id, SelectionRange {
-                            start: cursor,
-                            end: cursor,
-                        }, local_pos));
+                        found_selection = Some((
+                            *dom_id,
+                            ifc_root_node_id,
+                            SelectionRange {
+                                start: cursor,
+                                end: cursor,
+                            },
+                            local_pos,
+                        ));
                         break;
                     }
                 }
@@ -14932,13 +15443,16 @@ impl LayoutWindow {
                         let bounds = cached_layout.layout.bounds();
                         LogicalSize::new(bounds.width, bounds.height)
                     });
-                    let ancestor_scroll = self
-                        .accumulated_scroll(*dom_id, node_idx, Inclusivity::AncestorsOnly);
+                    let ancestor_scroll =
+                        self.accumulated_scroll(*dom_id, node_idx, Inclusivity::AncestorsOnly);
                     let screen_x = node_pos.x - ancestor_scroll.get().x;
                     let screen_y = node_pos.y - ancestor_scroll.get().y;
 
-                    if position.x < screen_x || position.x > screen_x + node_size.width ||
-                       position.y < screen_y || position.y > screen_y + node_size.height {
+                    if position.x < screen_x
+                        || position.x > screen_x + node_size.width
+                        || position.y < screen_y
+                        || position.y > screen_y + node_size.height
+                    {
                         continue;
                     }
 
@@ -14967,10 +15481,15 @@ impl LayoutWindow {
                         )
                     });
                     if let Some(cursor) = hit_cursor {
-                        found_selection = Some((*dom_id, node_id, SelectionRange {
-                            start: cursor,
-                            end: cursor,
-                        }, local_pos));
+                        found_selection = Some((
+                            *dom_id,
+                            node_id,
+                            SelectionRange {
+                                start: cursor,
+                                end: cursor,
+                            },
+                            local_pos,
+                        ));
                         break;
                     }
                 }
@@ -15031,8 +15550,14 @@ impl LayoutWindow {
             let tree = &layout_result.layout_tree;
 
             // Find layout node - ifc_root_node_id is always the IFC root, so it has inline_layout_result
-            let layout_idx = tree.nodes.iter().position(|n| n.dom_node_id == Some(ifc_root_node_id))?;
-            let cached_layout = tree.warm(LayoutNodeId::new(layout_idx))?.inline_layout_result.as_ref()?;
+            let layout_idx = tree
+                .nodes
+                .iter()
+                .position(|n| n.dom_node_id == Some(ifc_root_node_id))?;
+            let cached_layout = tree
+                .warm(LayoutNodeId::new(layout_idx))?
+                .inline_layout_result
+                .as_ref()?;
             let layout = Self::materialized_inline_layout(cached_layout);
 
             match click_count {
@@ -15053,35 +15578,38 @@ impl LayoutWindow {
         //
         // Check if the node OR ANY ANCESTOR is contenteditable before setting focus
         // The contenteditable attribute is typically on a parent div, not on the IFC root or text node
-        let is_contenteditable = self.layout_results.get(&dom_id)
-            .is_some_and(|lr| {
-                let node_hierarchy = lr.styled_dom.node_hierarchy.as_container();
-                let node_data = lr.styled_dom.node_data.as_ref();
+        let is_contenteditable = self.layout_results.get(&dom_id).is_some_and(|lr| {
+            let node_hierarchy = lr.styled_dom.node_hierarchy.as_container();
+            let node_data = lr.styled_dom.node_data.as_ref();
 
-                // Walk up the DOM tree to check if any ancestor has contenteditable
-                let mut current_node = Some(ifc_root_node_id);
-                while let Some(node_id) = current_node {
-                    if let Some(styled_node) = node_data.get(node_id.index()) {
-                        // Check BOTH: the contenteditable boolean field AND the attribute
-                        // NodeData has a direct `contenteditable: bool` field that should be
-                        // checked in addition to the attribute for robustness
-                        if styled_node.is_contenteditable() {
-                            return true;
-                        }
-
-                        // Also check the attribute (for backwards compatibility)
-                        let has_contenteditable_attr = styled_node.attributes().as_ref().iter().any(|attr| {
-                            matches!(attr, AttributeType::ContentEditable(_))
-                        });
-                        if has_contenteditable_attr {
-                            return true;
-                        }
+            // Walk up the DOM tree to check if any ancestor has contenteditable
+            let mut current_node = Some(ifc_root_node_id);
+            while let Some(node_id) = current_node {
+                if let Some(styled_node) = node_data.get(node_id.index()) {
+                    // Check BOTH: the contenteditable boolean field AND the attribute
+                    // NodeData has a direct `contenteditable: bool` field that should be
+                    // checked in addition to the attribute for robustness
+                    if styled_node.is_contenteditable() {
+                        return true;
                     }
-                    // Move to parent
-                    current_node = node_hierarchy.get(node_id).and_then(azul_core::styled_dom::NodeHierarchyItem::parent_id);
+
+                    // Also check the attribute (for backwards compatibility)
+                    let has_contenteditable_attr = styled_node
+                        .attributes()
+                        .as_ref()
+                        .iter()
+                        .any(|attr| matches!(attr, AttributeType::ContentEditable(_)));
+                    if has_contenteditable_attr {
+                        return true;
+                    }
                 }
-                false
-            });
+                // Move to parent
+                current_node = node_hierarchy
+                    .get(node_id)
+                    .and_then(azul_core::styled_dom::NodeHierarchyItem::parent_id);
+            }
+            false
+        });
 
         // NOTE: Do NOT call focus_manager.set_focused_node() here!
         // The click-to-focus system in event.rs (process_window_events) handles
@@ -15100,7 +15628,10 @@ impl LayoutWindow {
         });
         self.text_edit_manager.enter_focus_scope(scope);
         self.text_edit_manager.initialize_editing(
-            final_range.start, dom_id, ifc_root_node_id, ce_key,
+            final_range.start,
+            dom_id,
+            ifc_root_node_id,
+            ce_key,
         );
         // MWA-C-text_edit: double/triple-click computed the word/paragraph
         // range above but then threw it away — initialize_editing only
@@ -15124,7 +15655,10 @@ impl LayoutWindow {
         if is_contenteditable {
             let now = Instant::now();
             self.text_edit_manager.blink.reset_blink_on_input(now);
-            if self.timers.contains_key(&azul_core::task::CURSOR_BLINK_TIMER_ID) {
+            if self
+                .timers
+                .contains_key(&azul_core::task::CURSOR_BLINK_TIMER_ID)
+            {
                 self.text_edit_manager.blink.set_blink_timer_active(true);
             }
         }
@@ -15177,11 +15711,15 @@ impl LayoutWindow {
         // Hit-test the current drag position to get the focus cursor
         let layout_result = self.layout_results.get(&dom_id)?;
         let tree = &layout_result.layout_tree;
-        let layout_idx = tree.nodes.iter()
+        let layout_idx = tree
+            .nodes
+            .iter()
             .position(|n| n.dom_node_id == Some(node_id))?;
         // (the anchor node's cached inline layout is re-borrowed below,
         // after the cross-block branch may have taken &mut self)
-        tree.warm(LayoutNodeId::new(layout_idx))?.inline_layout_result.as_ref()?;
+        tree.warm(LayoutNodeId::new(layout_idx))?
+            .inline_layout_result
+            .as_ref()?;
 
         // The pointer in the anchor IFC's own space. This used to be spelled
         // out here as `current - node_pos + self_inclusive_scroll`, which is
@@ -15206,21 +15744,19 @@ impl LayoutWindow {
         // `node_box_on_screen` also takes the ANCESTORS' scroll off, which the
         // hand-rolled `current - node_pos` did not — an editable inside a
         // scrolled page fell out of its own anchor rect.
-        let anchor_rect_contains = self
-            .node_box_on_screen(dom_id, layout_idx)
-            .is_some_and(|screen| {
-                current_position.x >= screen.origin.x
-                    && current_position.y >= screen.origin.y
-                    && current_position.x <= screen.origin.x + screen.size.width
-                    && current_position.y <= screen.origin.y + screen.size.height
-            });
+        let anchor_rect_contains =
+            self.node_box_on_screen(dom_id, layout_idx)
+                .is_some_and(|screen| {
+                    current_position.x >= screen.origin.x
+                        && current_position.y >= screen.origin.y
+                        && current_position.x <= screen.origin.x + screen.size.width
+                        && current_position.y <= screen.origin.y + screen.size.height
+                });
         if !anchor_rect_contains {
             let global_hit = self.hittest_text_position_global(dom_id, current_position);
             if let Some((hit_node, hit_cursor)) = global_hit {
                 if hit_node != node_id
-                    && self.set_cross_block_selection(
-                        dom_id, node_id, anchor, hit_node, hit_cursor,
-                    )
+                    && self.set_cross_block_selection(dom_id, node_id, anchor, hit_node, hit_cursor)
                 {
                     self.text_edit_manager.mark_dirty();
                     self.regenerate_display_list_for_dom(dom_id);
@@ -15232,7 +15768,10 @@ impl LayoutWindow {
         // Re-borrow after the possible &mut use above.
         let layout_result = self.layout_results.get(&dom_id)?;
         let tree = &layout_result.layout_tree;
-        let cached = tree.warm(LayoutNodeId::new(layout_idx))?.inline_layout_result.as_ref()?;
+        let cached = tree
+            .warm(LayoutNodeId::new(layout_idx))?
+            .inline_layout_result
+            .as_ref()?;
         // (d6h) Materialized: sentinel-safe click hittest.
         let focus = Self::materialized_inline_layout(cached).hittest_point(local_pos)?;
 
@@ -15277,8 +15816,12 @@ impl LayoutWindow {
         // (vertical distance, horizontal distance, node, layout index)
         let mut best: Option<(f32, f32, NodeId, usize)> = None;
         for (idx, node) in tree.nodes.iter().enumerate() {
-            let Some(node_dom_id) = node.dom_node_id else { continue };
-            let Some(warm) = tree.warm(LayoutNodeId::new(idx)) else { continue };
+            let Some(node_dom_id) = node.dom_node_id else {
+                continue;
+            };
+            let Some(warm) = tree.warm(LayoutNodeId::new(idx)) else {
+                continue;
+            };
             if warm.inline_layout_result.is_none() {
                 continue;
             }
@@ -15288,7 +15831,9 @@ impl LayoutWindow {
             // scroll offset, so the pointer kept picking the same block however
             // far the view had moved. Its OWN scroll is excluded — that moves
             // the block's text, not the block.
-            let Some(screen) = self.node_box_on_screen(dom_id, idx) else { continue };
+            let Some(screen) = self.node_box_on_screen(dom_id, idx) else {
+                continue;
+            };
             let dy = if position.y < screen.origin.y {
                 screen.origin.y - position.y
             } else if position.y > screen.origin.y + screen.size.height {
@@ -15317,20 +15862,29 @@ impl LayoutWindow {
             }
         }
         let (_, _, node_dom_id, layout_idx) = best?;
-        let cached = tree.warm(LayoutNodeId::new(layout_idx))?.inline_layout_result.as_ref()?;
+        let cached = tree
+            .warm(LayoutNodeId::new(layout_idx))?
+            .inline_layout_result
+            .as_ref()?;
         // The winning block's own space, via the one conversion chain (this
         // used to be spelled out inline and skipped the content inset).
         let local = self.window_point_to_ifc_local(dom_id, layout_idx, position)?;
         // Clamp the local point into the block so line hit-testing lands on
         // the nearest line instead of failing outside the box. The clamp box is
         // the CONTENT box, matching the space the point is now in.
-        let size = tree.get(LayoutNodeId::new(layout_idx)).and_then(|n| n.used_size).unwrap_or_default();
+        let size = tree
+            .get(LayoutNodeId::new(layout_idx))
+            .and_then(|n| n.used_size)
+            .unwrap_or_default();
         let inset = tree.content_inset(LayoutNodeId::new(layout_idx));
         let bp = tree
             .get(LayoutNodeId::new(layout_idx))
             .map(|n| n.box_props.unpack());
         let (right, bottom) = bp.map_or((0.0, 0.0), |b| {
-            (b.padding.right + b.border.right, b.padding.bottom + b.border.bottom)
+            (
+                b.padding.right + b.border.right,
+                b.padding.bottom + b.border.bottom,
+            )
         });
         let clamped = local.clamp_to(
             size.width - inset.left - right,
@@ -15354,11 +15908,7 @@ impl LayoutWindow {
     /// ## Returns
     /// * `Some(Vec<DomNodeId>)` - Affected nodes if deletion occurred
     /// * `None` - If no cursor/selection exists or deletion failed
-    pub fn delete_selection(
-        &mut self,
-        target: DomNodeId,
-        forward: bool,
-    ) -> Option<Vec<DomNodeId>> {
+    pub fn delete_selection(&mut self, target: DomNodeId, forward: bool) -> Option<Vec<DomNodeId>> {
         let dom_id = target.dom;
         let node_id = target.node.into_crate_internal()?;
 
@@ -15377,9 +15927,8 @@ impl LayoutWindow {
         } else {
             crate::text3::edit::TextEdit::DeleteBackward
         };
-        let (new_content, new_selections) = crate::text3::edit::edit_text(
-            &content, &current_selections, &edit,
-        );
+        let (new_content, new_selections) =
+            crate::text3::edit::edit_text(&content, &current_selections, &edit);
 
         // MWA-C-undo_redo: deletions (Backspace / Delete / Cut all route
         // here) were never recorded — only insertions were undoable. Record
@@ -15419,9 +15968,7 @@ impl LayoutWindow {
                 }
                 #[cfg(not(feature = "std"))]
                 {
-                    azul_core::task::Instant::Tick(azul_core::task::SystemTick {
-                        tick_counter: 0,
-                    })
+                    azul_core::task::Instant::Tick(azul_core::task::SystemTick { tick_counter: 0 })
                 }
             };
             let pre_state = NodeStateSnapshot {
@@ -15522,8 +16069,7 @@ impl LayoutWindow {
                                 0
                             };
                             let hi = if i == er {
-                                cursor_byte_offset_in_run(&run.text, &range.end)
-                                    .min(run.text.len())
+                                cursor_byte_offset_in_run(&run.text, &range.end).min(run.text.len())
                             } else {
                                 run.text.len()
                             };
@@ -15543,10 +16089,14 @@ impl LayoutWindow {
         let node_id = mc.node_id.node.into_crate_internal()?;
 
         // Collect range selections (collapsed cursors contribute nothing to a copy).
-        let ranges: Vec<_> = mc.selections.iter().filter_map(|s| match &s.selection {
-            Selection::Range(r) => Some(*r),
-            Selection::Cursor(_) => None,
-        }).collect();
+        let ranges: Vec<_> = mc
+            .selections
+            .iter()
+            .filter_map(|s| match &s.selection {
+                Selection::Range(r) => Some(*r),
+                Selection::Cursor(_) => None,
+            })
+            .collect();
         if ranges.is_empty() {
             return None;
         }
@@ -15584,10 +16134,12 @@ impl LayoutWindow {
                 for ri in first_idx..=last_idx {
                     if let Some(InlineContent::Text(run)) = content.get(ri) {
                         if ri == first_idx {
-                            let off = cursor_byte_offset_in_run(&run.text, &first_cur).min(run.text.len());
+                            let off = cursor_byte_offset_in_run(&run.text, &first_cur)
+                                .min(run.text.len());
                             acc.push(&run.text[off..], &run.style);
                         } else if ri == last_idx {
-                            let off = cursor_byte_offset_in_run(&run.text, &last_cur).min(run.text.len());
+                            let off =
+                                cursor_byte_offset_in_run(&run.text, &last_cur).min(run.text.len());
                             acc.push(&run.text[..off], &run.style);
                         } else {
                             acc.push(&run.text, &run.style);
@@ -15614,18 +16166,16 @@ impl LayoutWindow {
         node_id: NodeId,
     ) -> bool {
         // Get the VirtualView's current layout bounds (needed for check_reinvoke)
-        let Some(bounds) = Self::get_virtual_view_bounds_from_layout(
-            &self.layout_results,
-            dom_id,
-            node_id,
-        ) else {
+        let Some(bounds) =
+            Self::get_virtual_view_bounds_from_layout(&self.layout_results, dom_id, node_id)
+        else {
             return false; // Not a VirtualView or no layout info
         };
 
         // Ask the VirtualViewManager whether this VirtualView needs re-invocation
-        let reason = self.virtual_view_manager.check_reinvoke(
-            dom_id, node_id, &self.scroll_manager, bounds,
-        );
+        let reason =
+            self.virtual_view_manager
+                .check_reinvoke(dom_id, node_id, &self.scroll_manager, bounds);
 
         if let Some(reason) = reason {
             // Queue the VirtualView for re-invocation in the next render
@@ -15772,10 +16322,7 @@ impl LayoutWindow {
             for ((dom_id, node_id), new_rect) in &current {
                 if let Some(old_rect) = self.resize_watch.get(&(*dom_id, *node_id)) {
                     let old_rect = if dpi_changed {
-                        LogicalRect::new(
-                            old_rect.origin,
-                            LogicalSize::new(-1.0, -1.0),
-                        )
+                        LogicalRect::new(old_rect.origin, LogicalSize::new(-1.0, -1.0))
                     } else {
                         *old_rect
                     };
@@ -15824,10 +16371,7 @@ impl LayoutWindow {
     pub fn queue_all_virtual_view_reinvoke(&mut self) {
         let mut updates: BTreeMap<DomId, FastBTreeSet<NodeId>> = BTreeMap::new();
         for (dom_id, node_id) in self.virtual_view_manager.all_view_keys() {
-            updates
-                .entry(dom_id)
-                .or_default()
-                .insert(node_id);
+            updates.entry(dom_id).or_default().insert(node_id);
         }
         self.queue_virtual_view_updates(updates);
     }
@@ -15901,7 +16445,9 @@ impl LayoutWindow {
         let layout_index = layout_indices[0];
 
         // Get position
-        let position = *layout_result.calculated_positions.get(layout_index.index())?;
+        let position = *layout_result
+            .calculated_positions
+            .get(layout_index.index())?;
 
         // Get size
         let layout_node = layout_result.layout_tree.get(layout_index)?;
@@ -16055,9 +16601,9 @@ impl LayoutWindow {
             skip_gpu_sync: _,
             e2e_mount: _,
             #[cfg(feature = "e2e-server")]
-            e2e_scratch: _,
+                e2e_scratch: _,
             #[cfg(feature = "pdf")]
-            fragmentation_context: _,
+                fragmentation_context: _,
             safe_area_insets: _,
             // App-level animation CONFIG (durations + fn pointers), no node ids.
             system_animations_override: _,
@@ -16076,9 +16622,9 @@ impl LayoutWindow {
             input_interpreter: _,
             post_filter: _,
             custom_e2e_op: _,
-                routes: _,
+            routes: _,
             #[cfg(feature = "icu")]
-            icu_localizer: _,
+                icu_localizer: _,
             // Lifecycle events carry NodeIds, but they are produced BY this very
             // reconciliation and are already expressed in NEW ids (Mount/Update/
             // Resize), or deliberately in OLD ids resolved before the swap
@@ -16202,7 +16748,10 @@ impl LayoutWindow {
                     .node
                     .into_crate_internal()
                     .and_then(|n| map.resolve(n))
-                    .map(|n| DomNodeId { dom, node: NodeHierarchyItemId::from_crate_internal(Some(n)) });
+                    .map(|n| DomNodeId {
+                        dom,
+                        node: NodeHierarchyItemId::from_crate_internal(Some(n)),
+                    });
             }
         }
         // An in-flight scrollbar-thumb drag holds the NodeId of its scroll
@@ -16291,8 +16840,7 @@ mod autotest_generated {
     // ---- thread writeback drain ------------------------------------------
 
     /// Counts the writebacks that actually reached the main thread.
-    static DRAIN_DELIVERED: std::sync::atomic::AtomicUsize =
-        std::sync::atomic::AtomicUsize::new(0);
+    static DRAIN_DELIVERED: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
 
     struct DrainStep(usize);
 
@@ -16362,7 +16910,14 @@ mod autotest_generated {
         let mut retired = false;
         for _ in 0..200 {
             let (changes, _) = win.run_all_threads(
-                &mut data, &handle, &gl, style.clone(), &sc, &prev, &cur, &rr,
+                &mut data,
+                &handle,
+                &gl,
+                style.clone(),
+                &sc,
+                &prev,
+                &cur,
+                &rr,
             );
             for change in &changes {
                 if matches!(
@@ -16580,7 +17135,10 @@ mod autotest_generated {
     #[test]
     fn frame_damage_area_of_degenerate_rects_is_defined_not_panicking() {
         // Zero-size rect contributes nothing.
-        assert_eq!(FrameDamage::Rects(vec![rect(5.0, 5.0, 0.0, 0.0)]).area(1.0), 0.0);
+        assert_eq!(
+            FrameDamage::Rects(vec![rect(5.0, 5.0, 0.0, 0.0)]).area(1.0),
+            0.0
+        );
         // Negative extents produce a negative "area" rather than being clamped
         // — pinned so a future clamp is a deliberate change, not a silent one.
         assert_eq!(
@@ -16769,7 +17327,17 @@ mod autotest_generated {
             FrameDamage::Rects(vec![rect(136.9, 70.9, 0.2, 0.2)]),
             FrameDamage::Rects(vec![rect(0.0, 0.0, 1.0, 1.0); 40]),
         ];
-        let dpis = [0.0_f32, 0.5, 1.0, 2.0, 3.5, 1e9, f32::NAN, f32::INFINITY, -2.0];
+        let dpis = [
+            0.0_f32,
+            0.5,
+            1.0,
+            2.0,
+            3.5,
+            1e9,
+            f32::NAN,
+            f32::INFINITY,
+            -2.0,
+        ];
         for d in &damages {
             for dpi in dpis {
                 for force in [false, true] {
@@ -17145,12 +17713,7 @@ mod autotest_generated {
     #[test]
     fn scrollbar_opacity_stays_opaque_through_the_delay_window() {
         for elapsed in [0_u64, 1, 250, 499, 500] {
-            let v = opacity(
-                Some(tick(0)),
-                tick(elapsed),
-                tick_dur(500),
-                tick_dur(200),
-            );
+            let v = opacity(Some(tick(0)), tick(elapsed), tick_dur(500), tick_dur(200));
             assert_eq!(v, 1.0, "must stay opaque at elapsed={elapsed}");
         }
     }
@@ -17209,10 +17772,16 @@ mod autotest_generated {
 
         // Inside the delay it is still opaque: 30 frames is 500ms exactly, and
         // the delay check is `ratio < 1.0`.
-        assert_eq!(opacity(Some(tick(0)), tick(29), sys_dur_ms(500), sys_dur_ms(200)), 1.0);
+        assert_eq!(
+            opacity(Some(tick(0)), tick(29), sys_dur_ms(500), sys_dur_ms(200)),
+            1.0
+        );
         // Halfway through the fade: 500ms delay + 100ms = 36 frames.
         let v = opacity(Some(tick(0)), tick(36), sys_dur_ms(500), sys_dur_ms(200));
-        assert!((v - 0.5).abs() < 0.05, "expected ~0.5 halfway through the fade, got {v}");
+        assert!(
+            (v - 0.5).abs() < 0.05,
+            "expected ~0.5 halfway through the fade, got {v}"
+        );
     }
 
     #[test]
@@ -17267,13 +17836,21 @@ mod autotest_generated {
         let map = crate::managers::NodeIdMap::from_pairs([(NodeId::new(5), NodeId::new(9))]);
         // Node 7 survived nothing -> the drag must END, not retarget.
         assert_eq!(
-            remap_scrollbar_hit_id(ScrollbarHitId::VerticalThumb(dom, NodeId::new(7)), dom, &map),
+            remap_scrollbar_hit_id(
+                ScrollbarHitId::VerticalThumb(dom, NodeId::new(7)),
+                dom,
+                &map
+            ),
             None
         );
         // An empty map unmounts everything.
         let empty = crate::managers::NodeIdMap::from_pairs(Vec::<(NodeId, NodeId)>::new());
         assert_eq!(
-            remap_scrollbar_hit_id(ScrollbarHitId::VerticalThumb(dom, NodeId::new(5)), dom, &empty),
+            remap_scrollbar_hit_id(
+                ScrollbarHitId::VerticalThumb(dom, NodeId::new(5)),
+                dom,
+                &empty
+            ),
             None
         );
         // An absurd node id is a lookup miss, not a panic.
@@ -17311,7 +17888,11 @@ mod autotest_generated {
 
         let lr = LayoutResult::new(
             DisplayList::default(),
-            vec![String::new(), "a".repeat(10_000), "☃/🇺🇳/\u{202e}".to_string()],
+            vec![
+                String::new(),
+                "a".repeat(10_000),
+                "☃/🇺🇳/\u{202e}".to_string(),
+            ],
         );
         assert_eq!(lr.warnings.len(), 3);
         assert_eq!(lr.warnings[1].len(), 10_000);
@@ -17387,7 +17968,11 @@ mod autotest_generated {
     #[test]
     fn node_getters_return_none_on_an_empty_window_for_every_hostile_id() {
         let w = fresh_window();
-        for dom in [DomId::ROOT_ID, DomId { inner: 0 }, DomId { inner: usize::MAX }] {
+        for dom in [
+            DomId::ROOT_ID,
+            DomId { inner: 0 },
+            DomId { inner: usize::MAX },
+        ] {
             for node in hostile_node_ids() {
                 let id = DomNodeId { dom, node };
                 assert!(w.get_node_size(id).is_none(), "size {id:?}");
@@ -17447,7 +18032,9 @@ mod autotest_generated {
 
         // The root has no parent, but does have children.
         assert!(w.get_parent(root).is_none());
-        let first = w.get_first_child(root).expect("root must have a first child");
+        let first = w
+            .get_first_child(root)
+            .expect("root must have a first child");
         let last = w.get_last_child(root).expect("root must have a last child");
         assert_ne!(first, last);
         assert_eq!(w.get_parent(first), Some(root));
@@ -17456,7 +18043,11 @@ mod autotest_generated {
         // Walking forward from `first` reaches `last` in exactly 2 hops.
         let mid = w.get_next_sibling(first).expect("second child");
         assert_eq!(w.get_next_sibling(mid), Some(last));
-        assert_eq!(w.get_next_sibling(last), None, "last child has no successor");
+        assert_eq!(
+            w.get_next_sibling(last),
+            None,
+            "last child has no successor"
+        );
 
         // ...and the reverse walk is symmetric.
         assert_eq!(w.get_previous_sibling(last), Some(mid));
@@ -17479,7 +18070,10 @@ mod autotest_generated {
             let id = dnid(i);
             assert!(w.get_node_size(id).is_none(), "size for node {i}");
             assert!(w.get_node_position(id).is_none(), "position for node {i}");
-            assert!(w.get_node_hit_test_bounds(id).is_none(), "bounds for node {i}");
+            assert!(
+                w.get_node_hit_test_bounds(id).is_none(),
+                "bounds for node {i}"
+            );
         }
     }
 
@@ -17516,9 +18110,9 @@ mod autotest_generated {
     /// answer; the requirement is that it ANSWERS instead of aborting.
     #[test]
     fn a_node_id_that_outlived_its_dom_does_not_panic() {
-        let dom = StyledDom::create_from_dom(
-            Dom::create_body().with_child(Dom::create_text_do_not_use_without_block_level_wrapper("hi")),
-        );
+        let dom = StyledDom::create_from_dom(Dom::create_body().with_child(
+            Dom::create_text_do_not_use_without_block_level_wrapper("hi"),
+        ));
         let len = dom.styled_nodes.as_container().len();
 
         for stale in [len, len + 1, len + 6, len + 100, usize::MAX / 2] {
@@ -17547,8 +18141,9 @@ mod autotest_generated {
         }
 
         // body > text("hello") => 2 nodes.
-        let with_text =
-            StyledDom::create_from_dom(Dom::create_body().with_child(Dom::create_text_do_not_use_without_block_level_wrapper("hello")));
+        let with_text = StyledDom::create_from_dom(Dom::create_body().with_child(
+            Dom::create_text_do_not_use_without_block_level_wrapper("hello"),
+        ));
         assert_eq!(with_text.node_hierarchy.len(), 2);
         assert!(
             LayoutWindow::node_has_text_content(&with_text, NodeId::new(0)),
@@ -17561,9 +18156,18 @@ mod autotest_generated {
 
         // Empty and astral-plane text still count as text nodes.
         for s in ["", "🇺🇳👩‍👩‍👧‍👦", "\u{202e}\u{0}"] {
-            let d = StyledDom::create_from_dom(Dom::create_body().with_child(Dom::create_text_do_not_use_without_block_level_wrapper(s)));
-            assert!(LayoutWindow::node_has_text_content(&d, NodeId::new(1)), "{s:?}");
-            assert!(LayoutWindow::node_has_text_content(&d, NodeId::new(0)), "{s:?}");
+            let d = StyledDom::create_from_dom(
+                Dom::create_body()
+                    .with_child(Dom::create_text_do_not_use_without_block_level_wrapper(s)),
+            );
+            assert!(
+                LayoutWindow::node_has_text_content(&d, NodeId::new(1)),
+                "{s:?}"
+            );
+            assert!(
+                LayoutWindow::node_has_text_content(&d, NodeId::new(0)),
+                "{s:?}"
+            );
         }
     }
 
@@ -17603,8 +18207,11 @@ mod autotest_generated {
     fn contenteditable_is_detected_and_inherited() {
         let mut w = fresh_window();
         let dom = StyledDom::create_from_dom(
-            Dom::create_body()
-                .with_child(Dom::create_div().with_contenteditable(true).with_child(Dom::create_div())),
+            Dom::create_body().with_child(
+                Dom::create_div()
+                    .with_contenteditable(true)
+                    .with_child(Dom::create_div()),
+            ),
         );
         assert_eq!(dom.node_hierarchy.len(), 3);
         w.layout_results
@@ -17643,21 +18250,32 @@ mod autotest_generated {
         let w = window_for(StyledDom::create_from_dom(
             Dom::create_div()
                 .with_contenteditable(true)
-                .with_child(Dom::create_p().with_child(Dom::create_text_do_not_use_without_block_level_wrapper("hello"))),
+                .with_child(Dom::create_p().with_child(
+                    Dom::create_text_do_not_use_without_block_level_wrapper("hello"),
+                )),
         ));
-        assert_eq!(text_of(&w, 0), "hello", "a <p> wrapper must not hide the value");
+        assert_eq!(
+            text_of(&w, 0),
+            "hello",
+            "a <p> wrapper must not hide the value"
+        );
         assert_eq!(text_of(&w, 1), "hello", "and the <p> itself reads the same");
 
         // Inline wrappers count too — the buffer is the flattened inline content
         // of the subtree, not just its direct text children.
-        let w = window_for(StyledDom::create_from_dom(
-            Dom::create_div().with_child(
-                Dom::create_p()
-                    .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("a"))
-                    .with_child(Dom::create_em().with_child(Dom::create_text_do_not_use_without_block_level_wrapper("b")))
-                    .with_child(Dom::create_span().with_child(Dom::create_text_do_not_use_without_block_level_wrapper("c"))),
-            ),
-        ));
+        let w =
+            window_for(StyledDom::create_from_dom(
+                Dom::create_div().with_child(
+                    Dom::create_p()
+                        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("a"))
+                        .with_child(Dom::create_em().with_child(
+                            Dom::create_text_do_not_use_without_block_level_wrapper("b"),
+                        ))
+                        .with_child(Dom::create_span().with_child(
+                            Dom::create_text_do_not_use_without_block_level_wrapper("c"),
+                        )),
+                ),
+            ));
         assert_eq!(text_of(&w, 0), "abc");
     }
 
@@ -17667,8 +18285,12 @@ mod autotest_generated {
         // must not leak into an editable value.
         let w = window_for(StyledDom::create_from_dom(
             Dom::create_div()
-                .with_child(Dom::create_head().with_child(Dom::create_text_do_not_use_without_block_level_wrapper("metadata")))
-                .with_child(Dom::create_p().with_child(Dom::create_text_do_not_use_without_block_level_wrapper("body"))),
+                .with_child(Dom::create_head().with_child(
+                    Dom::create_text_do_not_use_without_block_level_wrapper("metadata"),
+                ))
+                .with_child(Dom::create_p().with_child(
+                    Dom::create_text_do_not_use_without_block_level_wrapper("body"),
+                )),
         ));
         assert_eq!(text_of(&w, 0), "body");
         assert_eq!(text_of(&w, 1), "", "a metadata container collects nothing");
@@ -17686,9 +18308,13 @@ mod autotest_generated {
                 .with_child(
                     Dom::create_p()
                         .with_attribute(AttributeType::ContentEditable(false))
-                        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper("Type here...")),
+                        .with_child(Dom::create_text_do_not_use_without_block_level_wrapper(
+                            "Type here...",
+                        )),
                 )
-                .with_child(Dom::create_p().with_child(Dom::create_text_do_not_use_without_block_level_wrapper("real value"))),
+                .with_child(Dom::create_p().with_child(
+                    Dom::create_text_do_not_use_without_block_level_wrapper("real value"),
+                )),
         ));
         assert_eq!(text_of(&w, 0), "real value");
         // The wall is about the parent's collection, not a global mute: asked
@@ -17704,13 +18330,22 @@ mod autotest_generated {
         // the placeholder, so `reshape_text_node` has to ask the caret first.
         let mut w = window_for(StyledDom::create_from_dom(
             Dom::create_div()
-                .with_child(Dom::create_p().with_child(Dom::create_text_do_not_use_without_block_level_wrapper("prompt")))
-                .with_child(Dom::create_p().with_child(Dom::create_text_do_not_use_without_block_level_wrapper("value"))),
+                .with_child(Dom::create_p().with_child(
+                    Dom::create_text_do_not_use_without_block_level_wrapper("prompt"),
+                ))
+                .with_child(Dom::create_p().with_child(
+                    Dom::create_text_do_not_use_without_block_level_wrapper("value"),
+                )),
         ));
 
         assert_eq!(
             w.ifc_candidate_children(DomId::ROOT_ID, NodeId::new(0)),
-            vec![NodeId::new(1), NodeId::new(3), NodeId::new(2), NodeId::new(4)],
+            vec![
+                NodeId::new(1),
+                NodeId::new(3),
+                NodeId::new(2),
+                NodeId::new(4)
+            ],
             "direct children in document order first, then deeper descendants"
         );
 
@@ -17728,7 +18363,12 @@ mod autotest_generated {
         ));
         assert_eq!(
             w.ifc_candidate_children(DomId::ROOT_ID, NodeId::new(0)),
-            vec![NodeId::new(3), NodeId::new(1), NodeId::new(2), NodeId::new(4)],
+            vec![
+                NodeId::new(3),
+                NodeId::new(1),
+                NodeId::new(2),
+                NodeId::new(4)
+            ],
             "the caret's block must be searched first"
         );
     }
@@ -17790,7 +18430,9 @@ mod autotest_generated {
     }
 
     extern "C" fn time_tick_1000() -> Instant {
-        Instant::Tick(azul_core::task::SystemTick { tick_counter: 1_000 })
+        Instant::Tick(azul_core::task::SystemTick {
+            tick_counter: 1_000,
+        })
     }
 
     extern "C" fn time_tick_max() -> Instant {
@@ -17808,7 +18450,10 @@ mod autotest_generated {
         let mut w = fresh_window();
         let id = TimerId { id: 1 };
         assert!(w.get_timer(&id).is_none());
-        assert!(w.remove_timer(&id).is_none(), "removing an absent timer is None");
+        assert!(
+            w.remove_timer(&id).is_none(),
+            "removing an absent timer is None"
+        );
 
         w.add_timer(id, Timer::default());
         assert!(w.get_timer(&id).is_some());
@@ -17843,7 +18488,10 @@ mod autotest_generated {
     #[test]
     fn tick_timers_reports_every_registered_timer_regardless_of_the_clock() {
         let mut w = fresh_window();
-        assert!(w.tick_timers(tick(0)).is_empty(), "no timers => nothing ready");
+        assert!(
+            w.tick_timers(tick(0)).is_empty(),
+            "no timers => nothing ready"
+        );
 
         for i in 0..3 {
             w.add_timer(TimerId { id: i }, Timer::default());
@@ -17953,7 +18601,10 @@ mod autotest_generated {
         // Landing exactly ON the threshold counts as its small side.
         assert!(breakpoints_crossed(&bp, 750.0, 720.0));
         assert!(!breakpoints_crossed(&bp, 720.0, 600.0));
-        assert!(!breakpoints_crossed(&[], 100.0, 9999.0), "no thresholds, no crossings");
+        assert!(
+            !breakpoints_crossed(&[], 100.0, 9999.0),
+            "no thresholds, no crossings"
+        );
     }
 
     #[test]
@@ -18243,7 +18894,9 @@ mod autotest_generated {
                 children_rect: rect(40.0, 40.0, 10.0, 10.0),
             },
         );
-        let got = w.get_scroll_position(DomId::ROOT_ID, node).expect("written");
+        let got = w
+            .get_scroll_position(DomId::ROOT_ID, node)
+            .expect("written");
         assert_eq!(got.children_rect.origin, pos(0.0, 0.0));
     }
 
@@ -18316,7 +18969,9 @@ mod autotest_generated {
             },
         );
         assert_eq!(w.get_dom_ids().len(), 2);
-        assert!(w.get_scroll_position(DomId::ROOT_ID, NodeId::new(0)).is_some());
+        assert!(w
+            .get_scroll_position(DomId::ROOT_ID, NodeId::new(0))
+            .is_some());
 
         w.clear_caches();
 
@@ -18328,7 +18983,8 @@ mod autotest_generated {
         assert!(w.layout_cache.cached_display_list.is_none());
         assert_eq!(w.layout_cache.prev_dom_ptr, 0);
         assert!(
-            w.get_scroll_position(DomId::ROOT_ID, NodeId::new(0)).is_none(),
+            w.get_scroll_position(DomId::ROOT_ID, NodeId::new(0))
+                .is_none(),
             "clear_caches replaces the ScrollManager"
         );
 
@@ -18352,7 +19008,10 @@ mod autotest_generated {
 
         assert!(w.get_or_create_gpu_cache(a).transform_keys.is_empty());
         assert!(w.get_gpu_cache(&a).is_some());
-        assert!(w.get_gpu_cache(&b).is_none(), "creation must not leak across DOMs");
+        assert!(
+            w.get_gpu_cache(&b).is_none(),
+            "creation must not leak across DOMs"
+        );
 
         // Re-creating returns the same (still empty) cache, not a second one.
         assert!(w.get_or_create_gpu_cache(a).transform_keys.is_empty());
@@ -18420,7 +19079,9 @@ mod autotest_generated {
         };
 
         let win = laid_out(host(true), 400.0, 300.0);
-        let size = win.get_node_size(dnid).expect("the editable div is laid out");
+        let size = win
+            .get_node_size(dnid)
+            .expect("the editable div is laid out");
         assert!(
             size.height > 8.0 && size.height < 48.0,
             "an empty editing host keeps ONE line of height (the strut), got {size:?}"
@@ -18428,12 +19089,23 @@ mod autotest_generated {
         let layout = win
             .get_inline_layout_for_node(DomId::ROOT_ID, inner)
             .expect("an empty editing host keeps an inline layout for its caret");
-        assert!(layout.items.is_empty(), "…with no items: the caret painter's strut branch");
+        assert!(
+            layout.items.is_empty(),
+            "…with no items: the caret painter's strut branch"
+        );
         // ...and with CONSTRAINTS, so the first keystroke has a line box to
         // be shaped into (`reshape_text_node` drops an edit whose IFC carries
         // none — which is how an empty TextInput ate its first character).
-        let lr = win.layout_results.get(&DomId::ROOT_ID).expect("layout result");
-        let idx = *lr.layout_tree.dom_to_layout.get(&inner).and_then(|v| v.first()).expect("mapped");
+        let lr = win
+            .layout_results
+            .get(&DomId::ROOT_ID)
+            .expect("layout result");
+        let idx = *lr
+            .layout_tree
+            .dom_to_layout
+            .get(&inner)
+            .and_then(|v| v.first())
+            .expect("mapped");
         let cached = lr
             .layout_tree
             .warm(idx)
@@ -18445,13 +19117,17 @@ mod autotest_generated {
         );
 
         let plain = laid_out(host(false), 400.0, 300.0);
-        let size = plain.get_node_size(dnid).expect("the plain div is laid out");
+        let size = plain
+            .get_node_size(dnid)
+            .expect("the plain div is laid out");
         assert!(
             size.height.abs() < 0.5,
             "a non-editable empty block still collapses to zero height, got {size:?}"
         );
         assert!(
-            plain.get_inline_layout_for_node(DomId::ROOT_ID, inner).is_none(),
+            plain
+                .get_inline_layout_for_node(DomId::ROOT_ID, inner)
+                .is_none(),
             "…and keeps no inline layout (an empty IFC renders nothing)"
         );
     }
@@ -18487,7 +19163,11 @@ mod autotest_generated {
             "b must start 50 + max(10, 20, 30, 5) = 80 below a, got {}",
             b_y - a_y
         );
-        assert!((e_y - a_y) >= 50.0 && (e_y - a_y) <= 80.5, "the empty block sits inside the seam: {}", e_y - a_y);
+        assert!(
+            (e_y - a_y) >= 50.0 && (e_y - a_y) <= 80.5,
+            "the empty block sits inside the seam: {}",
+            e_y - a_y
+        );
     }
 
     /// THE CLASS (AzWidgets 2026-08-21, "placeholder drawn low"): an EMPTY
@@ -18506,8 +19186,15 @@ mod autotest_generated {
         // body(0) > wrap(1) > e(2)
         let (wrap_y, wrap_h) = y_and_height(&win, 1);
         let (e_y, _) = y_and_height(&win, 2);
-        assert!((wrap_h - 21.0).abs() < 0.5, "padding 4 + ONE collapsed margin 13 + padding 4 = 21, got {wrap_h}");
-        assert!((e_y - wrap_y - 17.0).abs() < 0.5, "the empty block's border edges sit after its top margin: 4 + 13 = 17, got {}", e_y - wrap_y);
+        assert!(
+            (wrap_h - 21.0).abs() < 0.5,
+            "padding 4 + ONE collapsed margin 13 + padding 4 = 21, got {wrap_h}"
+        );
+        assert!(
+            (e_y - wrap_y - 17.0).abs() < 0.5,
+            "the empty block's border edges sit after its top margin: 4 + 13 = 17, got {}",
+            e_y - wrap_y
+        );
 
         // After a sibling, under the same padded parent: counted once too.
         let dom = Dom::create_body().with_child(
@@ -18518,7 +19205,10 @@ mod autotest_generated {
         );
         let win = laid_out(StyledDom::create_from_dom(dom), 400.0, 300.0);
         let (_, wrap_h) = y_and_height(&win, 1);
-        assert!((wrap_h - 31.0).abs() < 0.5, "4 + 10 + 13 + 4 = 31, got {wrap_h}");
+        assert!(
+            (wrap_h - 31.0).abs() < 0.5,
+            "4 + 10 + 13 + 4 = 31, got {wrap_h}"
+        );
 
         // And the parent's OWN top margin never leaks into its content box
         // through an empty first child (the "feet to meters" mix).
@@ -18529,7 +19219,10 @@ mod autotest_generated {
         );
         let win = laid_out(StyledDom::create_from_dom(dom), 400.0, 300.0);
         let (_, wrap_h) = y_and_height(&win, 1);
-        assert!((wrap_h - 21.0).abs() < 0.5, "the parent's margin is not added inside it: {wrap_h}");
+        assert!(
+            (wrap_h - 21.0).abs() < 0.5,
+            "the parent's margin is not added inside it: {wrap_h}"
+        );
     }
 
     #[test]
@@ -18551,7 +19244,9 @@ mod autotest_generated {
     fn get_node_bounds_is_none_for_missing_dom_and_missing_node() {
         let win = laid_out(fixture_dom(), 200.0, 150.0);
         // Missing DOM.
-        assert!(win.get_node_bounds(DomId { inner: 9 }, NodeId::new(0)).is_none());
+        assert!(win
+            .get_node_bounds(DomId { inner: 9 }, NodeId::new(0))
+            .is_none());
         // Out-of-range node in a real DOM.
         assert!(win
             .get_node_bounds(DomId::ROOT_ID, NodeId::new(9_999))
@@ -18583,7 +19278,8 @@ mod autotest_generated {
         let mut win = fresh_window();
         let sc = ExternalSystemCallbacks::rust_internal();
         assert!(
-            win.time_until_next_timer_ms(&sc.get_system_time_fn).is_none(),
+            win.time_until_next_timer_ms(&sc.get_system_time_fn)
+                .is_none(),
             "no timers => can block indefinitely"
         );
         assert!(
@@ -18780,7 +19476,12 @@ mod autotest_generated {
 
         // TextArea-shaped: border box at (10, 20), 200x100, padding 4, border 1.
         let border_box = BorderBoxRect(rect(10.0, 20.0, 200.0, 100.0));
-        let edge = |v: f32| EdgeSizes { top: v, right: v, bottom: v, left: v };
+        let edge = |v: f32| EdgeSizes {
+            top: v,
+            right: v,
+            bottom: v,
+            left: v,
+        };
         let scrollport = border_box.to_padding_box(&edge(1.0)).rect();
         assert_eq!(scrollport, rect(11.0, 21.0, 198.0, 98.0), "padding box");
         let content_box = border_box.to_content_box(&edge(4.0), &edge(1.0)).rect();
@@ -18789,8 +19490,10 @@ mod autotest_generated {
         // A caret 83px down the inline layout, 12px tall, at scroll 0. It is
         // painted at content_origin.y + 83 = 108 and ends at 120 — ONE PIXEL
         // past the scrollport's bottom edge (21 + 98 = 119). It is cut off.
-        let caret = LogicalRect::new(pos(content_box.origin.x, content_box.origin.y + 83.0),
-                                     size(1.0, 12.0));
+        let caret = LogicalRect::new(
+            pos(content_box.origin.x, content_box.origin.y + 83.0),
+            size(1.0, 12.0),
+        );
         let delta = calculate_instant_scroll_delta(caret, scrollport);
         assert!(
             delta.y > 0.0,
@@ -18818,7 +19521,12 @@ mod autotest_generated {
     fn the_scrollport_origin_and_size_come_off_one_box() {
         use crate::solver3::{display_list::BorderBoxRect, geometry::EdgeSizes};
 
-        let border = EdgeSizes { top: 1.0, right: 3.0, bottom: 1.0, left: 3.0 };
+        let border = EdgeSizes {
+            top: 1.0,
+            right: 3.0,
+            bottom: 1.0,
+            left: 3.0,
+        };
         let bb = BorderBoxRect(rect(100.0, 50.0, 200.0, 80.0));
         let port = bb.to_padding_box(&border).rect();
         assert_eq!(port.origin, pos(103.0, 51.0));
@@ -18898,9 +19606,18 @@ mod autotest_generated {
         let win = laid_out(fixture_dom(), 200.0, 150.0);
         // The fixture's divs have no padding and no border — which is exactly
         // why the WebRender/CPU divergence stayed latent in the widget set.
-        assert_eq!(win.content_inset_of(DomId::ROOT_ID, NodeId::new(1)), ContentInset::ZERO);
-        assert_eq!(win.content_inset_of(DomId::ROOT_ID, NodeId::new(9_999)), ContentInset::ZERO);
-        assert_eq!(win.content_inset_of(DomId { inner: 42 }, NodeId::new(0)), ContentInset::ZERO);
+        assert_eq!(
+            win.content_inset_of(DomId::ROOT_ID, NodeId::new(1)),
+            ContentInset::ZERO
+        );
+        assert_eq!(
+            win.content_inset_of(DomId::ROOT_ID, NodeId::new(9_999)),
+            ContentInset::ZERO
+        );
+        assert_eq!(
+            win.content_inset_of(DomId { inner: 42 }, NodeId::new(0)),
+            ContentInset::ZERO
+        );
     }
 
     #[test]
@@ -18935,13 +19652,19 @@ mod autotest_generated {
             },
         );
         assert!(!win.layout_results.is_empty());
-        assert!(win.get_scroll_position(DomId::ROOT_ID, NodeId::new(1)).is_some());
+        assert!(win
+            .get_scroll_position(DomId::ROOT_ID, NodeId::new(1))
+            .is_some());
 
         win.clear_caches();
 
-        assert!(win.layout_results.is_empty(), "layout results must be cleared");
         assert!(
-            win.get_scroll_position(DomId::ROOT_ID, NodeId::new(1)).is_none(),
+            win.layout_results.is_empty(),
+            "layout results must be cleared"
+        );
+        assert!(
+            win.get_scroll_position(DomId::ROOT_ID, NodeId::new(1))
+                .is_none(),
             "the ScrollManager must be reset"
         );
         assert!(win.layout_cache.tree.is_none());
@@ -18962,18 +19685,26 @@ mod autotest_generated {
         // (container > p > text). The old direct-children scan returned
         // None here, the caret then seeded on the block container (no
         // inline layout) and programmatic focus never painted a caret.
-        let dom = StyledDom::create_from_dom(Dom::create_body().with_child(
-            Dom::create_div()
-                .with_child(Dom::create_div().with_child(Dom::create_text_do_not_use_without_block_level_wrapper("first para")))
-                .with_child(Dom::create_div().with_child(Dom::create_text_do_not_use_without_block_level_wrapper("last para"))),
-        ));
+        let dom = StyledDom::create_from_dom(
+            Dom::create_body().with_child(
+                Dom::create_div()
+                    .with_child(Dom::create_div().with_child(
+                        Dom::create_text_do_not_use_without_block_level_wrapper("first para"),
+                    ))
+                    .with_child(Dom::create_div().with_child(
+                        Dom::create_text_do_not_use_without_block_level_wrapper("last para"),
+                    )),
+            ),
+        );
         let win = laid_out(dom, 400.0, 300.0);
         let container = NodeId::new(1); // body(0) > div(1)
         let found = win
             .find_last_text_child(DomId::ROOT_ID, container)
             .expect("subtree walk finds the nested text node");
         let lr = win.get_layout_result(&DomId::ROOT_ID).unwrap();
-        let ty = lr.styled_dom.node_data.as_container()[found].get_node_type().clone();
+        let ty = lr.styled_dom.node_data.as_container()[found]
+            .get_node_type()
+            .clone();
         assert!(
             matches!(ty, NodeType::Text(ref t) if t.as_str() == "last para"),
             "must be the LAST text node in document order, got {ty:?}"
@@ -18983,15 +19714,19 @@ mod autotest_generated {
     #[test]
     fn text_node_navigation_is_none_on_an_empty_window() {
         let win = fresh_window();
-        assert!(win.find_next_text_node(&DomId::ROOT_ID, NodeId::new(0)).is_none());
-        assert!(win.find_prev_text_node(&DomId::ROOT_ID, NodeId::new(0)).is_none());
+        assert!(win
+            .find_next_text_node(&DomId::ROOT_ID, NodeId::new(0))
+            .is_none());
+        assert!(win
+            .find_prev_text_node(&DomId::ROOT_ID, NodeId::new(0))
+            .is_none());
     }
 
     #[test]
     fn text_node_navigation_walks_a_real_dom_without_running_off_the_end() {
-        let dom = StyledDom::create_from_dom(
-            Dom::create_body().with_child(Dom::create_text_do_not_use_without_block_level_wrapper("hello world")),
-        );
+        let dom = StyledDom::create_from_dom(Dom::create_body().with_child(
+            Dom::create_text_do_not_use_without_block_level_wrapper("hello world"),
+        ));
         let win = laid_out(dom, 200.0, 150.0);
         let node_count = win
             .get_layout_result(&DomId::ROOT_ID)
@@ -19007,7 +19742,8 @@ mod autotest_generated {
         );
         // Searching backward from node 0 must terminate at None too.
         assert!(
-            win.find_prev_text_node(&DomId::ROOT_ID, NodeId::new(0)).is_none(),
+            win.find_prev_text_node(&DomId::ROOT_ID, NodeId::new(0))
+                .is_none(),
             "no node exists before the first one"
         );
     }
@@ -19046,7 +19782,9 @@ fn alloc_format_merge(first_kept: &str, last_kept: &str) -> String {
 /// Scale is applied about the node's own origin and then translated, matching
 /// what the FLIP maths produced: `first` and `last` are both top-left rects, so
 /// the offset is already expressed from the same corner the scale grows from.
-const fn flip_to_matrix(t: azul_core::animation::FlipTransform) -> azul_core::transform::ComputedTransform3D {
+const fn flip_to_matrix(
+    t: azul_core::animation::FlipTransform,
+) -> azul_core::transform::ComputedTransform3D {
     azul_core::transform::ComputedTransform3D {
         m: [
             [t.scale_x, 0.0, 0.0, 0.0],
@@ -19267,10 +20005,11 @@ impl Zombie {
     /// there is ONE clock, and the drop happens at t=1 exactly.
     #[must_use]
     pub fn is_done(&self, animations: &azul_core::animation::AnimationManager) -> bool {
-        self.exits
-            .values()
-            .all(|k| animations.get(*k).is_none_or(azul_core::animation::ActiveAnim::is_finished))
-            && self.tracks.values().all(AnimTrack::is_done)
+        self.exits.values().all(|k| {
+            animations
+                .get(*k)
+                .is_none_or(azul_core::animation::ActiveAnim::is_finished)
+        }) && self.tracks.values().all(AnimTrack::is_done)
     }
 }
 
@@ -19400,7 +20139,11 @@ impl AnimTrack {
     }
 
     /// Piecewise sample of one channel at eased-per-segment `t`.
-    fn sample_channel(stops: &[(f32, f32)], t: f32, timing: azul_css::props::basic::animation::AnimationTiming) -> Option<f32> {
+    fn sample_channel(
+        stops: &[(f32, f32)],
+        t: f32,
+        timing: azul_css::props::basic::animation::AnimationTiming,
+    ) -> Option<f32> {
         let first = stops.first()?;
         if t <= first.0 {
             return Some(first.1);
@@ -19415,7 +20158,9 @@ impl AnimTrack {
             if t >= t0 && t <= t1 {
                 let span = (t1 - t0).max(f32::EPSILON);
                 // CSS semantics: the timing function eases each SEGMENT.
-                let local = timing.to_interpolation().evaluate(f64::from((t - t0) / span));
+                let local = timing
+                    .to_interpolation()
+                    .evaluate(f64::from((t - t0) / span));
                 return Some(v0 + (v1 - v0) * local);
             }
         }
@@ -19462,7 +20207,6 @@ impl AnimTrack {
         with_start(&mut self.rotate_deg, s.rotate_deg, 0.0, 0.0);
         with_start(&mut self.opacity, s.opacity, 1.0, 1.0);
     }
-
 }
 
 /// Compile a parsed `@keyframes` block into an [`AnimTrack`], resolving
@@ -19502,7 +20246,9 @@ pub fn compile_keyframes_track(
         for prop in stop.props.as_ref() {
             match prop {
                 CssProperty::Transform(v) => {
-                    let Some(transforms) = v.get_property() else { continue };
+                    let Some(transforms) = v.get_property() else {
+                        continue;
+                    };
                     let (mut tx, mut ty) = (0.0f32, 0.0f32);
                     let (mut sx, mut sy) = (1.0f32, 1.0f32);
                     let mut rot = 0.0f32;
@@ -19651,7 +20397,12 @@ pub fn resolve_named_track(
     // Reverse: the LAST `@keyframes` definition of a name wins (CSS rule).
     for kf in retained_css.keyframes.as_ref().iter().rev() {
         if kf.name.as_str() == anim.name.as_str() {
-            return Some(finish(compile_keyframes_track(kf, rect, duration_s, anim.timing)));
+            return Some(finish(compile_keyframes_track(
+                kf,
+                rect,
+                duration_s,
+                anim.timing,
+            )));
         }
     }
     for f in node_data.animation_callbacks() {
@@ -19791,12 +20542,16 @@ impl LayoutWindow {
             let snapshot: &AzulPixmap = match zombie.snapshot.get() {
                 Some((bits, px)) if *bits == dpi_bits => px,
                 Some(_) => {
-                    let Some(px) = render_retained() else { continue };
+                    let Some(px) = render_retained() else {
+                        continue;
+                    };
                     fresh = px;
                     &fresh
                 }
                 None => {
-                    let Some(px) = render_retained() else { continue };
+                    let Some(px) = render_retained() else {
+                        continue;
+                    };
                     drop(zombie.snapshot.set((dpi_bits, px)));
                     match zombie.snapshot.get() {
                         Some((_, px)) => px,
@@ -19910,8 +20665,16 @@ impl LayoutWindow {
                 if let Some(h) = job.height_cut {
                     sh = sh.min((h * dpi_factor).ceil().max(0.0) as u32);
                 }
-                let cut_off = if job.translate_x < 0.0 { full_sw - sw } else { 0 };
-                let cut_off_y = if job.translate_y < 0.0 { full_sh - sh } else { 0 };
+                let cut_off = if job.translate_x < 0.0 {
+                    full_sw - sw
+                } else {
+                    0
+                };
+                let cut_off_y = if job.translate_y < 0.0 {
+                    full_sh - sh
+                } else {
+                    0
+                };
                 if sw == 0 || sh == 0 {
                     continue;
                 }
@@ -19937,9 +20700,8 @@ impl LayoutWindow {
                 let (cx, cy) = (f64::from(sw) / 2.0, f64::from(sh) / 2.0);
                 let (sin, cos) = f64::from(job.rotate_deg).to_radians().sin_cos();
                 let (jsx, jsy) = (f64::from(job.scale_x), f64::from(job.scale_y));
-                let mut m = agg_rust::trans_affine::TransAffine::new_custom(
-                    1.0, 0.0, 0.0, 1.0, -cx, -cy,
-                );
+                let mut m =
+                    agg_rust::trans_affine::TransAffine::new_custom(1.0, 0.0, 0.0, 1.0, -cx, -cy);
                 m.multiply(&agg_rust::trans_affine::TransAffine::new_custom(
                     jsx * cos,
                     jsx * sin,
@@ -20017,7 +20779,9 @@ impl LayoutWindow {
                 ));
             }
             for (node, tr) in &z.tracks {
-                let Some(frozen) = z.rects.get(node) else { continue };
+                let Some(frozen) = z.rects.get(node) else {
+                    continue;
+                };
                 let rect = z.live_rects.get(node).unwrap_or(frozen);
                 let s = z
                     .tick_samples
@@ -20052,8 +20816,7 @@ impl LayoutWindow {
                     let x0 = r.origin.x.max(frozen.origin.x);
                     let y0 = r.origin.y.max(frozen.origin.y);
                     let x1 = (r.origin.x + r.size.width).min(frozen.origin.x + frozen.size.width);
-                    let y1 =
-                        (r.origin.y + r.size.height).min(frozen.origin.y + frozen.size.height);
+                    let y1 = (r.origin.y + r.size.height).min(frozen.origin.y + frozen.size.height);
                     if x1 <= x0 || y1 <= y0 {
                         continue;
                     }
@@ -20081,35 +20844,53 @@ mod zombie_tests {
         let mut m = AnimationManager::new();
         let fast = AnimKey(1);
         let slow = AnimKey(2);
-        m.start_exit(fast, (-50.0, 0.0), Interp::Curve {
-            function: azul_css::props::basic::animation::AnimationInterpolationFunction::Linear,
-            duration_secs: 0.01,
-        });
-        m.start_exit(slow, (-50.0, 0.0), Interp::Curve {
-            function: azul_css::props::basic::animation::AnimationInterpolationFunction::Linear,
-            duration_secs: 10.0,
-        });
+        m.start_exit(
+            fast,
+            (-50.0, 0.0),
+            Interp::Curve {
+                function: azul_css::props::basic::animation::AnimationInterpolationFunction::Linear,
+                duration_secs: 0.01,
+            },
+        );
+        m.start_exit(
+            slow,
+            (-50.0, 0.0),
+            Interp::Curve {
+                function: azul_css::props::basic::animation::AnimationInterpolationFunction::Linear,
+                duration_secs: 10.0,
+            },
+        );
 
-        let exits: alloc::collections::BTreeMap<_, _> =
-            [(azul_core::dom::NodeId::new(0), fast), (azul_core::dom::NodeId::new(1), slow)]
-                .into_iter()
-                .collect();
+        let exits: alloc::collections::BTreeMap<_, _> = [
+            (azul_core::dom::NodeId::new(0), fast),
+            (azul_core::dom::NodeId::new(1), slow),
+        ]
+        .into_iter()
+        .collect();
 
         // Advance past the fast one but nowhere near the slow one.
         m.tick(0.05);
-        assert!(m.get(fast).is_none_or(|a| a.is_finished()), "fast exit should be done");
-        let all_done = exits
-            .values()
-            .all(|k| m.get(*k).is_none_or(azul_core::animation::ActiveAnim::is_finished));
-        assert!(!all_done, "the zombie must NOT be reaped while one exit is mid-flight");
+        assert!(
+            m.get(fast).is_none_or(|a| a.is_finished()),
+            "fast exit should be done"
+        );
+        let all_done = exits.values().all(|k| {
+            m.get(*k)
+                .is_none_or(azul_core::animation::ActiveAnim::is_finished)
+        });
+        assert!(
+            !all_done,
+            "the zombie must NOT be reaped while one exit is mid-flight"
+        );
 
         // Run the slow one out too.
         for _ in 0..400 {
             m.tick(0.05);
         }
-        let all_done = exits
-            .values()
-            .all(|k| m.get(*k).is_none_or(azul_core::animation::ActiveAnim::is_finished));
+        let all_done = exits.values().all(|k| {
+            m.get(*k)
+                .is_none_or(azul_core::animation::ActiveAnim::is_finished)
+        });
         assert!(all_done, "every exit settled, so the zombie is reapable");
     }
 
@@ -20133,7 +20914,11 @@ mod zombie_tests {
         m.start_exit(key, (-50.0, 0.0), Interp::Spring(Spring::SMOOTH));
         let anim = m.get(key).expect("still animating");
         assert_eq!(anim.class, azul_core::animation::AnimClass::Exit);
-        assert_eq!(m.len(), 1, "an exit replaces, it does not stack a second animation");
+        assert_eq!(
+            m.len(),
+            1,
+            "an exit replaces, it does not stack a second animation"
+        );
     }
 }
 
@@ -20194,7 +20979,6 @@ mod reconciliation_tests {
         );
     }
 }
-
 
 /// The tween progress ratio is a ratio of two CLOCK durations, not of two
 /// millisecond integers.
@@ -20310,11 +21094,13 @@ mod tween_clock_unit_tests {
     }
 
     fn editable_paragraph(text: &str) -> Dom {
-        let mut editor = Dom::create_div()
-            .with_ids_and_classes(vec![IdOrClass::Class("p".into())].into());
+        let mut editor =
+            Dom::create_div().with_ids_and_classes(vec![IdOrClass::Class("p".into())].into());
         editor.set_contenteditable(true);
         editor.set_tab_index(TabIndex::Auto);
-        editor.with_child(Dom::create_text_do_not_use_without_block_level_wrapper(text))
+        editor.with_child(Dom::create_text_do_not_use_without_block_level_wrapper(
+            text,
+        ))
     }
 
     /// `body(0) > div[contenteditable](1) > text(2)`, laid out, with an editing

--- a/layout/src/window.rs
+++ b/layout/src/window.rs
@@ -7360,8 +7360,21 @@ impl LayoutWindow {
             focus_node.node.into_crate_internal().and_then(|node_id| {
                 // Check if this node or any ancestor is contenteditable
                 if self.is_node_contenteditable_inherited_internal(focus_node.dom, node_id) {
-                    // Find the text node where the cursor should be placed
-                    let text_node_id = self.find_last_text_child(focus_node.dom, node_id)
+                    // Find the text node where the cursor should be placed.
+                    //
+                    // An editing host with NO text anywhere under it — a brand
+                    // new document, whose whole content is one empty `<p>` —
+                    // has no text node to name, and falling back to the host
+                    // itself seeds the caret on a block that has no inline
+                    // layout, so it can never be painted or typed into (the
+                    // 2026-08-11 failure `find_last_text_child`'s subtree walk
+                    // was written for, in its remaining form). Anchor on the
+                    // host's last EMPTY EDITABLE LINE instead: `layout_ifc`
+                    // gives that one the editing-host strut, which is exactly
+                    // a line a caret can stand on.
+                    let text_node_id = self
+                        .find_last_text_child(focus_node.dom, node_id)
+                        .or_else(|| self.find_last_empty_editable_line(focus_node.dom, node_id))
                         .unwrap_or(node_id);
                     Some((focus_node.dom, node_id, text_node_id))
                 } else {
@@ -11977,6 +11990,42 @@ impl LayoutWindow {
             }
         }
         last_text
+    }
+
+    /// The last descendant of `parent_node_id` that is an IFC root with NO
+    /// clusters — an empty editable line.
+    ///
+    /// The companion of [`Self::find_last_text_child`] for an editing host that
+    /// has no text at all. Such a host still has line boxes: `layout_ifc` keeps
+    /// the editing-host strut for every empty editable IFC root, and that strut
+    /// is what `paint_cursor` draws the caret on. Naming the strut's node here
+    /// is what makes focusing a blank document produce a VISIBLE caret instead
+    /// of an editing session anchored on a block with no inline layout.
+    fn find_last_empty_editable_line(
+        &self,
+        dom_id: DomId,
+        parent_node_id: NodeId,
+    ) -> Option<NodeId> {
+        let layout_result = self.layout_results.get(&dom_id)?;
+        let hierarchy = layout_result.styled_dom.node_hierarchy.as_container();
+
+        let mut found: Option<NodeId> = None;
+        let mut stack = vec![parent_node_id];
+        while let Some(n) = stack.pop() {
+            if self.get_inline_layout_for_node(dom_id, n).is_some() {
+                found = Some(n);
+            }
+            let mut children = Vec::new();
+            let mut child = hierarchy[n].first_child_id(n);
+            while let Some(c) = child {
+                children.push(c);
+                child = hierarchy[c].next_sibling_id();
+            }
+            for c in children.into_iter().rev() {
+                stack.push(c);
+            }
+        }
+        found
     }
 
     /// Checks if a node has text content.

--- a/layout/tests/all.rs
+++ b/layout/tests/all.rs
@@ -156,6 +156,8 @@ mod caret_reveal_and_session_identity;
 mod caret_scroll_glide;
 #[path = "caret_tween.rs"]
 mod caret_tween;
+#[path = "click_into_a_virtual_view_page.rs"]
+mod click_into_a_virtual_view_page;
 #[path = "cpurender_image_probe.rs"]
 mod cpurender_image_probe;
 #[path = "cross_block_selection.rs"]

--- a/layout/tests/click_into_a_virtual_view_page.rs
+++ b/layout/tests/click_into_a_virtual_view_page.rs
@@ -1,0 +1,380 @@
+//! Clicking a page inside a `VirtualView` must place the caret under the
+//! pointer — AzWriter's document canvas, reduced to its load-bearing shape.
+//!
+//! AzWriter (`examples/azul-writer`) paints its document as a stack of A4
+//! sheets inside a `VirtualView`: only a window of pages is materialised, into
+//! a NESTED dom the engine composites at
+//! `host.bounds.origin + (materialized_origin - scroll_offset)`. Each sheet
+//! holds one `contenteditable` content root with the page's blocks under it.
+//!
+//! Three things have to hold for a click to become a caret, and each one was
+//! broken:
+//!
+//! 1. the hit test must find the nested dom's nodes — it clipped the child to
+//!    a viewport that MOVED with the scrolled content, so past the first
+//!    screenful nothing in the page was hittable at all;
+//! 2. an EMPTY editable line must accept a caret — `hittest_cursor` answers
+//!    `None` for a layout with no clusters, which is exactly the editing-host
+//!    strut a blank document is made of, so a new document could not be
+//!    clicked into;
+//! 3. focusing an empty editing host must anchor the caret on a line that can
+//!    be painted, not on the host block itself.
+//!
+//! The DOM here is built with `StyledDom::create_from_dom`, the same entry the
+//! shell uses — `create(dom, Css::empty())` skips the per-subtree inline-CSS
+//! scoping and the page canvas never resolves its flex size.
+
+use azul_core::callbacks::{VirtualViewCallback, VirtualViewCallbackInfo, VirtualViewReturn};
+use azul_core::dom::{Dom, DomId, NodeId, NodeType, OptionDom};
+use azul_core::geom::{LogicalPosition, LogicalRect, LogicalSize};
+use azul_core::refany::RefAny;
+use azul_core::resources::RendererResources;
+use azul_core::styled_dom::StyledDom;
+use azul_layout::headless::CpuHitTester;
+use azul_layout::managers::hover::InputPointId;
+use azul_layout::{
+    callbacks::ExternalSystemCallbacks, window::LayoutWindow, window_state::FullWindowState,
+};
+use rust_fontconfig::FcFontCache;
+use std::sync::{Arc, Mutex};
+
+/// A4 at 96 dpi with 1 inch margins — `document::a4_page_setup()`.
+const PAGE_W: f32 = 794.0;
+const PAGE_H: f32 = 1123.0;
+const PAGE_PAD: f32 = 96.0;
+/// One sheet plus its bottom margin — `editor_ui::page_stride`.
+const STRIDE: f32 = PAGE_H + 16.0;
+const TOTAL_PAGES: usize = 12;
+
+const WIN_W: f32 = 1400.0;
+const WIN_H: f32 = 900.0;
+/// Height of the fake title band + ribbon above the canvas.
+const CHROME_H: f32 = 150.0;
+
+/// What the document holds: `None` = the blank "Document1" (one implicit empty
+/// paragraph, exactly what `markdown_to_content_dom("")` produces).
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Doc {
+    Blank,
+    Paragraphs,
+}
+
+struct Probe {
+    doc: Doc,
+    /// The window the callback last materialised, and the offset it saw.
+    first: usize,
+    count: usize,
+    scroll_y: f32,
+}
+
+type Shared = Arc<Mutex<Probe>>;
+
+/// One page sheet: the white A4 box, with the page's `contenteditable`
+/// content root inside its margin box.
+fn page_dom(doc: Doc, page_idx: usize) -> Dom {
+    let sheet_css = format!(
+        "width: {}px; height: {}px; background: white; flex-grow: 0; flex-shrink: 0; \
+         border: 1px solid #a6a6a6; margin-bottom: 16px; box-sizing: border-box; \
+         padding: {}px; overflow: hidden;",
+        PAGE_W as isize, PAGE_H as isize, PAGE_PAD as isize,
+    );
+    // The `contenteditable` flag lives on the content ROOT, and the blocks are
+    // its children — `document::unwrap_html_shell` builds exactly this shape.
+    let mut content = Dom::create_div().with_css("display: block;");
+    content.set_contenteditable(true);
+    let content = match doc {
+        // The implicit empty paragraph a blank document still gets.
+        Doc::Blank => content.with_child(Dom::create_p()),
+        Doc::Paragraphs => content.with_child(Dom::create_p_with_text(format!(
+            "Paragraph {page_idx} of the document, long enough to click into."
+        ))),
+    };
+    Dom::create_div().with_css(&sheet_css).with_child(content)
+}
+
+/// `editor_ui::pages_virtual_view`, structurally verbatim.
+extern "C" fn pages_view(mut data: RefAny, info: VirtualViewCallbackInfo) -> VirtualViewReturn {
+    let probe = data.downcast_ref::<Shared>().expect("probe").clone();
+    let mut probe = probe.lock().unwrap();
+
+    let viewport_h = info.bounds.get_logical_size().height;
+    let first_visible = (info.scroll_offset.y.max(0.0) / STRIDE) as usize;
+    let first = first_visible.saturating_sub(1);
+    let visible = (viewport_h / STRIDE).ceil() as usize + 2;
+    let count = visible.max(3).min(TOTAL_PAGES.saturating_sub(first));
+    probe.first = first;
+    probe.count = count;
+    probe.scroll_y = info.scroll_offset.y;
+
+    let mut col =
+        Dom::create_div().with_css("display: flex; flex-direction: column; align-items: center;");
+    for page_idx in first..(first + count) {
+        col.add_child(page_dom(probe.doc, page_idx));
+    }
+
+    VirtualViewReturn {
+        dom: OptionDom::Some(col),
+        materialized: LogicalRect::new(
+            LogicalPosition::new(0.0, first as f32 * STRIDE),
+            LogicalSize::new(PAGE_W + 2.0, count as f32 * STRIDE),
+        ),
+        virtual_rect: LogicalRect::new(
+            LogicalPosition::zero(),
+            LogicalSize::new(PAGE_W + 2.0, TOTAL_PAGES as f32 * STRIDE),
+        ),
+    }
+}
+
+struct Harness {
+    lw: LayoutWindow,
+    probe: Shared,
+}
+
+impl Harness {
+    fn new(doc: Doc) -> Self {
+        let probe: Shared = Arc::new(Mutex::new(Probe {
+            doc,
+            first: 0,
+            count: 0,
+            scroll_y: 0.0,
+        }));
+        let mut lw = LayoutWindow::new(FcFontCache::build()).unwrap();
+        let mut window_state = FullWindowState::default();
+        window_state.size.dimensions = LogicalSize::new(WIN_W, WIN_H);
+        lw.current_window_state = window_state;
+        let mut h = Self { lw, probe };
+        h.relayout();
+        h
+    }
+
+    fn relayout(&mut self) {
+        let canvas = Dom::create_div()
+            .with_css(
+                "flex-grow: 1; min-height: 0px; background: #e3e3e3; display: flex; \
+                 flex-direction: column; align-items: center; padding-top: 18px; \
+                 overflow: hidden;",
+            )
+            .with_child(
+                Dom::create_virtual_view(
+                    RefAny::new(self.probe.clone()),
+                    VirtualViewCallback::create(pages_view),
+                )
+                .with_css("flex-grow: 1; min-height: 0px; width: 100%;"),
+            );
+        let dom = Dom::create_body()
+            .with_css(
+                "display: flex; flex-direction: column; margin: 0; padding: 0; height: 100%; \
+                 background: white; font-size: 15px;",
+            )
+            .with_child(
+                Dom::create_div()
+                    .with_css(
+                        "display: flex; flex-direction: column; flex-grow: 1; min-height: 0px;",
+                    )
+                    .with_child(
+                        Dom::create_div()
+                            .with_css(&format!("height: {}px; flex-grow: 0;", CHROME_H as isize)),
+                    )
+                    .with_child(canvas)
+                    .with_child(Dom::create_div().with_css("height: 24px; flex-grow: 0;")),
+            );
+        let styled_dom = StyledDom::create_from_dom(dom);
+        let window_state = self.lw.current_window_state.clone();
+        let renderer_resources = RendererResources::default();
+        let system_callbacks = ExternalSystemCallbacks::rust_internal();
+        let mut debug_messages = Some(Vec::new());
+        self.lw
+            .layout_and_generate_display_list(
+                styled_dom,
+                &window_state,
+                &renderer_resources,
+                &system_callbacks,
+                &mut debug_messages,
+            )
+            .unwrap();
+    }
+
+    /// The pages `VirtualView` host node and the nested dom it mounted.
+    fn virtual_view(&self) -> (DomId, NodeId) {
+        let lr = self
+            .lw
+            .get_layout_result(&DomId::ROOT_ID)
+            .expect("root layout");
+        let n = lr.styled_dom.node_data.as_container().len();
+        (0..n)
+            .map(NodeId::new)
+            .find_map(|node| {
+                self.lw
+                    .virtual_view_manager
+                    .get_nested_dom_id(DomId::ROOT_ID, node)
+                    .map(|child| (child, node))
+            })
+            .expect("the canvas mounted a VirtualView")
+    }
+
+    /// The shells' `perform_hit_test` + `update_hit_test_at`, CPU arm, then
+    /// the click-to-caret entry point they call on mouse-down.
+    fn click_at(&mut self, position: LogicalPosition) {
+        let mut tester = CpuHitTester::new();
+        tester.rebuild_from_layout_with_gpu(
+            &self.lw.layout_results,
+            Some(&self.lw.gpu_state_manager),
+        );
+        let focused = self.lw.focus_manager.get_focused_node().copied();
+        let hit = {
+            let scroll_manager = &self.lw.scroll_manager;
+            let gpu = &self.lw.gpu_state_manager;
+            let resolve = |d: DomId, n: NodeId| scroll_manager.get_current_offset(d, n);
+            let resolve_tf = |d: DomId, n: NodeId| {
+                gpu.caches
+                    .get(&d)
+                    .and_then(|c| c.css_current_transform_values.get(&n))
+                    .copied()
+            };
+            let hits = tester.hit_test_scrolled(position, &resolve, &resolve_tf);
+            azul_layout::headless::convert_cpu_hit_test_to_full(
+                &tester,
+                &hits,
+                focused,
+                &self.lw.layout_results,
+                position,
+                &resolve,
+                &resolve_tf,
+            )
+        };
+        self.lw.hover_manager.push_hit_test(InputPointId::Mouse, hit);
+        self.lw.process_mouse_click_for_selection(position, 0);
+    }
+
+    /// Window-space rect of a node in a (possibly nested) dom, where the
+    /// rasteriser puts it.
+    fn window_rect(&self, dom: DomId, node: NodeId) -> Option<(LogicalPosition, LogicalSize)> {
+        let lr = self.lw.get_layout_result(&dom)?;
+        let idx = *lr.layout_tree.dom_to_layout.get(&node)?.first()?;
+        let pos = lr.calculated_positions.get(idx.index()).copied()?;
+        let size = lr.layout_tree.nodes.get(idx.index())?.used_size?;
+        let lift = self.lw.window_space_offset_of_dom(dom);
+        Some((LogicalPosition::new(pos.x + lift.x, pos.y + lift.y), size))
+    }
+
+    /// The first block in `dom` that is a `contenteditable` host, and the
+    /// first `<p>` under it.
+    fn first_editable_line(&self, dom: DomId) -> NodeId {
+        let lr = self.lw.get_layout_result(&dom).expect("nested layout");
+        let nd = lr.styled_dom.node_data.as_container();
+        (0..nd.len())
+            .map(NodeId::new)
+            .find(|id| matches!(nd[*id].get_node_type(), NodeType::P))
+            .expect("a materialised page has a paragraph")
+    }
+}
+
+/// A loaded document: clicking a quarter of the way into the first
+/// paragraph's line must place the caret in that paragraph.
+#[test]
+fn clicking_a_paragraph_on_a_materialised_page_places_the_caret_in_it() {
+    let mut h = Harness::new(Doc::Paragraphs);
+    let (nested, _vv) = h.virtual_view();
+    let para = h.first_editable_line(nested);
+    let (origin, size) = h.window_rect(nested, para).expect("the paragraph has a box");
+
+    let target = LogicalPosition::new(origin.x + size.width * 0.25, origin.y + size.height * 0.5);
+    h.click_at(target);
+
+    let session = h
+        .lw
+        .text_edit_manager
+        .multi_cursor
+        .as_ref()
+        .map(|mc| mc.node_id);
+    assert!(
+        session.is_some(),
+        "clicking the text of a page sheet placed no caret at all \
+         (click {target:?}, paragraph {origin:?} {size:?})"
+    );
+    assert_eq!(
+        session.unwrap().dom,
+        nested,
+        "the caret session must live in the VirtualView's nested dom"
+    );
+}
+
+/// A NEW document: the page is the implicit empty paragraph. Clicking that
+/// line must still place a caret, or the document cannot be typed into.
+///
+/// The editing-host strut exists precisely so an empty editable keeps ONE line
+/// box for a caret to stand on; `hittest_cursor` returning `None` for a layout
+/// with no clusters made that line unclickable.
+#[test]
+fn clicking_the_empty_line_of_a_blank_document_places_a_caret() {
+    let mut h = Harness::new(Doc::Blank);
+    let (nested, _vv) = h.virtual_view();
+    let line = h.first_editable_line(nested);
+    let (origin, size) = h
+        .window_rect(nested, line)
+        .expect("the empty paragraph keeps a strut line box");
+    assert!(
+        size.height > 0.0,
+        "the editing-host strut must give the empty paragraph a line box"
+    );
+
+    let target = LogicalPosition::new(origin.x + 20.0, origin.y + size.height * 0.5);
+    h.click_at(target);
+
+    assert!(
+        h.lw.text_edit_manager.has_active_editing(),
+        "clicking the blank page's empty line placed no caret, so typing goes \
+         nowhere (click {target:?}, line {origin:?} {size:?})"
+    );
+}
+
+/// Scrolled deep into the document the materialised window no longer starts at
+/// row 0, so `content_offset` is a large negative number. The child's VIEWPORT
+/// does not move with it: the pointer is still over the canvas, and a click
+/// must still reach the page under it.
+#[test]
+fn clicking_a_page_after_scrolling_past_the_first_screenful_still_places_a_caret() {
+    let mut h = Harness::new(Doc::Paragraphs);
+    let (_nested, vv) = h.virtual_view();
+    h.lw.scroll_manager.set_scroll_position(
+        DomId::ROOT_ID,
+        vv,
+        LogicalPosition::new(0.0, 3.0 * STRIDE),
+        azul_core::task::Instant::from(std::time::Instant::now()),
+    );
+    h.relayout();
+    let content_offset = h.lw.virtual_view_content_offset(DomId::ROOT_ID, vv);
+    assert!(
+        content_offset.y < -1.0,
+        "the scenario needs a non-zero content offset to prove anything, got \
+         {content_offset:?}"
+    );
+
+    let (nested, _) = h.virtual_view();
+    // Every paragraph of the materialised window; click the first one whose
+    // line is actually inside the canvas viewport.
+    let lr = h.lw.get_layout_result(&nested).expect("nested layout");
+    let nd = lr.styled_dom.node_data.as_container();
+    let paras: Vec<NodeId> = (0..nd.len())
+        .map(NodeId::new)
+        .filter(|id| matches!(nd[*id].get_node_type(), NodeType::P))
+        .collect();
+    drop(lr);
+    let visible = paras
+        .into_iter()
+        .filter_map(|p| h.window_rect(nested, p).map(|r| (p, r)))
+        .find(|(_, (origin, size))| {
+            origin.y >= CHROME_H && origin.y + size.height <= WIN_H - 24.0
+        })
+        .expect("at least one materialised paragraph is inside the canvas viewport");
+    let (_, (origin, size)) = visible;
+
+    let target = LogicalPosition::new(origin.x + size.width * 0.25, origin.y + size.height * 0.5);
+    h.click_at(target);
+
+    assert!(
+        h.lw.text_edit_manager.has_active_editing(),
+        "after scrolling, a click on a visible page paragraph placed no caret \
+         (click {target:?}, paragraph {origin:?} {size:?}, content_offset {content_offset:?})"
+    );
+}

--- a/layout/tests/click_into_a_virtual_view_page.rs
+++ b/layout/tests/click_into_a_virtual_view_page.rs
@@ -248,7 +248,9 @@ impl Harness {
                 &resolve_tf,
             )
         };
-        self.lw.hover_manager.push_hit_test(InputPointId::Mouse, hit);
+        self.lw
+            .hover_manager
+            .push_hit_test(InputPointId::Mouse, hit);
         self.lw.process_mouse_click_for_selection(position, 0);
     }
 
@@ -307,17 +309,18 @@ fn clicking_a_paragraph_on_a_materialised_page_places_the_caret_in_it() {
     let mut h = Harness::new(Doc::Paragraphs);
     let (nested, _vv) = h.virtual_view();
     let para = h.first_editable_line(nested);
-    let (origin, size) = h.window_rect(nested, para).expect("the paragraph has a box");
+    let (origin, size) = h
+        .window_rect(nested, para)
+        .expect("the paragraph has a box");
 
     let target = LogicalPosition::new(origin.x + size.width * 0.25, origin.y + size.height * 0.5);
     h.click_at(target);
 
-    let session = h
-        .lw
-        .text_edit_manager
-        .multi_cursor
-        .as_ref()
-        .map(|mc| mc.node_id);
+    let session =
+        h.lw.text_edit_manager
+            .multi_cursor
+            .as_ref()
+            .map(|mc| mc.node_id);
     assert!(
         session.is_some(),
         "clicking the text of a page sheet placed no caret at all \
@@ -394,9 +397,7 @@ fn clicking_a_page_after_scrolling_past_the_first_screenful_still_places_a_caret
     let visible = paras
         .into_iter()
         .filter_map(|p| h.window_rect(nested, p).map(|r| (p, r)))
-        .find(|(_, (origin, size))| {
-            origin.y >= CHROME_H && origin.y + size.height <= WIN_H - 24.0
-        })
+        .find(|(_, (origin, size))| origin.y >= CHROME_H && origin.y + size.height <= WIN_H - 24.0)
         .expect("at least one materialised paragraph is inside the canvas viewport");
     let (_, (origin, size)) = visible;
 
@@ -441,14 +442,14 @@ fn focusing_a_blank_documents_editing_host_anchors_the_caret_on_its_empty_line()
     };
     let window_state = h.lw.current_window_state.clone();
     h.lw.focus_manager.set_focused_node(Some(focus));
-    let _ = h.lw.handle_focus_change_for_cursor_blink(Some(focus), &window_state);
+    let _ =
+        h.lw.handle_focus_change_for_cursor_blink(Some(focus), &window_state);
 
-    let pending = h
-        .lw
-        .focus_manager
-        .pending_contenteditable_focus
-        .clone()
-        .expect("focusing a contenteditable flags a deferred caret");
+    let pending =
+        h.lw.focus_manager
+            .pending_contenteditable_focus
+            .clone()
+            .expect("focusing a contenteditable flags a deferred caret");
     assert_eq!(
         pending.container_node_id, host,
         "focus itself still belongs to the editing host"

--- a/layout/tests/click_into_a_virtual_view_page.rs
+++ b/layout/tests/click_into_a_virtual_view_page.rs
@@ -20,20 +20,26 @@
 //! 3. focusing an empty editing host must anchor the caret on a line that can
 //!    be painted, not on the host block itself.
 //!
+//! (3) is also the STARTUP caret, which never involves a click at all: AzWriter
+//! calls `set_focus_to_path(ROOT, ".mw-doc")` once the first layout exists, and
+//! that resolves to the editing host, so the engine alone decides which line
+//! the caret lands on.
+//!
 //! The DOM here is built with `StyledDom::create_from_dom`, the same entry the
 //! shell uses — `create(dom, Css::empty())` skips the per-subtree inline-CSS
 //! scoping and the page canvas never resolves its flex size.
 
 use azul_core::callbacks::{VirtualViewCallback, VirtualViewCallbackInfo, VirtualViewReturn};
-use azul_core::dom::{Dom, DomId, NodeId, NodeType, OptionDom};
+use azul_core::dom::{Dom, DomId, DomNodeId, NodeId, NodeType, OptionDom};
 use azul_core::geom::{LogicalPosition, LogicalRect, LogicalSize};
 use azul_core::refany::RefAny;
 use azul_core::resources::RendererResources;
-use azul_core::styled_dom::StyledDom;
+use azul_core::styled_dom::{NodeHierarchyItemId, StyledDom};
 use azul_layout::headless::CpuHitTester;
 use azul_layout::managers::hover::InputPointId;
 use azul_layout::{
-    callbacks::ExternalSystemCallbacks, window::LayoutWindow, window_state::FullWindowState,
+    callbacks::ExternalSystemCallbacks, solver3::display_list::DisplayListItem,
+    window::LayoutWindow, window_state::FullWindowState,
 };
 use rust_fontconfig::FcFontCache;
 use std::sync::{Arc, Mutex};
@@ -267,6 +273,31 @@ impl Harness {
             .find(|id| matches!(nd[*id].get_node_type(), NodeType::P))
             .expect("a materialised page has a paragraph")
     }
+
+    /// The first page's editing host — the content root `.mw-doc` sits on, and
+    /// the node `set_focus_to_path` resolves to.
+    fn first_editing_host(&self, dom: DomId) -> NodeId {
+        let lr = self.lw.get_layout_result(&dom).expect("nested layout");
+        let nd = lr.styled_dom.node_data.as_container();
+        (0..nd.len())
+            .map(NodeId::new)
+            .find(|id| nd[*id].is_contenteditable())
+            .expect("a materialised page has a contenteditable content root")
+    }
+
+    /// How many carets the rasteriser would draw in `dom`. The blink-off phase
+    /// still emits the item (with alpha 0), so this counts a caret that EXISTS,
+    /// not one that happens to be lit this frame.
+    fn caret_rects(&self, dom: DomId) -> usize {
+        self.lw
+            .get_layout_result(&dom)
+            .expect("nested layout")
+            .display_list
+            .items
+            .iter()
+            .filter(|item| matches!(item, DisplayListItem::CursorRect { .. }))
+            .count()
+    }
 }
 
 /// A loaded document: clicking a quarter of the way into the first
@@ -376,5 +407,74 @@ fn clicking_a_page_after_scrolling_past_the_first_screenful_still_places_a_caret
         h.lw.text_edit_manager.has_active_editing(),
         "after scrolling, a click on a visible page paragraph placed no caret \
          (click {target:?}, paragraph {origin:?} {size:?}, content_offset {content_offset:?})"
+    );
+}
+/// AzWriter's STARTUP caret on a brand-new document, with no click involved:
+/// 150 ms after the window opens the app calls `set_focus_to_path(ROOT,
+/// ".mw-doc")`, which resolves to the editing HOST — the class sits on the
+/// content root, never on a line inside it.
+///
+/// A blank document has no text node anywhere under that host, so
+/// `find_last_text_child` answers `None` and the old fallback anchored the
+/// editing session on the host itself. The host is a block container: it has
+/// no inline layout, so `paint_cursor` returns before it reaches a caret and
+/// there is nothing on screen to type into. The anchor has to be the host's
+/// empty editable LINE, the one `layout_ifc` gave the editing-host strut.
+#[test]
+fn focusing_a_blank_documents_editing_host_anchors_the_caret_on_its_empty_line() {
+    let mut h = Harness::new(Doc::Blank);
+    let (nested, _vv) = h.virtual_view();
+    let host = h.first_editing_host(nested);
+    let line = h.first_editable_line(nested);
+    assert!(
+        h.caret_rects(nested) == 0,
+        "premise: nothing is focused yet, so no caret is painted"
+    );
+
+    // `dll/.../shell2/common/event.rs`'s SetFocusTarget arm, verbatim: adopt
+    // the focus, flag the deferred contenteditable caret, finalize it. (The
+    // shell also scrolls the node into view between the first two; that moves
+    // the viewport, never the anchor.)
+    let focus = DomNodeId {
+        dom: nested,
+        node: NodeHierarchyItemId::from_crate_internal(Some(host)),
+    };
+    let window_state = h.lw.current_window_state.clone();
+    h.lw.focus_manager.set_focused_node(Some(focus));
+    let _ = h.lw.handle_focus_change_for_cursor_blink(Some(focus), &window_state);
+
+    let pending = h
+        .lw
+        .focus_manager
+        .pending_contenteditable_focus
+        .clone()
+        .expect("focusing a contenteditable flags a deferred caret");
+    assert_eq!(
+        pending.container_node_id, host,
+        "focus itself still belongs to the editing host"
+    );
+    assert_eq!(
+        pending.text_node_id, line,
+        "the caret must be anchored on the empty editable LINE ({line:?}); \
+         anchoring it on the host block ({host:?}) is an editing session whose \
+         caret has no inline layout to be painted in"
+    );
+
+    assert!(
+        h.lw.finalize_pending_focus_changes(),
+        "the deferred caret must be seeded in the pass after layout"
+    );
+    assert!(
+        h.lw.text_edit_manager.has_active_editing(),
+        "a focused blank document is an open editing session"
+    );
+
+    h.lw.regenerate_display_list_for_dom(nested);
+    assert_eq!(
+        h.caret_rects(nested),
+        1,
+        "the blank page must paint exactly one caret — with the session \
+         anchored on the host block instead, `paint_cursor` finds no inline \
+         layout and the new document shows no caret at all"
     );
 }

--- a/layout/tests/text_edit_seam_regressions.rs
+++ b/layout/tests/text_edit_seam_regressions.rs
@@ -10,6 +10,8 @@
 //! - Typing into a node that only INHERITS `contenteditable` must land.
 //! - A click on plain selectable text must not claim the blink timer, and a
 //!   focus change must not erase the selection that same click made.
+//! - The FIRST character typed into an EMPTY editable must land: it has no
+//!   text run for the insert to splice into.
 
 use azul_core::{
     dom::{Dom, DomId, DomNodeId, IdOrClass, NodeId},
@@ -749,5 +751,96 @@ fn an_ime_composition_in_a_deeply_nested_editable_is_shaped() {
         glyph_count(&lw) > before,
         "the composition was never shaped: {before} glyphs before, {} after",
         glyph_count(&lw)
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The first character typed into an EMPTY editable
+// ---------------------------------------------------------------------------
+
+/// `text3::edit::insert_text` splices into `content[cursor.source_run]`. An
+/// editable with no text at all collects to an EMPTY buffer, so run 0 does not
+/// exist, the splice found nothing and the function returned the content
+/// unchanged — the first keystroke was silently dropped and the editable could
+/// never be typed into at all. A caret blinked in it the whole time.
+///
+/// This is the shape a brand-new AzWriter document has (an empty `<p>` under
+/// the editing host) and the shape every text widget has before its first
+/// character.
+///
+/// NOT yet fixed, and deliberately not asserted here: the character lands in
+/// the BUFFER but still paints no glyph. `reshape_text_node` shapes through
+/// `shape_text_for_relayout`, which can only use fonts a previous layout
+/// already LOADED — an editable that has never held text never loaded one, so
+/// stage 3 returns zero shaped items for the first character and the IFC keeps
+/// its empty strut layout. `cargo test ... the_first_character` is green while
+/// AzWriter still looks dead on a new document; the missing half is font
+/// loading on the incremental reshape path.
+#[test]
+fn the_first_character_typed_into_an_empty_p_wrapped_editable_lands() {
+    // body(0) > div[contenteditable](1) > div.p(2) — no text node anywhere.
+    let mut lw = layout(Dom::create_body().with_child(
+        Dom::create_div().with_contenteditable(true).with_child(with_class(Dom::create_div(), "p")),
+    ));
+    const HOST: usize = 1;
+    assert_eq!(text_of(&lw, HOST), "", "premise: the editable starts empty");
+
+    lw.focus_manager.set_focused_node(Some(dnid(HOST)));
+    lw.record_text_input("X");
+    let _ = lw.apply_text_changeset();
+
+    assert_eq!(
+        text_of(&lw, HOST),
+        "X",
+        "the first character typed into an empty editable must land — with no \
+         run to splice into, the insert was a silent no-op and the document \
+         could not be started"
+    );
+}
+
+/// The same defect without the block wrapper: a bare `div[contenteditable]`
+/// with no children at all.
+#[test]
+fn the_first_character_typed_into_a_flat_empty_editable_lands() {
+    let mut lw = layout(
+        Dom::create_body().with_child(Dom::create_div().with_contenteditable(true)),
+    );
+    const HOST: usize = 1;
+    assert_eq!(text_of(&lw, HOST), "", "premise: the editable starts empty");
+
+    lw.focus_manager.set_focused_node(Some(dnid(HOST)));
+    lw.record_text_input("X");
+    let _ = lw.apply_text_changeset();
+
+    assert_eq!(text_of(&lw, HOST), "X");
+}
+
+/// The seeded run must carry the BLOCK's style, not `StyleProperties::default()`
+/// — the first character has to be the size the editable is styled at, or every
+/// new document starts one character of the wrong font.
+#[test]
+fn the_first_character_typed_into_an_empty_editable_keeps_the_blocks_style() {
+    // `.big` is 40px; the default would be the 14px body size.
+    let mut lw = layout(Dom::create_body().with_child(
+        with_class(Dom::create_div(), "big").with_contenteditable(true),
+    ));
+    const HOST: usize = 1;
+
+    lw.focus_manager.set_focused_node(Some(dnid(HOST)));
+    lw.record_text_input("X");
+    let _ = lw.apply_text_changeset();
+    assert_eq!(text_of(&lw, HOST), "X");
+
+    let size = lw
+        .get_text_before_textinput(DomId::ROOT_ID, NodeId::new(HOST))
+        .iter()
+        .find_map(|c| match c {
+            azul_layout::text3::cache::InlineContent::Text(run) => Some(run.style.font_size_px),
+            _ => None,
+        })
+        .expect("the edited buffer has a text run");
+    assert!(
+        (size - 40.0).abs() < 0.01,
+        "the seeded run must inherit the editable's own font-size, got {size}"
     );
 }

--- a/layout/tests/text_edit_seam_regressions.rs
+++ b/layout/tests/text_edit_seam_regressions.rs
@@ -173,8 +173,11 @@ const EDITOR: usize = 1;
 
 fn flat_editable(content: &str) -> LayoutWindow {
     layout(
-        Dom::create_body()
-            .with_child(Dom::create_div().with_contenteditable(true).with_child(text(content))),
+        Dom::create_body().with_child(
+            Dom::create_div()
+                .with_contenteditable(true)
+                .with_child(text(content)),
+        ),
     )
 }
 
@@ -234,7 +237,11 @@ fn cancelling_an_ime_composition_puts_the_clean_base_back_on_screen() {
     lw.text_edit_manager.clear_preedit();
     lw.apply_preedit_to_text_cache(DomId::ROOT_ID, NodeId::new(EDITOR));
 
-    assert_eq!(glyph_count(&lw), base, "no composed glyph survives the cancel");
+    assert_eq!(
+        glyph_count(&lw),
+        base,
+        "no composed glyph survives the cancel"
+    );
     assert_eq!(text_of(&lw, EDITOR), "ab");
 }
 
@@ -250,9 +257,13 @@ const IFC_ROOT: usize = 2;
 
 #[test]
 fn the_first_click_into_a_p_wrapped_editable_keeps_the_clicked_caret() {
-    let mut lw = layout(Dom::create_body().with_child(
-        Dom::create_div().with_contenteditable(true).with_child(block(text("hello world"))),
-    ));
+    let mut lw = layout(
+        Dom::create_body().with_child(
+            Dom::create_div()
+                .with_contenteditable(true)
+                .with_child(block(text("hello world"))),
+        ),
+    );
 
     lw.process_mouse_click_for_selection(LogicalPosition::new(6.0, 6.0), 0)
         .expect("the click lands in the paragraph");
@@ -290,9 +301,13 @@ fn the_first_click_into_a_p_wrapped_editable_keeps_the_clicked_caret() {
 #[test]
 fn typing_into_a_node_that_only_inherits_contenteditable_reaches_the_text() {
     // body(0) > div[contenteditable](1) > div.p(2) > text(3)
-    let mut lw = layout(Dom::create_body().with_child(
-        Dom::create_div().with_contenteditable(true).with_child(block(text("hi"))),
-    ));
+    let mut lw = layout(
+        Dom::create_body().with_child(
+            Dom::create_div()
+                .with_contenteditable(true)
+                .with_child(block(text("hi"))),
+        ),
+    );
     const INNER: usize = 2;
 
     lw.focus_manager.set_focused_node(Some(dnid(INNER)));
@@ -327,7 +342,9 @@ fn static_text_then(second: Dom) -> LayoutWindow {
 #[test]
 fn clicking_plain_selectable_text_does_not_claim_the_blink_timer() {
     let mut lw = static_text_then(
-        Dom::create_div().with_contenteditable(true).with_child(text("editable")),
+        Dom::create_div()
+            .with_contenteditable(true)
+            .with_child(text("editable")),
     );
 
     lw.process_mouse_click_for_selection(LogicalPosition::new(6.0, 6.0), 0)
@@ -478,9 +495,13 @@ fn home_with_an_active_selection_travels_to_the_line_start() {
 #[test]
 fn the_caret_rect_answers_for_the_session_node_not_the_focused_node() {
     // body(0) > container(1) > div.p(2) > text(3)
-    let mut lw = layout(Dom::create_body().with_child(
-        Dom::create_div().with_contenteditable(true).with_child(block(text("hello world"))),
-    ));
+    let mut lw = layout(
+        Dom::create_body().with_child(
+            Dom::create_div()
+                .with_contenteditable(true)
+                .with_child(block(text("hello world"))),
+        ),
+    );
     let at_start = first_cluster_cursor(&lw, IFC_ROOT);
 
     lw.text_edit_manager
@@ -507,11 +528,13 @@ fn the_caret_rect_answers_for_the_session_node_not_the_focused_node() {
 #[test]
 fn a_caret_two_levels_below_the_ifc_root_is_painted() {
     // body(0) > container(1) > div.p(2) > span(3) > text(4)
-    let mut lw = layout(Dom::create_body().with_child(
-        Dom::create_div()
-            .with_contenteditable(true)
-            .with_child(block(Dom::create_span_with_text("rich text"))),
-    ));
+    let mut lw = layout(
+        Dom::create_body().with_child(
+            Dom::create_div()
+                .with_contenteditable(true)
+                .with_child(block(Dom::create_span_with_text("rich text"))),
+        ),
+    );
     const DEEP_TEXT: usize = 4;
 
     let at_start = first_cluster_cursor(&lw, IFC_ROOT);
@@ -599,7 +622,8 @@ fn the_preedit_underline_spans_the_measured_advance_not_an_eight_pixel_guess() {
     start_editing(&mut lw, EDITOR, 0);
 
     let composed = "MM";
-    lw.text_edit_manager.set_preedit(composed.to_string(), -1, -1);
+    lw.text_edit_manager
+        .set_preedit(composed.to_string(), -1, -1);
     lw.apply_preedit_to_text_cache(DomId::ROOT_ID, NodeId::new(EDITOR));
 
     let width = underline_width(&lw).expect("a live composition is underlined");
@@ -730,9 +754,9 @@ fn a_burst_of_keystrokes_lands_in_order() {
 #[test]
 fn an_ime_composition_in_a_deeply_nested_editable_is_shaped() {
     let dom = Dom::create_body().with_child(
-        Dom::create_div().with_contenteditable(true).with_child(
-            Dom::create_div().with_child(Dom::create_div().with_child(text("ab"))),
-        ),
+        Dom::create_div()
+            .with_contenteditable(true)
+            .with_child(Dom::create_div().with_child(Dom::create_div().with_child(text("ab")))),
     );
     let mut lw = layout(dom);
 
@@ -779,9 +803,13 @@ fn an_ime_composition_in_a_deeply_nested_editable_is_shaped() {
 #[test]
 fn the_first_character_typed_into_an_empty_p_wrapped_editable_lands() {
     // body(0) > div[contenteditable](1) > div.p(2) — no text node anywhere.
-    let mut lw = layout(Dom::create_body().with_child(
-        Dom::create_div().with_contenteditable(true).with_child(with_class(Dom::create_div(), "p")),
-    ));
+    let mut lw = layout(
+        Dom::create_body().with_child(
+            Dom::create_div()
+                .with_contenteditable(true)
+                .with_child(with_class(Dom::create_div(), "p")),
+        ),
+    );
     const HOST: usize = 1;
     assert_eq!(text_of(&lw, HOST), "", "premise: the editable starts empty");
 
@@ -802,9 +830,8 @@ fn the_first_character_typed_into_an_empty_p_wrapped_editable_lands() {
 /// with no children at all.
 #[test]
 fn the_first_character_typed_into_a_flat_empty_editable_lands() {
-    let mut lw = layout(
-        Dom::create_body().with_child(Dom::create_div().with_contenteditable(true)),
-    );
+    let mut lw =
+        layout(Dom::create_body().with_child(Dom::create_div().with_contenteditable(true)));
     const HOST: usize = 1;
     assert_eq!(text_of(&lw, HOST), "", "premise: the editable starts empty");
 
@@ -821,9 +848,10 @@ fn the_first_character_typed_into_a_flat_empty_editable_lands() {
 #[test]
 fn the_first_character_typed_into_an_empty_editable_keeps_the_blocks_style() {
     // `.big` is 40px; the default would be the 14px body size.
-    let mut lw = layout(Dom::create_body().with_child(
-        with_class(Dom::create_div(), "big").with_contenteditable(true),
-    ));
+    let mut lw = layout(
+        Dom::create_body()
+            .with_child(with_class(Dom::create_div(), "big").with_contenteditable(true)),
+    );
     const HOST: usize = 1;
 
     lw.focus_manager.set_focused_node(Some(dnid(HOST)));


### PR DESCRIPTION
Finishes the platform half of the Wacom integration, and closes the
`false, // eraser: identified via tool/button labels, not valuators` that had been
sitting in the X11 pen feed.

Stacked conceptually on `5d0bf0743` (Wayland pad), already on master.

## Context

`CallbackInfo::get_wacom_pad` and `GestureAndDragManager::update_pad_state` have
shipped for a while, and `get_wacom_pad` is in api.json — but **`update_pad_state`
had exactly one caller in the whole tree: its own unit test.** The accessor returned
`None` on every platform, always. Only the producers were missing.

## Eraser

XI2 has no "what kind of tool is this" field, so the driver's device NAME is the only
signal — `xf86-input-wacom` emits `"<tablet> Pen stylus"`, `"<tablet> Pen eraser"`,
`"<tablet> Pad pad"`. Same convention the touchpad detection in this file already
relies on.

macOS (`pointingDeviceType == Eraser`) and Windows (`PEN_FLAG_ERASER`) already did
this correctly — **X11 was the only platform lying about it.**

## Pad

A pad is a SLAVE device and usually floating, so its buttons are never routed through
a master pointer and the existing `XIAllMasterDevices` selection never delivered them.
It has to be selected on explicitly, per device.

- buttons → `express_keys` bitset (XI2 buttons are 1-based, the bitset 0-based; ≥32 is
  dropped rather than wrapped onto another key)
- ring/strip valuator → `touch_ring`, normalised through the valuator's own min/max
- pad events return **before** the pointer translation: a pad has no cursor and no
  meaningful surface coordinates, so falling through would synthesise clicks and moves
  at whatever stale position the event carried

The ring is reported only while a finger is on it, so an **absent valuator in a frame
is the "finger lifted" signal** — X11 gives no other.

## Not implemented, deliberately

- **Windows/macOS pads** — neither public API has the concept. `POINTER_PEN_INFO`
  describes a pen only; ExpressKeys are Wintab (a vendor DLL). macOS `NSEvent` has
  tablet subtypes for the pen but nothing for the pad. A pad is, in public-API terms,
  a Linux concept.
- **Mode-switch** — would need a `mode` field on `WacomPadState`, a `#[repr(C)]` type
  in api.json. ABI change, out of scope while the API is settling.

No api.json change: both the accessor and the setter already exist.

## ⚠ Verification status

**Written blind on macOS against protocol documentation. No tablet has ever been
attached to this code.** Checked for `x86_64-unknown-linux-gnu` (where it compiles)
and macOS native (to prove nothing else broke); clippy gate and preflight contracts
pass. Device verification is tracked separately — the three most likely-wrong
assumptions are the X11 device-name match, the ring valuator labels, and the
ring-vs-strip unit difference on Wayland.

Known gap: X11 has no focus-loss/device-removal reset for pad state (Wayland does),
so a held ExpressKey could latch. Worth fixing during device verification.