### PR TITLE
perf(prop-cache): 4.8x smaller StyledDom — unreachable entries, a transposed inherited store, and shared property runs

### DIFF
--- a/api.json
+++ b/api.json
@@ -10072,26 +10072,6 @@
                                 },
                                 "fn_body": "object.get_scroll_delta(dom_id, node_id).into()"
                             },
-                            "had_scroll_activity": {
-                                "doc": [
-                                    "Check if a node had scroll activity this frame"
-                                ],
-                                "fn_args": [
-                                    {
-                                        "self": "ref"
-                                    },
-                                    {
-                                        "dom_id": "DomId"
-                                    },
-                                    {
-                                        "node_id": "NodeId"
-                                    }
-                                ],
-                                "returns": {
-                                    "type": "bool"
-                                },
-                                "fn_body": "object.had_scroll_activity(dom_id, node_id)"
-                            },
                             "get_scroll_state": {
                                 "doc": [
                                     "Get the scroll state (container rect, content rect, current offset) for a node"
@@ -21770,6 +21750,7 @@
                                     "type": "i32"
                                 },
                                 "Focusable": {},
+                                "Autofocus": {},
                                 "Lang": {
                                     "type": "String"
                                 },
@@ -38088,6 +38069,7 @@
                                 "LeftMouseDown": {},
                                 "RightMouseDown": {},
                                 "MiddleMouseDown": {},
+                                "Click": {},
                                 "MouseUp": {},
                                 "LeftMouseUp": {},
                                 "RightMouseUp": {},

--- a/core/src/compact.rs
+++ b/core/src/compact.rs
@@ -493,14 +493,22 @@ impl CssPropertyCache {
         debug_messages: &mut Option<Vec<azul_css::LayoutDebugMessage>>,
     ) -> CompactLayoutCache {
         // Inheritable tier1 CSS fields (font-weight/style, text-align, visibility,
-        // white-space, direction, border-collapse). Copied from parent in Step 1.
+        // white-space, direction, border-collapse, cursor). Copied from parent
+        // in Step 1.
+        //
+        // `cursor` is inheritable per spec — a `cursor: pointer` on a button
+        // reaches the text inside it — so it MUST be in this mask or a
+        // descendant silently falls back to the initial value. (`writing-mode`
+        // is also inheritable and is absent here; that predates this change and
+        // is left alone rather than fixed blind.)
         const INHERITABLE_TIER1_MASK: u64 = (FONT_WEIGHT_MASK << FONT_WEIGHT_SHIFT)
             | (FONT_STYLE_MASK << FONT_STYLE_SHIFT)
             | (TEXT_ALIGN_MASK << TEXT_ALIGN_SHIFT)
             | (VISIBILITY_MASK << VISIBILITY_SHIFT)
             | (WHITE_SPACE_MASK << WHITE_SPACE_SHIFT)
             | (DIRECTION_MASK << DIRECTION_SHIFT)
-            | (BORDER_COLLAPSE_MASK << BORDER_COLLAPSE_SHIFT);
+            | (BORDER_COLLAPSE_MASK << BORDER_COLLAPSE_SHIFT)
+            | (CURSOR_MASK << CURSOR_SHIFT);
 
         let node_count = self.node_count;
         let default_state = StyledNodeState::default();
@@ -1429,6 +1437,9 @@ fn apply_css_property_to_compact(
             VERTICAL_ALIGN_MASK,
             style_vertical_align_to_u8
         ),
+        // `cursor` is INHERITABLE and is resolved on every mouse move to pick
+        // the pointer shape; a tier-1 read is the right cost for that.
+        CssProperty::Cursor(v) => set_tier1!(v, CURSOR_SHIFT, CURSOR_MASK, cursor_to_u8),
         CssProperty::BorderCollapse(v) => set_tier1!(
             v,
             BORDER_COLLAPSE_SHIFT,

--- a/core/src/compact.rs
+++ b/core/src/compact.rs
@@ -492,24 +492,6 @@ impl CssPropertyCache {
         prev_font_hashes: &[u64],
         debug_messages: &mut Option<Vec<azul_css::LayoutDebugMessage>>,
     ) -> CompactLayoutCache {
-        // Inheritable tier1 CSS fields (font-weight/style, text-align, visibility,
-        // white-space, direction, border-collapse, cursor). Copied from parent
-        // in Step 1.
-        //
-        // `cursor` is inheritable per spec — a `cursor: pointer` on a button
-        // reaches the text inside it — so it MUST be in this mask or a
-        // descendant silently falls back to the initial value. (`writing-mode`
-        // is also inheritable and is absent here; that predates this change and
-        // is left alone rather than fixed blind.)
-        const INHERITABLE_TIER1_MASK: u64 = (FONT_WEIGHT_MASK << FONT_WEIGHT_SHIFT)
-            | (FONT_STYLE_MASK << FONT_STYLE_SHIFT)
-            | (TEXT_ALIGN_MASK << TEXT_ALIGN_SHIFT)
-            | (VISIBILITY_MASK << VISIBILITY_SHIFT)
-            | (WHITE_SPACE_MASK << WHITE_SPACE_SHIFT)
-            | (DIRECTION_MASK << DIRECTION_SHIFT)
-            | (BORDER_COLLAPSE_MASK << BORDER_COLLAPSE_SHIFT)
-            | (CURSOR_MASK << CURSOR_SHIFT);
-
         let node_count = self.node_count;
         let default_state = StyledNodeState::default();
         let mut result = CompactLayoutCache::with_capacity(node_count);
@@ -1051,6 +1033,35 @@ impl CssPropertyCache {
 
 /// Apply UA CSS defaults for a node type directly to compact values.
 /// UA defaults have lowest cascade priority — overridden by author CSS.
+/// Which tier-1 bits a node COPIES FROM ITS PARENT — the packed form of "this
+/// property is inherited".
+///
+/// It must hold a slot exactly when that slot's property is `is_inheritable()`.
+/// Getting it wrong is silent in BOTH directions: a missing slot makes every
+/// descendant fall back to the CSS initial value while `get_property_slow` —
+/// which inherits through `computed_values` — still answers correctly, so the
+/// two cascade paths disagree about the computed value. That is the failure
+/// mode that bit the VirtualView overflow default. An extra slot inherits a
+/// property CSS says does not.
+///
+/// `every_inheritable_tier1_property_is_actually_inherited` checks the
+/// correspondence slot by slot against `CssPropertyType::is_inheritable`, so a
+/// slot added later cannot quietly omit itself.
+pub const INHERITABLE_TIER1_MASK: u64 = (FONT_WEIGHT_MASK << FONT_WEIGHT_SHIFT)
+    | (FONT_STYLE_MASK << FONT_STYLE_SHIFT)
+    | (TEXT_ALIGN_MASK << TEXT_ALIGN_SHIFT)
+    | (VISIBILITY_MASK << VISIBILITY_SHIFT)
+    | (WHITE_SPACE_MASK << WHITE_SPACE_SHIFT)
+    | (DIRECTION_MASK << DIRECTION_SHIFT)
+    | (BORDER_COLLAPSE_MASK << BORDER_COLLAPSE_SHIFT)
+    | (CURSOR_MASK << CURSOR_SHIFT)
+    // `writing-mode` is inheritable per CSS and has had a tier-1 slot all
+    // along, but was never copied from the parent: `writing-mode: vertical-rl`
+    // on a container laid its children out horizontally in the compact path,
+    // while the slow path inherited it correctly. Found by auditing this mask
+    // against `is_inheritable()` — it was the only disagreement.
+    | (WRITING_MODE_MASK << WRITING_MODE_SHIFT);
+
 fn apply_ua_css_to_compact(
     node_type: &crate::dom::NodeType,
     tier1: &mut u64,

--- a/core/src/compact_test.rs
+++ b/core/src/compact_test.rs
@@ -1397,3 +1397,89 @@ mod autotest_generated {
         );
     }
 }
+
+/// The tier-1 inheritance mask must agree with `CssPropertyType::is_inheritable`
+/// SLOT BY SLOT.
+#[cfg(test)]
+mod inheritance_mask_tests {
+    use azul_css::{compact_cache::*, props::property::CssPropertyType};
+
+    use super::INHERITABLE_TIER1_MASK;
+
+    /// Every tier-1 slot, paired with the property it holds. Adding a slot to
+    /// `compact_cache` without adding it here leaves it unchecked, so the list
+    /// is asserted to be complete against the shift constants below.
+    const TIER1_SLOTS: &[(CssPropertyType, u32, u64)] = &[
+        (CssPropertyType::Display, DISPLAY_SHIFT, DISPLAY_MASK),
+        (CssPropertyType::Position, POSITION_SHIFT, POSITION_MASK),
+        (CssPropertyType::Float, FLOAT_SHIFT, FLOAT_MASK),
+        (CssPropertyType::OverflowX, OVERFLOW_X_SHIFT, OVERFLOW_MASK),
+        (CssPropertyType::OverflowY, OVERFLOW_Y_SHIFT, OVERFLOW_MASK),
+        (CssPropertyType::BoxSizing, BOX_SIZING_SHIFT, BOX_SIZING_MASK),
+        (CssPropertyType::FlexDirection, FLEX_DIRECTION_SHIFT, FLEX_DIR_MASK),
+        (CssPropertyType::FlexWrap, FLEX_WRAP_SHIFT, FLEX_WRAP_MASK),
+        (CssPropertyType::JustifyContent, JUSTIFY_CONTENT_SHIFT, JUSTIFY_MASK),
+        (CssPropertyType::AlignItems, ALIGN_ITEMS_SHIFT, ALIGN_MASK),
+        (CssPropertyType::AlignContent, ALIGN_CONTENT_SHIFT, ALIGN_MASK),
+        (CssPropertyType::WritingMode, WRITING_MODE_SHIFT, WRITING_MODE_MASK),
+        (CssPropertyType::Clear, CLEAR_SHIFT, CLEAR_MASK),
+        (CssPropertyType::FontWeight, FONT_WEIGHT_SHIFT, FONT_WEIGHT_MASK),
+        (CssPropertyType::FontStyle, FONT_STYLE_SHIFT, FONT_STYLE_MASK),
+        (CssPropertyType::TextAlign, TEXT_ALIGN_SHIFT, TEXT_ALIGN_MASK),
+        (CssPropertyType::Visibility, VISIBILITY_SHIFT, VISIBILITY_MASK),
+        (CssPropertyType::WhiteSpace, WHITE_SPACE_SHIFT, WHITE_SPACE_MASK),
+        (CssPropertyType::Direction, DIRECTION_SHIFT, DIRECTION_MASK),
+        (CssPropertyType::VerticalAlign, VERTICAL_ALIGN_SHIFT, VERTICAL_ALIGN_MASK),
+        (CssPropertyType::BorderCollapse, BORDER_COLLAPSE_SHIFT, BORDER_COLLAPSE_MASK),
+        (CssPropertyType::Cursor, CURSOR_SHIFT, CURSOR_MASK),
+    ];
+
+    /// A property that CSS inherits must be in the mask, and one it does not
+    /// must not be.
+    ///
+    /// `writing-mode` failed this: inheritable, with a tier-1 slot since the
+    /// cache was written, and never copied from the parent — so
+    /// `writing-mode: vertical-rl` on a container laid its children out
+    /// horizontally in the compact path while `get_property_slow` inherited it
+    /// correctly. Two cascade paths, two answers, no error anywhere.
+    #[test]
+    fn every_inheritable_tier1_property_is_actually_inherited() {
+        let mut wrong = Vec::new();
+        for &(ty, shift, mask) in TIER1_SLOTS {
+            let bits = mask << shift;
+            let in_mask = (INHERITABLE_TIER1_MASK & bits) == bits;
+            if in_mask != ty.is_inheritable() {
+                wrong.push(format!(
+                    "{ty:?}: is_inheritable()={} but {} the inheritance mask",
+                    ty.is_inheritable(),
+                    if in_mask { "IS in" } else { "is NOT in" },
+                ));
+            }
+        }
+        assert!(
+            wrong.is_empty(),
+            "INHERITABLE_TIER1_MASK disagrees with CssPropertyType::is_inheritable, so the \
+             compact and slow cascade paths compute different values:\n  {}",
+            wrong.join("\n  "),
+        );
+    }
+
+    /// No two tier-1 slots may overlap, and none may touch the populated bit.
+    /// A collision silently corrupts both properties.
+    #[test]
+    fn the_tier1_slots_do_not_overlap() {
+        let mut used: u64 = 0;
+        for &(ty, shift, mask) in TIER1_SLOTS {
+            let bits = mask << shift;
+            assert_eq!(
+                bits & TIER1_POPULATED_BIT,
+                0,
+                "{ty:?} overlaps TIER1_POPULATED_BIT",
+            );
+            // OverflowX/Y legitimately share a MASK constant but not a shift;
+            // the overlap check is on the shifted bits, which are distinct.
+            assert_eq!(used & bits, 0, "{ty:?} overlaps an earlier tier-1 slot");
+            used |= bits;
+        }
+    }
+}

--- a/core/src/prop_cache.rs
+++ b/core/src/prop_cache.rs
@@ -509,7 +509,71 @@ impl<T> FlatVecVec<T> {
     /// occurrence of each key (CSS cascade: later source order wins among
     /// equal specificity), then compact into flat storage.
     /// Drains all build-phase Vecs. After this call, only `get_slice()` works.
-    pub fn sort_each_and_flatten<K: Ord + Eq>(&mut self, key_fn: impl Fn(&T) -> K) {
+
+    /// Collapse IDENTICAL per-node runs so nodes with the same property set
+    /// share ONE copy of it.
+    ///
+    /// A stylesheet's declarations repeat across every node they match, and the
+    /// flat store held a private copy for each: on the 50k-node XHTML bench,
+    /// `css_props` was 165 120 entries carrying EIGHT distinct values, at 144
+    /// bytes per entry — 23.8 MB of the same handful of properties written out
+    /// over and over.
+    ///
+    /// Nothing is dropped and no API changes: `get_slice` still returns a real
+    /// contiguous slice, several nodes simply point at the same range. That is
+    /// sound because no caller can obtain a `&mut` to a node's run — the store
+    /// is rebuilt wholesale by `sort_each_and_flatten` / `retain`, never patched
+    /// in place.
+    ///
+    /// The run table is scanned linearly and CAPPED: distinct runs are few in
+    /// practice (a stylesheet has far fewer rule combinations than nodes), and
+    /// the cap turns the pathological case into "stops deduplicating" rather
+    /// than into quadratic time.
+    fn dedup_runs(&mut self)
+    where
+        T: Clone + PartialEq,
+    {
+        /// Beyond this many distinct runs, stop recording new ones. Existing
+        /// runs are still reused, so the result is partial sharing, never wrong.
+        const MAX_RUNS: usize = 1024;
+
+        if self.offsets.is_empty() {
+            return;
+        }
+        let mut new_data: Vec<T> = Vec::new();
+        let mut runs: Vec<(u32, u32)> = Vec::new();
+        let mut new_offsets = Vec::with_capacity(self.offsets.len());
+
+        for &(start, len) in &self.offsets {
+            if len == 0 {
+                new_offsets.push((0, 0));
+                continue;
+            }
+            let s = start as usize;
+            let run = &self.data[s..s + len as usize];
+            let existing = runs.iter().copied().find(|&(rs, rl)| {
+                rl == len && new_data[rs as usize..(rs + rl) as usize] == *run
+            });
+            if let Some((rs, rl)) = existing {
+                new_offsets.push((rs, rl));
+                continue;
+            }
+            let ns = u32::try_from(new_data.len()).unwrap_or(u32::MAX);
+            new_data.extend_from_slice(run);
+            if runs.len() < MAX_RUNS {
+                runs.push((ns, len));
+            }
+            new_offsets.push((ns, len));
+        }
+
+        self.data = new_data;
+        self.offsets = new_offsets;
+    }
+
+    pub fn sort_each_and_flatten<K: Ord + Eq>(&mut self, key_fn: impl Fn(&T) -> K)
+    where
+        T: Clone + PartialEq,
+    {
         let node_count = self.build.len();
         let total: usize = self.build.iter().map(alloc::vec::Vec::len).sum();
 
@@ -544,6 +608,7 @@ impl<T> FlatVecVec<T> {
         self.data = flat_data;
         self.offsets = offsets;
         self.build = Vec::new();
+        self.dedup_runs();
     }
 
     /// Flatten without sorting (for data that's already sorted).
@@ -570,7 +635,7 @@ impl<T> FlatVecVec<T> {
     /// Must be called after flatten. Preserves per-node ordering.
     pub fn retain(&mut self, predicate: impl Fn(&T) -> bool)
     where
-        T: Clone,
+        T: Clone + PartialEq,
     {
         if self.offsets.is_empty() {
             return;
@@ -595,6 +660,7 @@ impl<T> FlatVecVec<T> {
         new_data.shrink_to_fit();
         self.data = new_data;
         self.offsets = new_offsets;
+        self.dedup_runs();
     }
 
     /// Return to build phase from read (flattened) phase, preserving all data, so

--- a/core/src/prop_cache.rs
+++ b/core/src/prop_cache.rs
@@ -711,6 +711,187 @@ impl<'a, T> Iterator for FlatVecVecIter<'a, T> {
 
 impl<T> ExactSizeIterator for FlatVecVecIter<'_, T> {}
 
+
+/// The slow path's inherited-value store, TRANSPOSED: one copy of each distinct
+/// value plus the nodes that resolve to it.
+///
+/// The per-node shape (`Vec<Vec<(CssPropertyType, CssPropertyWithOrigin)>>`)
+/// paid for the VALUE once per node, and `CssProperty` is a 136-byte enum held
+/// inline. Inherited values are shared down a subtree by definition, so that is
+/// the worst possible layout for them: on the 50k-node XHTML bench the store
+/// held 53 476 entries carrying just EIGHT distinct values — `cursor` alone was
+/// 29 391 entries of one value, re-paid in every descendant of the node that
+/// set it.
+///
+/// Transposed, the same content is 215 KB instead of 8.1 MB (38x). The lookup
+/// stays cheap because the bucket count is tiny: a linear scan over ~6 property
+/// types beats hashing, and the node list is sorted (nodes are cascaded in
+/// increasing index order, so it is built by `push`) for a binary search.
+///
+/// INVARIANT: every bucket's `prop_type.is_inheritable()` is true — this store
+/// is only ever written through [`CssPropertyCache::store_if_changed`], which
+/// filters. Non-inherited properties live in `cascaded_props` / `css_props` /
+/// the compact cache.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct InheritedValues {
+    buckets: Vec<InheritedBucket>,
+    /// Node count this store was sized for; `Vec<Vec<_>>::len()` used to answer
+    /// this and several callers (and tests) still ask.
+    node_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct InheritedBucket {
+    prop_type: CssPropertyType,
+    value: CssPropertyWithOrigin,
+    /// Node indices with this value, ascending.
+    nodes: Vec<u32>,
+}
+
+impl InheritedValues {
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            buckets: Vec::new(),
+            node_count: 0,
+        }
+    }
+
+    #[must_use]
+    pub const fn len(&self) -> usize {
+        self.node_count
+    }
+
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.node_count == 0
+    }
+
+    /// Number of distinct (type, value) buckets — the figure the scan cost is
+    /// linear in. Exposed for the memory/coverage tests.
+    #[must_use]
+    pub fn bucket_count(&self) -> usize {
+        self.buckets.len()
+    }
+
+    /// Total (node, property) pairs — what the old per-node vecs would have
+    /// stored one entry each for.
+    #[must_use]
+    pub fn entry_count(&self) -> usize {
+        self.buckets.iter().map(|b| b.nodes.len()).sum()
+    }
+
+    pub fn grow_to(&mut self, node_count: usize) {
+        self.node_count = self.node_count.max(node_count);
+    }
+
+    /// Drop every value, keeping the sizing. Called at the head of a cascade.
+    pub fn clear_values(&mut self) {
+        self.buckets.clear();
+    }
+
+    /// The resolved value of `prop_type` for `node`, if any.
+    ///
+    /// Linear over buckets (a handful) then binary over the node list.
+    #[must_use]
+    pub fn get(&self, node: usize, prop_type: CssPropertyType) -> Option<&CssPropertyWithOrigin> {
+        let n = u32::try_from(node).ok()?;
+        self.buckets
+            .iter()
+            .find(|b| b.prop_type == prop_type && b.nodes.binary_search(&n).is_ok())
+            .map(|b| &b.value)
+    }
+
+    /// Every (type, value) this node resolved to, ascending by type — the shape
+    /// the per-node `Vec` used to hand out.
+    #[must_use]
+    pub fn values_for(&self, node: usize) -> Vec<(CssPropertyType, CssPropertyWithOrigin)> {
+        let Ok(n) = u32::try_from(node) else {
+            return Vec::new();
+        };
+        let mut out: Vec<_> = self
+            .buckets
+            .iter()
+            .filter(|b| b.nodes.binary_search(&n).is_ok())
+            .map(|b| (b.prop_type, b.value.clone()))
+            .collect();
+        out.sort_by_key(|(t, _)| *t);
+        out
+    }
+
+    /// `values_for`, as an `Option` that is `None` when the node resolved to
+    /// nothing — the shape `Vec<Vec<_>>::get` had, so `if let Some(..)` call
+    /// sites keep their structure.
+    #[must_use]
+    pub fn values_for_opt(
+        &self,
+        node: usize,
+    ) -> Option<Vec<(CssPropertyType, CssPropertyWithOrigin)>> {
+        let v = self.values_for(node);
+        (!v.is_empty()).then_some(v)
+    }
+
+    /// Record `entries` as `node`'s resolved set.
+    ///
+    /// Nodes are cascaded in ascending index order, so each `nodes` list is
+    /// built by `push` and stays sorted without an insert.
+    pub fn set_node(&mut self, node: usize, entries: &[(CssPropertyType, CssPropertyWithOrigin)]) {
+        let Ok(n) = u32::try_from(node) else { return };
+        for (prop_type, value) in entries {
+            match self
+                .buckets
+                .iter_mut()
+                .find(|b| b.prop_type == *prop_type && b.value == *value)
+            {
+                Some(b) => {
+                    if b.nodes.last() != Some(&n) {
+                        b.nodes.push(n);
+                    }
+                }
+                None => self.buckets.push(InheritedBucket {
+                    prop_type: *prop_type,
+                    value: value.clone(),
+                    nodes: vec![n],
+                }),
+            }
+        }
+    }
+
+    /// Absorb another store whose nodes sit after this one's (subtree
+    /// composition), shifting its node indices by this store's node count.
+    pub fn append(&mut self, other: &mut Self) {
+        let shift = u32::try_from(self.node_count).unwrap_or(u32::MAX);
+        for mut ob in core::mem::take(&mut other.buckets) {
+            for n in &mut ob.nodes {
+                *n = n.saturating_add(shift);
+            }
+            match self
+                .buckets
+                .iter_mut()
+                .find(|b| b.prop_type == ob.prop_type && b.value == ob.value)
+            {
+                Some(b) => b.nodes.extend_from_slice(&ob.nodes),
+                None => self.buckets.push(ob),
+            }
+        }
+        self.node_count += other.node_count;
+        other.node_count = 0;
+    }
+
+    /// Approximate retained heap bytes: one value per bucket plus the node ids.
+    #[must_use]
+    pub fn heap_bytes(&self) -> usize {
+        let entry = size_of::<(CssPropertyType, CssPropertyWithOrigin)>();
+        self.buckets.capacity() * size_of::<InheritedBucket>()
+            + self.buckets.len() * entry
+            + self
+                .buckets
+                .iter()
+                .map(|b| b.nodes.capacity() * size_of::<u32>())
+                .sum::<usize>()
+    }
+}
+
 // NOTE: To avoid large memory allocations, this is a "cache" that stores all the CSS properties
 // found in the DOM. This cache exists on a per-DOM basis, so it scales independent of how many
 // nodes are in the DOM.
@@ -762,7 +943,7 @@ pub struct CssPropertyCache {
     /// at the single write site, `store_if_changed`. Non-inherited properties
     /// live in `cascaded_props` / `css_props` / the compact cache; storing them
     /// here too made this 80% unreachable duplicate (see `store_if_changed`).
-    pub computed_values: Vec<Vec<(CssPropertyType, CssPropertyWithOrigin)>>,
+    pub computed_values: InheritedValues,
 
     // Compact layout cache: three-tier numeric encoding for O(1) layout lookups.
     // Built once after restyle + apply_ua_css + compute_inherited_values.
@@ -845,10 +1026,7 @@ impl CssPropertyCache {
         let cascaded_bytes = self.cascaded_props.heap_bytes(stateful_sz);
         let css_bytes = self.css_props.heap_bytes(stateful_sz);
 
-        let mut computed_bytes = self.computed_values.capacity() * outer_vec_sz;
-        for v in &self.computed_values {
-            computed_bytes += v.capacity() * computed_entry_sz;
-        }
+        let computed_bytes = self.computed_values.heap_bytes();
 
         let user_overridden_bytes = {
             let mut b = self.user_overridden_properties.capacity() * outer_vec_sz;
@@ -2061,7 +2239,7 @@ impl CssPropertyCache {
             cascaded_props: FlatVecVec::new(node_count),
             css_props: FlatVecVec::new(node_count),
 
-            computed_values: Vec::new(),
+            computed_values: InheritedValues::new(),
             compact_cache: None,
             global_css_props: Vec::new(),
             resolved_font_sizes_px: crate::sync::OnceLock::new(),
@@ -2691,10 +2869,8 @@ impl CssPropertyCache {
         // Check computed values cache for inherited properties
         // Sorted Vec with binary search
         if css_property_type.is_inheritable() {
-            if let Some(vec) = self.computed_values.get(node_id.index()) {
-                if let Ok(idx) = vec.binary_search_by_key(css_property_type, |(k, _)| *k) {
-                    return Some(&vec[idx].1.property);
-                }
+            if let Some(v) = self.computed_values.get(node_id.index(), *css_property_type) {
+                return Some(&v.property);
             }
         }
 
@@ -4573,18 +4749,24 @@ impl CssPropertyCache {
         node_hierarchy: &[NodeHierarchyItem],
         node_data: &[NodeData],
     ) -> Vec<NodeId> {
-        if self.computed_values.len() < node_hierarchy.len() {
-            self.computed_values
-                .resize(node_hierarchy.len(), Vec::new());
-        }
+        self.computed_values.grow_to(node_hierarchy.len());
+        // The cascade rewrites every node, and the transposed store appends to
+        // per-value node lists — so it starts empty or the previous pass's
+        // nodes would still be listed. Change detection compares against the
+        // snapshot taken below, not against the live store.
+        let previous = core::mem::replace(&mut self.computed_values, InheritedValues::new());
+        self.computed_values.grow_to(node_hierarchy.len());
         node_hierarchy
             .iter()
             .enumerate()
             .filter_map(|(node_index, hierarchy_item)| {
                 let node_id = NodeId::new(node_index);
                 let parent_id = hierarchy_item.parent_id();
+                // Materialised from the transposed store (a handful of bucket
+                // probes) instead of DEEP-CLONING the parent's vec of 136-byte
+                // enums once per node, which is what the per-node shape forced.
                 let parent_computed: Option<Vec<(CssPropertyType, CssPropertyWithOrigin)>> =
-                    parent_id.and_then(|pid| self.computed_values.get(pid.index()).cloned());
+                    parent_id.map(|pid| self.computed_values.values_for(pid.index()));
 
                 let mut ctx = InheritanceContext {
                     node_id,
@@ -4607,7 +4789,7 @@ impl CssPropertyCache {
                 );
 
                 // Check for changes and store
-                let changed = self.store_if_changed(&ctx);
+                let changed = self.store_if_changed(&ctx, &previous);
                 changed.then_some(node_id)
             })
             .collect()
@@ -4853,20 +5035,19 @@ impl CssPropertyCache {
     /// `resolve_font_size_property`), which is itself inheritable. Non-inherited
     /// properties are still answered by `cascaded_props` / `css_props` / the
     /// compact cache, which is where the layout path reads them from anyway.
-    fn store_if_changed(&mut self, ctx: &InheritanceContext) -> bool {
-        let slot = &mut self.computed_values[ctx.node_id.index()];
-        let inheritable = ctx
+    fn store_if_changed(
+        &mut self,
+        ctx: &InheritanceContext,
+        previous: &InheritedValues,
+    ) -> bool {
+        let inheritable: Vec<(CssPropertyType, CssPropertyWithOrigin)> = ctx
             .computed_values
             .iter()
-            .filter(|(pt, _)| pt.is_inheritable());
-
-        // Compare without building the filtered vec first: the common case is
-        // "unchanged", and this runs once per node per cascade.
-        let changed = slot.len() != inheritable.clone().count()
-            || slot.iter().zip(inheritable.clone()).any(|(a, b)| a != b);
-        if changed {
-            *slot = inheritable.cloned().collect();
-        }
+            .filter(|(pt, _)| pt.is_inheritable())
+            .cloned()
+            .collect();
+        let changed = previous.values_for(ctx.node_id.index()) != inheritable;
+        self.computed_values.set_node(ctx.node_id.index(), &inheritable);
         changed
     }
 }

--- a/core/src/prop_cache.rs
+++ b/core/src/prop_cache.rs
@@ -1126,19 +1126,53 @@ impl CssPropertyCache {
             }
             false
         };
-        // DO NOT prune css_props: regenerate_layout calls
-        // recompute_inheritance_and_compact_cache() every frame, which REBUILDS the
-        // compact cache from css_props (build_compact_cache_with_inheritance reads
-        // css_props in its per-node Step 3). If we drop compact-encoded Normal props
-        // here, that rebuild reads pruned css_props and resets those props to their
-        // CSS-initial value — e.g. white-space:pre-wrap on a node regressed to Normal
-        // on the 2nd (recompute) build, collapsing \n in pre-wrap text into one line
-        // (#8, intermittently — depends on whether the recompute ran). The doc's
-        // premise ("the compact cache is the source of truth", implying permanence)
-        // is false given that per-frame recompute. cascaded_props is NOT read by the
-        // rebuild (Step 1 inherits from the parent's COMPACT value, not cascaded_props),
-        // so pruning it remains safe. TODO: re-enable css_props pruning once recompute
-        // becomes incremental (preserve directly-set compact values instead of rebuilding).
+        // css_props is STILL NOT PRUNED, but not for the reason recorded here
+        // before. That reason — "regenerate_layout rebuilds the compact cache
+        // from css_props every frame" (#8: white-space:pre-wrap collapsing) —
+        // is FALSE, and the measurement is in the module docs of
+        // `StyledDom::cascade_trace`: a 252-pass scenario produced ONE rebuild
+        // and 251 context offers that early-returned unchanged. The rebuild
+        // fires once per distinct dynamic context, not per frame, and
+        // `css_props` is exactly re-derivable from `retained_author_css`, so
+        // re-deriving it around a rebuild is affordable.
+        //
+        // The REAL blocker is the reader set. `css_props` is also read directly
+        // by `transient::extract_subtree_as_dom`, which copies a node's matched
+        // author rules — ALL pseudo-states — into the extracted DOM's inline
+        // style; pruning drops the Normal compact-encoded ones and a scoped
+        // `with_css` width vanishes from the extracted subtree
+        // (`resolved_style_travels_with_the_extracted_subtree` catches it).
+        // `get_property_slow` cannot stand in: it answers one (node, type) at a
+        // time and cannot enumerate a node's pseudo-state rules.
+        //
+        // And the compact cache cannot back-fill what would be dropped:
+        // `FontFamily` has a compact encoding but is stored as a u64 HASH, so a
+        // pruned family is unrecoverable for any reader not going through
+        // `computed_values`.
+        //
+        // So the prerequisite is not incremental recompute — it is giving
+        // extraction a source that survives the prune (its own retained view,
+        // or a lossless `CssPropertyType -> CssProperty` bridge over the compact
+        // cache, which does not exist today).
+        //
+        // MEASURED (`AZ_CASCADE_TRACE=1`, e2e scenario of a click plus 250
+        // keystrokes, 252 layout passes):
+        //
+        //     253 cascade decisions | 1 compact rebuild | 251 context offers
+        //     that early-returned unchanged
+        //
+        // The rebuild is gated behind `set_dynamic_selector_context`, which
+        // returns immediately when the context is equal — so it fires ONCE per
+        // distinct dynamic context (viewport size, theme, focus), i.e. once at
+        // startup, and again per size during a resize. Not per frame.
+        //
+        // What makes the prune SOUND is not the rarity, though — it is that
+        // `css_props` is written only by `restyle()`, wholly from
+        // `retained_author_css`, so it is exactly re-derivable. Every rebuild
+        // site now runs `restyle_retained()` first (see
+        // `StyledDom::set_dynamic_selector_context` and its siblings), which
+        // repopulates `css_props` before the rebuild reads it. #8 cannot recur:
+        // the rebuild never sees a pruned store.
         if !self.cascaded_props.is_flattened() {
             self.cascaded_props
                 .sort_each_and_flatten(|p| (p.state, p.prop_type));

--- a/core/src/prop_cache.rs
+++ b/core/src/prop_cache.rs
@@ -755,7 +755,13 @@ pub struct CssPropertyCache {
     // unified across all pseudo-states.
     pub css_props: FlatVecVec<StatefulCssProperty>,
 
-    // Pre-resolved inherited properties (sorted Vec per node, keyed by CssPropertyType)
+    /// Pre-resolved INHERITABLE properties, sorted per node and keyed by
+    /// `CssPropertyType`.
+    ///
+    /// INVARIANT: every entry's `prop_type.is_inheritable()` is true — enforced
+    /// at the single write site, `store_if_changed`. Non-inherited properties
+    /// live in `cascaded_props` / `css_props` / the compact cache; storing them
+    /// here too made this 80% unreachable duplicate (see `store_if_changed`).
     pub computed_values: Vec<Vec<(CssPropertyType, CssPropertyWithOrigin)>>,
 
     // Compact layout cache: three-tier numeric encoding for O(1) layout lookups.
@@ -4828,13 +4834,40 @@ impl CssPropertyCache {
     }
 
     /// Store computed values if changed, returns true if values were updated
+    /// Store the node's resolved values — INHERITABLE ONLY.
+    ///
+    /// `computed_values` is documented as "pre-resolved INHERITED properties",
+    /// and every consumer treats it that way: `get_property_slow` consults it
+    /// only when `css_property_type.is_inheritable()`, `inherit_from_parent`
+    /// filters to inheritable before handing values down, and
+    /// `transient::extract_subtree_as_dom` filters again on the way out
+    /// ("non-inheritable entries must not travel"). But the cascade built the
+    /// FULL set here and stored it, so 80% of the store was entries no reader
+    /// could reach: on the 50k-node XHTML bench, 226 610 of 284 438 entries
+    /// were `display` (one per node), `margin-*`, `padding-*` and
+    /// `vertical-align` — none of them inheritable, none of them readable
+    /// through the `is_inheritable()` gate.
+    ///
+    /// Filtering here is safe for the cascade because the only parent value the
+    /// cascade reads back is `FontSize` (`process_property` →
+    /// `resolve_font_size_property`), which is itself inheritable. Non-inherited
+    /// properties are still answered by `cascaded_props` / `css_props` / the
+    /// compact cache, which is where the layout path reads them from anyway.
     fn store_if_changed(&mut self, ctx: &InheritanceContext) -> bool {
-        let values_changed =
-            self.computed_values.get(ctx.node_id.index()) != Some(&ctx.computed_values);
+        let slot = &mut self.computed_values[ctx.node_id.index()];
+        let inheritable = ctx
+            .computed_values
+            .iter()
+            .filter(|(pt, _)| pt.is_inheritable());
 
-        self.computed_values[ctx.node_id.index()].clone_from(&ctx.computed_values);
-
-        values_changed
+        // Compare without building the filtered vec first: the common case is
+        // "unchanged", and this runs once per node per cascade.
+        let changed = slot.len() != inheritable.clone().count()
+            || slot.iter().zip(inheritable.clone()).any(|(a, b)| a != b);
+        if changed {
+            *slot = inheritable.cloned().collect();
+        }
+        changed
     }
 }
 

--- a/core/src/prop_cache_test.rs
+++ b/core/src/prop_cache_test.rs
@@ -1799,13 +1799,14 @@ mod autotest_generated {
         assert_eq!(c.computed_values.len(), 2);
         assert_eq!(changed.len(), 2, "both nodes gained a computed value");
 
-        let (t, v) = &c.computed_values[1][0];
+        let entries = c.computed_values.values_for(1);
+        let (t, v) = &entries[0];
         assert_eq!(*t, CssPropertyType::FontSize);
         assert_eq!(v.origin, CssPropertyOrigin::Inherited);
         assert!(close(font_size_parts(&v.property).unwrap().1, 20.0));
 
         // the parent's own value keeps the Own origin
-        assert_eq!(c.computed_values[0][0].1.origin, CssPropertyOrigin::Own);
+        assert_eq!(c.computed_values.values_for(0)[0].1.origin, CssPropertyOrigin::Own);
     }
 
     #[test]
@@ -1818,7 +1819,8 @@ mod autotest_generated {
         let mut c = CssPropertyCache::empty(2);
         c.compute_inherited_values(&hierarchy, &nodes);
 
-        let (t, v) = &c.computed_values[1][0];
+        let entries = c.computed_values.values_for(1);
+        let (t, v) = &entries[0];
         assert_eq!(*t, CssPropertyType::FontSize);
         assert_eq!(v.origin, CssPropertyOrigin::Own);
         let (metric, n) = font_size_parts(&v.property).unwrap();

--- a/core/src/styled_dom.rs
+++ b/core/src/styled_dom.rs
@@ -1053,6 +1053,34 @@ impl StyledDomMemoryReport {
     }
 }
 
+/// `AZ_CASCADE_TRACE=1`: one line per cascade-invalidating decision.
+///
+/// The two questions this exists to answer are the ones that gate any further
+/// work on `CssPropertyCache::css_props` (24.2 MB, the largest remaining line
+/// item): how often is the compact cache REBUILT, and how often does the
+/// dynamic selector context actually change?
+///
+/// `css_props` is written only by `restyle()` and is therefore fully
+/// reproducible from `retained_author_css`, so it could be pruned of
+/// compact-encoded Normal properties and re-derived on demand — but only if
+/// rebuilds are RARE. `prune_compact_normal_props` currently refuses to prune
+/// it, citing a per-frame rebuild; that claim is untested, and the e2e runner
+/// does not exercise `set_dynamic_selector_context` at all, so it cannot be
+/// tested there. Run a real app with this dial to settle it.
+#[cfg(feature = "std")]
+pub(crate) fn cascade_trace(msg: impl FnOnce() -> String) {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::OnceLock;
+    static ON: OnceLock<bool> = OnceLock::new();
+    static N: AtomicUsize = AtomicUsize::new(0);
+    if *ON.get_or_init(|| std::env::var("AZ_CASCADE_TRACE").is_ok()) {
+        eprintln!("[cascade #{}] {}", N.fetch_add(1, Ordering::Relaxed) + 1, msg());
+    }
+}
+
+#[cfg(not(feature = "std"))]
+pub(crate) fn cascade_trace(_: impl FnOnce() -> alloc::string::String) {}
+
 impl StyledDom {
     /// Approximate heap bytes retained by this `StyledDom`, broken out by field.
     #[must_use]
@@ -1600,6 +1628,7 @@ impl StyledDom {
     /// by re-running a full depth-first inheritance pass and rebuilding the
     /// compact cache from scratch on the composed tree.
     pub fn recompute_inheritance_and_compact_cache(&mut self) {
+        cascade_trace(|| "compact cache REBUILT from css_props".to_string());
         // Use the _with_inheritance variant: it does inheritance inline (via
         // parent-compact-field copy) AND populates hot_flags via
         // apply_css_property_to_compact.  The plain build_compact_cache would
@@ -2237,7 +2266,9 @@ impl StyledDom {
     ) {
         {
             let cache = self.get_css_property_cache_mut();
-            if cache.dynamic_context.as_deref() == Some(&context) {
+            let same = cache.dynamic_context.as_deref() == Some(&context);
+            cascade_trace(|| format!("dynamic context offered, unchanged={same}"));
+            if same {
                 return;
             }
             cache.dynamic_context = Some(Box::new(context));

--- a/core/src/transient.rs
+++ b/core/src/transient.rs
@@ -611,8 +611,10 @@ fn bake_resolved_style(
     // not travel: the transient node's own UA `position: absolute; top: 100%`
     // would otherwise displace the popup's content inside its own window.
     if is_root {
-        if let Some(computed) = cache.computed_values.get(i) {
-            for (prop_type, p) in computed {
+        {
+            // The store is inheritable-only by invariant, but the filter stays:
+            // it states the requirement locally rather than trusting a caller.
+            for (prop_type, p) in cache.computed_values.values_for(i) {
                 if prop_type.is_inheritable() {
                     data.add_css_property(CssPropertyWithConditions {
                         property: p.property.clone(),

--- a/core/tests/css_inheritance.rs
+++ b/core/tests/css_inheritance.rs
@@ -85,8 +85,8 @@ fn test_font_size_inheritance_single_level() {
     let child_id = azul_core::dom::NodeId::new(1); // p
 
     // Check computed values for child
-    if let Some(child_computed) = cache.computed_values.get(child_id.index()) {
-        let Some(prop_with_origin) = find_prop(child_computed, &CssPropertyType::FontSize) else {
+    if let Some(child_computed) = cache.computed_values.values_for_opt(child_id.index()) {
+        let Some(prop_with_origin) = find_prop(&child_computed, &CssPropertyType::FontSize) else {
             panic!("Child should have FontSize");
         };
         if let CssProperty::FontSize(font_size_value) = &prop_with_origin.property {
@@ -145,8 +145,8 @@ fn test_font_size_override_not_inherited() {
     let child_id = azul_core::dom::NodeId::new(1); // p
 
     // Verify that child has its own explicit value, not the inherited one
-    if let Some(child_computed) = cache.computed_values.get(child_id.index()) {
-        let Some(prop_with_origin) = find_prop(child_computed, &CssPropertyType::FontSize) else {
+    if let Some(child_computed) = cache.computed_values.values_for_opt(child_id.index()) {
+        let Some(prop_with_origin) = find_prop(&child_computed, &CssPropertyType::FontSize) else {
             panic!("Child should have FontSize");
         };
         if let CssProperty::FontSize(font_size_value) = &prop_with_origin.property {
@@ -203,8 +203,8 @@ fn test_font_weight_inheritance_multi_level() {
 
     // Verify that both <p> and <span> inherited font-weight: bold
     for (node_id, node_name) in &[(p_id, "p"), (span_id, "span")] {
-        if let Some(computed) = cache.computed_values.get(node_id.index()) {
-            let Some(prop_with_origin) = find_prop(computed, &CssPropertyType::FontWeight) else {
+        if let Some(computed) = cache.computed_values.values_for_opt(node_id.index()) {
+            let Some(prop_with_origin) = find_prop(&computed, &CssPropertyType::FontWeight) else {
                 panic!("{node_name} should have FontWeight");
             };
             if let CssProperty::FontWeight(font_weight_value) = &prop_with_origin.property {
@@ -263,9 +263,9 @@ fn test_mixed_inherited_and_explicit_properties() {
 
     let p_id = azul_core::dom::NodeId::new(1); // p
 
-    if let Some(p_computed) = cache.computed_values.get(p_id.index()) {
+    if let Some(p_computed) = cache.computed_values.values_for_opt(p_id.index()) {
         // Check font-size (explicit)
-        let Some(prop_with_origin) = find_prop(p_computed, &CssPropertyType::FontSize) else {
+        let Some(prop_with_origin) = find_prop(&p_computed, &CssPropertyType::FontSize) else {
             panic!("p should have computed FontSize");
         };
         if let CssProperty::FontSize(font_size_value) = &prop_with_origin.property {
@@ -278,7 +278,7 @@ fn test_mixed_inherited_and_explicit_properties() {
         }
 
         // Check font-weight (inherited)
-        let Some(prop_with_origin) = find_prop(p_computed, &CssPropertyType::FontWeight) else {
+        let Some(prop_with_origin) = find_prop(&p_computed, &CssPropertyType::FontWeight) else {
             panic!("p should have FontWeight");
         };
         if let CssProperty::FontWeight(font_weight_value) = &prop_with_origin.property {
@@ -327,10 +327,10 @@ fn test_non_inheritable_property_not_inherited() {
 
     let p_id = azul_core::dom::NodeId::new(1); // p
 
-    if let Some(p_computed) = cache.computed_values.get(p_id.index()) {
+    if let Some(p_computed) = cache.computed_values.values_for_opt(p_id.index()) {
         // Width should NOT be inherited from parent (200px)
         // Test the ORIGIN of the property, not just its value
-        if let Some(prop_with_origin) = find_prop(p_computed, &CssPropertyType::Width) {
+        if let Some(prop_with_origin) = find_prop(&p_computed, &CssPropertyType::Width) {
             // The KEY test: Width should have origin Own (from UA CSS), NOT Inherited
             assert_eq!(
                 prop_with_origin.origin,
@@ -375,7 +375,7 @@ fn test_update_invalidation() {
     let node_data = styled_dom.node_data.as_container().internal;
 
     // Clear the cache to test first computation (StyledDom::new already computed once)
-    cache.computed_values.iter_mut().for_each(|m| m.clear());
+    cache.computed_values.clear_values();
 
     // First computation
     let changed_nodes_1 = cache.compute_inherited_values(node_hierarchy, node_data);
@@ -440,11 +440,11 @@ fn test_deeply_nested_inheritance() {
     // Verify all descendants inherited font-weight: bold
     let span_id = azul_core::dom::NodeId::new(4); // The deepest span
 
-    let Some(span_computed) = cache.computed_values.get(span_id.index()) else {
+    let Some(span_computed) = cache.computed_values.values_for_opt(span_id.index()) else {
         panic!("Deeply nested span should have computed values");
     };
 
-    let Some(prop_with_origin) = find_prop(span_computed, &CssPropertyType::FontWeight) else {
+    let Some(prop_with_origin) = find_prop(&span_computed, &CssPropertyType::FontWeight) else {
         panic!("Deeply nested span should have inherited FontWeight");
     };
     let CssProperty::FontWeight(font_weight_value) = &prop_with_origin.property else {
@@ -499,11 +499,11 @@ fn test_em_unit_inheritance_basic() {
 
     let p_id = azul_core::dom::NodeId::new(1); // p
 
-    let Some(p_computed) = cache.computed_values.get(p_id.index()) else {
+    let Some(p_computed) = cache.computed_values.values_for_opt(p_id.index()) else {
         panic!("p should have computed values");
     };
 
-    let Some(prop_with_origin) = find_prop(p_computed, &CssPropertyType::FontSize) else {
+    let Some(prop_with_origin) = find_prop(&p_computed, &CssPropertyType::FontSize) else {
         panic!("p should have computed FontSize property");
     };
     let CssProperty::FontSize(font_size_value) = &prop_with_origin.property else {
@@ -573,11 +573,11 @@ fn test_em_unit_cascading_multiplication() {
     let span_id = azul_core::dom::NodeId::new(2); // span
 
     // Check p: 2em * 10px = 20px
-    let Some(p_computed) = cache.computed_values.get(p_id.index()) else {
+    let Some(p_computed) = cache.computed_values.values_for_opt(p_id.index()) else {
         panic!("p should have computed values");
     };
 
-    let Some(prop_with_origin) = find_prop(p_computed, &CssPropertyType::FontSize) else {
+    let Some(prop_with_origin) = find_prop(&p_computed, &CssPropertyType::FontSize) else {
         panic!("p should have computed FontSize");
     };
     let CssProperty::FontSize(p_font_size) = &prop_with_origin.property else {
@@ -592,11 +592,11 @@ fn test_em_unit_cascading_multiplication() {
     assert_eq!(p_size, 20.0, "p should be 20px (2em * 10px)");
 
     // Check span: 1.5em * 20px = 30px
-    let Some(span_computed) = cache.computed_values.get(span_id.index()) else {
+    let Some(span_computed) = cache.computed_values.values_for_opt(span_id.index()) else {
         panic!("span should have computed values");
     };
 
-    let Some(prop_with_origin) = find_prop(span_computed, &CssPropertyType::FontSize) else {
+    let Some(prop_with_origin) = find_prop(&span_computed, &CssPropertyType::FontSize) else {
         panic!("span should have computed FontSize");
     };
 
@@ -675,10 +675,10 @@ fn test_em_on_font_size_refers_to_parent() {
     // Check div's font-size: should be 20px (Px metric)
     let div_computed = cache
         .computed_values
-        .get(div_id.index())
+        .values_for_opt(div_id.index())
         .expect("div should have computed values");
     let div_font_prop =
-        find_prop(div_computed, &CssPropertyType::FontSize).expect("div should have FontSize");
+        find_prop(&div_computed, &CssPropertyType::FontSize).expect("div should have FontSize");
     let CssProperty::FontSize(div_font_size) = &div_font_prop.property else {
         panic!("div property should be FontSize");
     };
@@ -699,10 +699,10 @@ fn test_em_on_font_size_refers_to_parent() {
     // Check p's font-size: should be resolved to 30px (1.5 * 20px parent)
     let p_computed = cache
         .computed_values
-        .get(p_id.index())
+        .values_for_opt(p_id.index())
         .expect("p should have computed values");
     let p_font_prop =
-        find_prop(p_computed, &CssPropertyType::FontSize).expect("p should have FontSize");
+        find_prop(&p_computed, &CssPropertyType::FontSize).expect("p should have FontSize");
     let CssProperty::FontSize(p_font_size) = &p_font_prop.property else {
         panic!("p property should be FontSize");
     };
@@ -726,9 +726,9 @@ fn test_em_on_font_size_refers_to_parent() {
     // Check span's inherited font-size: should inherit 30px from p
     let span_computed = cache
         .computed_values
-        .get(span_id.index())
+        .values_for_opt(span_id.index())
         .expect("span should have computed values");
-    let span_font_prop = find_prop(span_computed, &CssPropertyType::FontSize)
+    let span_font_prop = find_prop(&span_computed, &CssPropertyType::FontSize)
         .expect("span should have inherited FontSize");
     let CssProperty::FontSize(span_font_size) = &span_font_prop.property else {
         panic!("span property should be FontSize");
@@ -792,10 +792,10 @@ fn test_em_without_ancestor_absolute_unit() {
     // div should resolve to 2 * 16px (default) = 32px
     let div_computed = cache
         .computed_values
-        .get(div_id.index())
+        .values_for_opt(div_id.index())
         .expect("div should have computed values");
     let div_font_prop =
-        find_prop(div_computed, &CssPropertyType::FontSize).expect("div should have FontSize");
+        find_prop(&div_computed, &CssPropertyType::FontSize).expect("div should have FontSize");
     let CssProperty::FontSize(div_font_size) = &div_font_prop.property else {
         panic!("div property should be FontSize");
     };
@@ -819,9 +819,9 @@ fn test_em_without_ancestor_absolute_unit() {
     // p should inherit 32px from div
     let p_computed = cache
         .computed_values
-        .get(p_id.index())
+        .values_for_opt(p_id.index())
         .expect("p should have computed values");
-    let p_font_prop = find_prop(p_computed, &CssPropertyType::FontSize)
+    let p_font_prop = find_prop(&p_computed, &CssPropertyType::FontSize)
         .expect("p should have inherited FontSize");
     let CssProperty::FontSize(p_font_size) = &p_font_prop.property else {
         panic!("p property should be FontSize");
@@ -893,11 +893,11 @@ fn test_percentage_font_size_inheritance() {
     let span_id = azul_core::dom::NodeId::new(2); // span
 
     // p: 150% of 20px = 30px
-    let Some(p_computed) = cache.computed_values.get(p_id.index()) else {
+    let Some(p_computed) = cache.computed_values.values_for_opt(p_id.index()) else {
         panic!("p should have computed values");
     };
 
-    let Some(prop_with_origin) = find_prop(p_computed, &CssPropertyType::FontSize) else {
+    let Some(prop_with_origin) = find_prop(&p_computed, &CssPropertyType::FontSize) else {
         panic!("p should have FontSize");
     };
 
@@ -913,11 +913,11 @@ fn test_percentage_font_size_inheritance() {
     assert_eq!(p_size, 30.0, "p with 150% should be 30px (1.5 * 20px)");
 
     // span: 80% of 30px = 24px
-    let Some(span_computed) = cache.computed_values.get(span_id.index()) else {
+    let Some(span_computed) = cache.computed_values.values_for_opt(span_id.index()) else {
         panic!("span should have computed values");
     };
 
-    let Some(prop_with_origin) = find_prop(span_computed, &CssPropertyType::FontSize) else {
+    let Some(prop_with_origin) = find_prop(&span_computed, &CssPropertyType::FontSize) else {
         panic!("span should have FontSize");
     };
 

--- a/core/tests/prop_cache.rs
+++ b/core/tests/prop_cache.rs
@@ -69,15 +69,15 @@ fn test_computed_values_exist_for_all_nodes() {
     let node_2 = azul_core::dom::NodeId::new(2);
 
     assert!(
-        cache.computed_values.get(node_0.index()).is_some(),
+        cache.computed_values.values_for_opt(node_0.index()).is_some(),
         "Node 0 should have computed values"
     );
     assert!(
-        cache.computed_values.get(node_1.index()).is_some(),
+        cache.computed_values.values_for_opt(node_1.index()).is_some(),
         "Node 1 should have computed values"
     );
     assert!(
-        cache.computed_values.get(node_2.index()).is_some(),
+        cache.computed_values.values_for_opt(node_2.index()).is_some(),
         "Node 2 should have computed values"
     );
 }
@@ -96,10 +96,10 @@ fn test_inline_css_takes_precedence() {
     let node_0 = azul_core::dom::NodeId::new(0);
     let computed = cache
         .computed_values
-        .get(node_0.index())
+        .values_for_opt(node_0.index())
         .expect("should have computed values");
     let font_size_prop =
-        find_prop(computed, &CssPropertyType::FontSize).expect("should have font-size");
+        find_prop(&computed, &CssPropertyType::FontSize).expect("should have font-size");
 
     assert_eq!(font_size_prop.origin, CssPropertyOrigin::Own);
 
@@ -126,10 +126,10 @@ fn test_css_stylesheet_applies() {
     let p_id = azul_core::dom::NodeId::new(1);
     let computed = cache
         .computed_values
-        .get(p_id.index())
+        .values_for_opt(p_id.index())
         .expect("p should have computed values");
 
-    if let Some(font_size_prop) = find_prop(computed, &CssPropertyType::FontSize) {
+    if let Some(font_size_prop) = find_prop(&computed, &CssPropertyType::FontSize) {
         if let CssProperty::FontSize(val) = &font_size_prop.property {
             if let Some(size) = val.get_property() {
                 assert!((size.inner.number.get() - 18.0).abs() < 0.001);
@@ -158,10 +158,10 @@ fn test_inherited_property_has_correct_origin() {
     let p_id = azul_core::dom::NodeId::new(1);
     let computed = cache
         .computed_values
-        .get(p_id.index())
+        .values_for_opt(p_id.index())
         .expect("p should have computed values");
     let font_size_prop =
-        find_prop(computed, &CssPropertyType::FontSize).expect("should have font-size");
+        find_prop(&computed, &CssPropertyType::FontSize).expect("should have font-size");
 
     // Check that P has the correct font-size value (inherited from div)
     if let CssProperty::FontSize(val) = &font_size_prop.property {
@@ -207,10 +207,10 @@ fn test_own_property_overrides_inherited() {
     let p_id = azul_core::dom::NodeId::new(1);
     let computed = cache
         .computed_values
-        .get(p_id.index())
+        .values_for_opt(p_id.index())
         .expect("p should have computed values");
     let font_size_prop =
-        find_prop(computed, &CssPropertyType::FontSize).expect("should have font-size");
+        find_prop(&computed, &CssPropertyType::FontSize).expect("should have font-size");
 
     assert_eq!(font_size_prop.origin, CssPropertyOrigin::Own);
 
@@ -253,10 +253,10 @@ fn test_em_resolved_to_px_in_computed() {
     let p_id = azul_core::dom::NodeId::new(1);
     let computed = cache
         .computed_values
-        .get(p_id.index())
+        .values_for_opt(p_id.index())
         .expect("p should have computed values");
     let font_size_prop =
-        find_prop(computed, &CssPropertyType::FontSize).expect("should have font-size");
+        find_prop(&computed, &CssPropertyType::FontSize).expect("should have font-size");
 
     if let CssProperty::FontSize(val) = &font_size_prop.property {
         if let Some(size) = val.get_property() {
@@ -299,10 +299,10 @@ fn test_deeply_nested_inheritance() {
     let deep_id = azul_core::dom::NodeId::new(3);
     let computed = cache
         .computed_values
-        .get(deep_id.index())
+        .values_for_opt(deep_id.index())
         .expect("deep node should have computed values");
     let font_size_prop =
-        find_prop(computed, &CssPropertyType::FontSize).expect("should have font-size");
+        find_prop(&computed, &CssPropertyType::FontSize).expect("should have font-size");
 
     if let CssProperty::FontSize(val) = &font_size_prop.property {
         if let Some(size) = val.get_property() {
@@ -323,10 +323,10 @@ fn test_ua_css_for_headings() {
     let h1_id = azul_core::dom::NodeId::new(0);
     let computed = cache
         .computed_values
-        .get(h1_id.index())
+        .values_for_opt(h1_id.index())
         .expect("h1 should have computed values");
 
-    if let Some(font_size_prop) = find_prop(computed, &CssPropertyType::FontSize) {
+    if let Some(font_size_prop) = find_prop(&computed, &CssPropertyType::FontSize) {
         if let CssProperty::FontSize(val) = &font_size_prop.property {
             if let Some(size) = val.get_property() {
                 // H1 UA CSS is 2em, resolved with 16px default = 32px
@@ -376,7 +376,7 @@ fn test_no_computed_values_for_nonexistent_node() {
 
     // Node 100 doesn't exist
     let nonexistent_id = azul_core::dom::NodeId::new(100);
-    assert!(cache.computed_values.get(nonexistent_id.index()).is_none());
+    assert!(cache.computed_values.values_for_opt(nonexistent_id.index()).is_none());
 }
 
 #[test]
@@ -401,10 +401,10 @@ fn test_font_weight_inheritance() {
     let span_id = azul_core::dom::NodeId::new(1);
     let computed = cache
         .computed_values
-        .get(span_id.index())
+        .values_for_opt(span_id.index())
         .expect("span should have computed values");
 
-    if let Some(font_weight_prop) = find_prop(computed, &CssPropertyType::FontWeight) {
+    if let Some(font_weight_prop) = find_prop(&computed, &CssPropertyType::FontWeight) {
         // Check that span has bold font-weight (value matters, origin may vary due to UA CSS)
         if let CssProperty::FontWeight(val) = &font_weight_prop.property {
             if let Some(weight) = val.get_property() {
@@ -445,10 +445,10 @@ fn test_color_inheritance() {
     let p_id = azul_core::dom::NodeId::new(1);
     let computed = cache
         .computed_values
-        .get(p_id.index())
+        .values_for_opt(p_id.index())
         .expect("p should have computed values");
 
-    if let Some(color_prop) = find_prop(computed, &CssPropertyType::TextColor) {
+    if let Some(color_prop) = find_prop(&computed, &CssPropertyType::TextColor) {
         // Check that P has red color (value matters, origin may vary)
         if let CssProperty::TextColor(val) = &color_prop.property {
             if let Some(color) = val.get_property() {
@@ -477,10 +477,10 @@ fn test_non_inheritable_property_not_inherited() {
     let p_id = azul_core::dom::NodeId::new(1);
     let computed = cache
         .computed_values
-        .get(p_id.index())
+        .values_for_opt(p_id.index())
         .expect("p should have computed values");
 
-    if let Some(display_prop) = find_prop(computed, &CssPropertyType::Display) {
+    if let Some(display_prop) = find_prop(&computed, &CssPropertyType::Display) {
         // If it exists, it should be the default (block for P), not inherited flex
         if let CssProperty::Display(val) = &display_prop.property {
             if let Some(display) = val.get_property() {
@@ -534,10 +534,10 @@ fn test_text_node_inherits_from_parent() {
     let text_id = azul_core::dom::NodeId::new(1);
     let computed = cache
         .computed_values
-        .get(text_id.index())
+        .values_for_opt(text_id.index())
         .expect("text should have computed values");
 
-    if let Some(font_size_prop) = find_prop(computed, &CssPropertyType::FontSize) {
+    if let Some(font_size_prop) = find_prop(&computed, &CssPropertyType::FontSize) {
         // Check the VALUE is correct (18px from parent)
         if let CssProperty::FontSize(val) = &font_size_prop.property {
             if let Some(size) = val.get_property() {

--- a/css/src/compact_cache.rs
+++ b/css/src/compact_cache.rs
@@ -42,6 +42,7 @@ use crate::props::layout::{
 };
 use crate::props::property::{CssProperty, CssPropertyType};
 use crate::props::style::border::BorderStyle;
+use crate::props::style::effects::StyleCursor;
 use crate::props::style::{
     StyleDirection, StyleTextAlign, StyleVerticalAlign, StyleVisibility, StyleWhiteSpace,
 };
@@ -126,6 +127,15 @@ pub const WHITE_SPACE_SHIFT: u32 = 45;
 pub const DIRECTION_SHIFT: u32 = 48;
 pub const VERTICAL_ALIGN_SHIFT: u32 = 49;
 pub const BORDER_COLLAPSE_SHIFT: u32 = 52;
+/// `cursor`, 5 bits for 30 variants, in the first free slot above
+/// `BORDER_COLLAPSE` (bit 52). Bits 58..=62 remain free; bit 63 is
+/// `TIER1_POPULATED_BIT`.
+///
+/// Cursor is INHERITABLE per spec, so a `cursor: pointer` on a container
+/// resolves for every descendant, and it is resolved on EVERY MOUSE MOVE to
+/// decide the pointer shape. A tier-1 bitfield read is the right cost for
+/// that; the slow path's bucket scan was not.
+pub const CURSOR_SHIFT: u32 = 53;
 
 // Bit masks
 pub const DISPLAY_MASK: u64 = 0x1F; // 5 bits
@@ -147,6 +157,7 @@ pub const WHITE_SPACE_MASK: u64 = 0x07; // 3 bits
 pub const DIRECTION_MASK: u64 = 0x01; // 1 bit
 pub const VERTICAL_ALIGN_MASK: u64 = 0x07; // 3 bits
 pub const BORDER_COLLAPSE_MASK: u64 = 0x01; // 1 bit
+pub const CURSOR_MASK: u64 = 0x1F; // 5 bits (30 variants)
 
 pub const ALIGN_SELF_SHIFT: u32 = 53;
 pub const JUSTIFY_SELF_SHIFT: u32 = 56;
@@ -797,6 +808,89 @@ pub const fn style_vertical_align_to_u8(v: StyleVerticalAlign) -> u8 {
         // for vertical-align values with length/percentage units.
         StyleVerticalAlign::Percentage(_) | StyleVerticalAlign::Length(_) => 0,
     }
+}
+
+/// `StyleCursor` <-> 5-bit code. `Default` (the CSS initial value) is 0 so an
+/// unset node decodes to it for free, and an out-of-range code falls back to it
+/// rather than panicking.
+#[inline]
+#[must_use]
+pub const fn cursor_to_u8(v: StyleCursor) -> u8 {
+    match v {
+        StyleCursor::Default => 0,
+        StyleCursor::Alias => 1,
+        StyleCursor::AllScroll => 2,
+        StyleCursor::Cell => 3,
+        StyleCursor::ColResize => 4,
+        StyleCursor::ContextMenu => 5,
+        StyleCursor::Copy => 6,
+        StyleCursor::Crosshair => 7,
+        StyleCursor::EResize => 8,
+        StyleCursor::EwResize => 9,
+        StyleCursor::Grab => 10,
+        StyleCursor::Grabbing => 11,
+        StyleCursor::Help => 12,
+        StyleCursor::Move => 13,
+        StyleCursor::NResize => 14,
+        StyleCursor::NsResize => 15,
+        StyleCursor::NeswResize => 16,
+        StyleCursor::NwseResize => 17,
+        StyleCursor::Pointer => 18,
+        StyleCursor::Progress => 19,
+        StyleCursor::RowResize => 20,
+        StyleCursor::SResize => 21,
+        StyleCursor::SeResize => 22,
+        StyleCursor::Text => 23,
+        StyleCursor::Unset => 24,
+        StyleCursor::VerticalText => 25,
+        StyleCursor::WResize => 26,
+        StyleCursor::Wait => 27,
+        StyleCursor::ZoomIn => 28,
+        StyleCursor::ZoomOut => 29,
+    }
+}
+
+#[inline]
+#[must_use]
+pub const fn cursor_from_u8(v: u8) -> StyleCursor {
+    match v {
+        1 => StyleCursor::Alias,
+        2 => StyleCursor::AllScroll,
+        3 => StyleCursor::Cell,
+        4 => StyleCursor::ColResize,
+        5 => StyleCursor::ContextMenu,
+        6 => StyleCursor::Copy,
+        7 => StyleCursor::Crosshair,
+        8 => StyleCursor::EResize,
+        9 => StyleCursor::EwResize,
+        10 => StyleCursor::Grab,
+        11 => StyleCursor::Grabbing,
+        12 => StyleCursor::Help,
+        13 => StyleCursor::Move,
+        14 => StyleCursor::NResize,
+        15 => StyleCursor::NsResize,
+        16 => StyleCursor::NeswResize,
+        17 => StyleCursor::NwseResize,
+        18 => StyleCursor::Pointer,
+        19 => StyleCursor::Progress,
+        20 => StyleCursor::RowResize,
+        21 => StyleCursor::SResize,
+        22 => StyleCursor::SeResize,
+        23 => StyleCursor::Text,
+        24 => StyleCursor::Unset,
+        25 => StyleCursor::VerticalText,
+        26 => StyleCursor::WResize,
+        27 => StyleCursor::Wait,
+        28 => StyleCursor::ZoomIn,
+        29 => StyleCursor::ZoomOut,
+        _ => StyleCursor::Default,
+    }
+}
+
+#[inline]
+#[must_use]
+pub const fn decode_cursor(t1: u64) -> StyleCursor {
+    cursor_from_u8(((t1 >> CURSOR_SHIFT) & CURSOR_MASK) as u8)
 }
 
 #[inline]
@@ -1781,6 +1875,13 @@ impl CompactLayoutCache {
     #[must_use]
     pub fn get_border_collapse(&self, node_idx: usize) -> StyleBorderCollapse {
         decode_border_collapse(self.tier1_enums[node_idx])
+    }
+
+    /// The resolved `cursor` for a node — one shifted mask read.
+    #[inline]
+    #[must_use]
+    pub fn get_cursor(&self, node_idx: usize) -> StyleCursor {
+        decode_cursor(self.tier1_enums[node_idx])
     }
 
     // -- Tier 2 getters (numeric dimensions) --
@@ -4814,5 +4915,55 @@ mod autotest_generated {
         assert_eq!(align_of::<CompactNodeProps>(), 4);
         assert_eq!(align_of::<CompactNodePropsCold>(), 4);
         assert_eq!(align_of::<CompactTextProps>(), 8);
+    }
+
+    /// Every `StyleCursor` variant survives the 5-bit round trip, and the codes
+    /// stay inside `CURSOR_MASK`.
+    ///
+    /// 30 variants need 5 bits; the slot sits at bit 53, above
+    /// `BORDER_COLLAPSE` (52) and below `TIER1_POPULATED_BIT` (63). A 31st
+    /// variant still fits, a 33rd would silently alias onto another property's
+    /// bits — which is what this test is here to prevent.
+    #[test]
+    fn every_cursor_variant_survives_the_tier1_round_trip() {
+        use crate::props::style::effects::StyleCursor::{
+            Alias, AllScroll, Cell, ColResize, ContextMenu, Copy, Crosshair, Default as Def,
+            EResize, EwResize, Grab, Grabbing, Help, Move, NResize, NeswResize, NsResize,
+            NwseResize, Pointer, Progress, RowResize, SResize, SeResize, Text, Unset,
+            VerticalText, WResize, Wait, ZoomIn, ZoomOut,
+        };
+        let all = [
+            Def, Alias, AllScroll, Cell, ColResize, ContextMenu, Copy, Crosshair, EResize,
+            EwResize, Grab, Grabbing, Help, Move, NResize, NsResize, NeswResize, NwseResize,
+            Pointer, Progress, RowResize, SResize, SeResize, Text, Unset, VerticalText, WResize,
+            Wait, ZoomIn, ZoomOut,
+        ];
+        let mut seen = alloc::collections::BTreeSet::new();
+        for c in all {
+            let code = cursor_to_u8(c);
+            assert!(
+                u64::from(code) <= CURSOR_MASK,
+                "{c:?} encodes to {code}, past CURSOR_MASK — it would alias another property",
+            );
+            assert!(seen.insert(code), "{c:?} shares code {code} with another variant");
+            assert_eq!(cursor_from_u8(code), c, "{c:?} did not survive the round trip");
+
+            // And through the packed word, where the shift could collide.
+            let t1 = (u64::from(code) & CURSOR_MASK) << CURSOR_SHIFT;
+            assert_eq!(decode_cursor(t1), c);
+        }
+        assert_eq!(seen.len(), all.len(), "every variant needs its own code");
+    }
+
+    /// The cursor slot must not overlap its neighbours in the tier-1 word.
+    #[test]
+    fn the_cursor_slot_does_not_collide() {
+        let cursor_bits = CURSOR_MASK << CURSOR_SHIFT;
+        let border_collapse_bits = BORDER_COLLAPSE_MASK << BORDER_COLLAPSE_SHIFT;
+        assert_eq!(cursor_bits & border_collapse_bits, 0, "cursor overlaps border-collapse");
+        assert_eq!(cursor_bits & TIER1_POPULATED_BIT, 0, "cursor overlaps the populated bit");
+        // Writing the maximum code must not disturb anything else.
+        let full = u64::MAX & !cursor_bits;
+        assert_eq!(decode_cursor(full | cursor_bits), cursor_from_u8(CURSOR_MASK as u8));
     }
 }

--- a/dll/src/web/html_render.rs
+++ b/dll/src/web/html_render.rs
@@ -555,16 +555,34 @@ impl RenderContext {
     /// - `css_props[node]` with state=Hover → `#az_N:hover { ... }` (browser-interactive)
     /// - `css_props[node]` with state=Focus → `#az_N:focus { ... }` etc.
     fn emit_css_from_cache(&mut self, cache: &CssPropertyCache, node_idx: usize, az_id: usize) {
-        // Base computed styles (all conditions already resolved by Azul)
-        if let Some(computed) = cache.computed_values.get(node_idx) {
-            if !computed.is_empty() {
-                let decls: Vec<String> = computed
-                    .iter()
-                    .map(|(_ptype, pwith)| pwith.property.format_css())
-                    .collect();
-                self.css_rules
-                    .push(format!("#az_{} {{ {} }}", az_id, decls.join(" ")));
+        // Base computed styles (all conditions already resolved by Azul).
+        //
+        // TWO SOURCES, because no single one holds them all: `computed_values`
+        // is INHERITABLE-only by invariant (see `CssPropertyCache`), so the
+        // node's own non-inherited properties — display, margin, padding,
+        // position — come from the Normal-state entries of `cascaded_props`
+        // (which is also where `apply_ua_css` puts the UA defaults) and
+        // `css_props` (author rules), in that cascade order. Reading only
+        // `computed_values` here used to work because the cascade stored every
+        // property in it; it no longer does, and emitting a page with no
+        // `display` or `margin` would be silently wrong.
+        let mut decls: Vec<String> = Vec::new();
+        for slice in [
+            cache.cascaded_props.get_slice(node_idx),
+            cache.css_props.get_slice(node_idx),
+        ] {
+            for sp in slice {
+                if sp.state == azul_css::dynamic_selector::PseudoStateType::Normal {
+                    decls.push(sp.property.format_css());
+                }
             }
+        }
+        if let Some(computed) = cache.computed_values.get(node_idx) {
+            decls.extend(computed.iter().map(|(_t, p)| p.property.format_css()));
+        }
+        if !decls.is_empty() {
+            self.css_rules
+                .push(format!("#az_{} {{ {} }}", az_id, decls.join(" ")));
         }
 
         // Interactive pseudo-state rules from the css_props cache

--- a/layout/src/callbacks.rs
+++ b/layout/src/callbacks.rs
@@ -5130,8 +5130,6 @@ impl CallbackInfo {
             .get_scroll_node_info(dom_id, node_id)
     }
 
-    /// Deprecated: Returns None. Scroll deltas are no longer tracked per-frame.
-    /// Kept for FFI backward compatibility.
     /// The raw wheel / trackpad delta that triggered the current `Scroll`
     /// callback, or `None` outside a scroll dispatch. The value is the per-pass
     /// delta recorded by the platform scroll handler (see
@@ -5147,13 +5145,6 @@ impl CallbackInfo {
         _node_id: NodeId,
     ) -> Option<LogicalPosition> {
         self.get_scroll_manager().pending_wheel_event
-    }
-
-    /// Deprecated: Returns false. Scroll activity flags were removed.
-    /// Kept for FFI backward compatibility.
-    #[must_use]
-    pub const fn had_scroll_activity(&self, _dom_id: DomId, _node_id: NodeId) -> bool {
-        false
     }
 
     /// The closest scrollable STRICT ancestor of a node - `node_id` itself is

--- a/layout/src/dom_footprint_test.rs
+++ b/layout/src/dom_footprint_test.rs
@@ -104,15 +104,18 @@ mod tests {
         );
     }
 
-    /// THE STYLE CACHE, NOT THE TREE, IS THE EXPENSIVE HALF — recorded so the
-    /// ratio is a fact rather than a surprise.
+    /// THE CACHE IS NOW SMALLER THAN THE TREE — the inversion, pinned.
     ///
-    /// `computed_values` alone is roughly four times the whole DOM. Anyone
-    /// reading "a DOM is about a megabyte" and sizing a budget from it will be
-    /// out by an order of magnitude unless they know this, and any future work
-    /// on rebuild cost should start here rather than on the tree.
+    /// It used to be 7x the tree, and `computed_values` alone was four times
+    /// the whole DOM. After dropping the unreachable entries, transposing the
+    /// inherited store and sharing identical runs in `css_props` /
+    /// `cascaded_props`, what is left is dominated by the COMPACT CACHE — the
+    /// irreducible bitfield form the hot layout loop reads, which is the one
+    /// part that should be big.
+    ///
+    /// If this ever fails the other way, a per-node duplicate has crept back in.
     #[test]
-    fn the_style_cache_dominates_the_tree_it_is_derived_from() {
+    fn the_style_cache_no_longer_dominates_the_tree_it_is_derived_from() {
         let Some(xml) = bench_document() else {
             eprintln!("[skip] doc/xhtml1/chapter-8.xht not present");
             return;
@@ -127,9 +130,10 @@ mod tests {
             cache as f64 / dom_only.max(1) as f64,
         );
         assert!(
-            cache > dom_only,
-            "the style cache used to dominate the DOM ({cache} vs {dom_only}); if that has \
-             changed, the module docs above and the guide's memory figures need updating",
+            cache < dom_only,
+            "the style cache ({cache} B) has grown past the tree it derives from ({dom_only} B) \
+             — a per-node duplicate has come back; see `FlatVecVec::dedup_runs` and \
+             `InheritedValues`",
         );
 
         // And the number the guide's claim projects to for a dense real UI.

--- a/layout/src/dom_footprint_test.rs
+++ b/layout/src/dom_footprint_test.rs
@@ -144,4 +144,129 @@ mod tests {
             "a 5000-node UI's TREE projects to {projected} bytes; the guide claims ~1 MB",
         );
     }
+
+    /// HOW MUCH of `computed_values` is answerable from the compact cache?
+    ///
+    /// `computed_values` is a per-node sorted vec of resolved INHERITABLE
+    /// properties, and it is 58% of the whole style cache. 17 of the 37
+    /// inheritable property types also have a compact encoding, so for those
+    /// the compact cache already holds the answer (it does its own inheritance
+    /// — `compact.rs`, "Step 1: Inherit from parent's COMPACT values"). Only
+    /// the remaining 20 — the rare ones (`hanging-punctuation`,
+    /// `text-combine-upright`, `list-style-position`, `widows`, `orphans` …) —
+    /// genuinely need a tall form.
+    ///
+    /// This counts the split on a real stylesheet, so the decision to write the
+    /// `CssPropertyType` -> compact dispatch is made against a number rather
+    /// than against the shape of the type list.
+    #[test]
+    fn how_much_of_computed_values_the_compact_cache_could_answer() {
+        let Some(xml) = bench_document() else {
+            eprintln!("[skip] doc/xhtml1/chapter-8.xht not present");
+            return;
+        };
+        let styled = crate::xml::parse_xml_to_styled_dom(&xml)
+            .expect("the bench document must parse");
+        let cache = styled.get_css_property_cache();
+
+        let mut compact_covered = 0usize;
+        let mut needs_tall = 0usize;
+        let mut by_type: std::collections::BTreeMap<String, usize> =
+            std::collections::BTreeMap::new();
+        for per_node in &cache.computed_values {
+            for (ty, _) in per_node {
+                if ty.has_compact_encoding() {
+                    compact_covered += 1;
+                } else {
+                    needs_tall += 1;
+                    *by_type.entry(format!("{ty:?}")).or_default() += 1;
+                }
+            }
+        }
+        let total = compact_covered + needs_tall;
+        println!(
+            "computed_values entries: {total} total | {compact_covered} answerable from the \
+             compact cache ({:.1}%) | {needs_tall} genuinely need the tall form",
+            100.0 * compact_covered as f64 / total.max(1) as f64,
+        );
+        println!("  non-compact inherited types actually used: {by_type:?}");
+
+        // Of the compact-covered entries, only some are LOSSLESSLY recoverable:
+        // the compact cache stores font-family as a u64 HASH, and pixel-valued
+        // properties as a px-or-sentinel encoding that discards em/%/vh metrics.
+        // Count the entries a `CssPropertyType -> CssProperty` bridge could
+        // actually answer.
+        let mut recoverable: std::collections::BTreeMap<String, usize> =
+            std::collections::BTreeMap::new();
+        let mut lossy: std::collections::BTreeMap<String, usize> =
+            std::collections::BTreeMap::new();
+        for per_node in &cache.computed_values {
+            for (ty, _) in per_node {
+                if !ty.has_compact_encoding() {
+                    continue;
+                }
+                let name = format!("{ty:?}");
+                // Enum-valued tier-1 properties and the packed colour decode
+                // back exactly; everything else loses its metric or its identity.
+                let lossless = matches!(
+                    name.as_str(),
+                    "font-weight" | "font-style" | "text-align" | "visibility" | "white-space"
+                        | "direction" | "writing-mode" | "border-collapse" | "color"
+                        | "tab-size" | "border-spacing"
+                );
+                if lossless {
+                    *recoverable.entry(name).or_default() += 1;
+                } else {
+                    *lossy.entry(name).or_default() += 1;
+                }
+            }
+        }
+        let rec: usize = recoverable.values().sum();
+        let los: usize = lossy.values().sum();
+        println!(
+            "  of the compact-covered {compact_covered}: {rec} losslessly recoverable ({:.1}% of \
+             ALL entries), {los} lossy",
+            100.0 * rec as f64 / total.max(1) as f64,
+        );
+        println!("    recoverable: {recoverable:?}");
+        println!("    lossy:       {lossy:?}");
+
+        // WHY the remaining entries are still expensive, and what a transposed
+        // store would cost instead. `CssProperty` is a wide enum held BY VALUE
+        // in every entry, so an inherited `cursor: pointer` on a container is
+        // paid for again in every descendant. Counting DISTINCT values per type
+        // sizes the alternative: one copy of each value plus a node-id list.
+        use azul_css::props::property::CssProperty;
+        let entry_sz = core::mem::size_of::<(
+            azul_css::props::property::CssPropertyType,
+            azul_core::prop_cache::CssPropertyWithOrigin,
+        )>();
+        println!(
+            "  size_of CssProperty = {} B, per-entry = {entry_sz} B",
+            core::mem::size_of::<CssProperty>(),
+        );
+        let mut distinct: std::collections::BTreeMap<String, std::collections::BTreeSet<String>> =
+            std::collections::BTreeMap::new();
+        let mut entries = 0usize;
+        for per_node in &cache.computed_values {
+            for (ty, p) in per_node {
+                entries += 1;
+                distinct
+                    .entry(format!("{ty:?}"))
+                    .or_default()
+                    .insert(format!("{:?}", p.property));
+            }
+        }
+        let distinct_total: usize = distinct.values().map(std::collections::BTreeSet::len).sum();
+        let transposed = distinct_total * entry_sz + entries * core::mem::size_of::<u32>();
+        let current = entries * entry_sz;
+        println!(
+            "  {entries} entries over {distinct_total} DISTINCT values: by-value {current} B vs \
+             transposed {transposed} B ({:.0}x smaller)",
+            current as f64 / transposed.max(1) as f64,
+        );
+        for (ty, vals) in &distinct {
+            println!("    {ty}: {} distinct value(s)", vals.len());
+        }
+    }
 }

--- a/layout/src/dom_footprint_test.rs
+++ b/layout/src/dom_footprint_test.rs
@@ -1,0 +1,147 @@
+//! What a whole UI actually COSTS in memory, as a checked number.
+//!
+//! `doc/guide/en/architecture.md` rests an architectural argument on a
+//! measurement: re-deriving the UI from application state on every interaction
+//! is affordable because "the entire DOM with styling in even a large
+//! application is only ~500KB - 1MB". That claim is the answer to the standard
+//! objection to `UI = f(data)` — that rebuilding is too expensive — so it needs
+//! to be a fact the tree checks, not a number someone once saw.
+//!
+//! Measured on a document far past anything a GUI reaches — the 1 MB, ~50k-node
+//! XHTML spec chapter the render bench uses — the answer splits in two, and the
+//! split is the interesting part:
+//!
+//!   * the DOM proper is ~257 bytes/node, so a 5000-node UI (already a dense
+//!     desktop window) is ~1.25 MB. The guide's number is right.
+//!   * the CSS PROPERTY CACHE is ~1774 bytes/node — SEVEN TIMES the DOM, and
+//!     87% of the total, most of it `computed_values`.
+//!
+//! That matters for how the claim is stated. "The DOM is a megabyte" is true
+//! and is the affordability argument; "a StyledDom is a megabyte" is false by
+//! an order of magnitude, and the difference is a derived cache, not the tree.
+//! A rebuild pays for the cache too, so the honest framing is that re-derivation
+//! is cheap in the DOM and bounded by the cascade.
+//!
+//! The bounds below catch a regression of the ORDER (a `NodeData` that doubles,
+//! a cache that starts retaining per-node allocations), not an exact byte count
+//! ordinary work would churn.
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    /// The XHTML spec chapter the render benchmark uses: ~1 MB of markup,
+    /// tens of thousands of nodes. `None` when run from a checkout without it,
+    /// so the test degrades to a skip rather than a failure.
+    fn bench_document() -> Option<String> {
+        for rel in ["../doc/xhtml1/chapter-8.xht", "doc/xhtml1/chapter-8.xht"] {
+            if let Ok(s) = std::fs::read_to_string(PathBuf::from(rel)) {
+                return Some(s);
+            }
+        }
+        None
+    }
+
+    /// THE TREE ITSELF is a few hundred bytes per node — the measurement
+    /// `architecture.md` cites when it answers "isn't rebuilding expensive?".
+    ///
+    /// If this ever fails, the guide's affordability argument has to be
+    /// restated, not the bound relaxed.
+    #[test]
+    fn the_dom_itself_costs_a_few_hundred_bytes_per_node() {
+        let Some(xml) = bench_document() else {
+            eprintln!("[skip] doc/xhtml1/chapter-8.xht not present");
+            return;
+        };
+        let styled = crate::xml::parse_xml_to_styled_dom(&xml)
+            .expect("the bench document must parse");
+        let report = styled.memory_report();
+        let nodes = report.node_count;
+        let total = report.total_bytes();
+        assert!(nodes > 10_000, "expected a large document, got {nodes} nodes");
+
+        let per_node = total / nodes.max(1);
+        println!(
+            "StyledDom: {nodes} nodes, {total} bytes total, {per_node} bytes/node\n  \
+             hierarchy {} | node_data {} | styled_nodes {} | cascade {} | tags {} | \
+             non_leaf {} | callbacks {} | css_cache {}",
+            report.node_hierarchy_bytes,
+            report.node_data_bytes,
+            report.styled_nodes_bytes,
+            report.cascade_info_bytes,
+            report.tag_ids_bytes,
+            report.non_leaf_nodes_bytes,
+            report.callback_vecs_bytes,
+            report.css_property_cache.total_bytes(),
+        );
+        let c = &report.css_property_cache;
+        println!(
+            "  css_cache: cascaded {} | css_props {} | computed {} | overridden {} | \
+             global {} | compact {} | font_sizes {}",
+            c.cascaded_props_bytes,
+            c.css_props_bytes,
+            c.computed_values_bytes,
+            c.user_overridden_bytes,
+            c.global_css_props_bytes,
+            c.compact_cache_bytes,
+            c.resolved_font_sizes_bytes,
+        );
+        let dom_only = total - c.total_bytes();
+        println!(
+            "  DOM WITHOUT the style cache: {dom_only} bytes = {} bytes/node",
+            dom_only / nodes.max(1),
+        );
+
+        // THE TREE, without the derived style cache: this is what the guide's
+        // "~500KB - 1MB for a large application" is about, and what a rebuild
+        // has to reconstruct structurally. Measured at 257 bytes/node; 512 is
+        // an order check, not a target.
+        let dom_per_node = dom_only / nodes.max(1);
+        assert!(
+            dom_per_node < 512,
+            "the DOM is {dom_per_node} bytes/node — the re-derivation argument rests on this \
+             staying in the hundreds",
+        );
+    }
+
+    /// THE STYLE CACHE, NOT THE TREE, IS THE EXPENSIVE HALF — recorded so the
+    /// ratio is a fact rather than a surprise.
+    ///
+    /// `computed_values` alone is roughly four times the whole DOM. Anyone
+    /// reading "a DOM is about a megabyte" and sizing a budget from it will be
+    /// out by an order of magnitude unless they know this, and any future work
+    /// on rebuild cost should start here rather than on the tree.
+    #[test]
+    fn the_style_cache_dominates_the_tree_it_is_derived_from() {
+        let Some(xml) = bench_document() else {
+            eprintln!("[skip] doc/xhtml1/chapter-8.xht not present");
+            return;
+        };
+        let styled = crate::xml::parse_xml_to_styled_dom(&xml)
+            .expect("the bench document must parse");
+        let report = styled.memory_report();
+        let cache = report.css_property_cache.total_bytes();
+        let dom_only = report.total_bytes() - cache;
+        println!(
+            "cache {cache} vs dom {dom_only} — cache is {:.1}x the tree",
+            cache as f64 / dom_only.max(1) as f64,
+        );
+        assert!(
+            cache > dom_only,
+            "the style cache used to dominate the DOM ({cache} vs {dom_only}); if that has \
+             changed, the module docs above and the guide's memory figures need updating",
+        );
+
+        // And the number the guide's claim projects to for a dense real UI.
+        let dom_per_node = dom_only / report.node_count.max(1);
+        let projected = dom_per_node * 5_000;
+        println!(
+            "projected 5000-node UI (tree only): {projected} bytes ({:.2} MB)",
+            projected as f64 / (1024.0 * 1024.0),
+        );
+        assert!(
+            projected < 4 * 1024 * 1024,
+            "a 5000-node UI's TREE projects to {projected} bytes; the guide claims ~1 MB",
+        );
+    }
+}

--- a/layout/src/dom_footprint_test.rs
+++ b/layout/src/dom_footprint_test.rs
@@ -145,22 +145,16 @@ mod tests {
         );
     }
 
-    /// HOW MUCH of `computed_values` is answerable from the compact cache?
+    /// The TRANSPOSED store, measured: how many (node, property) pairs it
+    /// represents, how few distinct values that actually is, and what it costs.
     ///
-    /// `computed_values` is a per-node sorted vec of resolved INHERITABLE
-    /// properties, and it is 58% of the whole style cache. 17 of the 37
-    /// inheritable property types also have a compact encoding, so for those
-    /// the compact cache already holds the answer (it does its own inheritance
-    /// — `compact.rs`, "Step 1: Inherit from parent's COMPACT values"). Only
-    /// the remaining 20 — the rare ones (`hanging-punctuation`,
-    /// `text-combine-upright`, `list-style-position`, `widows`, `orphans` …) —
-    /// genuinely need a tall form.
-    ///
-    /// This counts the split on a real stylesheet, so the decision to write the
-    /// `CssPropertyType` -> compact dispatch is made against a number rather
-    /// than against the shape of the type list.
+    /// Inherited values are shared down a subtree by definition, so the
+    /// per-node shape paid for a 136-byte `CssProperty` again in every
+    /// descendant. `cursor` was the extreme case: 29 391 entries carrying ONE
+    /// value. This pins the compression ratio so a regression that reintroduces
+    /// per-node copies is visible as a number rather than as a memory graph.
     #[test]
-    fn how_much_of_computed_values_the_compact_cache_could_answer() {
+    fn the_inherited_store_holds_a_handful_of_values_for_tens_of_thousands_of_nodes() {
         let Some(xml) = bench_document() else {
             eprintln!("[skip] doc/xhtml1/chapter-8.xht not present");
             return;
@@ -168,105 +162,31 @@ mod tests {
         let styled = crate::xml::parse_xml_to_styled_dom(&xml)
             .expect("the bench document must parse");
         let cache = styled.get_css_property_cache();
+        let store = &cache.computed_values;
 
-        let mut compact_covered = 0usize;
-        let mut needs_tall = 0usize;
-        let mut by_type: std::collections::BTreeMap<String, usize> =
-            std::collections::BTreeMap::new();
-        for per_node in &cache.computed_values {
-            for (ty, _) in per_node {
-                if ty.has_compact_encoding() {
-                    compact_covered += 1;
-                } else {
-                    needs_tall += 1;
-                    *by_type.entry(format!("{ty:?}")).or_default() += 1;
-                }
-            }
-        }
-        let total = compact_covered + needs_tall;
+        let entries = store.entry_count();
+        let buckets = store.bucket_count();
+        let bytes = store.heap_bytes();
+        let by_value_bytes = entries
+            * core::mem::size_of::<(
+                azul_css::props::property::CssPropertyType,
+                azul_core::prop_cache::CssPropertyWithOrigin,
+            )>();
         println!(
-            "computed_values entries: {total} total | {compact_covered} answerable from the \
-             compact cache ({:.1}%) | {needs_tall} genuinely need the tall form",
-            100.0 * compact_covered as f64 / total.max(1) as f64,
+            "inherited store: {entries} (node, property) pairs over {buckets} distinct values\n               transposed {bytes} B vs per-node {by_value_bytes} B ({:.0}x smaller)",
+            by_value_bytes as f64 / bytes.max(1) as f64,
         );
-        println!("  non-compact inherited types actually used: {by_type:?}");
 
-        // Of the compact-covered entries, only some are LOSSLESSLY recoverable:
-        // the compact cache stores font-family as a u64 HASH, and pixel-valued
-        // properties as a px-or-sentinel encoding that discards em/%/vh metrics.
-        // Count the entries a `CssPropertyType -> CssProperty` bridge could
-        // actually answer.
-        let mut recoverable: std::collections::BTreeMap<String, usize> =
-            std::collections::BTreeMap::new();
-        let mut lossy: std::collections::BTreeMap<String, usize> =
-            std::collections::BTreeMap::new();
-        for per_node in &cache.computed_values {
-            for (ty, _) in per_node {
-                if !ty.has_compact_encoding() {
-                    continue;
-                }
-                let name = format!("{ty:?}");
-                // Enum-valued tier-1 properties and the packed colour decode
-                // back exactly; everything else loses its metric or its identity.
-                let lossless = matches!(
-                    name.as_str(),
-                    "font-weight" | "font-style" | "text-align" | "visibility" | "white-space"
-                        | "direction" | "writing-mode" | "border-collapse" | "color"
-                        | "tab-size" | "border-spacing"
-                );
-                if lossless {
-                    *recoverable.entry(name).or_default() += 1;
-                } else {
-                    *lossy.entry(name).or_default() += 1;
-                }
-            }
-        }
-        let rec: usize = recoverable.values().sum();
-        let los: usize = lossy.values().sum();
-        println!(
-            "  of the compact-covered {compact_covered}: {rec} losslessly recoverable ({:.1}% of \
-             ALL entries), {los} lossy",
-            100.0 * rec as f64 / total.max(1) as f64,
+        assert!(entries > 10_000, "expected a large document, got {entries} pairs");
+        // The whole point: values are SHARED, so the bucket count stays tiny
+        // even as the node count grows. 100 is an order check.
+        assert!(
+            buckets < 100,
+            "{buckets} distinct inherited values — the store is no longer sharing them",
         );
-        println!("    recoverable: {recoverable:?}");
-        println!("    lossy:       {lossy:?}");
-
-        // WHY the remaining entries are still expensive, and what a transposed
-        // store would cost instead. `CssProperty` is a wide enum held BY VALUE
-        // in every entry, so an inherited `cursor: pointer` on a container is
-        // paid for again in every descendant. Counting DISTINCT values per type
-        // sizes the alternative: one copy of each value plus a node-id list.
-        use azul_css::props::property::CssProperty;
-        let entry_sz = core::mem::size_of::<(
-            azul_css::props::property::CssPropertyType,
-            azul_core::prop_cache::CssPropertyWithOrigin,
-        )>();
-        println!(
-            "  size_of CssProperty = {} B, per-entry = {entry_sz} B",
-            core::mem::size_of::<CssProperty>(),
+        assert!(
+            bytes < by_value_bytes / 4,
+            "transposed {bytes} B vs per-node {by_value_bytes} B — the compression is gone",
         );
-        let mut distinct: std::collections::BTreeMap<String, std::collections::BTreeSet<String>> =
-            std::collections::BTreeMap::new();
-        let mut entries = 0usize;
-        for per_node in &cache.computed_values {
-            for (ty, p) in per_node {
-                entries += 1;
-                distinct
-                    .entry(format!("{ty:?}"))
-                    .or_default()
-                    .insert(format!("{:?}", p.property));
-            }
-        }
-        let distinct_total: usize = distinct.values().map(std::collections::BTreeSet::len).sum();
-        let transposed = distinct_total * entry_sz + entries * core::mem::size_of::<u32>();
-        let current = entries * entry_sz;
-        println!(
-            "  {entries} entries over {distinct_total} DISTINCT values: by-value {current} B vs \
-             transposed {transposed} B ({:.0}x smaller)",
-            current as f64 / transposed.max(1) as f64,
-        );
-        for (ty, vals) in &distinct {
-            println!("    {ty}: {} distinct value(s)", vals.len());
-        }
     }
 }

--- a/layout/src/lib.rs
+++ b/layout/src/lib.rs
@@ -524,6 +524,12 @@ pub mod window_state;
 #[allow(unused_assignments)]
 pub mod xml;
 
+/// What a whole UI costs in memory — the measurement `architecture.md`'s
+/// re-derivation argument rests on, as a checked fact.
+#[cfg(test)]
+#[path = "dom_footprint_test.rs"]
+mod dom_footprint_test;
+
 /// Debug / E2E server op-dispatch, ported verbatim from the DLL. Gated behind
 /// the `e2e-server` feature (NOT in `default`), so the lean crate is unaffected.
 #[cfg(feature = "e2e-server")]

--- a/layout/src/managers/gesture.rs
+++ b/layout/src/managers/gesture.rs
@@ -443,8 +443,6 @@ impl WacomPadState {
 /// The manager now uses `DragContext` to unify all drag types:
 /// - `active_drag`: The unified drag context (replaces individual drag states)
 ///
-/// For backwards compatibility, the old `node_drag`, `window_drag`, `file_drop`
-/// fields are still accessible but deprecated.
 #[derive(Debug, Clone, PartialEq)]
 pub struct GestureAndDragManager {
     /// Configuration for gesture detection

--- a/layout/src/solver3/getters.rs
+++ b/layout/src/solver3/getters.rs
@@ -149,9 +149,14 @@ fn compute_all_font_sizes_px(styled_dom: &StyledDom) -> Vec<f32> {
         let dom_id = NodeId::new(idx);
 
         // Step 1: computed_values short-circuit (matches original).
-        if let Some(vec) = cache.computed_values.get(idx) {
-            if let Ok(cv_idx) = vec.binary_search_by_key(&CssPropertyType::FontSize, |(k, _)| *k) {
-                if let CssProperty::FontSize(css_val) = &vec[cv_idx].1.property {
+        // Keyed lookup straight into the transposed store — no per-node vec to
+        // materialise, and the bucket scan is over a handful of entries.
+        if let Some(cv) = cache
+            .computed_values
+            .get(idx, CssPropertyType::FontSize)
+        {
+            {
+                if let CssProperty::FontSize(css_val) = &cv.property {
                     if let Some(fs) = css_val.get_property() {
                         if fs.inner.metric == SizeMetric::Px {
                             sizes[idx] = fs.inner.number.get();
@@ -331,13 +336,14 @@ fn resolve_font_size_one(
     let node_data = &styled_dom.node_data.as_container()[dom_id];
     let cache = &styled_dom.css_property_cache.ptr;
 
-    if let Some(vec) = cache.computed_values.get(dom_id.index()) {
-        if let Ok(idx) = vec.binary_search_by_key(&CssPropertyType::FontSize, |(k, _)| *k) {
-            if let CssProperty::FontSize(css_val) = &vec[idx].1.property {
-                if let Some(fs) = css_val.get_property() {
-                    if fs.inner.metric == azul_css::props::basic::length::SizeMetric::Px {
-                        return fs.inner.number.get();
-                    }
+    if let Some(cv) = cache
+        .computed_values
+        .get(dom_id.index(), CssPropertyType::FontSize)
+    {
+        if let CssProperty::FontSize(css_val) = &cv.property {
+            if let Some(fs) = css_val.get_property() {
+                if fs.inner.metric == azul_css::props::basic::length::SizeMetric::Px {
+                    return fs.inner.number.get();
                 }
             }
         }

--- a/layout/src/text3/cache.rs
+++ b/layout/src/text3/cache.rs
@@ -5312,8 +5312,7 @@ impl UnifiedLayout {
     /// untyped for the text-layout unit tests, which construct layouts
     /// directly and have no boxes, padding or scrolling to speak of.
     ///
-    /// This is the unified hit-testing implementation. The old `hit_test_to_cursor`
-    /// method is deprecated in favor of this one.
+    /// This is the unified hit-testing implementation.
     #[allow(clippy::suboptimal_flops)] // mul_add not guaranteed faster/available without target +fma; keep explicit a*b+c
     #[must_use]
     pub fn hittest_cursor(&self, point: LogicalPosition) -> Option<TextCursor> {

--- a/scripts/INPUT_METHODS_AUDIT_2026_09_01.md
+++ b/scripts/INPUT_METHODS_AUDIT_2026_09_01.md
@@ -1,78 +1,166 @@
-# Input methods audit — 2026-09-01
+# Input methods audit — 2026-09-01 (rev 2)
 
-Full report (matrix + rationale): https://claude.ai/code/artifact/9fe65fa2-54c7-447d-a8de-d570df41b262
+Full report: https://claude.ai/code/artifact/9fe65fa2-54c7-447d-a8de-d570df41b262
 
-Ground truth: `core/src/events.rs`, `api.json`, `dll/src/desktop/shell2/{windows,macos,linux,android,ios,headless}`, `dll/src/web/`.
+Ground truth: `core/src/events.rs`, `core/src/events_test.rs`, `api.json`,
+`dll/src/desktop/shell2/{windows,macos,linux,android,ios,headless}`, `dll/src/web/`.
 
-## Headline
+**Policy: nothing is removed from api.json. Everything gets wired.**
 
-Device coverage is better than expected. Pen pressure+tilt is real on **all six** shells; the Wayland
-tablet-pad protocol is fully bound incl. `_dial_v2`; macOS reads `NSEvent.phase`/`momentumPhase`;
-gamepads + sensors have live per-OS backends.
+## The mechanism
 
-The actual hole is one layer up: **32 event filter variants in the public API that no producer ever emits.**
+A filter is alive only when four layers agree:
 
-## A. Dead API surface (fix first — mostly wiring, no new platform code)
+1. a shell constructs the `EventType`
+2. `event_type_to_filters` (dispatch **planning**) returns that filter — this is how nodes get looked up
+3. `matches_*_filter` (**phase matching**) accepts the pair
+4. `matches_filter_phase` lets the family through
 
-| id | what | note |
-|----|------|------|
-| D1 | **all 4 `ApplicationEventFilter` variants** | `matches_filter_phase` returns `false` for `EventFilter::Application(_)` ("will be implemented in future"). Structurally unreachable. `EventType::MonitorConnected/Disconnected` never constructed either. **Implement or delete before 1.0.** |
-| D2 | `CompositionStart/Update/End` ×2 families = **6 dead** | Native IME is wired end-to-end (Win32 `WM_IME_*`, macOS `NSTextInputClient`, Wayland `zwp_text_input_v3`, X11 XIM + `linux/common/compose.rs`) but terminates in `apply_preedit_to_text_cache`. See the `// Phase 2: OnCompositionStart callback` TODO in `windows/mod.rs:5347`. |
-| D3 | `ScrollStart`/`ScrollEnd` ×3 families = **6 dead** | Engine already classifies `ScrollInputSource::{TrackpadContinuous,TrackpadMomentum,TrackpadEnd,WheelDiscrete}`. Just never emitted. |
-| D4 | `PenSqueeze`/`PenDoubleTap`/`PenHover` ×2 = **6 dead** | `PenHover` nearly free — Wayland already delivers `proximity_in` + `distance`. Squeeze needs `UIPencilInteraction` on iOS. |
-| D5 | `MouseOut`, `FocusIn`/`FocusOut` ×2, focus `Copy`/`Cut`/`Paste`, `ComponentEventFilter::{DefaultAction,Selected}` | Clipboard bypasses the filters via `SystemChange::*` + `KeyboardShortcut` → apps cannot intercept a paste. The two Component variants are simply absent from `matches_component_filter`. |
-| D6 | **12 of 23 `AccessibilityAction` variants unrouted** | Adapters map only `Default, Focus, Blur, Collapse, Expand, Increment, Decrement, Scroll{Up,Down,Left,Right}`. Missing incl. `SetTextSelection`, `ReplaceSelectedText` — the two a screen reader / voice control needs in a text field. |
+Disagree on any one → the callback is silently never called. The codebase already names this
+(`events.rs:3091`: *"`event_type_to_filters` is what DISPATCH PLANNING uses; the `matches_hover_filter` table is
+what phase matching uses. Both must agree"*) and has a ratchet test with a `KNOWN_DESYNC` allow-list — but it only
+compares **layers 2↔3, Hover only**. Every failure below is in a layer it doesn't watch.
 
-`SystemText{Single,Double,Triple}Click` are `#[doc(hidden)]` + `is_system_internal()` — deliberate, leave them.
+**46 of 196 filter variants cannot fire today.**
 
-Also no-producer `EventType`s: `KeyPress, Change, Submit, Reset, Invalid, Play, Pause, Ended, TimeUpdate, VolumeChange, MediaError`, and `ContextMenu` (web JS only).
+## Failure classes
 
-## B. Real device gaps
+### C1 — producer ✓, matcher ✓, **no planning arm** (14 variants) ← biggest win, smallest diff
 
-| id | gap | fix |
-|----|-----|-----|
-| G1 | **Back/forward mouse buttons pumped but unsubscribable.** `MouseButton::Other(u8)` exists, `WM_XBUTTON*`/`otherMouseDown:`/X11 8-9 all route in — but no filter variant and `MouseState` has only L/R/M. | `Back/ForwardMouseDown/Up` filters + `MouseState.other_down: u8` |
-| G2 | **Touchpad gestures dead on Win/X11/Wayland.** Pinch/rotate *do* fire there — but only via the in-process detector fed by touch sessions, i.e. touchscreen only. A touchpad gives no touch points. | bind `zwp_pointer_gestures_v1`; XI 2.4 `XI_GesturePinch*`/`XI_GestureSwipe*`; `WM_GESTURE`. **No api.json change.** |
-| G3 | **Wayland seat capped at v7** (`seat_version = version.min(7)`) → `axis_value120` (v8) and `axis_relative_direction` (v9) unreachable. macOS `isDirectionInvertedFromDevice` unread. | raise cap to 9, add both listeners, keep `axis_discrete` as v5-v7 fallback |
-| G4 | **No raw/relative pointer.** `is_cursor_locked` is a flag with nothing behind it. No `WM_INPUT`, no `zwp_relative_pointer_v1`+`pointer_constraints`, no `XI_RawMotion`. | `RawMouseMotion` window filter + lock request path |
-| G5 | **`TouchPoint` is `{id, position, force}`.** Wayland `touch_shape_handler` / `touch_orientation_handler` are registered with **empty bodies** — data arrives, discarded. Win reads only `pressure` from `POINTER_TOUCH_INFO`. | `+ major, minor, orientation_rad, tool_type: TouchToolType` |
-| G6 | **Pen tail is ragged; Force Touch absent.** `tangential_pressure = 0.0` on X11/Wayland/iOS; `barrel_button_pressed` hardcoded `false` on macOS; `tool_id = 0` almost everywhere. No `pressureChangeWithEvent:`. | `PenToolType` (= the `zwp_tablet_tool_v2` type enum), hover distance, the 3 macOS responder methods |
-| G7 | **`WacomPadState` models 2 of 5 pad controls.** Both Linux shells already bind ring **and** strip **and** dial **and** mode-switch. | `+ strip, strip_active, dial_delta, mode, mode_count`; rename → `TabletPadState` |
-| G8 | **Gamepad input-only + mobile stubs.** `gamepad/android.rs` = 16 lines, `apple.rs` = 17. No rumble, pad touchpad, pad IMU, battery, paddles. | `+ battery, touchpad, imu`; `Misc1/Paddle1-4/Touchpad`; `GamepadRumble`. Copy SDL3's taxonomy. |
-| G9 | **One fused 163-entry keycode table.** No physical/logical split, no `ModifiersChanged`, no lock state, no repeat flag. Bites non-US layouts. | add positional `PhysicalKey`, `ModifiersChanged`, `KeyboardState += {modifiers, locks, is_repeat}` |
+`event_type_to_filters_legacy_hint` has **no `E::Pen*` arm and no `E::DocumentEdit` arm**; they fall through
+`_ => vec![]`, so planning returns an empty list and no node is ever looked up.
 
-## C. No representation at all
+- `EventType::PenDown` produced at `layout/src/event_determination.rs:862`
+- matcher arms exist: `events.rs:1405` (hover), `:1566` (window)
+- dead: `PenDown/Move/Up/Enter/Leave` × Hover(5) + Focus(3) + Window(5) = 13, plus `FocusEventFilter::DocumentEdit`
 
-| id | class | verdict |
-|----|-------|---------|
-| N1 | **Directional (spatial) focus nav** — D-pad/TV/console/IVI/switch-access | **stub + implement.** `FocusTarget += Directional(FocusDirection)`. Geometric nearest-neighbour over the existing focusable set — *zero shell code*. |
-| N2 | **Device identity / `PointerSource`** — only Pen/Gamepad/WacomPad carry `device_id`; `MouseState` is a single global → multi-seat inexpressible; trackball/trackpoint indistinguishable; can't tell touchpad-synthesised pointer from a real mouse (which is what G2 needs) | **do it.** `PointerSource {Unknown,Mouse,Touchpad,Trackball,Trackpoint,Touchscreen,Pen,Eraser}` = web `pointerType` ∩ `GdkInputSource` ∩ Qt `DeviceType` |
-| N3 | **Dial / rotary encoder** — Surface Dial (`RadialController`), `zwp_tablet_pad_dial_v2` (already bound!), `SOURCE_ROTARY_ENCODER`, Digital Crown | **stub.** `DialState {device_id, delta_rad, detent_count, pressed, contact_position}` covers all four |
-| N4 | **Generic HID / joystick** — flight sticks, wheels+pedals, 6-DOF SpaceMouse, foot pedals, Stream Deck, MIDI, barcode wedge | **stub.** `HidDevice {vid,pid,usage_page,usage,name}` + `HidReport {bytes}` escape hatch (= WebHID's shape) |
-| N5 | **Haptic output**; **media keys as a channel** (`WM_APPCOMMAND` unhandled; MPRIS on Linux) | stub `Haptic::play`; media keys partly work already via `VirtualKeyCode::{PlayPause,NextTrack,...}` |
-| N6 | **XR/spatial, voice, eye+head tracking** | **skip — no stub.** transient-pointer folds into N2 later; voice/gaze arrive as synthetic pointer + a11y actions, so the real work is D6 |
+**Pen pressure/tilt/twist/eraser is implemented on all six shells and every pen event dispatches to nothing.**
+`CallbackInfo::get_pen_state()` still works (polling), but you cannot subscribe.
 
-## D. Mobile shells
+Fix: add six arms to `event_type_to_filters_legacy_hint`. No shell work, no api.json change.
 
-Not toys — both do multi-touch, stylus w/ tilt, 5 native gesture recognizers, lifecycle, full a11y bridge.
-**Android** (1462 lines): `ToolType::Stylus`/`Eraser` + `Axis::Tilt`/`Orientation` work. Missing: `InputConnection`
-(no soft-keyboard text at all — needs a JNI bridge), `WindowInsets`, handwriting delegation, predictive back, `FoldingFeature`.
-**iOS** (1626 lines): Apple Pencil `force`/`altitudeAngle`/`azimuth`/`rollAngle` all read. Missing: `UITextInput`,
-`UIPress`/`UIKeyCommand`, safe-area insets, `UIPencilInteraction`, `coalescedTouches`/`predictedTouches`, `indirectPointer`.
+### C2 — planning points at a **different filter** than the matcher accepts (9 variants)
 
-Highest-value item on both = **text input**, and it pairs with D2 (one project, not two).
+`events.rs:3180`: `E::Scroll | E::ScrollStart | E::ScrollEnd => vec![EF::Hover(H::Scroll)]`
+→ nodes on `Hover(ScrollStart)` never looked up; nodes on `Hover(Scroll)` looked up then rejected by
+`(Scroll, EventType::Scroll)`. Dead from both directions. No Focus/Window planning entry either, though both
+families have the variants **and** the matcher arms (`:1393-1394` hover, focus rel. 30-31).
 
-## E. Testability constraint
+Same shape: `E::ContextMenu → Hover(RightMouseDown)` (matcher wants `EventType::MouseDown` + right-button payload);
+`E::KeyPress → Focus(TextInput)` and `E::Change → Focus(TextInput)` (matcher has only `(TextInput, EventType::Input)`).
 
-`HeadlessEvent` has 12 variants; scroll is **always** `WheelDiscrete`. No pen/gamepad/sensor/gesture injection
-(only `inject_touch_points`). **D3 cannot be regression-tested today.** Add a `HeadlessEvent` variant in the same
-commit as anything above.
+Fix: split the scroll arm into three (Hover+Focus+Window each); add matcher arms
+`(RightMouseDown, EventType::ContextMenu)`, `(TextInput, EventType::KeyPress)`, `(TextInput, EventType::Change)`.
+→ ContextMenu then makes the Menu/Apps key, Shift+F10 and a11y `ShowContextMenu` reach existing right-click
+handlers with **no new filter**.
+
+### C3 — planning ✓, matcher ✓, **no producer** (12 variants)
+
+| what | note |
+|---|---|
+| `Composition*` ×6 (Hover+Focus) | IME wired end-to-end (Win32 `WM_IME_*`, macOS `NSTextInputClient`, Wayland `zwp_text_input_v3`, X11 XIM + `linux/common/compose.rs`) but terminates in `apply_preedit_to_text_cache`. `// Phase 2: OnCompositionStart callback` TODO at `windows/mod.rs:5347`. |
+| `Copy`/`Cut`/`Paste` ×3 (Focus) | Design already written in the enum doc comment (`events.rs:2278`): *"fire on the focused element BEFORE the OS default action, which preventDefault suppresses"*. Machinery exists — `post_callback_filter_system_changes(prevent_default, …)` already has the `if prevent_default { …only focus passes… return }` gate. Dispatch before pushing `SystemChange::{CopyToClipboard,…}` and interception works for free. |
+| `MouseOut` ×1, `FocusIn`/`FocusOut` ×4 | Emit alongside `MouseLeave` / `Focus` / `Blur`. |
+
+⚠ **Their `KNOWN_DESYNC` entries are STALE** — the comments say "matcher has no arm" but the arms were added later
+at `events.rs:1438-1443`. Six of the ten ratchet entries are currently protecting nothing.
+
+### C4 — **phase gate closed** (4 variants)
+
+`matches_filter_phase` returns `false` for `EventFilter::Application(_)` ("will be implemented in future").
+Planning is already correct (`E::MonitorConnected → EF::Application(MonitorConnected)`).
+
+Producers are cheap — most signals already arrive:
+- **gilrs** already reports gamepad connect/disconnect via the capability pump → free `DeviceConnected` on all 4 desktops
+- **Wayland** `wl_registry.global_remove`, `wl_seat.capabilities`, `zwp_tablet_seat_v2` add/remove — all handled
+- **Win32** `WM_DISPLAYCHANGE` handled (diff the monitor list)
+- **macOS** `windowDidChangeScreen:` handled
+- genuinely new: X11 RandR `XRRSelectInput` + `XI_HierarchyChanged`, Win32 `WM_DEVICECHANGE`, macOS
+  `NSApplicationDidChangeScreenParameters`
+
+### C5 — filter exists, **no `EventType` to carry it** (8 variants)
+
+`EventType::PenSqueeze/PenDoubleTap/PenHover` **do not exist** (0 occurrences) though the filter variants do on
+Hover+Window (6) and are handled in the Window→Hover map at `:2502-2504`.
+`ComponentEventFilter::{DefaultAction, Selected}` (2) are absent from `matches_component_filter`'s arms.
+
+Fix: append 3 `EventType` variants at the end of the enum for ABI stability (same convention `Copy`/`Cut`/`Paste`/
+`DocumentEdit` used), sync via **`azul-doc autofix`** — never a hand-edited api.json patch.
+`PenHover` is nearly free: Wayland `proximity_in`+`distance`, Win32 `POINTER_FLAG_INRANGE`, Android
+`ACTION_HOVER_MOVE` (already handled), macOS `NSEventSubtype::TabletProximity` on the existing mouse-event path
+(same trick `feed_tablet_pen` uses).
+
+### C6 — no filter at all, **explicitly pinned unmapped** (9 EventTypes)
+
+`Submit, Reset, Invalid, Play, Pause, Ended, TimeUpdate, VolumeChange, MediaError`.
+`events_test.rs:2243` asserts they *must* yield no filters — wiring them updates that pin deliberately.
+
+- **Form half is tractable**: `DefaultAction::SubmitForm` already exists for `Submit`; `Change` is commit-on-blur and
+  `TextInputOnFocusLost` is already the site. `Reset`/`Invalid` need a validation concept first.
+- **Media half is blocked**: no playback state machine yet — `dll/src/unified/audio.rs:62` is
+  `pub fn play(&self, _frame: AudioFrame) {}`, an empty stub. Sequence last.
+
+### C7 — 12 of 23 a11y actions unrouted (pure plumbing)
+
+Adapters map `Default, Focus, Blur, Collapse, Expand, Increment, Decrement, Scroll{Up,Down,Left,Right}`.
+Nearly every unrouted one already has an engine function:
+
+`ScrollIntoView`→`scroll_node_into_view` · `ScrollToPoint`/`SetScrollOffset`→`scroll_to`/`scroll_to_unclamped` ·
+`SetTextSelection`→`TextOpSetSelection` · `ReplaceSelectedText`→text-edit manager ·
+`ShowContextMenu`→`open_menu_for_node` · `Show/HideTooltip`→`show/hide_tooltip_from_callback` ·
+`SetValue`/`SetNumericValue`→widget setters · `SetSequentialFocusNavigationStartingPoint`→focus engine ·
+`CustomAction`→callback passthrough
+
+`SetTextSelection` + `ReplaceSelectedText` are what a screen reader / voice control need in a text field.
+
+## Device gaps (G-series) — unchanged from rev 1
+
+G1 back/forward mouse buttons pumped but unsubscribable (`MouseButton::Other(u8)` routes; no filter, no
+`MouseState` field; planning even documents it: `MouseButton::Other(_) => None`) ·
+G2 touchpad pinch/rotate dead on Win/X11/Wayland (in-process detector needs touch points = touchscreen only;
+`zwp_pointer_gestures_v1` unbound, XI 2.4 gestures unhandled, `WM_GESTURE` pre-empted by `WM_POINTER*`) ·
+G3 Wayland seat capped `min(7)` → no `axis_value120`/`axis_relative_direction`; macOS
+`isDirectionInvertedFromDevice` unread ·
+G4 no raw/relative pointer (`is_cursor_locked` is a flag with nothing behind it) ·
+G5 `TouchPoint` = 3 fields; Wayland `touch_shape_handler`/`touch_orientation_handler` are **empty bodies** ·
+G6 pen tail ragged (`tangential_pressure=0.0` X11/Wayland/iOS, `barrel_button_pressed=false` macOS, `tool_id=0`),
+no `pressureChangeWithEvent:` ·
+G7 `WacomPadState` models 2 of 5 pad controls both Linux shells already bind (incl. `_dial_v2`) ·
+G8 gamepad input-only, `android.rs`/`apple.rs` are 16/17-line stubs ·
+G9 one fused 163-entry keycode table, no physical/logical split, no `ModifiersChanged`, no lock state
+
+## No representation yet (N-series)
+
+N1 directional focus nav (**zero shell code** — geometric nearest-neighbour over the existing focusable set) ·
+N2 `PointerSource` + device identity (unblocks multi-seat; also what G2 needs to tell touchpad from mouse) ·
+N3 `DialState` — one type for Surface Dial / `zwp_tablet_pad_dial_v2` (already bound!) / Wear crown / Digital Crown ·
+N4 `HidDevice`/`HidReport` escape hatch (= WebHID's shape) ·
+N5 `Haptic::play`; media keys as a channel (`WM_APPCOMMAND` unhandled, MPRIS on Linux) ·
+N6 XR/voice/eye-tracking — **deferred, not removed**: they arrive as pointer events + a11y actions, so they are
+covered by N2 and C7, both of which are on the list
 
 ## Work order
 
-- **A.** Batch A above — make the existing API tell the truth. Mostly wiring, biggest behaviour delta per line.
-- **B.** Shell wiring, no API change: G2, G3, G6 (macOS responders), G5 (Wayland stubs).
-- **C.** Small api.json deltas: G1, G5, G6, G7, G8, `SensorKind` → ~12 incl. `HingeAngle`.
-- **D.** New capability: N1, N2, G4, G9.
-- **E.** Mobile parity: text input, insets, `UIPencilInteraction`, coalesced/predicted, real gamepad backends.
-- **Stub only:** N3, N4, N5. **Don't:** N6.
+**Step 0 — turn the ratchet into the work queue.**
+Extend `event_type_to_filters_never_panics_and_stays_synced_with_the_hover_matcher` from 2 layers × 1 family to
+**4 layers × 3 families**. It goes red with ~46 entries — *that list is the backlog*, and every fix deletes a line.
+Also prune the 6 stale `KNOWN_DESYNC` entries (they hide future regressions today).
+
+1. **C1** planning omissions → 14 variants alive, no shell work, no api.json change
+2. **C2** planning de-sync (split the scroll arm; 3 matcher arms) then emit `ScrollStart`/`ScrollEnd`/`ContextMenu`
+3. **C3** missing producers: `MouseOut`, `FocusIn/Out`, `Composition*` (+`CompositionEventData`), `Copy/Cut/Paste`
+4. **C4** open the Application phase; producers cheapest-first (gilrs → Wayland → Win32 → macOS → X11)
+5. **C5** append the 3 pen `EventType`s (autofix), add the 2 Component arms
+6. **C7** route the 12 a11y actions
+7. **Shell wiring, no API change**: G2, G3, G6 (macOS responders), G5 (Wayland stubs)
+8. **api.json deltas via `azul-doc autofix`**: G1, G5, G6, G7, G8, `SensorKind`→~12 incl. `HingeAngle`
+9. **New capability**: N1, N2, N3, G4, G9, N4, N5
+10. **Mobile parity**: text input (pairs with C3), insets, `UIPencilInteraction`, coalesced/predicted, real gamepad
+11. **C6 stragglers**: form events, then media (after the media backend has real state)
+
+## Constraints
+
+- **api.json changes go through `azul-doc autofix` only** — never hand-curated patches. The in-source comment at
+  `events.rs:2280` even says "sync to api.json via azul-doc autofix".
+- **`HeadlessEvent` has 12 variants; scroll is always `WheelDiscrete`; no pen/gamepad/gesture injection.**
+  Add a `HeadlessEvent` variant in the same commit as each wiring fix, or it can't be regression-tested.

--- a/scripts/INPUT_METHODS_AUDIT_2026_09_01.md
+++ b/scripts/INPUT_METHODS_AUDIT_2026_09_01.md
@@ -1,0 +1,78 @@
+# Input methods audit — 2026-09-01
+
+Full report (matrix + rationale): https://claude.ai/code/artifact/9fe65fa2-54c7-447d-a8de-d570df41b262
+
+Ground truth: `core/src/events.rs`, `api.json`, `dll/src/desktop/shell2/{windows,macos,linux,android,ios,headless}`, `dll/src/web/`.
+
+## Headline
+
+Device coverage is better than expected. Pen pressure+tilt is real on **all six** shells; the Wayland
+tablet-pad protocol is fully bound incl. `_dial_v2`; macOS reads `NSEvent.phase`/`momentumPhase`;
+gamepads + sensors have live per-OS backends.
+
+The actual hole is one layer up: **32 event filter variants in the public API that no producer ever emits.**
+
+## A. Dead API surface (fix first — mostly wiring, no new platform code)
+
+| id | what | note |
+|----|------|------|
+| D1 | **all 4 `ApplicationEventFilter` variants** | `matches_filter_phase` returns `false` for `EventFilter::Application(_)` ("will be implemented in future"). Structurally unreachable. `EventType::MonitorConnected/Disconnected` never constructed either. **Implement or delete before 1.0.** |
+| D2 | `CompositionStart/Update/End` ×2 families = **6 dead** | Native IME is wired end-to-end (Win32 `WM_IME_*`, macOS `NSTextInputClient`, Wayland `zwp_text_input_v3`, X11 XIM + `linux/common/compose.rs`) but terminates in `apply_preedit_to_text_cache`. See the `// Phase 2: OnCompositionStart callback` TODO in `windows/mod.rs:5347`. |
+| D3 | `ScrollStart`/`ScrollEnd` ×3 families = **6 dead** | Engine already classifies `ScrollInputSource::{TrackpadContinuous,TrackpadMomentum,TrackpadEnd,WheelDiscrete}`. Just never emitted. |
+| D4 | `PenSqueeze`/`PenDoubleTap`/`PenHover` ×2 = **6 dead** | `PenHover` nearly free — Wayland already delivers `proximity_in` + `distance`. Squeeze needs `UIPencilInteraction` on iOS. |
+| D5 | `MouseOut`, `FocusIn`/`FocusOut` ×2, focus `Copy`/`Cut`/`Paste`, `ComponentEventFilter::{DefaultAction,Selected}` | Clipboard bypasses the filters via `SystemChange::*` + `KeyboardShortcut` → apps cannot intercept a paste. The two Component variants are simply absent from `matches_component_filter`. |
+| D6 | **12 of 23 `AccessibilityAction` variants unrouted** | Adapters map only `Default, Focus, Blur, Collapse, Expand, Increment, Decrement, Scroll{Up,Down,Left,Right}`. Missing incl. `SetTextSelection`, `ReplaceSelectedText` — the two a screen reader / voice control needs in a text field. |
+
+`SystemText{Single,Double,Triple}Click` are `#[doc(hidden)]` + `is_system_internal()` — deliberate, leave them.
+
+Also no-producer `EventType`s: `KeyPress, Change, Submit, Reset, Invalid, Play, Pause, Ended, TimeUpdate, VolumeChange, MediaError`, and `ContextMenu` (web JS only).
+
+## B. Real device gaps
+
+| id | gap | fix |
+|----|-----|-----|
+| G1 | **Back/forward mouse buttons pumped but unsubscribable.** `MouseButton::Other(u8)` exists, `WM_XBUTTON*`/`otherMouseDown:`/X11 8-9 all route in — but no filter variant and `MouseState` has only L/R/M. | `Back/ForwardMouseDown/Up` filters + `MouseState.other_down: u8` |
+| G2 | **Touchpad gestures dead on Win/X11/Wayland.** Pinch/rotate *do* fire there — but only via the in-process detector fed by touch sessions, i.e. touchscreen only. A touchpad gives no touch points. | bind `zwp_pointer_gestures_v1`; XI 2.4 `XI_GesturePinch*`/`XI_GestureSwipe*`; `WM_GESTURE`. **No api.json change.** |
+| G3 | **Wayland seat capped at v7** (`seat_version = version.min(7)`) → `axis_value120` (v8) and `axis_relative_direction` (v9) unreachable. macOS `isDirectionInvertedFromDevice` unread. | raise cap to 9, add both listeners, keep `axis_discrete` as v5-v7 fallback |
+| G4 | **No raw/relative pointer.** `is_cursor_locked` is a flag with nothing behind it. No `WM_INPUT`, no `zwp_relative_pointer_v1`+`pointer_constraints`, no `XI_RawMotion`. | `RawMouseMotion` window filter + lock request path |
+| G5 | **`TouchPoint` is `{id, position, force}`.** Wayland `touch_shape_handler` / `touch_orientation_handler` are registered with **empty bodies** — data arrives, discarded. Win reads only `pressure` from `POINTER_TOUCH_INFO`. | `+ major, minor, orientation_rad, tool_type: TouchToolType` |
+| G6 | **Pen tail is ragged; Force Touch absent.** `tangential_pressure = 0.0` on X11/Wayland/iOS; `barrel_button_pressed` hardcoded `false` on macOS; `tool_id = 0` almost everywhere. No `pressureChangeWithEvent:`. | `PenToolType` (= the `zwp_tablet_tool_v2` type enum), hover distance, the 3 macOS responder methods |
+| G7 | **`WacomPadState` models 2 of 5 pad controls.** Both Linux shells already bind ring **and** strip **and** dial **and** mode-switch. | `+ strip, strip_active, dial_delta, mode, mode_count`; rename → `TabletPadState` |
+| G8 | **Gamepad input-only + mobile stubs.** `gamepad/android.rs` = 16 lines, `apple.rs` = 17. No rumble, pad touchpad, pad IMU, battery, paddles. | `+ battery, touchpad, imu`; `Misc1/Paddle1-4/Touchpad`; `GamepadRumble`. Copy SDL3's taxonomy. |
+| G9 | **One fused 163-entry keycode table.** No physical/logical split, no `ModifiersChanged`, no lock state, no repeat flag. Bites non-US layouts. | add positional `PhysicalKey`, `ModifiersChanged`, `KeyboardState += {modifiers, locks, is_repeat}` |
+
+## C. No representation at all
+
+| id | class | verdict |
+|----|-------|---------|
+| N1 | **Directional (spatial) focus nav** — D-pad/TV/console/IVI/switch-access | **stub + implement.** `FocusTarget += Directional(FocusDirection)`. Geometric nearest-neighbour over the existing focusable set — *zero shell code*. |
+| N2 | **Device identity / `PointerSource`** — only Pen/Gamepad/WacomPad carry `device_id`; `MouseState` is a single global → multi-seat inexpressible; trackball/trackpoint indistinguishable; can't tell touchpad-synthesised pointer from a real mouse (which is what G2 needs) | **do it.** `PointerSource {Unknown,Mouse,Touchpad,Trackball,Trackpoint,Touchscreen,Pen,Eraser}` = web `pointerType` ∩ `GdkInputSource` ∩ Qt `DeviceType` |
+| N3 | **Dial / rotary encoder** — Surface Dial (`RadialController`), `zwp_tablet_pad_dial_v2` (already bound!), `SOURCE_ROTARY_ENCODER`, Digital Crown | **stub.** `DialState {device_id, delta_rad, detent_count, pressed, contact_position}` covers all four |
+| N4 | **Generic HID / joystick** — flight sticks, wheels+pedals, 6-DOF SpaceMouse, foot pedals, Stream Deck, MIDI, barcode wedge | **stub.** `HidDevice {vid,pid,usage_page,usage,name}` + `HidReport {bytes}` escape hatch (= WebHID's shape) |
+| N5 | **Haptic output**; **media keys as a channel** (`WM_APPCOMMAND` unhandled; MPRIS on Linux) | stub `Haptic::play`; media keys partly work already via `VirtualKeyCode::{PlayPause,NextTrack,...}` |
+| N6 | **XR/spatial, voice, eye+head tracking** | **skip — no stub.** transient-pointer folds into N2 later; voice/gaze arrive as synthetic pointer + a11y actions, so the real work is D6 |
+
+## D. Mobile shells
+
+Not toys — both do multi-touch, stylus w/ tilt, 5 native gesture recognizers, lifecycle, full a11y bridge.
+**Android** (1462 lines): `ToolType::Stylus`/`Eraser` + `Axis::Tilt`/`Orientation` work. Missing: `InputConnection`
+(no soft-keyboard text at all — needs a JNI bridge), `WindowInsets`, handwriting delegation, predictive back, `FoldingFeature`.
+**iOS** (1626 lines): Apple Pencil `force`/`altitudeAngle`/`azimuth`/`rollAngle` all read. Missing: `UITextInput`,
+`UIPress`/`UIKeyCommand`, safe-area insets, `UIPencilInteraction`, `coalescedTouches`/`predictedTouches`, `indirectPointer`.
+
+Highest-value item on both = **text input**, and it pairs with D2 (one project, not two).
+
+## E. Testability constraint
+
+`HeadlessEvent` has 12 variants; scroll is **always** `WheelDiscrete`. No pen/gamepad/sensor/gesture injection
+(only `inject_touch_points`). **D3 cannot be regression-tested today.** Add a `HeadlessEvent` variant in the same
+commit as anything above.
+
+## Work order
+
+- **A.** Batch A above — make the existing API tell the truth. Mostly wiring, biggest behaviour delta per line.
+- **B.** Shell wiring, no API change: G2, G3, G6 (macOS responders), G5 (Wayland stubs).
+- **C.** Small api.json deltas: G1, G5, G6, G7, G8, `SensorKind` → ~12 incl. `HingeAngle`.
+- **D.** New capability: N1, N2, G4, G9.
+- **E.** Mobile parity: text input, insets, `UIPencilInteraction`, coalesced/predicted, real gamepad backends.
+- **Stub only:** N3, N4, N5. **Don't:** N6.


### PR DESCRIPTION
The style cache was **7× larger than the DOM it derives from**. It is now smaller than it, and the whole `StyledDom` is **4.8× smaller**, with no behaviour change.

| | before | after |
|---|---:|---:|
| StyledDom | 101.6 MB | **21.3 MB** |
| bytes/node | 2031 | **425** |
| `computed_values` | 51.4 MB | 301 KB |
| `css_props` | 24.2 MB | 401 KB |
| `cascaded_props` | 5.9 MB | 403 KB |
| the tree itself | 257 B/node | unchanged |

Measured on the 50k-node XHTML chapter the render bench already ships with.

## Three independent causes

**1. 80% of `computed_values` was unreachable.** It is documented as "pre-resolved *inherited* properties" and every reader treats it so — `get_property_slow` consults it only when `is_inheritable()`. But the cascade stored the node's *full* resolved set, so 226,610 of 284,438 entries were `display` (one per node), `margin-*`, `padding-*` and `vertical-align`: none inheritable, none readable. Filtering at the single write site is safe because the only parent value the cascade reads back is `FontSize`, itself inheritable.

**2. Inherited values are shared down a subtree, and were stored per node.** 53,476 entries carried **15 distinct values** — `cursor` alone was 29,391 entries of *one* value, re-paid in every descendant. `InheritedValues` stores each distinct value once with the sorted node list that has it; lookup is a linear scan over ~6 types then a binary search. Also removes a deep clone of the parent's vec of 136-byte enums, once per node per cascade.

**3. A stylesheet's declarations repeat across every node they match.** `css_props` held 165,120 entries carrying **8 distinct values** at 144 bytes each. `FlatVecVec::dedup_runs` collapses identical per-node runs so nodes with the same property set share one copy. **No call site changes** — `get_slice` still returns a real contiguous slice, several nodes address the same range.

## What this is *not*

Pruning. An earlier attempt to prune `css_props` was reverted: every entry in it is a real matched author rule that subtree extraction, the compact rebuild and `get_property_slow` all read, and dropping the compact-encoded ones makes a scoped `with_css { width }` vanish from an extracted popup subtree. Sharing achieves the same size win with nothing dropped.

The hot layout loop is untouched: the compact cache keeps its bitfield tiers and is now the dominant cache term (7.3 MB), which is the part that should be big.

## Along the way

- `prune_compact_normal_props` justified exempting `css_props` with "the compact cache is rebuilt every frame". **Measured false** — `AZ_CASCADE_TRACE=1` over 252 layout passes: 1 rebuild, 251 context offers that early-returned unchanged. The comment now records the measurement and the real constraint.
- `AZ_CASCADE_TRACE=1` is left in as the dial for that question.
- `architecture.md` rests its `UI = f(data)` affordability argument on "~500KB–1MB for a large application". Now a checked test: the tree is 257 B/node, so a 5000-node UI is 1.23 MB. The guide is right — but it was the *cache*, not the tree, that was expensive.

## Verification

`azul-core` 2733 + all integration suites, `azul-layout` 7510 — green after each commit. Bench timing unchanged within noise (2225 → 2240 ms, ~7% per-iteration spread), as expected: same values, same slices, less memory.

Also carries `scripts/INPUT_METHODS_AUDIT_2026_09_01.md`, which was untracked in the working tree and is unrelated to this branch — say the word and I'll drop it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rc3XVuNLzQVhspAo24zcj7