### PR TITLE
fonts: migrate azul-core/azul-layout to rust-fontconfig 5.0 (+ azul-* 0.0.16, printpdf 0.12.8)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -732,6 +732,16 @@ jobs:
           cargo check -p azul-layout --no-default-features --features "xml"
           cargo check -p azul-layout --no-default-features --features "text_layout,font_loading,svg,xml"
 
+      # printpdf's exact azul-layout surface (its `html` feature): text layout,
+      # hyphenation, font loading, xml, pdf - and NO cpurender/svg. No other
+      # combination in this matrix enables `pdf` or `text_layout_hyphenation`,
+      # which is how the missing cpurender gates on `tray_icon` and
+      # `rasterize_svg_clip_to_r8` only surfaced in printpdf's own build.
+      # Keep in sync with printpdf/Cargo.toml (`text_layout`,
+      # `text_layout_hyphenation`, `html` feature lists).
+      - name: Check azul-layout with printpdf's feature set (no cpurender)
+        run: cargo check -p azul-layout --no-default-features --features "std,text_layout,text_layout_hyphenation,font_loading,xml,pdf"
+
   dll_windows_unit_tests:
     # Runs Windows backend unit tests.
     name: azul-dll unit tests (Windows backend)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -734,7 +734,7 @@ dependencies = [
  "gl-context-loader",
  "libm",
  "proptest",
- "rust-fontconfig",
+ "rust-fontconfig 5.0.0",
  "serde",
  "serde_json",
  "url",
@@ -819,7 +819,7 @@ dependencies = [
  "pyo3-log",
  "rclip-core",
  "rich-clipboard",
- "rust-fontconfig",
+ "rust-fontconfig 5.0.0",
  "security-framework",
  "serde",
  "serde_json",
@@ -865,7 +865,7 @@ dependencies = [
  "quote",
  "rayon",
  "regex",
- "rust-fontconfig",
+ "rust-fontconfig 5.0.0",
  "rustls",
  "rustls-rustcrypto",
  "serde",
@@ -941,7 +941,7 @@ dependencies = [
  "png",
  "regex-lite",
  "roxmltree 0.21.1",
- "rust-fontconfig",
+ "rust-fontconfig 5.0.0",
  "rustls",
  "rustls-rustcrypto",
  "serde",
@@ -6260,7 +6260,7 @@ dependencies = [
  "getrandom 0.4.3",
  "image",
  "lopdf",
- "rust-fontconfig",
+ "rust-fontconfig 4.6.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -7049,6 +7049,17 @@ name = "rust-fontconfig"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1738b9f962e0c1740976aa5f59c004d132a05c0be99cab3e096a9354a5ab4684"
+dependencies = [
+ "allsorts-azul",
+ "mmapio",
+ "xmlparser",
+]
+
+[[package]]
+name = "rust-fontconfig"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65891c2639e01103a60309be01deb83d1707a291b03ef3f5fe4162693ac053b0"
 dependencies = [
  "allsorts-azul",
  "bincode 1.3.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -728,13 +728,13 @@ dependencies = [
 
 [[package]]
 name = "azul-core"
-version = "0.0.14"
+version = "0.0.16"
 dependencies = [
  "azul-css",
  "gl-context-loader",
  "libm",
  "proptest",
- "rust-fontconfig 5.0.0",
+ "rust-fontconfig",
  "serde",
  "serde_json",
  "url",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "azul-css"
-version = "0.0.14"
+version = "0.0.16"
 dependencies = [
  "azul-simplecss",
  "libm",
@@ -819,7 +819,7 @@ dependencies = [
  "pyo3-log",
  "rclip-core",
  "rich-clipboard",
- "rust-fontconfig 5.0.0",
+ "rust-fontconfig",
  "security-framework",
  "serde",
  "serde_json",
@@ -865,7 +865,7 @@ dependencies = [
  "quote",
  "rayon",
  "regex",
- "rust-fontconfig 5.0.0",
+ "rust-fontconfig",
  "rustls",
  "rustls-rustcrypto",
  "serde",
@@ -905,7 +905,7 @@ dependencies = [
 
 [[package]]
 name = "azul-layout"
-version = "0.0.14"
+version = "0.0.16"
 dependencies = [
  "accesskit",
  "accesskit_consumer 0.38.0",
@@ -941,13 +941,12 @@ dependencies = [
  "png",
  "regex-lite",
  "roxmltree 0.21.1",
- "rust-fontconfig 5.0.0",
+ "rust-fontconfig",
  "rustls",
  "rustls-rustcrypto",
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "short-uuid",
  "smallvec",
  "spmc",
  "strfmt",
@@ -961,7 +960,6 @@ dependencies = [
  "unicode-normalization",
  "unicode-segmentation",
  "ureq",
- "uuid",
  "webpki-roots",
  "writeable",
  "xmlparser",
@@ -6247,9 +6245,9 @@ dependencies = [
 
 [[package]]
 name = "printpdf"
-version = "0.12.7"
+version = "0.12.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f4d083138eb053f9af08c37069f506a1afc90667db3475d07bb271887da2f40"
+checksum = "95d50369c5e18e18d4716bd855172db3a70f9e82c966687ae051ea58138f285c"
 dependencies = [
  "allsorts-azul",
  "azul-core",
@@ -6260,7 +6258,7 @@ dependencies = [
  "getrandom 0.4.3",
  "image",
  "lopdf",
- "rust-fontconfig 4.6.0",
+ "rust-fontconfig",
  "serde",
  "serde_derive",
  "serde_json",
@@ -7046,17 +7044,6 @@ dependencies = [
 
 [[package]]
 name = "rust-fontconfig"
-version = "4.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1738b9f962e0c1740976aa5f59c004d132a05c0be99cab3e096a9354a5ab4684"
-dependencies = [
- "allsorts-azul",
- "mmapio",
- "xmlparser",
-]
-
-[[package]]
-name = "rust-fontconfig"
 version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65891c2639e01103a60309be01deb83d1707a291b03ef3f5fe4162693ac053b0"
@@ -7548,15 +7535,6 @@ name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
-
-[[package]]
-name = "short-uuid"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5cb9a7452a33ab94fd48d5f533d181a400bf56ec5a55cf788c470ad430f52a5"
-dependencies = [
- "uuid",
-]
 
 [[package]]
 name = "shuttle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,8 +84,27 @@ azul-layout = { path = "layout" }
 # find. printpdf 0.12.8+ declares `>=5.0, <6`, which intersects this
 # workspace's `>=5.0, <5.1` at 5.0.x — one copy. printpdf 0.12.7 and older
 # declare `<5` and CANNOT share a graph with this tree: the rust-fontconfig 5
-# migration, the azul-* 0.0.15 bump and dll's printpdf 0.12.8 pin land as
+# migration, the azul-* 0.0.16 bump and dll's printpdf 0.12.8 pin land as
 # ONE atomic pair (see the 0.0.14 history: bump alone = two azul_layouts).
+#
+# THE RELEASE ORDER, because the bump makes this workspace unbuildable until
+# printpdf catches up. printpdf pins azul-* EXACTLY (0.0.x semantics), so the
+# moment css/core/layout become a new version the published printpdf falls off the
+# [patch] above and drags crates.io azul-core 0.0.14 (rust-fontconfig <4.5)
+# into the graph. Nothing in-tree links until step 3:
+#
+#   1. bump azul-css/core/layout + every internal `version =` reference, then
+#      publish css, core, layout in that order. `cargo publish -p <crate>`
+#      does NOT work here — it resolves the whole workspace and hits the
+#      conflict above. Publish each from a copy of the crate directory with
+#      `[workspace]` appended to its manifest to detach it; azul-core and
+#      azul-layout need their predecessor on the index first.
+#   2. printpdf's paired PR goes green on its own and publishes.
+#   3. re-pin dll/Cargo.toml to the new printpdf; this tree goes green again.
+#
+# Do NOT shortcut step 1 with a `[patch.crates-io] printpdf = { path = .. }`.
+# It builds locally and publishes something nobody has tested — the exact
+# failure mode recorded for allsorts below.
 #
 # allsorts-azul is NOT patched. It used to be (`path = "third_party/allsorts"`), and that
 # is exactly how azul-layout 0.0.9 shipped broken: the vendored tree grew

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,17 +72,20 @@ azul-layout = { path = "layout" }
 # azul-layout and NO printpdf git patch is needed. (dll/ pins printpdf 0.12.5.)
 # rust-fontconfig: use crates.io (the vendored copy was a labelled REVERT; its
 # only functional delta was a web_lift-only hashbrown workaround). core/ and
-# layout/ pin `>=4.6, <4.7` (4.6.0 = the FcScanConfig injection release: scan
-# dirs + priority families come from the embedder, the old per-OS tables are
-# the explicit `os_defaults()` fallback).
+# layout/ pin `>=5.0, <5.1` (5.0 = the tiered FontFallbackChain — css groups
+# with per-script faces, script groups, last_resort — plus the
+# FcFallbackConfig generic-family model that absorbs the system fonts.conf
+# aliases; azul's own alias parsing went away with it). dll/ and doc/ say
+# `5.0`.
 #
 # THE SINGLE-COPY RULE still applies: every dependent's range must intersect
 # on ONE version or cargo resolves TWO rust-fontconfigs into one binary — two
 # independent FcFontCaches, i.e. layout resolving a font the renderer cannot
-# find. printpdf 0.12.6+ declares `>=4.4.9, <5`, which intersects this
-# workspace's `>=4.6, <4.7` at 4.6.x — one copy. (The PUBLISHED azul-layout
-# 0.0.14 still pins `<4.5`; that only matters for consumers of the published
-# crates, so the next azul-* crates.io release must carry the >=4.6 pin.)
+# find. printpdf 0.12.8+ declares `>=5.0, <6`, which intersects this
+# workspace's `>=5.0, <5.1` at 5.0.x — one copy. printpdf 0.12.7 and older
+# declare `<5` and CANNOT share a graph with this tree: the rust-fontconfig 5
+# migration, the azul-* 0.0.15 bump and dll's printpdf 0.12.8 pin land as
+# ONE atomic pair (see the 0.0.14 history: bump alone = two azul_layouts).
 #
 # allsorts-azul is NOT patched. It used to be (`path = "third_party/allsorts"`), and that
 # is exactly how azul-layout 0.0.9 shipped broken: the vendored tree grew

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 readme = "../README.md"
 name = "azul-core"
-version = "0.0.14"
+version = "0.0.16"
 # Lean published package: ship src only, not the test/bench/example/fuzz harnesses.
 exclude = ["tests", "benches", "examples", "fuzz"]
 authors = ["Felix Schütt <felix.schuett@maps4print.com>"]
@@ -18,7 +18,7 @@ resolver = "2"
 autoexamples = false
 
 [dependencies]
-azul-css                = { version = "0.0.14", path = "../css", default-features = false, features = ["parser"] }
+azul-css                = { version = "0.0.16", path = "../css", default-features = false, features = ["parser"] }
 libm                    = { version = "0.2.2",   default-features = false                   }
 gl-context-loader       = { version = "0.1.9", default-features = false }
 rust-fontconfig = { version = ">=5.0, <5.1", default-features = false, features = ["std"] }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -21,7 +21,7 @@ autoexamples = false
 azul-css                = { version = "0.0.14", path = "../css", default-features = false, features = ["parser"] }
 libm                    = { version = "0.2.2",   default-features = false                   }
 gl-context-loader       = { version = "0.1.9", default-features = false }
-rust-fontconfig = { version = ">=4.6, <4.7", default-features = false, features = ["std"] }
+rust-fontconfig = { version = ">=5.0, <5.1", default-features = false, features = ["std"] }
 serde                   = { version = "1.0", features = ["derive"], optional = true }
 # `float_roundtrip`: without it serde_json parses floats "best effort" (a plain
 # f64 multiply by a POW10 table entry), which is NOT exact: `Json::parse` then

--- a/css/Cargo.toml
+++ b/css/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 readme = "../README.md"
 name = "azul-css"
-version = "0.0.14"
+version = "0.0.16"
 # Lean published package: ship src only, not the test/bench/example/fuzz harnesses.
 exclude = ["tests", "benches", "examples", "fuzz"]
 authors = ["Felix Schütt <felix.schuett@maps4print.com>"]

--- a/dll/Cargo.toml
+++ b/dll/Cargo.toml
@@ -21,15 +21,15 @@ crate-type = ["cdylib", "staticlib", "rlib"]
 
 [dependencies]
 # Core crates - only needed for build-dll and link-static, NOT for link-dynamic
-azul-core = { path = "../core", version = "0.0.14", default-features = false, optional = true }
-azul-css = { path = "../css", version = "0.0.14", default-features = false, optional = true }
+azul-core = { path = "../core", version = "0.0.16", default-features = false, optional = true }
+azul-css = { path = "../css", version = "0.0.16", default-features = false, optional = true }
 # The dll uses azul_layout::widgets (43 sites) and azul_layout::desktop
 # (dialogs), so those features must be DECLARED here. They used to arrive
 # by accident: webrender took azul-layout with default features and cargo
 # feature unification handed the full default set to every crate in the
 # graph. Scoping webrender (2026-08-05) exposed the under-declaration -
 # the dll stopped compiling until this line named what it actually uses.
-azul-layout = { path = "../layout", version = "0.0.14", default-features = false, features = ["font_loading", "text_layout", "svg", "xml", "cpurender", "widgets", "extra", "icons", "image_decoding", "updater"], optional = true }
+azul-layout = { path = "../layout", version = "0.0.16", default-features = false, features = ["font_loading", "text_layout", "svg", "xml", "cpurender", "widgets", "extra", "icons", "image_decoding", "updater"], optional = true }
 
 # Logging
 log = { version = "0.4.17", default-features = false, optional = true }

--- a/dll/Cargo.toml
+++ b/dll/Cargo.toml
@@ -169,7 +169,7 @@ aegis = { version = "0.9", features = ["pure-rust"], optional = true }
 # display lists into PDF ops INCLUDING TEXT (SetFont/ShowText via
 # azul_layout::text3::glyphs::get_glyph_runs_pdf) — which dom_to_bytes uses;
 # without it PDFs contained rectangles only (the textless azul-writer bug).
-printpdf = { version = "0.12.7", default-features = false, features = ["html", "images", "png", "jpeg"], optional = true }
+printpdf = { version = "0.12.8", default-features = false, features = ["html", "images", "png", "jpeg"], optional = true }
 
 # Typed multi-flavor clipboard payloads: codecs (RTF/CF_HTML/uri-list/DIB/…)
 # and read/write policy. Deliberately OS-FREE — pure Rust, no system library —

--- a/dll/Cargo.toml
+++ b/dll/Cargo.toml
@@ -60,7 +60,7 @@ ext-php-rs = { version = "0.15", default-features = false, optional = true }
 # it has no equivalent on Android/iOS (no native modal API from a Rust
 # crate) and its 0.1.0 release uses an older `jni` API that doesn't
 # cross-compile for android targets. Declared per-target below.
-rust-fontconfig = { version = "4.6", default-features = false, features = ["std", "parsing", "async-registry", "cache"], optional = true }
+rust-fontconfig = { version = "5.0", default-features = false, features = ["std", "parsing", "async-registry", "cache"], optional = true }
 gl-context-loader = { version ="0.1.8", default-features = false, optional = true }
 webrender = { path = "../webrender/core", default-features = false, optional = true }
 once_cell = { version = "1.17.1", optional = true }

--- a/dll/src/desktop/app.rs
+++ b/dll/src/desktop/app.rs
@@ -568,20 +568,20 @@ impl AppInternal {
         let (fc_cache, font_registry) = {
             // Create the async font registry (returns immediately).
             //
-            // The scan directories and parse-priority families are INJECTED
-            // (rust-fontconfig >= 4.6): the crate no longer decides on its
-            // own where fonts live or which families matter — the embedder
-            // does, and `os_defaults()` is the explicitly-chosen fallback
-            // tier carrying the old per-OS tables. This is the seam through
-            // which a host can later scan portable-app font dirs, or put the
-            // DESKTOP-CONFIGURED family first (SystemStyle is detected after
+            // `new()` builds BOTH configs from the system (rust-fontconfig
+            // >= 5.0): the scan directories are the OS defaults plus the
+            // `<dir>`s of the system fonts.conf, and the fallback config is
+            // that file's `<alias><prefer>` lists - what the DESKTOP says
+            // `sans-serif` means - merged over the per-OS tables, with
+            // `FONTCONFIG_FILE` / `FONTCONFIG_PATH` honoured. azul used to
+            // parse fonts.conf itself and splice the aliases into every
+            // font stack; that is the crate's job now, ONE model of what a
+            // generic expands to. `new_with_configs` stays the seam for a
+            // host that wants to scan portable-app font dirs or put the
+            // desktop-configured family first (SystemStyle is detected after
             // this point today; the first-layout `request_fonts` warmup in
             // shell2/common/layout.rs already front-loads the detected fonts).
-            let registry = FcFontRegistry::new_with_config(
-                rust_fontconfig::config::FcScanConfig::os_defaults(
-                    rust_fontconfig::OperatingSystem::current(),
-                ),
-            );
+            let registry = FcFontRegistry::new();
 
             // Try to load on-disk font cache (~10-20ms if cache exists, 0ms otherwise)
             let had_cache = registry.load_from_disk_cache();

--- a/dll/tests/font_cache_regression.rs
+++ b/dll/tests/font_cache_regression.rs
@@ -35,7 +35,9 @@ use azul_core::refany::RefAny;
 use azul_core::resources::AppConfig;
 use azul_layout::window_state::WindowCreateOptions;
 use rust_fontconfig::registry::FcFontRegistry;
-use rust_fontconfig::{FcFont, FcFontCache, FcPattern, OperatingSystem};
+use rust_fontconfig::{
+    FcFallbackConfig, FcFont, FcFontCache, FcPattern, GenericFamily, OperatingSystem,
+};
 
 use azul::desktop::shell2::common::layout::should_request_fonts;
 use azul::desktop::shell2::common::PlatformWindow;
@@ -163,7 +165,7 @@ fn incomplete_build_with_nonempty_cache_still_loads_system_fonts() {
              real coverage here.\n\
              =====================================================================\n",
             OperatingSystem::current(),
-            OperatingSystem::current().get_sans_serif_fonts(&[]),
+            platform_sans_serif_families(),
         );
         return;
     };
@@ -284,10 +286,17 @@ fn installed_platform_ui_family() -> Option<String> {
         .into_iter()
         .filter_map(|(p, _)| p.family.clone())
         .collect();
-    OperatingSystem::current()
-        .get_sans_serif_fonts(&[])
+    platform_sans_serif_families()
         .into_iter()
         .find(|f| installed.contains(f))
+}
+
+/// The per-OS `sans-serif` table (rust-fontconfig's own defaults for this
+/// platform, without any fonts.conf aliases - the families the crate
+/// DECLARES as this OS's UI fonts).
+fn platform_sans_serif_families() -> Vec<String> {
+    FcFallbackConfig::os_defaults(OperatingSystem::current())
+        .expand_generic(GenericFamily::SansSerif, &[])
 }
 
 // ---------------------------------------------------------------------------

--- a/doc/Cargo.toml
+++ b/doc/Cargo.toml
@@ -67,6 +67,6 @@ rustls-rustcrypto = "0.0.2-alpha"
 webpki-roots = "1.0"
 libc = "0.2"
 nanospinner = "0.3"
-rust-fontconfig = { version = "4.6", default-features = false, features = ["std", "parsing", "async-registry"] }
+rust-fontconfig = { version = "5.0", default-features = false, features = ["std", "parsing", "async-registry"] }
 tungstenite = "0.24"
 sha2 = "0.10"

--- a/doc/Cargo.toml
+++ b/doc/Cargo.toml
@@ -40,9 +40,9 @@ comrak = { version = "0.48.0", default-features = false }
 # `e2e-server` pulls in the ported debug-server op dispatcher + headless runner
 # (azul_layout::e2e) that backs `azul-doc e2e <dir>`. It is NOT in azul-layout's
 # default features, so the published/lean crate and the DLL are unaffected.
-azul-layout = { version = "0.0.14", path = "../layout", default-features = false, features = ["std", "xml", "text_layout", "text_layout_hyphenation", "font_loading", "font_async_registry", "cpurender", "a11y", "e2e-server"]}
-azul-core = { version = "0.0.14", path = "../core", default-features = false, features = ["std"]}
-azul-css = { version = "0.0.14", path = "../css", default-features = false, features = ["parser"]}
+azul-layout = { version = "0.0.16", path = "../layout", default-features = false, features = ["std", "xml", "text_layout", "text_layout_hyphenation", "font_loading", "font_async_registry", "cpurender", "a11y", "e2e-server"]}
+azul-core = { version = "0.0.16", path = "../core", default-features = false, features = ["std"]}
+azul-css = { version = "0.0.16", path = "../css", default-features = false, features = ["parser"]}
 chrono = "0.4.40"
 image = { version = "0.25", default-features = false, features = ["png", "webp"] }
 base64 = "0.22.1"

--- a/doc/src/reftest/pipeline.rs
+++ b/doc/src/reftest/pipeline.rs
@@ -172,7 +172,8 @@ pub struct ReftestPipeline {
 impl ReftestPipeline {
     /// Write the hermetic fontconfig used for BOTH engines of a reftest run
     /// and export it via FONTCONFIG_FILE (which Chrome honours natively and
-    /// azul honours through `fontconfig_generic_aliases`).
+    /// azul honours through rust-fontconfig's `FcSystemConfig::from_system`,
+    /// the source of the aliases behind `FcFontRegistry::new`).
     ///
     /// Chrome does not ask fontconfig for "sans-serif": its own per-script
     /// defaults request "Arial"/"Times New Roman" and rely on the system's

--- a/layout/Cargo.toml
+++ b/layout/Cargo.toml
@@ -8,7 +8,7 @@
 [package]
 readme = "../README.md"
 name = "azul-layout"
-version = "0.0.14"
+version = "0.0.16"
 authors = ["Felix Schütt <felix.schuett@maps4print.com>"]
 license = "MIT"
 description = "Layout solver + font and image loader the Azul GUI framework"
@@ -55,8 +55,8 @@ autoexamples = true
 autotests = false
 
 [dependencies]
-azul-css                = { version = "0.0.14", path = "../css", default-features = false, features = ["parser"] }
-azul-core               = { version = "0.0.14", path = "../core", default-features = false }
+azul-css                = { version = "0.0.16", path = "../css", default-features = false, features = ["parser"] }
+azul-core               = { version = "0.0.16", path = "../core", default-features = false }
 # `pattern` form validation (11b-i-b). MINIMAL on purpose: only the string API,
 # no dependencies of its own. NOT optional-on-std, though -- regex-lite's own
 # lib.rs is `#[cfg(not(feature = "std"))] compile_error!("'std' is currently a

--- a/layout/Cargo.toml
+++ b/layout/Cargo.toml
@@ -68,7 +68,7 @@ image                   = { version = "0.25", default-features = false, optional
 # Explicit override to disable SIMD features that were broken in older versions
 # See: https://github.com/image-rs/image/issues/2705
 zune-jpeg               = { version = "0.5", default-features = false, features = ["std"], optional = true }
-rust-fontconfig = { version = ">=4.6, <4.7", default-features = false, optional = true }
+rust-fontconfig = { version = ">=5.0, <5.1", default-features = false, optional = true }
 libc                    = { version = "0.2", default-features = false, optional = true }
 serde                   = { version = "1.0", features = ["derive"] }
 brotli-decompressor     = { version = "5", default-features = false, features = ["std"], optional = true }

--- a/layout/src/solver3/getters.rs
+++ b/layout/src/solver3/getters.rs
@@ -3774,164 +3774,11 @@ pub const fn is_avoid_break_inside(break_inside: &BreakInside) -> bool {
 use std::collections::HashMap;
 
 use rust_fontconfig::{
-    FcFontCache, FcWeight, FontFallbackChain, PatternMatch, UnicodeRange,
-    DEFAULT_UNICODE_FALLBACK_SCRIPTS,
+    config::is_generic_family, FcFontCache, FcWeight, FontFallbackChain, PatternMatch,
+    UnicodeRange, DEFAULT_UNICODE_FALLBACK_SCRIPTS,
 };
 
 use crate::text3::cache::{FontChainKey, FontChainKeyOrRef, FontSelector, FontStack, FontStyle};
-
-/// Build a fontconfig `FontSelector` stack from a list of CSS font families.
-///
-/// Shared by `get_style_properties` and `collect_font_stacks_from_styled_dom`.
-/// `Ref` families are skipped (callers handle embedded fonts via `FontStack::Ref`),
-/// `SystemType` families expand to the platform's fallback chain, and the generic
-/// `sans-serif`/`serif`/`monospace` fallbacks are appended if not already present.
-///
-/// When `platform` is `None` (e.g. the paged / PDF layout path that hard-codes
-/// `system_style = None`), system fonts resolve via `Platform::current()` so the
-/// names stay in lock-step with the font-loading pass (which always uses
-/// `Platform::current()`); diverging to a bare "sans-serif" would not match the
-/// names the loader registered → zero glyphs → text collapses to 0 width.
-// The `platform` binding uses a pre-declared `let current;` so the else branch can
-// extend the lifetime of a freshly-computed Platform and hand back a reference to it;
-// map_or_else cannot express this (the closure would return a dangling local ref).
-#[allow(clippy::option_if_let_else)]
-/// The system's fontconfig `<alias><prefer>` lists for the CSS generic
-/// families (Linux only), parsed once per process.
-///
-/// Chromium - and every fontconfig-linked toolkit - resolves `sans-serif`
-/// through these aliases, so the SAME machine that renders reftests with
-/// Noto Sans in Chrome must not render Ubuntu in azul just because
-/// rust-fontconfig's hardcoded per-OS candidate list puts Ubuntu first.
-/// The preferred families are inserted BEFORE the generic in the selector
-/// stack; the generic stays, so rust-fontconfig's expansion still appends
-/// its own fallbacks after them.
-///
-/// Only the `<alias>` subset of the fontconfig configuration is read
-/// (fonts.conf + conf.d/*.conf in sorted order, matching fontconfig's
-/// accumulation order); everything else in those files is ignored.
-#[cfg(all(target_os = "linux", feature = "std"))]
-fn fontconfig_generic_aliases() -> &'static std::collections::BTreeMap<String, Vec<String>> {
-    use std::collections::BTreeMap;
-    use std::sync::OnceLock;
-    static ALIASES: OnceLock<BTreeMap<String, Vec<String>>> = OnceLock::new();
-    ALIASES.get_or_init(|| {
-        let mut map: BTreeMap<String, Vec<String>> = BTreeMap::new();
-        // FONTCONFIG_FILE overrides the system configuration wholesale -
-        // exactly like libfontconfig - which is how the reftest pipeline
-        // pins a hermetic font set for azul AND Chrome simultaneously.
-        if let Ok(custom) = std::env::var("FONTCONFIG_FILE") {
-            if !custom.is_empty() {
-                let files = vec![std::path::PathBuf::from(custom)];
-                collect_alias_files(&files, &mut map);
-                return map;
-            }
-        }
-        let mut files: Vec<std::path::PathBuf> = vec!["/etc/fonts/fonts.conf".into()];
-        if let Ok(dir) = std::fs::read_dir("/etc/fonts/conf.d") {
-            let mut confs: Vec<_> = dir
-                .filter_map(Result::ok)
-                .map(|e| e.path())
-                .filter(|p| p.extension().is_some_and(|e| e == "conf"))
-                .collect();
-            confs.sort();
-            files.extend(confs);
-        }
-        collect_alias_files(&files, &mut map);
-        map
-    })
-}
-
-/// Accumulate `<alias><prefer>` families from the given fontconfig files
-/// into `map` (generic-family keys only, first occurrence wins per family).
-#[cfg(all(target_os = "linux", feature = "std"))]
-fn collect_alias_files(
-    files: &[std::path::PathBuf],
-    map: &mut std::collections::BTreeMap<String, Vec<String>>,
-) {
-    for path in files {
-        let Ok(content) = std::fs::read_to_string(path) else {
-            continue;
-        };
-        let mut rest = content.as_str();
-        while let Some(start) = rest.find("<alias") {
-            let Some(end_rel) = rest[start..].find("</alias>") else {
-                break;
-            };
-            let block = &rest[start..start + end_rel];
-            rest = &rest[start + end_rel + "</alias>".len()..];
-            let Some(fam) = extract_xml_tag(block, "family") else {
-                continue;
-            };
-            let fam_lower = fam.to_ascii_lowercase();
-            if !matches!(fam_lower.as_str(), "sans-serif" | "serif" | "monospace") {
-                continue;
-            }
-            let Some(prefer_start) = block.find("<prefer>") else {
-                continue;
-            };
-            let prefer_end = block[prefer_start..]
-                .find("</prefer>")
-                .map_or(block.len(), |e| prefer_start + e);
-            let mut prefer_block = &block[prefer_start..prefer_end];
-            let entry = map.entry(fam_lower).or_default();
-            while let Some(f) = extract_xml_tag(prefer_block, "family") {
-                if !entry.iter().any(|e| e.eq_ignore_ascii_case(&f)) {
-                    entry.push(f.clone());
-                }
-                let Some(pos) = prefer_block.find("</family>") else {
-                    break;
-                };
-                prefer_block = &prefer_block[pos + "</family>".len()..];
-            }
-        }
-    }
-}
-
-/// First `<tag>...</tag>` text content inside `block`, trimmed.
-#[cfg(all(target_os = "linux", feature = "std"))]
-fn extract_xml_tag(block: &str, tag: &str) -> Option<String> {
-    let open = alloc::format!("<{tag}>");
-    let close = alloc::format!("</{tag}>");
-    let s = block.find(&open)? + open.len();
-    let e = block[s..].find(&close)? + s;
-    Some(block[s..e].trim().to_string())
-}
-
-/// Push `family` onto the selector stack, preceded by the system's
-/// fontconfig alias preferences when it is a CSS generic family (see
-/// `fontconfig_generic_aliases`).
-fn push_family_with_system_aliases(
-    stack: &mut Vec<FontSelector>,
-    family: String,
-    weight: FcWeight,
-    style: FontStyle,
-) {
-    #[cfg(all(target_os = "linux", feature = "std"))]
-    {
-        let lower = family.to_ascii_lowercase();
-        if matches!(lower.as_str(), "sans-serif" | "serif" | "monospace") {
-            if let Some(prefs) = fontconfig_generic_aliases().get(&lower) {
-                for pref in prefs {
-                    if !stack.iter().any(|f| f.family.eq_ignore_ascii_case(pref)) {
-                        stack.push(FontSelector {
-                            family: pref.clone(),
-                            weight,
-                            style,
-                            unicode_ranges: Vec::new(),
-                        });
-                    }
-                }
-            }
-        }
-    }
-    stack.push(FontSelector {
-        family,
-        weight,
-        style,
-        unicode_ranges: Vec::new(),
-    });
-}
 
 /// Memoised [`build_font_selector_stack`].
 ///
@@ -4013,6 +3860,29 @@ fn build_font_selector_stack_memo(
     built
 }
 
+/// Build a fontconfig `FontSelector` stack from a list of CSS font families.
+///
+/// Shared by `get_style_properties` and `collect_font_stacks_from_styled_dom`.
+/// `Ref` families are skipped (callers handle embedded fonts via `FontStack::Ref`),
+/// `SystemType` families expand to the platform's fallback chain, and the generic
+/// `sans-serif`/`serif`/`monospace` fallbacks are appended if not already present.
+///
+/// Generic families are pushed AS generics. rust-fontconfig expands them
+/// through its `FcFallbackConfig` - the platform's `fonts.conf`
+/// `<alias><prefer>` lists merged over the per-OS tables, see
+/// `FcFontRegistry::new` - so azul does no alias expansion of its own: ONE
+/// model decides what `sans-serif` means, and an alias family the system
+/// does not have costs a map lookup, not a resolver query.
+///
+/// When `platform` is `None` (e.g. the paged / PDF layout path that hard-codes
+/// `system_style = None`), system fonts resolve via `Platform::current()` so the
+/// names stay in lock-step with the font-loading pass (which always uses
+/// `Platform::current()`); diverging to a bare "sans-serif" would not match the
+/// names the loader registered → zero glyphs → text collapses to 0 width.
+// The `platform` binding uses a pre-declared `let current;` so the else branch can
+// extend the lifetime of a freshly-computed Platform and hand back a reference to it;
+// map_or_else cannot express this (the closure would return a dangling local ref).
+#[allow(clippy::option_if_let_else)]
 fn build_font_selector_stack(
     font_families: &StyleFontFamilyVec,
     platform: Option<&azul_css::system::Platform>,
@@ -4068,12 +3938,12 @@ fn build_font_selector_stack(
             // as_query_string, NOT as_string: FontManager queries fontconfig with the
             // RAW name. as_string() CSS-quotes whitespace names ("Times New Roman" ->
             // "\"Times New Roman\""), which corrupts the query for every multi-word font.
-            push_family_with_system_aliases(
-                &mut stack,
-                family.as_query_string(),
-                fc_weight,
-                fc_style,
-            );
+            stack.push(FontSelector {
+                family: family.as_query_string(),
+                weight: fc_weight,
+                style: fc_style,
+                unicode_ranges: Vec::new(),
+            });
         }
     }
 
@@ -4082,12 +3952,12 @@ fn build_font_selector_stack(
             .iter()
             .any(|f| f.family.eq_ignore_ascii_case(fallback))
         {
-            push_family_with_system_aliases(
-                &mut stack,
-                (*fallback).to_string(),
-                FcWeight::Normal,
-                FontStyle::Normal,
-            );
+            stack.push(FontSelector {
+                family: (*fallback).to_string(),
+                weight: FcWeight::Normal,
+                style: FontStyle::Normal,
+                unicode_ranges: Vec::new(),
+            });
         }
     }
 
@@ -4508,12 +4378,16 @@ pub fn collect_used_codepoints_all(styled_dom: &StyledDom) -> std::collections::
 /// in `FontMatch.unicode_ranges`). Always keeps at least the first
 /// match per group so a font listed in CSS doesn't disappear.
 ///
-/// `unicode_fallbacks` is filtered to only include fonts whose
-/// ranges intersect `used_chars` — Phase-6's
-/// [`scripts_present_in_styled_dom`] already scopes the *script
-/// blocks* but a single block (e.g. CJK Unified, U+4E00..U+9FFF)
-/// can have hundreds of matching system fonts; this prunes them
-/// down to the few that actually cover the codepoints used.
+/// The script tiers - each css group's `script_fonts` and the chain's
+/// `unicode_fallbacks` - are filtered to the fonts whose ranges intersect a
+/// used codepoint INSIDE the group's script range, and a group left with no
+/// fonts is dropped. Phase-6's [`scripts_present_in_styled_dom`] already
+/// scopes the *script blocks* but a single block (e.g. CJK Unified,
+/// U+4E00..U+9FFF) can have hundreds of matching system fonts; this prunes
+/// them down to the few that actually cover the codepoints used.
+///
+/// `last_resort` is never pruned: it is the "draw SOMETHING" tier
+/// (`ensure_chains_nonempty`), kept regardless of coverage.
 ///
 /// On excel.html (~ASCII-only) this drops the per-chain
 /// `css_fallbacks` from 5 → 1 in each group, eliminating ~20 of
@@ -4528,8 +4402,23 @@ pub fn prune_chain_to_used_chars(
             .iter()
             .any(|r| cp >= r.start && cp <= r.end)
     }
+    fn prune_script_groups(
+        groups: &mut Vec<rust_fontconfig::ScriptFallbackGroup>,
+        used_chars: &std::collections::BTreeSet<u32>,
+    ) {
+        for group in groups.iter_mut() {
+            let range = group.range;
+            group.fonts.retain(|fm| {
+                used_chars
+                    .iter()
+                    .any(|&cp| cp >= range.start && cp <= range.end && fm_covers(fm, cp))
+            });
+        }
+        groups.retain(|g| !g.fonts.is_empty());
+    }
 
     for group in &mut chain.css_fallbacks {
+        prune_script_groups(&mut group.script_fonts, used_chars);
         if group.fonts.is_empty() {
             continue;
         }
@@ -4548,9 +4437,7 @@ pub fn prune_chain_to_used_chars(
         group.fonts.truncate(keep);
     }
 
-    chain
-        .unicode_fallbacks
-        .retain(|fm| used_chars.iter().any(|&cp| fm_covers(fm, cp)));
+    prune_script_groups(&mut chain.unicode_fallbacks, used_chars);
 }
 
 /// Scan text-node content in `styled_dom` and return the subset of
@@ -4666,6 +4553,7 @@ fn split_memory_matches(
             groups.push(rust_fontconfig::CssFallbackGroup {
                 css_name: family.clone(),
                 fonts: vec![face.font_match.clone()],
+                script_fonts: Vec::new(),
             });
             continue;
         }
@@ -4679,6 +4567,7 @@ fn split_memory_matches(
             fallback.push(rust_fontconfig::CssFallbackGroup {
                 css_name: family.clone(),
                 fonts: vec![face.font_match.clone()],
+                script_fonts: Vec::new(),
             });
         }
     }
@@ -4751,107 +4640,6 @@ fn pick_memory_face(
 /// [`resolve_font_chains`] does and what every code path did before
 /// Phase 3.
 #[allow(clippy::implicit_hasher)] // internal; memory_families always uses the default hasher
-/// Concrete family names that exist ONLY because the fontconfig generic
-/// alias expansion invented them — the union of every `<alias><prefer>` list
-/// (see `fontconfig_generic_aliases`). Lowercased.
-///
-/// These are CANDIDATES, not requests: the system offers ~50 families per
-/// generic and expects most of them to be absent. Nothing in the document
-/// asked for `ZYSong18030`.
-#[cfg(all(target_os = "linux", feature = "std"))]
-fn alias_candidate_names() -> &'static std::collections::BTreeSet<String> {
-    use std::collections::BTreeSet;
-    use std::sync::OnceLock;
-    static S: OnceLock<BTreeSet<String>> = OnceLock::new();
-    S.get_or_init(|| {
-        fontconfig_generic_aliases()
-            .values()
-            .flatten()
-            .map(|f| f.to_ascii_lowercase())
-            .collect()
-    })
-}
-
-#[cfg(not(all(target_os = "linux", feature = "std")))]
-fn alias_candidate_names() -> &'static std::collections::BTreeSet<String> {
-    use std::collections::BTreeSet;
-    use std::sync::OnceLock;
-    static S: OnceLock<BTreeSet<String>> = OnceLock::new();
-    S.get_or_init(BTreeSet::new)
-}
-
-/// Lowercased family names the cache can actually serve.
-fn available_family_names(fc_cache: &FcFontCache) -> std::collections::BTreeSet<String> {
-    let mut out = std::collections::BTreeSet::new();
-    fc_cache.for_each_pattern(|pattern, _id| {
-        if let Some(f) = pattern.family.as_ref() {
-            out.insert(f.to_ascii_lowercase());
-        }
-    });
-    out
-}
-
-/// Drop the alias-expansion candidates the system cannot serve.
-///
-/// THE COST THIS REMOVES. Every CSS generic is expanded to the system's
-/// `<alias><prefer>` families ahead of the generic itself, so a stack of
-/// three generics reaches the resolver as ~150 concrete names. Resolving a
-/// name that is not installed is not free — measured at ~0.52 ms each,
-/// x142 misses = 73.8 ms of a 177 ms cold pagination, for TWO chains. The
-/// same 142 misses were also the wall of `UNRESOLVED font-family` warnings.
-///
-/// WHY THIS IS SAFE. azul does the generic expansion ITSELF
-/// (`push_family_with_system_aliases`), so every candidate reaching the
-/// resolver is already a concrete name — a concrete name absent from the
-/// cache cannot resolve by any route. Generics are never pruned (the
-/// resolver expands those internally), and neither is any family that is
-/// NOT an alias candidate: a name the DOCUMENT authored keeps its lookup
-/// and keeps its warning.
-///
-/// KNOWN TRADE-OFF: a family that is both authored AND on the system's
-/// prefer list (Arial, `DejaVu` Sans, ...) is pruned silently when absent.
-/// Its absence is what alias lists exist to absorb, so it is not a
-/// diagnostic worth a warning.
-fn prune_absent_alias_candidates(
-    families: &[String],
-    fc_cache: &FcFontCache,
-) -> (Vec<String>, usize) {
-    let aliases = alias_candidate_names();
-    if aliases.is_empty() {
-        return (families.to_vec(), 0);
-    }
-    let available = available_family_names(fc_cache);
-    let mut pruned = 0usize;
-    let kept = families
-        .iter()
-        .filter(|f| {
-            let drop = should_prune_family(f, aliases, &available);
-            if drop {
-                pruned += 1;
-            }
-            !drop
-        })
-        .cloned()
-        .collect();
-    (kept, pruned)
-}
-
-/// The decision behind [`prune_absent_alias_candidates`], over explicit sets
-/// so it can be tested without a system font configuration.
-///
-/// Prune ONLY when all three hold: the name was invented by the alias
-/// expansion, the system does not have it, and it is not a generic (the
-/// resolver expands those itself). Anything the DOCUMENT authored fails the
-/// first test and is always kept — lookup and warning intact.
-fn should_prune_family(
-    family: &str,
-    aliases: &std::collections::BTreeSet<String>,
-    available: &std::collections::BTreeSet<String>,
-) -> bool {
-    let lower = family.to_ascii_lowercase();
-    aliases.contains(&lower) && !available.contains(&lower) && !is_generic_family(family)
-}
-
 #[must_use]
 pub fn resolve_font_chains_with_registry(
     collected: &CollectedFontStacks,
@@ -4866,7 +4654,6 @@ pub fn resolve_font_chains_with_registry(
         .is_some()
         .then(std::time::Instant::now);
     let mut unresolved: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
-    let mut total_pruned = 0usize;
 
     // Resolve system/file font stacks via fontconfig
     for font_stack in &collected.font_stacks {
@@ -4926,22 +4713,10 @@ pub fn resolve_font_chains_with_registry(
             is_oblique,
         );
 
-        // Alias candidates the system cannot serve never reach the resolver:
-        // each one costs a real lookup (~0.52 ms) to learn what a set
-        // membership test answers for free. See
-        // `prune_absent_alias_candidates`.
-        let (disk_families, pruned_aliases) =
-            prune_absent_alias_candidates(&disk_families, fc_cache);
-        total_pruned += pruned_aliases;
-
         // Registry-aware resolve: scout-on-demand path when available.
         // See `resolve_font_chains_with_registry` doc for rationale.
         let mut chain = if disk_families.is_empty() {
-            FontFallbackChain {
-                css_fallbacks: Vec::new(),
-                unicode_fallbacks: Vec::new(),
-                original_stack: font_families.clone(),
-            }
+            FontFallbackChain::empty(&font_families)
         } else {
             registry.map_or_else(
                 || {
@@ -4977,45 +4752,17 @@ pub fn resolve_font_chains_with_registry(
         chain.css_fallbacks.extend(mem_fallbacks);
 
         // A family that produced no group matched NOTHING — record it (see
-        // `ResolvedFontChains::unresolved_families`).
+        // `ResolvedFontChains::unresolved_families`). Generics are exempt:
+        // rust-fontconfig expands them itself, and a generic with no faces
+        // is the empty-system case `ensure_chains_nonempty` handles, not an
+        // authoring mistake.
         for family in &font_families {
             let matched = chain
                 .css_fallbacks
                 .iter()
                 .any(|g| g.css_name.eq_ignore_ascii_case(family) && !g.fonts.is_empty());
-            // A pruned candidate is not a failed request — the expansion
-            // invented it and the system does not have it, which is the
-            // normal case an alias list exists to absorb. Reporting them
-            // buried the families the DOCUMENT actually asked for under
-            // ~142 lines of noise.
-            let is_absent_alias = !disk_families.iter().any(|d| d == family)
-                && alias_candidate_names().contains(&family.to_ascii_lowercase());
-            if !matched && !is_generic_family(family) && !is_absent_alias {
+            if !matched && !is_generic_family(family) {
                 unresolved.insert(family.clone());
-            }
-        }
-
-        // WEB-LIFT last resort (in azul-layout, NOT rust-fontconfig — so the fragile
-        // `with_memory_fonts` isn't re-codegen'd into a trapping shape): the lifted
-        // resolve_font_chain query path can return an EMPTY chain even when a fallback
-        // font IS registered (generic→OS-name expansion + token/unicode query is
-        // lift-fragile). If the chain has no fonts, append the first registered font so
-        // load_missing_for_chains / resolve_char find it and text shapes (not measure 0).
-        let total_fonts = chain
-            .css_fallbacks
-            .iter()
-            .map(|g| g.fonts.len())
-            .sum::<usize>()
-            + chain.unicode_fallbacks.len();
-        if total_fonts == 0 {
-            if let Some((_pattern, id)) = first_font_in_cache(fc_cache).as_ref() {
-                // Vec::new() ranges (not pattern.unicode_ranges.clone()) — the Vec-clone
-                // mis-lifts on the web backend and empty == "no range restriction" here.
-                chain.unicode_fallbacks.push(rust_fontconfig::FontMatch {
-                    id: *id,
-                    unicode_ranges: Vec::new(),
-                    fallbacks: Vec::new(),
-                });
             }
         }
 
@@ -5026,18 +4773,20 @@ pub fn resolve_font_chains_with_registry(
     // style.font_stack for FontStack::Ref and uses the font data directly.
     // No entries are inserted into `chains` for them.
 
-    let out = ResolvedFontChains {
+    let mut out = ResolvedFontChains {
         chains,
         unresolved_families: unresolved,
         last_resort_chains: 0,
     };
+    ensure_chains_nonempty(&mut out, fc_cache);
     if let Some(t0) = trace_t0 {
         eprintln!(
             "[paginate]   resolve_font_chains_with_registry {:?}: {} chain(s), {} \
-             unresolved family name(s), {total_pruned} absent alias candidate(s) pruned",
+             unresolved family name(s), {} last-resort chain(s)",
             t0.elapsed(),
             out.chains.len(),
             out.unresolved_families.len(),
+            out.last_resort_chains,
         );
     }
     report_unresolved_families(&out);
@@ -5067,16 +4816,28 @@ fn first_font_in_cache(fc_cache: &FcFontCache) -> Option<(rust_fontconfig::FcPat
     first
 }
 
-/// WEB-LIFT last resort, applied LIFT-SAFELY. The lifted backend drops in-place
-/// mutations made through `BTreeMap::values_mut()` (the pushed `FontMatch` is silently
-/// lost — same class as the cascade `From` mapped-collect drop) and mis-lifts the
-/// `pattern.unicode_ranges.clone()` Vec-clone. So this rebuilds the map with an explicit
-/// `for` loop (no `values_mut`) and appends a coverage-agnostic fallback using
-/// `Vec::new()` ranges (the convention already used across this file for "no specific
-/// range restriction"). Applied on BOTH resolver return paths — the fast path otherwise
-/// returns chains with no last resort at all, so when the lifted
-/// `query_matches`/`find_unicode_fallbacks` yields an empty chain even though a fallback
-/// font IS registered, the text node measures 0 → `LayoutError::InvalidTree`.
+/// The ONE last-resort rule: a chain that matched nothing at all gets the
+/// first font in the cache as its `last_resort`, so text renders in SOME
+/// font instead of measuring 0 (`LayoutError::InvalidTree`).
+///
+/// Both resolvers call this before returning, so no caller has to remember
+/// to. The face goes on `FontFallbackChain::last_resort`, the tier
+/// rust-fontconfig 5 reserves for exactly this - `resolve_codepoint` hands
+/// it out tagged `LAST_RESORT_SOURCE`, so coverage decisions
+/// (`crate::text3::cache::covering_font`) can tell "this font has the glyph"
+/// from "nothing has it, draw something" - and `prune_chain_to_used_chars`
+/// never touches that tier, so pruning cannot re-empty the chain.
+///
+/// azul does NOT populate `FcFallbackConfig::last_resort` for this: that
+/// tier is resolved eagerly into EVERY chain and its faces are loaded with
+/// the chain, whereas this only touches chains that came back empty.
+///
+/// Applied LIFT-SAFELY: the lifted (web) backend drops in-place mutations
+/// made through `values_mut()` - the pushed `FontMatch` is silently lost,
+/// same class as the cascade `From` mapped-collect drop - and mis-lifts the
+/// `pattern.unicode_ranges.clone()` Vec-clone. So this rebuilds the map with
+/// an explicit `for` loop and pushes a face with `Vec::new()` ranges (the
+/// convention across this file for "no range restriction").
 fn ensure_chains_nonempty(resolved: &mut ResolvedFontChains, fc_cache: &FcFontCache) {
     let Some((_pattern, fallback_id)) = first_font_in_cache(fc_cache) else {
         return;
@@ -5086,13 +4847,7 @@ fn ensure_chains_nonempty(resolved: &mut ResolvedFontChains, fc_cache: &FcFontCa
     let mut last_resort = 0usize;
     for key in keys {
         if let Some(mut chain) = resolved.chains.remove(&key) {
-            let total = chain
-                .css_fallbacks
-                .iter()
-                .map(|g| g.fonts.len())
-                .sum::<usize>()
-                + chain.unicode_fallbacks.len();
-            if total == 0 {
+            if chain.fonts().next().is_none() {
                 // NOT SILENT: this chain matched nothing at all. Every such
                 // chain gets the SAME arbitrary `fallback_id` — which is
                 // precisely how N distinct font-families collapsed onto one
@@ -5106,7 +4861,7 @@ fn ensure_chains_nonempty(resolved: &mut ResolvedFontChains, fc_cache: &FcFontCa
                         k.font_families
                     );
                 }
-                chain.unicode_fallbacks.push(rust_fontconfig::FontMatch {
+                chain.last_resort.push(rust_fontconfig::FontMatch {
                     id: fallback_id,
                     unicode_ranges: Vec::new(),
                     fallbacks: Vec::new(),
@@ -5168,7 +4923,6 @@ pub fn collect_and_resolve_font_chains_with_registration<T: ParsedFontTrait>(
                 &font_manager.memory_families,
             );
             extend_chains_to_cover(&mut fast, &used_chars, fc_cache, Some(registry));
-            ensure_chains_nonempty(&mut fast, fc_cache);
             return fast;
         }
     }
@@ -5200,14 +4954,9 @@ pub fn collect_and_resolve_font_chains_with_registration<T: ParsedFontTrait>(
         fc_cache,
         font_manager.registry.as_deref(),
     );
-    // WEB-LIFT last resort (AFTER the prune, so it survives — the prune drops fonts
-    // whose parsed cmap doesn't cover used_chars, which removes the registered fallback
-    // before it's parsed): if a chain ended up empty, append the first registered font
-    // so load_missing_for_chains finds it and text shapes instead of measuring 0.
-    // LIFT-SAFE rebuild (see ensure_chains_nonempty) — the old `values_mut()` +
-    // `unicode_ranges.clone()` version dropped the push in the lifted backend, leaving
-    // the chain empty (web-text-min n1 measured 0xfffffffe/auto → InvalidTree).
-    ensure_chains_nonempty(&mut resolved, fc_cache);
+    // No last-resort step here: the resolver already applied
+    // `ensure_chains_nonempty`, and the face it added sits on
+    // `last_resort`, which the prune above never touches.
     resolved
 }
 
@@ -5307,11 +5056,9 @@ pub fn resolve_font_chains_fast(
         }
         // Merge: memory-matched groups (in CSS order) + whatever the disk
         // probe found for the remaining families.
-        let mut chain = chains_out.pop().unwrap_or_else(|| FontFallbackChain {
-            css_fallbacks: Vec::new(),
-            unicode_fallbacks: Vec::new(),
-            original_stack: font_families.clone(),
-        });
+        let mut chain = chains_out
+            .pop()
+            .unwrap_or_else(|| FontFallbackChain::empty(&font_families));
         if !css_fallbacks.is_empty() {
             css_fallbacks.append(&mut chain.css_fallbacks);
             chain.css_fallbacks = css_fallbacks;
@@ -5346,40 +5093,47 @@ pub fn resolve_font_chains_fast(
         chains.insert(cache_key, chain);
     }
 
-    let out = ResolvedFontChains {
+    let mut out = ResolvedFontChains {
         chains,
         unresolved_families: unresolved,
         last_resort_chains: 0,
     };
+    ensure_chains_nonempty(&mut out, &registry.shared_cache());
     report_unresolved_families(&out);
     out
 }
 
 /// Give every chain a face for each of the DOM's codepoints it cannot draw.
 ///
-/// Both resolvers leave gaps. `request_fonts_fast` walks the stack's plain OS
-/// expansion (the sans-serif list: Ubuntu, Arial, `DejaVu` Sans, Noto Sans,
-/// Liberation Sans on Linux) and treats a codepoint no listed family covers
-/// as a miss for the shaper's .notdef — so Arabic in a `sans-serif` paragraph
-/// renders as boxes on any machine whose sans list has no Arabic face (Noto
-/// Sans does not carry it; "Noto Sans Arabic" is only reached through the
-/// script-aware expansion). The legacy resolver attaches unicode fallbacks
-/// only for the seven `scripts_present_in_styled_dom` blocks, so Hebrew or
-/// Thai in a Latin stack is on its own. [`faces_covering`] runs the
-/// script-aware lookup for exactly the chars left uncovered and appends what
-/// it finds as unicode fallbacks; the steady state for a document in a
-/// script its stack covers is no work at all.
+/// Both resolvers leave gaps. `request_fonts_fast` expands the stack through
+/// the fallback config (the generic's families plus the script candidates
+/// for the SEVEN default scripts) and probes those files' cmaps against the
+/// DOM's codepoints; a codepoint outside those scripts that no listed family
+/// covers is a miss for the shaper's .notdef - Hebrew or Thai in a Latin
+/// `sans-serif` stack, on a machine whose sans list has no such face. The
+/// legacy resolver attaches script fallbacks only for the blocks
+/// `scripts_present_in_styled_dom` reports, with the same gap. And neither
+/// resolver knows the in-memory fonts. [`faces_covering`] runs the
+/// script-aware lookup for exactly the chars left uncovered and what it
+/// finds is appended as one more unicode-fallback group; the steady state
+/// for a document in a script its stack covers is no work at all.
 ///
-/// Whitespace, controls and default-ignorables are not asked for (see
-/// `needs_own_glyph`); a face's coverage is judged by the OS/2 ranges its
-/// match carries, since nothing is loaded yet at this point.
+/// Coverage is judged by [`covering_font`], which does NOT count the
+/// last-resort face: that face is there so SOMETHING draws, not because it
+/// has the glyph. Whitespace, controls and default-ignorables are not asked
+/// for (see `needs_own_glyph`); a face's coverage is judged by the
+/// `unicode_ranges` its match carries, since nothing is loaded yet at this
+/// point. Under rust-fontconfig 5 those ranges are the font's exact cmap
+/// segments - OS/2's `ulUnicodeRange` is no longer consulted, and the block
+/// probes that used to round a single glyph up to its whole Unicode block
+/// are gone.
 fn extend_chains_to_cover(
     resolved: &mut ResolvedFontChains,
     used_chars: &std::collections::BTreeSet<char>,
     fc_cache: &FcFontCache,
     registry: Option<&rust_fontconfig::registry::FcFontRegistry>,
 ) {
-    use crate::text3::cache::{faces_covering, needs_own_glyph};
+    use crate::text3::cache::{append_coverage_faces, covering_font, faces_covering, needs_own_glyph};
 
     let wanted: Vec<char> = used_chars
         .iter()
@@ -5396,38 +5150,14 @@ fn extend_chains_to_cover(
         let uncovered: std::collections::BTreeSet<char> = wanted
             .iter()
             .copied()
-            .filter(|c| chain.resolve_char(fc_cache, *c).is_none())
+            .filter(|c| covering_font(chain, *c).is_none())
             .collect();
         if uncovered.is_empty() {
             continue;
         }
         let added = faces_covering(key, chain, uncovered, fc_cache, registry, &|_, _| None);
-        if !added.is_empty() {
-            chain.unicode_fallbacks.extend(added);
-        }
+        append_coverage_faces(chain, added);
     }
-}
-
-/// CSS generic families are not expected to match by name (they are
-/// expanded to concrete OS families before lookup), so a missing group for
-/// them is not a resolution failure worth reporting.
-fn is_generic_family(family: &str) -> bool {
-    matches!(
-        family.to_ascii_lowercase().as_str(),
-        "serif"
-            | "sans-serif"
-            | "monospace"
-            | "cursive"
-            | "fantasy"
-            | "system-ui"
-            | "ui-serif"
-            | "ui-sans-serif"
-            | "ui-monospace"
-            | "ui-rounded"
-            | "emoji"
-            | "math"
-            | "fangsong"
-    )
 }
 
 /// Log every family the resolver could not match, ONCE per process per
@@ -5504,15 +5234,9 @@ pub fn collect_font_ids_from_chains(chains: &ResolvedFontChains) -> HashSet<Font
     }
 
     for chain in chains.chains.values() {
-        // Collect from CSS fallbacks
-        for group in &chain.css_fallbacks {
-            for font in &group.fonts {
-                font_ids.insert(font.id);
-            }
-        }
-
-        // Collect from Unicode fallbacks
-        for font in &chain.unicode_fallbacks {
+        // Every tier: css groups (+ their script fonts), unicode fallbacks,
+        // last resort. `fonts()` dedups within a chain; the set dedups across.
+        for font in chain.fonts() {
             font_ids.insert(font.id);
         }
     }
@@ -7255,7 +6979,7 @@ mod autotest_generated {
             scrollbar::{ScrollbarColorCustom, ScrollbarFadeDelay, ScrollbarFadeDuration},
         },
     };
-    use rust_fontconfig::{CssFallbackGroup, FontMatch};
+    use rust_fontconfig::{CssFallbackGroup, FontMatch, ScriptFallbackGroup};
 
     use super::*;
 
@@ -7405,10 +7129,23 @@ mod autotest_generated {
         }
     }
 
+    /// A chain with `groups` as its css tier and `unicode` as ONE
+    /// full-range unicode-fallback group (none when `unicode` is empty).
     fn chain_with(groups: Vec<CssFallbackGroup>, unicode: Vec<FontMatch>) -> FontFallbackChain {
         FontFallbackChain {
             css_fallbacks: groups,
-            unicode_fallbacks: unicode,
+            unicode_fallbacks: if unicode.is_empty() {
+                Vec::new()
+            } else {
+                vec![ScriptFallbackGroup {
+                    range: UnicodeRange {
+                        start: 0,
+                        end: 0x10FFFF,
+                    },
+                    fonts: unicode,
+                }]
+            },
+            last_resort: Vec::new(),
             original_stack: Vec::new(),
         }
     }
@@ -8319,11 +8056,13 @@ mod autotest_generated {
                     CssFallbackGroup {
                         css_name: "Arial".to_string(),
                         fonts: vec![font_match(1, &[]), font_match(2, &[])],
+                        script_fonts: Vec::new(),
                     },
                     CssFallbackGroup {
                         css_name: "sans-serif".to_string(),
                         // FontId(1) also appears in the first group.
                         fonts: vec![font_match(1, &[]), font_match(3, &[])],
+                        script_fonts: Vec::new(),
                     },
                 ],
                 vec![font_match(3, &[]), font_match(u128::MAX, &[])],
@@ -8352,6 +8091,7 @@ mod autotest_generated {
                 vec![CssFallbackGroup {
                     css_name: "Nonexistent".to_string(),
                     fonts: Vec::new(),
+                    script_fonts: Vec::new(),
                 }],
                 Vec::new(),
             ),
@@ -8406,10 +8146,12 @@ mod autotest_generated {
                         font_match(2, &[]),
                         font_match(3, &[]),
                     ],
+                    script_fonts: Vec::new(),
                 },
                 CssFallbackGroup {
                     css_name: "B".to_string(),
                     fonts: vec![font_match(4, &[]), font_match(5, &[])],
+                    script_fonts: Vec::new(),
                 },
             ],
             vec![font_match(6, &[(0x4E00, 0x9FFF)])],
@@ -8437,6 +8179,7 @@ mod autotest_generated {
                     font_match(2, &[(0x80, 0x24F)]),    // Latin-1 supplement + extended
                     font_match(3, &[(0x0, 0x10_FFFF)]), // everything (must be dropped)
                 ],
+                script_fonts: Vec::new(),
             }],
             Vec::new(),
         );
@@ -8461,6 +8204,7 @@ mod autotest_generated {
                     font_match(1, &[(0x20, 0x7F)]),
                     font_match(2, &[(0x20, 0x7F)]),
                 ],
+                script_fonts: Vec::new(),
             }],
             vec![font_match(3, &[(0x20, 0x7F)])],
         );
@@ -8497,7 +8241,8 @@ mod autotest_generated {
                 1,
                 "U+{probe:04X} is inside the inclusive CJK range"
             );
-            assert_eq!(chain.unicode_fallbacks[0].id, FontId(1));
+            assert_eq!(chain.unicode_fallbacks[0].fonts.len(), 1);
+            assert_eq!(chain.unicode_fallbacks[0].fonts[0].id, FontId(1));
         }
         // One past each end of the range → no intersection.
         for probe in [0x4DFF_u32, 0xA000] {
@@ -8520,6 +8265,7 @@ mod autotest_generated {
             vec![CssFallbackGroup {
                 css_name: "A".to_string(),
                 fonts: Vec::new(),
+                script_fonts: Vec::new(),
             }],
             Vec::new(),
         );
@@ -8533,36 +8279,11 @@ mod autotest_generated {
     // build_font_selector_stack
     // =====================================================================
 
-    /// Strip the machine-dependent fontconfig alias insertions (the
-    /// families push_family_with_system_aliases prepends before each CSS
-    /// generic) so stack-shape assertions stay portable across systems.
-    fn without_system_alias_prefs(stack: &[FontSelector]) -> Vec<FontSelector> {
-        #[cfg(all(target_os = "linux", feature = "std"))]
-        {
-            let aliases = fontconfig_generic_aliases();
-            let alias_names: std::collections::BTreeSet<String> = aliases
-                .values()
-                .flatten()
-                .map(|s| s.to_ascii_lowercase())
-                .collect();
-            stack
-                .iter()
-                .filter(|s| !alias_names.contains(&s.family.to_ascii_lowercase()))
-                .cloned()
-                .collect()
-        }
-        #[cfg(not(all(target_os = "linux", feature = "std")))]
-        {
-            stack.to_vec()
-        }
-    }
-
     #[test]
     fn build_font_selector_stack_always_appends_the_three_generic_fallbacks() {
         let families = StyleFontFamilyVec::from_vec(Vec::new());
         let stack = build_font_selector_stack(&families, None, FcWeight::Normal, FontStyle::Normal);
 
-        let stack = without_system_alias_prefs(&stack);
         let names: Vec<&str> = stack.iter().map(|s| s.family.as_str()).collect();
         assert_eq!(names, ["sans-serif", "serif", "monospace"]);
         for s in &stack {
@@ -8632,7 +8353,6 @@ mod autotest_generated {
         ]);
         let stack = build_font_selector_stack(&families, None, FcWeight::Bold, FontStyle::Italic);
 
-        let stack = without_system_alias_prefs(&stack);
         assert_eq!(stack.len(), 5, "2 authored + 3 generic fallbacks");
         assert_eq!(stack[0].family, "Iosevka");
         assert_eq!(stack[1].family, "Menlo");
@@ -8780,7 +8500,6 @@ mod autotest_generated {
         )]);
         let stack = build_font_selector_stack(&families, None, FcWeight::Normal, FontStyle::Normal);
 
-        let stack = without_system_alias_prefs(&stack);
         assert_eq!(stack.len(), 3, "MONOSPACE + sans-serif + serif");
         assert_eq!(stack[0].family, "MONOSPACE");
         let lower: Vec<String> = stack.iter().map(|s| s.family.to_lowercase()).collect();
@@ -8797,7 +8516,6 @@ mod autotest_generated {
             StyleFontFamily::System("monospace".to_string().into()),
         ]);
         let stack = build_font_selector_stack(&families, None, FcWeight::Normal, FontStyle::Normal);
-        let stack = without_system_alias_prefs(&stack);
         assert_eq!(stack.len(), 3);
     }
 
@@ -8812,7 +8530,6 @@ mod autotest_generated {
         ]);
         let stack = build_font_selector_stack(&families, None, FcWeight::Normal, FontStyle::Normal);
 
-        let stack = without_system_alias_prefs(&stack);
         assert_eq!(stack.len(), 7, "4 authored + 3 generic fallbacks");
         assert_eq!(stack[0].family, "");
         assert_eq!(stack[2].family, "Ｍ🎉 ǝɔɐɟdʎʇ — «Шрифт»");
@@ -9837,66 +9554,5 @@ mod style_interning_tests {
              check, not returned"
         );
         assert_eq!(*rebuilt, *real, "the correct style is still produced");
-    }
-}
-
-#[cfg(test)]
-mod alias_prune_tests {
-    use super::should_prune_family;
-    use std::collections::BTreeSet;
-
-    fn set(v: &[&str]) -> BTreeSet<String> {
-        v.iter().map(|s| s.to_ascii_lowercase()).collect()
-    }
-
-    /// Only the alias expansion's own inventions get pruned.
-    ///
-    /// Resolving a family the system does not have costs a real lookup
-    /// (~0.52 ms measured); the generic expansion produces ~150 of them per
-    /// stack, which was 73.8 ms of a 177 ms cold pagination AND the wall of
-    /// `UNRESOLVED font-family` warnings. Pruning them is free. Pruning
-    /// anything else would silently change which font renders.
-    ///
-    /// NEGATIVE CONTROL: dropping the `aliases.contains(..)` term (prune
-    /// anything absent) fails the authored-family case; dropping the
-    /// `!available.contains(..)` term fails the installed-alias case;
-    /// dropping the generic guard fails the generic case. All three run and
-    /// seen.
-    #[test]
-    fn only_absent_alias_candidates_are_pruned() {
-        let aliases = set(&["DejaVu Sans", "ZYSong18030", "Cantarell"]);
-        let available = set(&["DejaVu Sans", "Liberation Sans"]);
-
-        // Invented by the expansion AND not installed -> the whole point.
-        assert!(should_prune_family("ZYSong18030", &aliases, &available));
-        assert!(should_prune_family("Cantarell", &aliases, &available));
-        // Case-insensitively, since CSS family names are.
-        assert!(should_prune_family("zysong18030", &aliases, &available));
-
-        // An alias candidate that IS installed must still be tried, or the
-        // system's preferred font stops being reachable.
-        assert!(!should_prune_family("DejaVu Sans", &aliases, &available));
-
-        // AUTHORED families are never pruned, present or not: pruning a
-        // missing one would also swallow its warning, which is the one
-        // diagnostic worth keeping.
-        assert!(!should_prune_family(
-            "Liberation Sans",
-            &aliases,
-            &available
-        ));
-        assert!(
-            !should_prune_family("Comic Sans MS", &aliases, &available),
-            "a family the document asked for is not an alias candidate, so it \
-             keeps its lookup AND its UNRESOLVED warning"
-        );
-
-        // Generics are expanded by the resolver itself.
-        for g in ["sans-serif", "serif", "monospace", "system-ui"] {
-            assert!(
-                !should_prune_family(g, &set(&[g]), &available),
-                "{g} must survive even if it appears in an alias list"
-            );
-        }
     }
 }

--- a/layout/src/text3/cache.rs
+++ b/layout/src/text3/cache.rs
@@ -758,7 +758,7 @@ pub fn append_coverage_faces(
         .push(rust_fontconfig::ScriptFallbackGroup {
             range: UnicodeRange {
                 start: 0,
-                end: 0x10FFFF,
+                end: 0x0010_FFFF,
             },
             fonts: faces,
         });

--- a/layout/src/text3/cache.rs
+++ b/layout/src/text3/cache.rs
@@ -549,7 +549,8 @@ fn fallback_ranges_for(chars: &BTreeSet<char>) -> Vec<UnicodeRange> {
 /// does not help, since the typed text lives in the content overlay, not in
 /// the DOM the resolver scans.)
 ///
-/// A char counts as covered when the chain resolves it by OS/2 ranges OR any
+/// A char counts as covered when the chain resolves it by OS/2 ranges
+/// ([`covering_font`], which does not count the last-resort face) OR any
 /// already-loaded face has it in its cmap — exactly the two checks the shaper
 /// makes before giving up. The rest go through [`faces_covering`].
 ///
@@ -590,7 +591,7 @@ pub fn missing_coverage_faces<T: ParsedFontTrait>(
             if !needs_own_glyph(ch) || !seen.insert(ch) {
                 continue;
             }
-            let covered = chain.resolve_char(fc_cache, ch).is_some()
+            let covered = covering_font(chain, ch).is_some()
                 || loaded.iter().any(|(_, font)| font.has_glyph(ch as u32));
             if !covered {
                 missing.entry(key.clone()).or_default().insert(ch);
@@ -650,12 +651,7 @@ pub fn faces_covering(
     if uncovered.is_empty() {
         return Vec::new();
     }
-    let mut known: HashSet<FontId> = chain
-        .css_fallbacks
-        .iter()
-        .flat_map(|g| g.fonts.iter().map(|f| f.id))
-        .chain(chain.unicode_fallbacks.iter().map(|f| f.id))
-        .collect();
+    let mut known: HashSet<FontId> = chain.fonts().map(|f| f.id).collect();
     let ranges = fallback_ranges_for(&uncovered);
     let italic = if key.italic {
         PatternMatch::True
@@ -689,8 +685,13 @@ pub fn faces_covering(
     };
 
     if let Some(registry) = registry {
-        let stack =
-            fc_cache.expand_font_families_config_first(&key.font_families, registry.os, &ranges);
+        // The stack expanded for the MISSING scripts (the probe itself only
+        // expands for the default seven): the generic's families, the
+        // script candidates for `ranges` (fonts.conf aliases merged over the
+        // OS tables) and the config's last resort.
+        let stack = fc_cache
+            .fallback_config()
+            .candidate_families(&key.font_families, &ranges);
         let probed = registry.request_fonts_fast(&[(stack, uncovered.clone())], key.weight, italic);
         for fm in probed
             .iter()
@@ -711,17 +712,56 @@ pub fn faces_covering(
             Some(&ranges),
             &mut trace,
         );
-        for fm in resolved
-            .css_fallbacks
-            .iter()
-            .flat_map(|g| g.fonts.iter())
-            .chain(resolved.unicode_fallbacks.iter())
-        {
+        for fm in resolved.fonts() {
             consider(fm, &mut uncovered);
         }
     }
 
     added
+}
+
+/// The font `chain` resolves `ch` to BY COVERAGE - `None` when nothing in
+/// the chain claims the codepoint.
+///
+/// This is the coverage question; `FontFallbackChain::resolve_codepoint` is
+/// not. Once a chain has a last-resort face (`ensure_chains_nonempty` gives
+/// one to every chain that matched nothing), `resolve_codepoint` hands that
+/// face out for EVERY codepoint, tagged `LAST_RESORT_SOURCE` - so asking it
+/// "is this char covered" would say yes for a char no font on the machine
+/// can draw, and `missing_coverage_faces` would never go looking for one.
+/// Every coverage decision goes through here; the shaper consults the last
+/// resort separately, after the cmap probe, as the tier it is.
+#[must_use]
+pub fn covering_font(chain: &rust_fontconfig::FontFallbackChain, ch: char) -> Option<FontId> {
+    match chain.resolve_codepoint(ch as u32) {
+        Some((id, source)) if source != rust_fontconfig::fallback::LAST_RESORT_SOURCE => Some(id),
+        _ => None,
+    }
+}
+
+/// Append faces found by [`faces_covering`] to `chain` as one more
+/// unicode-fallback group.
+///
+/// The group's range is the whole codepoint space: these faces were chosen
+/// by the cmap/OS-2 coverage of the specific chars that were missing, and
+/// the resolver already checks a face's own `unicode_ranges` before using
+/// it, so a narrower range would only restate what the `FontMatch` carries.
+pub fn append_coverage_faces(
+    chain: &mut rust_fontconfig::FontFallbackChain,
+    faces: Vec<rust_fontconfig::FontMatch>,
+) {
+    if faces.is_empty() {
+        return;
+    }
+    chain
+        .unicode_fallbacks
+        .push(rust_fontconfig::ScriptFallbackGroup {
+            range: UnicodeRange {
+                start: 0,
+                end: 0x10FFFF,
+            },
+            fonts: faces,
+        });
 }
 
 /// A map of pre-loaded fonts, keyed by `FontId` (from rust-fontconfig)
@@ -1020,43 +1060,12 @@ impl FontContext {
         let scripts = scripts_present_in_styled_dom(styled_dom);
         let mut chains = resolve_font_chains(&collected, &self.fc_cache, Some(&scripts));
         // Coverage-based prune (matches `collect_and_resolve_font_chains_with_registration`).
+        // A chain that matched nothing already carries its last-resort face
+        // (the resolver applied `ensure_chains_nonempty`), on the tier the
+        // prune never touches.
         let used_chars = collect_used_codepoints(styled_dom);
         for chain in chains.chains.values_mut() {
             prune_chain_to_used_chars(chain, &used_chars);
-        }
-        // WEB-LIFT last resort (after prune, so it survives — prune drops the registered
-        // fallback because its cmap isn't parsed yet): if a chain ended up with no fonts,
-        // append the first registered font so load_missing_for_chains finds it and text
-        // shapes instead of measuring 0. (Done in azul-layout, NOT rust-fontconfig, so the
-        // lift-fragile with_memory_fonts isn't re-codegen'd into a trapping shape.)
-        for chain in chains.chains.values_mut() {
-            let total = chain
-                .css_fallbacks
-                .iter()
-                .map(|g| g.fonts.len())
-                .sum::<usize>()
-                + chain.unicode_fallbacks.len();
-            if total == 0 {
-                // `list()` deep-copies the ENTIRE font database to read one entry;
-                // see `first_font_in_cache` in solver3::getters for the
-                // measurement (717k String clones, 2.3 MB retained).
-                let __first = {
-                    let mut f = None;
-                    self.fc_cache.for_each_pattern(|p, id| {
-                        if f.is_none() {
-                            f = Some((p.clone(), *id));
-                        }
-                    });
-                    f
-                };
-                if let Some((pattern, id)) = __first.as_ref() {
-                    chain.unicode_fallbacks.push(rust_fontconfig::FontMatch {
-                        id: *id,
-                        unicode_ranges: pattern.unicode_ranges.clone(),
-                        fallbacks: Vec::new(),
-                    });
-                }
-            }
         }
         self.font_chain_cache = chains.into_fontconfig_chains();
     }
@@ -1379,8 +1388,8 @@ impl<T: ParsedFontTrait> FontManager<T> {
     /// fast chain resolver can match it by name.
     ///
     /// `coverage` are the codepoint ranges the font actually covers.
-    /// Passing the true ranges matters: `FontFallbackChain::resolve_char`
-    /// skips any font that reports no coverage, and a font claiming
+    /// Passing the true ranges matters: the chain's coverage walk
+    /// (`covering_font`) skips any font that reports no coverage, and a font claiming
     /// coverage it doesn't have would render .notdef instead of falling
     /// back.
     ///
@@ -1998,7 +2007,7 @@ impl<T: ParsedFontTrait> FontManager<T> {
                 .entry(key.clone())
                 .or_insert_with(|| resolve_chain_on_miss(&key, &fc_cache));
             added += faces.len();
-            chain.unicode_fallbacks.extend(faces);
+            append_coverage_faces(chain, faces);
             resolved
                 .chains
                 .insert(FontChainKeyOrRef::Chain(key), chain.clone());
@@ -8991,7 +9000,6 @@ pub fn shape_visual_items_with_per_item_cache<T: ParsedFontTrait>(
 fn split_text_by_font_coverage<T: ParsedFontTrait>(
     text: &str,
     font_chain: &rust_fontconfig::FontFallbackChain,
-    fc_cache: &FcFontCache,
     loaded_fonts: &LoadedFonts<T>,
 ) -> Vec<(usize, usize, FontId)> {
     let mut segments: Vec<(usize, usize, FontId)> = Vec::new();
@@ -9002,18 +9010,16 @@ fn split_text_by_font_coverage<T: ParsedFontTrait>(
     let notdef_font_id = loaded_fonts.iter().map(|(id, _)| *id).min();
 
     // Per-character resolution is memoised for the duration of this call.
-    // `resolve_char` walks every fallback group's unicode ranges linearly AND
-    // clones a String for the matched css_name, and the loop below runs it
-    // once per CHARACTER — so a paragraph paid it ~200 times to answer ~40
-    // distinct questions. A `perf` profile of a steady-state frame put the
-    // cmap/range scanning at 7.8% of the whole frame, third behind the pixel
-    // blend and the scanline sweep, plus a share of the malloc traffic from
-    // those per-character String clones.
+    // The chain walk scans every fallback group's unicode ranges linearly,
+    // and the loop below runs it once per CHARACTER — so a paragraph paid it
+    // ~200 times to answer ~40 distinct questions. A `perf` profile of a
+    // steady-state frame put the cmap/range scanning at 7.8% of the whole
+    // frame, third behind the pixel blend and the scanline sweep.
     //
-    // The memo is call-scoped on purpose: `font_chain`, `fc_cache` and
-    // `loaded_fonts` are all fixed for the duration, so a character's answer
-    // cannot change within one call. A longer-lived cache would have to key
-    // on all three and is a different, riskier change.
+    // The memo is call-scoped on purpose: `font_chain` and `loaded_fonts`
+    // are both fixed for the duration, so a character's answer cannot
+    // change within one call. A longer-lived cache would have to key on
+    // both and is a different, riskier change.
     let mut resolved: alloc::collections::BTreeMap<char, Option<FontId>> =
         alloc::collections::BTreeMap::new();
 
@@ -9030,16 +9036,16 @@ fn split_text_by_font_coverage<T: ParsedFontTrait>(
             }
             continue;
         }
-        // Primary: the resolved fallback chain. Its coverage comes from
-        // rust-fontconfig's OS/2-derived `unicode_ranges`, which can MISS
-        // codepoints a font actually has in its cmap — e.g. Noto Sans CJK's
-        // JP face does not advertise the Hangul OS/2 block, so 한국어 resolves
-        // to None here even though that face's cmap covers it.
-        let font_id = font_chain
-            .resolve_char(fc_cache, ch)
-            .map(|(id, _)| id)
+        // Primary: the resolved fallback chain, BY COVERAGE (`covering_font`
+        // leaves the last-resort tier out; it is consulted last, below). Its
+        // coverage comes from rust-fontconfig's OS/2-derived
+        // `unicode_ranges`, which can MISS codepoints a font actually has in
+        // its cmap — e.g. Noto Sans CJK's JP face does not advertise the
+        // Hangul OS/2 block, so 한국어 resolves to None here even though that
+        // face's cmap covers it.
+        let font_id = covering_font(font_chain, ch)
             // The chain's OWN faces next, in chain order, by REAL cmap
-            // coverage. The metadata behind `resolve_char` is partial for a
+            // coverage. The metadata behind the range walk is partial for a
             // face the fast probe found: it records only the codepoints the
             // DOM had at probe time, so the first 'ü' typed into an ASCII
             // paragraph misses there even though the paragraph's face has
@@ -9048,10 +9054,7 @@ fn split_text_by_font_coverage<T: ParsedFontTrait>(
             // loaded face (the UI font, say) happens to sort first below.
             .or_else(|| {
                 font_chain
-                    .css_fallbacks
-                    .iter()
-                    .flat_map(|g| g.fonts.iter())
-                    .chain(font_chain.unicode_fallbacks.iter())
+                    .fonts()
                     .map(|fm| fm.id)
                     .find(|id| loaded_fonts.get(id).is_some_and(|f| f.has_glyph(ch as u32)))
             })
@@ -9069,9 +9072,19 @@ fn split_text_by_font_coverage<T: ParsedFontTrait>(
                     .map(|(id, _)| *id)
                     .min()
             })
-            // Last resort: no font advertises OR covers this codepoint. Assign it to
-            // the primary loaded face so the shaper emits a visible .notdef box and
-            // the byte range is preserved (following text is not shifted).
+            // Last resort: no font advertises OR covers this codepoint. The
+            // chain's own last-resort face first (the tier
+            // `ensure_chains_nonempty` fills for a chain that matched
+            // nothing), else the primary loaded face — so the shaper emits a
+            // visible .notdef box and the byte range is preserved (following
+            // text is not shifted).
+            .or_else(|| {
+                font_chain
+                    .last_resort
+                    .first()
+                    .map(|m| m.id)
+                    .filter(|id| loaded_fonts.get(id).is_some())
+            })
             .or(notdef_font_id);
         resolved.insert(ch, font_id);
         if let Some(font_id) = font_id {
@@ -9190,10 +9203,7 @@ pub(crate) fn shape_placeholder_text<T: ParsedFontTrait>(
             // (a prompt is app-authored, single-script text; per-glyph
             // fallback can come later if a real prompt ever needs it).
             let Some(font) = font_chain
-                .css_fallbacks
-                .iter()
-                .flat_map(|group| group.fonts.iter())
-                .chain(font_chain.unicode_fallbacks.iter())
+                .fonts()
                 .find_map(|m| loaded_fonts.get(&m.id))
             else {
                 return Vec::new();
@@ -9226,7 +9236,7 @@ fn shape_with_font_fallback<T: ParsedFontTrait>(
     static FONT_FB_DEBUG: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     let dbg = *FONT_FB_DEBUG.get_or_init(|| std::env::var_os("AZ_FONT_FALLBACK_DEBUG").is_some());
 
-    let segments = split_text_by_font_coverage(text, font_chain, fc_cache, loaded_fonts);
+    let segments = split_text_by_font_coverage(text, font_chain, loaded_fonts);
 
     if dbg && segments.len() > 1 {
         eprintln!(
@@ -9890,8 +9900,7 @@ pub fn shape_visual_items<T: ParsedFontTrait>(
                         };
 
                         // Per-character font fallback for CombinedText
-                        let segments =
-                            split_text_by_font_coverage(&text, font_chain, fc_cache, loaded_fonts);
+                        let segments = split_text_by_font_coverage(&text, font_chain, loaded_fonts);
                         let mut all_glyphs = Vec::new();
                         for (seg_start, seg_end, font_id) in &segments {
                             let Some(font) = loaded_fonts.get(font_id) else {

--- a/layout/src/window.rs
+++ b/layout/src/window.rs
@@ -5625,42 +5625,10 @@ impl LayoutWindow {
                 unsafe {
                     crate::az_mark(0x60770_u32, chains.chains.len() as u32);
                 }
-                // WEB-LIFT last resort (the DEFINITIVE spot — the layout's own `chains` that
-                // feed load_missing_for_chains below): the lifted font-query path can leave a
-                // chain with NO fonts even when a fallback IS registered (generic→OS-name +
-                // token/unicode query is lift-fragile). Append the first registered font to any
-                // empty chain so load_missing loads it + text shapes instead of measuring 0.
-                // Done here (azul-layout), NOT rust-fontconfig (which re-codegens the fragile
-                // with_memory_fonts into a trapping shape).
-                for chain in chains.chains.values_mut() {
-                    let total = chain
-                        .css_fallbacks
-                        .iter()
-                        .map(|g| g.fonts.len())
-                        .sum::<usize>()
-                        + chain.unicode_fallbacks.len();
-                    if total == 0 {
-                        // `list()` deep-copies the ENTIRE font database to read one
-                        // entry; see `first_font_in_cache` in solver3::getters.
-                        let __first = {
-                            let mut f = None;
-                            self.font_manager.fc_cache.for_each_pattern(|p, id| {
-                                if f.is_none() {
-                                    f = Some((p.clone(), *id));
-                                }
-                            });
-                            f
-                        };
-                        if let Some((pattern, id)) = __first.as_ref() {
-                            chain.unicode_fallbacks.push(rust_fontconfig::FontMatch {
-                                id: *id,
-                                unicode_ranges: pattern.unicode_ranges.clone(),
-                                fallbacks: Vec::new(),
-                            });
-                        }
-                    }
-                }
-                // [g80] chains after the window.rs last-resort loop (values_mut path).
+                // A chain that matched nothing already carries its last-resort
+                // face: the resolvers apply `ensure_chains_nonempty` (the ONE
+                // last-resort rule) before returning, so there is nothing to
+                // patch up here. The marker stays for the [g80] timeline.
                 unsafe {
                     crate::az_mark(0x60774_u32, chains.chains.len() as u32);
                 }
@@ -5684,7 +5652,9 @@ impl LayoutWindow {
                 // edit-time extension in `reshape_text_node` cannot help,
                 // since this replacement of the chain cache discards it.
                 {
-                    use crate::text3::cache::{missing_coverage_faces, FontChainKeyOrRef};
+                    use crate::text3::cache::{
+                        append_coverage_faces, missing_coverage_faces, FontChainKeyOrRef,
+                    };
                     let overlay_content: Vec<&[InlineContent]> = self
                         .content_overlay
                         .iter_text()
@@ -5710,7 +5680,7 @@ impl LayoutWindow {
                                 if let Some(chain) =
                                     chains.chains.get_mut(&FontChainKeyOrRef::Chain(key))
                                 {
-                                    chain.unicode_fallbacks.extend(faces);
+                                    append_coverage_faces(chain, faces);
                                 }
                             }
                         }
@@ -5723,8 +5693,8 @@ impl LayoutWindow {
                 // by `Arc<RwLock<_>>`, so builder writes performed
                 // during the `request_and_resolve_with_scripts`
                 // call above are immediately visible to every
-                // downstream `FontFallbackChain::resolve_char`
-                // lookup without any explicit refresh.
+                // downstream chain-coverage lookup without any
+                // explicit refresh.
                 if let Some(msgs) = debug_messages.as_mut() {
                     msgs.push(LayoutDebugMessage::info(format!(
                         "[FontLoading] Resolved {} font chains",

--- a/layout/tests/typed_script_font_fallback.rs
+++ b/layout/tests/typed_script_font_fallback.rs
@@ -13,7 +13,8 @@
 //! The fixtures use a MEMORY-ONLY `FcFontCache`: the system's fonts cannot
 //! rescue an assertion, and the only Arabic-capable face in the world is the
 //! mock one registered by the test. A wrong verdict is therefore the engine's,
-//! not the machine's.
+//! not the machine's. Its fallback config names the LATIN mocks for the
+//! generics (see `latin_generics`), the way a real machine's does.
 
 use azul_core::{
     dom::{Dom, DomId, DomNodeId, IdOrClass, NodeId},
@@ -28,14 +29,12 @@ use azul_layout::{
     window::LayoutWindow,
     window_state::FullWindowState,
 };
-use rust_fontconfig::{FcFontCache, UnicodeRange};
+use rust_fontconfig::{FcFallbackConfig, FcFontCache, GenericFamily, UnicodeRange};
 
 /// `Azul Mock Arabic`: beh/teh/lam/meem/alef + space, nothing else (see
-/// `tests/fonts/README.md`). Registered with exactly its cmap as coverage:
-/// fewer codepoints than the ASCII mocks, so the memory-only generic-family
-/// fallback (which ranks by declared coverage) keeps preferring a Latin face
-/// and the Arabic one is reachable ONLY through a script-aware lookup — the
-/// situation a real machine is in, where `sans-serif` names a Latin font.
+/// `tests/fonts/README.md`). Registered with exactly its cmap as coverage, so
+/// it can be found for Arabic by a script-aware (coverage) lookup and for
+/// nothing else.
 const MOCK_ARABIC: &[u8] = include_bytes!("fonts/azul-mock-arabic.ttf");
 const MOCK_ARABIC_COVERAGE: [UnicodeRange; 3] = [
     UnicodeRange {
@@ -98,10 +97,35 @@ fn run_layout(lw: &mut LayoutWindow, styled_dom: StyledDom) {
     .unwrap();
 }
 
+/// The fallback config of a real machine, in miniature: the generics name
+/// LATIN faces (the built-in ASCII mocks), so the Arabic mock is reachable
+/// ONLY through a script-aware lookup - the situation the tests are about,
+/// where `sans-serif` names a Latin font and Arabic needs a fallback.
+///
+/// rust-fontconfig 5 resolves a generic through this config. With NO config
+/// a generic gets the best-style faces of the whole cache, narrowest first,
+/// which on this three-font cache is the Arabic mock itself: the chain would
+/// cover Arabic from the start and the tests would pass without the code
+/// under test ever running.
+fn latin_generics() -> FcFallbackConfig {
+    let mut config = FcFallbackConfig::empty();
+    for (generic, family) in [
+        (GenericFamily::SansSerif, "Azul Mock Wide"),
+        (GenericFamily::Serif, "Azul Mock Wide"),
+        (GenericFamily::Monospace, "Azul Mock Mono"),
+    ] {
+        config
+            .generic_families
+            .insert(generic, vec![family.to_string()]);
+    }
+    config
+}
+
 /// A window over a memory-only cache: the two built-in mock faces (ASCII) plus
 /// the mock Arabic face, and NOTHING the machine has installed.
 fn window_with_mock_arabic(dom: Dom) -> LayoutWindow {
-    let mut lw = LayoutWindow::new(FcFontCache::default()).unwrap();
+    let fc_cache = FcFontCache::default().with_fallback_config(latin_generics());
+    let mut lw = LayoutWindow::new(fc_cache).unwrap();
     lw.font_manager
         .register_named_font("Azul Mock Arabic", MOCK_ARABIC, MOCK_ARABIC_COVERAGE.to_vec());
     let mut window_state = FullWindowState::default();
@@ -193,7 +217,7 @@ fn assert_premise_no_arabic(lw: &LayoutWindow) {
          sees the text the DOM contains; chain = {:#?}; loaded = {:?}",
         lw.font_manager.font_chain_cache.get(&mono_key(lw)).map(|c| (
             c.css_fallbacks.iter().map(|g| (g.css_name.clone(), g.fonts.iter().map(|f| (f.id, f.unicode_ranges.clone())).collect::<Vec<_>>())).collect::<Vec<_>>(),
-            c.unicode_fallbacks.iter().map(|f| (f.id, f.unicode_ranges.clone())).collect::<Vec<_>>(),
+            c.unicode_fallbacks.iter().map(|g| (g.range, g.fonts.iter().map(|f| (f.id, f.unicode_ranges.clone())).collect::<Vec<_>>())).collect::<Vec<_>>(),
         )),
         lw.font_manager.get_loaded_fonts().iter().map(|(id, _)| *id).collect::<Vec<_>>()
     );

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -2204,7 +2204,7 @@ version = "0.0.6"
 criteria = "safe-to-run"
 
 [[exemptions.rust-fontconfig]]
-version = "4.6.0"
+version = "5.0.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.rustc-demangle]]
@@ -2361,10 +2361,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.shlex]]
 version = "2.0.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.short-uuid]]
-version = "0.2.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.shuttle]]

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -1928,7 +1928,7 @@ version = "0.13.6"
 criteria = "safe-to-deploy"
 
 [[exemptions.printpdf]]
-version = "0.12.7"
+version = "0.12.8"
 criteria = "safe-to-deploy"
 
 [[exemptions.proc-macro-crate]]

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-azul-layout = { version = "0.0.14", path = "../layout", default-features = false, features = ["std", "xml", "text_layout", "font_loading", "cpurender"]}
-azul-core = { version = "0.0.14", path = "../core", default-features = false, features = ["std"]}
-azul-css = { version = "0.0.14", path = "../css", default-features = false, features = ["parser"]}
+azul-layout = { version = "0.0.16", path = "../layout", default-features = false, features = ["std", "xml", "text_layout", "font_loading", "cpurender"]}
+azul-core = { version = "0.0.16", path = "../core", default-features = false, features = ["std"]}
+azul-css = { version = "0.0.16", path = "../css", default-features = false, features = ["parser"]}
 azul-dll = { version = "0.0.8", path = "../dll", default-features = false }

--- a/webrender/api/Cargo.toml
+++ b/webrender/api/Cargo.toml
@@ -20,7 +20,7 @@ display_list_stats = []
 
 [dependencies]
 app_units = "0.7.3"
-azul-core = { version = "0.0.14", path = "../../core" }
+azul-core = { version = "0.0.16", path = "../../core" }
 bitflags = { version = "2", default-features = false, features = ["serde"] }
 byteorder = "1.2.1"
 euclid = { version = "0.22.6", default-features = false, features = ["serde"] }


### PR DESCRIPTION
The azul half of the rust-fontconfig 5 migration. Rebased onto master; the pair it was blocked on has shipped, so this now builds and merges on its own.

## What

- **`refactor(fonts)`** — azul-core/azul-layout on rust-fontconfig 5.0: `FontFallbackChain { css_fallbacks, unicode_fallbacks, last_resort, original_stack }`, `FcFallbackConfig`, `FcFontRegistry::new()`, `resolve_font_chain_with_scripts`.
  - Generic families are pushed to rfc **as generics**; azul's own fonts.conf alias parsing and alias pruning are deleted (rfc's registry absorbs aliases and honours `FONTCONFIG_FILE`). `is_generic_family` comes from rfc.
  - ONE last-resort rule: `ensure_chains_nonempty` (getters.rs) runs inside both resolvers and pushes `first_font_in_cache` onto `chain.last_resort`. azul does not populate `FcFallbackConfig::last_resort`.
  - Coverage decisions go through `text3::cache::covering_font` (a `LAST_RESORT_SOURCE` hit is not coverage); `faces_covering` / `missing_coverage_faces` results are appended via `append_coverage_faces` as one full-range `ScriptFallbackGroup`. `split_text_by_font_coverage` loses its fc_cache parameter.
  - Mock fixtures install an explicit `FcFallbackConfig` (`latin_generics()`): with an empty config rfc 5 ranks the narrowest face first when the stack matches nothing.
- **`docs(deps)`** — the workspace manifest's pin note, restated for 5.0 and the versions that actually shipped.
- **`ci(feature-matrix)`** — a row checking azul-layout with exactly printpdf's feature set. No other combination in the matrix enables `pdf` or `text_layout_hyphenation`.
- **`release`** — azul-css / azul-core / azul-layout **0.0.16**.
- **`deps(dll)`** — printpdf **0.12.8**.

## Coverage semantics change with rfc 5 — for the better

Not visible in the diff, but worth knowing, measured against the base-14 fonts printpdf embeds:

| font | true non-`.notdef` cps | rfc 4.6 reported | rfc 5.0 reported |
|---|---|---|---|
| Symbol | 43 | **0** | 43 |
| ZapfDingbats | 10 | **0** | 10 |
| Helvetica | 213 | 256 | 213 |
| Times-Italic | 275 | 512 | 275 |

rfc 4 returned *empty* coverage for the two symbol fonts (so they were skipped entirely during per-character fallback) and block-rounded everyone else into claiming glyphs they do not have. Over-claiming is the harmful direction: the resolver stops at the first font whose ranges contain the codepoint, so a bogus claim wins the character and renders `.notdef` instead of falling through. rfc 5 reads cmap segments exactly.

## The deadlock is resolved

Published today, in order: azul-css/core/layout `0.0.15` → printpdf `0.12.8` → `0.0.16`. `0.0.15` is **yanked** — printpdf's matrix caught two defects in it that only printpdf reaches (it is the only consumer building azul-layout without `cpurender` **and** without `xml`, across all three wasm targets): `uuid` broke every wasm build, and `DocumentChangeset::apply_to_dom` reached into the `xml`-gated `document_edit` from an ungated impl block. Both fixed on master by #465 and folded in here.

## Verified after the rebase

- `cargo metadata` resolves — this was impossible while printpdf 0.12.7 pinned rfc `<5`.
- **ONE `rust-fontconfig 5.0.0`** in the graph, reached by azul-core, azul-layout, printpdf and the glyph rasterizer alike.
- `cargo check -p azul-dll --features build-dll` clean, after `azul-doc autofix` (0 patches — the FFI surface is untouched) and `azul-doc codegen all`.
- `azul-core` and `azul-layout` clean at default features and at printpdf's reduced `std,text_layout,font_loading` set.

Supersedes #455 (auto-closed when its base branch was deleted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzMoAeNs1A5P6PEA4fbVRx