### PR TITLE
doc: assemble-context resolves binding names, admits a dirty tree, and ships a writing brief

### DIFF
--- a/doc/src/assemble_context.rs
+++ b/doc/src/assemble_context.rs
@@ -12,12 +12,14 @@
 //!     writing model produces a better page in ONE turn with no tools at all.
 //!
 //! So this command does the first half and hands over a file. Each bundle
-//! carries four sections: the page exactly as it ships, the machine checks
-//! azul-doc can answer with no model at all, a fact-check the agent fills in,
-//! and a `## Sources` appendix of real excerpts pinned to the current commit.
-//! The writing model then needs nothing but the bundle.
+//! carries five sections: the page exactly as it ships, the machine checks
+//! azul-doc can answer with no model at all (including the unfinished-work
+//! markers in the page's own source), a fact-check the agent fills in, a
+//! `## Sources` appendix of real excerpts pinned to the current commit, and
+//! the writing instructions. The writing model then needs nothing but the
+//! bundle.
 //!
-//! Two properties are deliberate:
+//! Three properties are deliberate:
 //!
 //!   - **The bundle names its commit.** An excerpt is only evidence if you know
 //!     which tree it came from. Every bundle records `git rev-parse HEAD`, and
@@ -28,13 +30,19 @@
 //!     API names, dangling links — azul-doc knows all of these for certain, and
 //!     `--no-agent` produces a bundle carrying exactly them. The agent is asked
 //!     only for what needs judgement.
+//!   - **The bundle cannot hide unfinished work.** Section 2b lists every
+//!     `TODO` / `FIXME` / `todo!(` / `unimplemented!(` in the files the page
+//!     tracks. A model that never sees them cannot tell a shipped feature from
+//!     an aspirational one, and writes confident prose about both; a model that
+//!     sees an EMPTY list learns something equally useful — the hedging in the
+//!     page is obsolete and should go.
 //!
 //! Which pages count as shipping is `docgen::guide::get_guide_list()` — the
 //! same list the website builds from, so a page that does not ship does not get
 //! a bundle and a page that ships cannot be forgotten.
 
 use std::{
-    collections::BTreeSet,
+    collections::{BTreeMap, BTreeSet},
     fs,
     path::{Path, PathBuf},
     process::Command,
@@ -190,6 +198,144 @@ fn public_api_names(api: &ApiData) -> BTreeSet<String> {
     names
 }
 
+/// Fold a name to the shape every binding agrees on: ASCII letters and digits,
+/// lowercased, with whatever separator the language chose thrown away.
+///
+/// `Dom.CreateBody` (C#), `Dom::create_body` (Rust) and `dom.create_body`
+/// (Python) all fold to `domcreatebody`, so ONE api.json entry answers for
+/// every binding's spelling of it. Without this the check reports a page for
+/// writing its own language's naming convention.
+fn fold_name(name: &str) -> String {
+    name.chars()
+        .filter(char::is_ascii_alphanumeric)
+        .map(|c| c.to_ascii_lowercase())
+        .collect()
+}
+
+/// The api.json spellings a C-ABI symbol could be. `AzDom_createBody` is
+/// `Dom::createBody`; `AzUpdate_RefreshDom` is `Update::RefreshDom`; `AzUpdate`
+/// is `Update`.
+///
+/// Deliberately does NOT yield the bare type or the bare member: accepting
+/// `AzDom_thisWasNeverAFunction` because `Dom` exists would turn the check off
+/// rather than fix it. The generated header is what settles a real member whose
+/// api.json name is spelled differently.
+///
+/// Empty for anything that is not `Az` + an uppercase letter, so a page's own
+/// `AzFoo` placeholder stays visible.
+fn demangle_binding_name(token: &str) -> Vec<String> {
+    let Some(rest) = token.strip_prefix("Az") else {
+        return Vec::new();
+    };
+    if !rest.chars().next().is_some_and(|c| c.is_ascii_uppercase()) {
+        return Vec::new();
+    }
+    match rest.split_once('_') {
+        Some((ty, member)) if !ty.is_empty() && !member.is_empty() => {
+            vec![format!("{ty}::{member}"), format!("{ty}.{member}")]
+        }
+        _ => vec![rest.to_string()],
+    }
+}
+
+fn is_ident_byte(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'_'
+}
+
+/// Every `Az…` identifier in the generated C header.
+///
+/// The header is the one artifact that spells the C-ABI names exactly as a
+/// binding page spells them, so a name it exports IS public API whatever
+/// api.json calls it — this is what settles `AzString_fromConstStr`, whose
+/// api.json counterpart is `String::from_c_str`, a different name entirely.
+///
+/// Returns an empty set (and no source) when codegen has never run; the check
+/// then says so instead of blaming the page.
+fn binding_symbols(project_root: &Path) -> (BTreeSet<String>, Option<String>) {
+    const REL: &str = "target/codegen/azul.h";
+    let Ok(src) = fs::read_to_string(project_root.join(REL)) else {
+        return (BTreeSet::new(), None);
+    };
+    let mut out = BTreeSet::new();
+    let bytes = src.as_bytes();
+    let mut i = 0usize;
+    while i < bytes.len() {
+        let starts_here = bytes[i] == b'A'
+            && bytes.get(i + 1) == Some(&b'z')
+            && (i == 0 || !is_ident_byte(bytes[i - 1]));
+        if !starts_here {
+            i += 1;
+            continue;
+        }
+        let mut j = i + 2;
+        while j < bytes.len() && is_ident_byte(bytes[j]) {
+            j += 1;
+        }
+        // `Az` on its own is a namespace prefix in prose, not a symbol.
+        if j > i + 2 {
+            out.insert(src[i..j].to_string());
+        }
+        i = j;
+    }
+    (out, Some(REL.to_string()))
+}
+
+/// Everything a backticked name can legitimately be checked against.
+///
+/// This exists because a BINDING page does not spell api.json's names. The C
+/// guide writes `AzDom_createBody`, C# writes `Dom.CreateBody`, api.json says
+/// `Dom::create_body` — three spellings of one function. Comparing strings
+/// reported all of them as "not public API": 17 phantom findings on the C page
+/// alone, every one of which would have sent the fact-check agent hunting a
+/// function that is right there in `azul.h`.
+struct ApiVocabulary {
+    /// api.json's own spellings, verbatim.
+    names: BTreeSet<String>,
+    /// The same names under [`fold_name`], so a naming convention cannot make a
+    /// real name look missing.
+    folded: BTreeSet<String>,
+    /// `Az…` symbols exported by the generated C header.
+    binding: BTreeSet<String>,
+    /// Which file `binding` came from, or `None` if codegen has not run.
+    binding_source: Option<String>,
+}
+
+impl ApiVocabulary {
+    fn new(names: BTreeSet<String>, project_root: &Path) -> Self {
+        let folded = names.iter().map(|n| fold_name(n)).collect();
+        let (binding, binding_source) = binding_symbols(project_root);
+        Self {
+            names,
+            folded,
+            binding,
+            binding_source,
+        }
+    }
+
+    /// Does this project export the thing the page calls `token`, under ANY of
+    /// the spellings a binding could use?
+    fn knows(&self, token: &str) -> bool {
+        if self.names.contains(token) || self.binding.contains(token) {
+            return true;
+        }
+        if self.folded.contains(&fold_name(token)) {
+            return true;
+        }
+        demangle_binding_name(token)
+            .iter()
+            .any(|n| self.names.contains(n) || self.folded.contains(&fold_name(n)))
+    }
+
+    /// One clause naming what a name was compared against, so the reader of a
+    /// finding knows how hard azul-doc looked before reporting it.
+    fn reference_clause(&self) -> String {
+        match &self.binding_source {
+            Some(src) => format!("api.json (any binding's spelling) or `{src}`"),
+            None => "api.json (any binding's spelling)".to_string(),
+        }
+    }
+}
+
 /// Backticked identifiers in `body` that LOOK like public API names — a
 /// CamelCase word, or a `Class::member` / `Class.member` pair.
 ///
@@ -237,13 +383,110 @@ fn api_like_identifiers(body: &str) -> BTreeSet<String> {
     out
 }
 
+// ── Honesty: what the tracked source admits is unfinished ──────────────
+
+/// One unfinished-work marker in a file the page documents.
+#[derive(Clone)]
+struct Marker {
+    file: String,
+    line: usize,
+    text: String,
+}
+
+/// The markers a maintainer left in one file: `TODO` and `FIXME` in any
+/// comment, plus the two macros that make a claim false at RUNTIME rather than
+/// merely in prose — `todo!(` and `unimplemented!(`.
+///
+/// A missing or unreadable file yields nothing; check 1 already reports a
+/// tracked file that does not exist, and reporting it twice teaches nothing.
+fn scan_markers(project_root: &Path, rel: &str) -> Vec<Marker> {
+    const NEEDLES: [&str; 4] = ["TODO", "FIXME", "todo!(", "unimplemented!("];
+    let Ok(src) = fs::read_to_string(project_root.join(rel)) else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for (i, line) in src.lines().enumerate() {
+        if !NEEDLES.iter().any(|n| line.contains(n)) {
+            continue;
+        }
+        let trimmed = line.trim();
+        // A tracked file can be generated JSON with enormous lines. The marker
+        // is the signal; the line it sits in is not worth a screenful.
+        let text = if trimmed.chars().count() > 160 {
+            trimmed.chars().take(157).collect::<String>() + "…"
+        } else {
+            trimmed.to_string()
+        };
+        out.push(Marker {
+            file: rel.to_string(),
+            line: i + 1,
+            text,
+        });
+    }
+    out
+}
+
+/// What the page and its source admit about their own maturity.
+struct MaturityReport {
+    /// The page's own `maturity:` frontmatter key, when it carries one.
+    page_maturity: Option<String>,
+    /// The guide's `*WIP.*` hedging paragraph, quoted, if the body has one.
+    wip_paragraph: Option<String>,
+    /// Tracked files that were actually read.
+    files_scanned: usize,
+    markers: Vec<Marker>,
+}
+
+/// Read every tracked file once per RUN, not once per page: `api.json` is
+/// tracked by dozens of guides and is megabytes long.
+fn maturity_report(
+    project_root: &Path,
+    fm: &Frontmatter,
+    body: &str,
+    cache: &mut BTreeMap<String, Vec<Marker>>,
+) -> MaturityReport {
+    let mut markers = Vec::new();
+    let mut files_scanned = 0usize;
+    for f in &fm.tracked_files {
+        if !project_root.join(f).exists() {
+            continue;
+        }
+        files_scanned += 1;
+        let found = cache
+            .entry(f.clone())
+            .or_insert_with(|| scan_markers(project_root, f));
+        markers.extend(found.iter().cloned());
+    }
+    MaturityReport {
+        page_maturity: {
+            let m = fm.maturity.trim();
+            (!m.is_empty()).then(|| m.to_string())
+        },
+        // The guide's house style for "do not trust this yet" is a paragraph
+        // that starts `*WIP.*`. It is prose, so only the body can be asked.
+        wip_paragraph: body
+            .lines()
+            .find(|l| l.trim_start().starts_with("*WIP"))
+            .map(|l| {
+                let t = l.trim();
+                if t.chars().count() > 200 {
+                    t.chars().take(197).collect::<String>() + "…"
+                } else {
+                    t.to_string()
+                }
+            }),
+        files_scanned,
+        markers,
+    }
+}
+
 /// Everything azul-doc can settle about one page without a model.
 fn machine_checks(
     project_root: &Path,
     page_path: &Path,
     fm: &Frontmatter,
     body: &str,
-    api_names: &BTreeSet<String>,
+    vocab: &ApiVocabulary,
     link_problems: &[lint_links::Problem],
 ) -> Vec<Check> {
     let mut checks = Vec::new();
@@ -308,28 +551,46 @@ fn machine_checks(
         }
     }
 
-    // 3. Names the page presents as API that api.json does not export. Either
-    //    the name is wrong, or it is internal and the page should not present
-    //    it as the reader's API.
+    // 3. Names the page presents as API that this project does not export
+    //    under ANY binding's spelling. Either the name is wrong, or it is
+    //    internal and the page should not present it as the reader's API, or
+    //    it is a placeholder the example invented.
+    //
+    //    "Under any binding's spelling" is the whole point: a C page writes
+    //    `AzDom_createBody` for what api.json calls `Dom::create_body`, and
+    //    reporting that as missing is noise the reader has to disprove.
     let unknown: Vec<String> = api_like_identifiers(body)
         .into_iter()
-        .filter(|n| !api_names.contains(n))
+        .filter(|n| !vocab.knows(n))
         .collect();
     if unknown.is_empty() {
         checks.push(Check {
             severity: "ok",
-            detail: "every backticked API-looking name in the prose exists in api.json."
-                .to_string(),
+            detail: format!(
+                "every backticked API-looking name in the prose resolves to {}.",
+                vocab.reference_clause(),
+            ),
         });
     } else {
         checks.push(Check {
             severity: "check",
             detail: format!(
-                "{} backticked name(s) are not public API in api.json — a renamed function, or \
-                 an internal type the page presents as the reader's: {}",
+                "{} backticked name(s) resolve to nothing in {} — a renamed function, an internal \
+                 type the page presents as the reader's, or a name the example invented: {}",
                 unknown.len(),
+                vocab.reference_clause(),
                 unknown.join(", "),
             ),
+        });
+    }
+    if vocab.binding_source.is_none() {
+        checks.push(Check {
+            severity: "note",
+            detail: "`target/codegen/azul.h` is not present, so C-ABI spellings \
+                     (`AzDom_createBody`) could only be resolved by demangling. Any `Az…` name \
+                     listed above may be a false alarm; run `azul-doc codegen all` and re-run to \
+                     settle it."
+                .to_string(),
         });
     }
 
@@ -356,6 +617,11 @@ fn machine_checks(
 /// A fence long enough to quote a markdown page that itself contains fences.
 const OUTER_FENCE: &str = "`````";
 
+/// How many markers a bundle prints before it starts eliding. A page that
+/// tracks `dll/src/lib.rs` would otherwise bury its own prose under a work
+/// list that belongs in an issue tracker.
+const MARKER_CAP: usize = 40;
+
 fn render_bundle(
     guide: &Guide,
     page_rel: &str,
@@ -363,6 +629,7 @@ fn render_bundle(
     fm: &Frontmatter,
     head: &Head,
     checks: &[Check],
+    maturity: &MaturityReport,
     agent_pass: bool,
 ) -> String {
     let mut out = String::new();
@@ -380,7 +647,7 @@ fn render_bundle(
             &head.sha
         },
         if head.dirty {
-            " **(working tree DIRTY — excerpts below may not exist at this SHA)**"
+            " **(NOT what this bundle was built from — see the warning below)**"
         } else {
             ""
         },
@@ -397,17 +664,30 @@ fn render_bundle(
         },
     ));
 
+    // A dirty tree is the normal state while writing docs, so this is a
+    // warning and not a refusal — but the bundle must not claim a commit it
+    // cannot vouch for. Excerpts were read from disk, and disk is not the SHA.
+    if head.dirty {
+        out.push_str(
+            "> ⚠ **The working tree has UNCOMMITTED CHANGES.** Everything below was read from \
+             the working tree, not from the commit named above. Excerpts and line numbers \
+             describe the files as they are on disk; they may not match that commit, and the \
+             commit alone will not reproduce them.\n\n",
+        );
+    }
+
     out.push_str(
         "## How to use this file\n\nYou are rewriting the page in section 1. Everything you need \
          is in this file — do not go looking for anything else.\n\n1. Read section 1: the page as \
-         it ships today.\n2. Read sections 2 and 3: every statement in them is a fact about the \
-         source at the commit above, and outranks the page.\n3. Read section 4: verbatim source \
-         excerpts. They are the evidence. If the page and an excerpt disagree, the excerpt is \
-         right.\n4. Emit the COMPLETE new page — YAML frontmatter first, then the prose. Keep the \
-         frontmatter's `slug`, `title`, `language`, `audience` and `guide_order` exactly as they \
-         are; update `tracked_files` if section 2 says a file moved, and set `last_generated_rev` \
-         to the commit above.\n5. Do not append the sources to the page. They are context, not \
-         content.\n\n",
+         it ships today.\n2. Read sections 2, 2b and 3: every statement in them is a fact about \
+         the source, produced by reading it, and outranks the page.\n3. Read section 4: verbatim \
+         source excerpts. They are the evidence. If the page and an excerpt disagree, the excerpt \
+         is right.\n4. Read section 5: how to write the page. It is the last word on style, \
+         honesty and what your output may contain.\n5. Emit the COMPLETE new page — YAML \
+         frontmatter first, then the prose. Keep the frontmatter's `slug`, `title`, `language`, \
+         `audience` and `guide_order` exactly as they are; update `tracked_files` if section 2 \
+         says a file moved, and set `last_generated_rev` to the commit above.\n6. Do not append \
+         the sources to the page. They are context, not content.\n\n",
     );
 
     out.push_str("## 1. The page as it ships today\n\n");
@@ -435,21 +715,138 @@ fn render_bundle(
         out.push('\n');
     }
 
+    out.push_str(&render_maturity_section(fm, maturity));
+
     if agent_pass {
         out.push_str(
             "## 3. Fact-check\n\n<!-- assemble-context: the agent replaces this block. -->\n\n_Not \
              filled in yet._\n\n## 4. Sources\n\n<!-- assemble-context: the agent replaces this \
-             block. -->\n\n_Not filled in yet._\n",
+             block. -->\n\n_Not filled in yet._\n\n",
         );
     } else {
         out.push_str(
             "## 3. Fact-check\n\n_Skipped: this bundle was assembled with `--no-agent`, so nothing \
-             read the prose against the source. Section 2 is still authoritative._\n\n## 4. \
-             Sources\n\n_Skipped: `--no-agent`._\n",
+             read the prose against the source. Sections 2 and 2b are still authoritative._\n\n## \
+             4. Sources\n\n_Skipped: `--no-agent`. Every code example in the page is therefore \
+             unverified: do not add new ones, and delete any you cannot justify from the page \
+             itself._\n\n",
         );
     }
+
+    out.push_str(WRITING_INSTRUCTIONS);
     out
 }
+
+/// Section 2b: what the page's own source admits is unfinished.
+///
+/// The absence of markers is as informative as their presence — it is the only
+/// evidence the writing model gets that a hedge in the prose is obsolete — so
+/// an empty list is printed loudly instead of being skipped.
+fn render_maturity_section(fm: &Frontmatter, m: &MaturityReport) -> String {
+    let mut out = String::from(
+        "## 2b. Unfinished work behind this page\n\nEvery `TODO`, `FIXME`, `todo!(` and \
+         `unimplemented!(` in the files this page tracks, so the page cannot describe an \
+         unfinished thing as finished. Machine-produced from the tree; no model was involved.\n\n",
+    );
+
+    match &m.page_maturity {
+        Some(v) => out.push_str(&format!(
+            "- the page declares `maturity: {v}` in its own frontmatter.\n"
+        )),
+        None => out.push_str("- the page declares no `maturity` key.\n"),
+    }
+    match &m.wip_paragraph {
+        Some(p) => out.push_str(&format!("- the page carries a WIP paragraph: {p}\n")),
+        None => out.push_str("- the page carries no `*WIP.*` paragraph.\n"),
+    }
+
+    if fm.tracked_files.is_empty() {
+        out.push_str(
+            "- the page tracks no files, so nothing could be scanned. THIS IS NOT EVIDENCE THAT \
+             THE FEATURE IS FINISHED — it is evidence that nobody said which source to look at.\n\n",
+        );
+        return out;
+    }
+
+    if m.markers.is_empty() {
+        out.push_str(&format!(
+            "- **{} tracked file(s) scanned; NO markers found.** The code behind this page carries \
+             no admission of unfinished work. If the page hedges — a `maturity: wip` key, a \
+             `*WIP.*` paragraph, \"not yet\", \"planned\" — the hedge is unsupported and should \
+             go.\n\n",
+            m.files_scanned,
+        ));
+        return out;
+    }
+
+    out.push_str(&format!(
+        "- **{} tracked file(s) scanned; {} marker(s) found.** A page that describes any of these \
+         as working is wrong, not merely optimistic.\n",
+        m.files_scanned,
+        m.markers.len(),
+    ));
+    for mk in m.markers.iter().take(MARKER_CAP) {
+        out.push_str(&format!("- `{}:{}` — {}\n", mk.file, mk.line, mk.text));
+    }
+    if m.markers.len() > MARKER_CAP {
+        out.push_str(&format!(
+            "\n_({} further marker(s) not listed; the cap is {}. Grep the tracked files if you \
+             need them all.)_\n",
+            m.markers.len() - MARKER_CAP,
+            MARKER_CAP,
+        ));
+    }
+    out.push('\n');
+    out
+}
+
+// ── The writing model's instructions ───────────────────────────────────
+
+/// Section 5. The bundle's last word, and the only part addressed to the model
+/// that actually emits the page.
+///
+/// It is a constant because it must be IDENTICAL in every bundle: the writing
+/// model is a fresh context each time, and a rule that varies per page is a
+/// rule that gets applied inconsistently across the guide.
+const WRITING_INSTRUCTIONS: &str = r#"## 5. How to write this page
+
+You are the writing model. Everything above is your input; this section is your brief.
+
+### What you output
+
+- Output the finished Markdown page and NOTHING else. No preamble, no sign-off, no "here is the
+  rewritten page", no explanation of what you changed.
+- The reader has never seen this codebase and will never see this bundle. Never mention the
+  bundle, the fact-check, the sources, a model, or the fact that the page was rewritten.
+
+### How it reads
+
+- Short sentences, one idea each. Plain words over clever ones. Prefer the concrete noun to the
+  abstraction.
+- Say what a thing does, and why a reader would want it, BEFORE how to call it.
+- Do not write: we, let's, simply, just, easy, obviously, note that, it's worth mentioning, in
+  this section we will. Do not hedge when the source settles the answer.
+- Match the shipping page's length unless the findings require more.
+
+### What you may claim
+
+- Every code example must be copied from section 4 verbatim, or assembled only from signatures
+  shown there. Never invent an API, a field, an argument or a default. If section 4 does not
+  settle it, leave it out.
+- Fix every finding in section 3. A finding marked WRONG must not survive in any form.
+- Keep the page's front matter, its title, and the headings a reader navigates by. Reorganise
+  only where section 3 shows the current order misleads.
+
+### Honesty about maturity
+
+- If the marker list in section 2b is empty for this page's tracked files, the feature ships:
+  delete any `*WIP.*` paragraph, and drop the `wip` claim from the front matter by setting
+  `maturity: mature`. (The `maturity` key itself is required — change its value, never remove
+  the key.)
+- If markers remain, keep ONE plain sentence naming exactly what is not finished, and delete the
+  vague hedging around it.
+- Never describe something as working when the source has a `todo!` or `unimplemented!` for it.
+"#;
 
 // ── The agent's instructions ───────────────────────────────────────────
 
@@ -468,14 +865,16 @@ A different model — one with no tools — will rewrite `{page_rel}` from the b
 `{bundle_rel}` and nothing else. Your job is to put everything that model needs into that
 bundle, and to make sure none of it is wrong.
 
-The bundle already contains the page as it ships (section 1) and the checks azul-doc could
-settle without a model (section 2). You fill in sections 3 and 4, in place, with Edit.
+The bundle already contains the page as it ships (section 1), the checks azul-doc could settle
+without a model (sections 2 and 2b), and the writing model's own brief (section 5). You fill in
+sections 3 and 4, in place, with Edit.
 
 ## The tree you are working against
 
 Commit `{sha}`. Read the source with Read and Grep at this commit; do not reason from memory
 about what azul's API looks like, and do not trust the page you are checking — it is the thing
 under test.
+{dirty_note}
 
 ## Section 3 — Fact-check
 
@@ -498,6 +897,13 @@ Write one entry per finding:
 Order them most-misleading first. A wrong function signature a reader would type outranks a
 stale sentence in an overview paragraph. If you find nothing wrong, say so in one line — that
 is a real and useful result.
+
+A page that describes something as working while its tracked source has a `todo!(` or
+`unimplemented!(` for that thing is a WRONG finding, not a stylistic one — the reader's program
+panics. Section 2b lists those markers; check the ones that touch what the page promises, and
+record the verdict with the marker's `path:line` as evidence. The reverse matters too: a page
+hedging about a feature whose source carries no marker at all is claiming a limitation that does
+not exist, which is also WRONG.
 
 Also flag what the page is MISSING that its tracked files clearly support: a public entry point
 with no mention, a footgun the source guards against and the prose never warns about. One line
@@ -537,8 +943,10 @@ Rules that matter:
 ## Rules
 
 - Edit ONLY `{bundle_rel}`. Do not touch the guide page, the source, or anything else.
-- Replace the two `_Not filled in yet._` placeholders. Leave sections 1 and 2 exactly as they are:
-  section 1 is the input the writer diffs against, section 2 is machine output you cannot improve.
+- Replace the two `_Not filled in yet._` placeholders and nothing else. Sections 1, 2, 2b and 5
+  stay byte-for-byte as they are: section 1 is the input the writer diffs against, sections 2 and
+  2b are machine output you cannot improve, and section 5 is the writing model's brief — it is not
+  addressed to you and must reach it intact, at the END of the file.
 - Do not rewrite the prose, do not suggest wording, do not add a "suggested rewrite" section. The
   writing model does that, and your suggestions would anchor it to your phrasing.
 - If the page is fine and well-covered, a short section 3 and a solid section 4 is the correct
@@ -552,6 +960,14 @@ When you are done, reply with one line: the number of findings and the number of
             "HEAD".to_string()
         } else {
             head.sha.clone()
+        },
+        // The excerpts you are about to paste come off disk. If disk is not the
+        // commit, saying "at commit X" in section 4 is a claim the bundle
+        // cannot back, so the agent is told to describe the tree it can see.
+        dirty_note = if head.dirty {
+            "\nThe working tree has UNCOMMITTED CHANGES. Read the files as they are on disk, and\nwherever these instructions say \"at this commit\", read \"in the working tree\": your excerpts\nand line numbers must match what is on disk, not what that commit holds. Say so in section 4 if\nan excerpt comes from a modified file."
+        } else {
+            ""
         },
     )
 }
@@ -582,7 +998,18 @@ pub fn run(cfg: &Config) -> Result<(), String> {
             api_path.display()
         );
     }
+    let vocab = ApiVocabulary::new(api_names, project_root);
+    if vocab.binding_source.is_none() {
+        eprintln!(
+            "[warn] target/codegen/azul.h not found; C-ABI spellings (`AzDom_createBody`) can \
+             only be demangled, not confirmed. Run `azul-doc codegen all` for a cleaner \
+             public-API check."
+        );
+    }
     let link_problems = lint_links::check_guide_links(project_root);
+    // Tracked files repeat across pages — `api.json` alone is tracked by dozens
+    // and is megabytes long — so each file is read at most once per run.
+    let mut marker_cache: BTreeMap<String, Vec<Marker>> = BTreeMap::new();
 
     let guides = get_guide_list();
     println!(
@@ -596,7 +1023,10 @@ pub fn run(cfg: &Config) -> Result<(), String> {
         if head.dirty { " (dirty tree)" } else { "" },
     );
 
-    let mut written = 0usize;
+    // (bundle path relative to the project root, page title) — the summary's
+    // whole job is to be pasteable, so it must not print absolute paths the
+    // owner would have to edit.
+    let mut written: Vec<(String, String)> = Vec::new();
     let mut skipped = 0usize;
     for guide in &guides {
         if let Some(f) = &cfg.filter {
@@ -615,18 +1045,17 @@ pub fn run(cfg: &Config) -> Result<(), String> {
             }
         };
         // A page with no frontmatter still gets a bundle — it is exactly the
-        // page most likely to be wrong — with an empty Frontmatter standing in.
-        let (fm, body) = parse_frontmatter(&raw_page)
-            .unwrap_or_else(|| (serde_yaml::from_str("{}").unwrap(), raw_page.clone()));
+        // page most likely to be wrong — with a stub Frontmatter standing in.
+        // The stub carries the three keys serde has no default for, so an
+        // unparsable page produces a bundle instead of a panic.
+        let (fm, body) = parse_frontmatter(&raw_page).unwrap_or_else(|| {
+            let stub = serde_yaml::from_str("slug: ''\ntitle: ''\nmaturity: ''")
+                .expect("stub frontmatter carries every field without a serde default");
+            (stub, raw_page.clone())
+        });
 
-        let checks = machine_checks(
-            project_root,
-            &page_path,
-            &fm,
-            &body,
-            &api_names,
-            &link_problems,
-        );
+        let checks = machine_checks(project_root, &page_path, &fm, &body, &vocab, &link_problems);
+        let maturity = maturity_report(project_root, &fm, &body, &mut marker_cache);
         let bundle = render_bundle(
             guide,
             &page_rel,
@@ -634,6 +1063,7 @@ pub fn run(cfg: &Config) -> Result<(), String> {
             &fm,
             &head,
             &checks,
+            &maturity,
             !cfg.no_agent,
         );
         let bpath = bundle_path(project_root, &guide.file_name);
@@ -651,23 +1081,32 @@ pub fn run(cfg: &Config) -> Result<(), String> {
                     .map_err(|e| format!("write {}: {}", ppath.display(), e))?;
             }
         }
-        written += 1;
+        written.push((
+            bpath
+                .strip_prefix(project_root)
+                .unwrap_or(&bpath)
+                .to_string_lossy()
+                .replace('\\', "/"),
+            guide.title.clone(),
+        ));
     }
 
     println!(
         "wrote {} bundle(s) to {} ({} filtered out)",
-        written,
+        written.len(),
         bdir.display(),
         skipped
     );
 
     if cfg.no_agent {
         println!("--no-agent: sections 3 and 4 were left unfilled.");
+        print_summary(project_root, &written);
         return Ok(());
     }
     if cfg.dry_run {
         println!("--dry-run: prompts written, no agents dispatched.");
         println!("  prompts: {}", pdir.display());
+        print_summary(project_root, &written);
         return Ok(());
     }
 
@@ -688,9 +1127,58 @@ pub fn run(cfg: &Config) -> Result<(), String> {
     };
     crate::reftest::autodoc::dispatch_prompt_agents(&ar, &pdir, "CTX")?;
 
-    println!("\nBundles ready: {}", bdir.display());
-    println!("Hand one to the writing model; it needs no tools and no repo access.");
+    print_summary(project_root, &written);
     Ok(())
+}
+
+/// Above this many bundles, one line each is a wall the owner scrolls past.
+const SUMMARY_LIST_CAP: usize = 12;
+
+/// The last thing the command prints: where the bundles are and how to get one
+/// into a writing model.
+///
+/// The bundle is only useful once it is in a chat window, and on macOS that is
+/// `pbcopy`. Printing the exact command removes the step where the owner has to
+/// go find the file and remember what the tool called it.
+fn print_summary(project_root: &Path, written: &[(String, String)]) {
+    let bdir = bundles_dir(project_root);
+    let bdir_rel = bdir
+        .strip_prefix(project_root)
+        .unwrap_or(&bdir)
+        .to_string_lossy()
+        .replace('\\', "/");
+
+    if written.is_empty() {
+        println!("\nNo bundles were assembled (every page was filtered out).");
+        return;
+    }
+
+    println!(
+        "\n=== {} bundle(s) assembled in {} ===\n",
+        written.len(),
+        bdir_rel,
+    );
+
+    if written.len() <= SUMMARY_LIST_CAP {
+        // Widest path first so the `#` comments line up in a terminal.
+        let width = written.iter().map(|(p, _)| p.len()).max().unwrap_or(0);
+        for (path, title) in written {
+            println!("pbcopy < {path:<width$}   # {title}");
+        }
+    } else {
+        println!("Too many to list. To copy one:\n");
+        println!("  pbcopy < {bdir_rel}/<slug>.md          # slugs: `ls {bdir_rel}`\n");
+        println!("To work through all of them, one paste at a time:\n");
+        println!("  for f in {bdir_rel}/*.md; do");
+        println!("      pbcopy < \"$f\"; echo \"copied $f — paste it, then press enter\"; read _");
+        println!("  done");
+    }
+
+    println!(
+        "\nEach bundle is self-contained — the page, the checks, the fact-check, verbatim source \
+         excerpts and the writing brief — so it can be pasted straight into a writing model with \
+         no tools and no repo access.",
+    );
 }
 
 #[cfg(test)]
@@ -730,6 +1218,216 @@ mod tests {
             OUTER_FENCE.len() > 3,
             "a 3-backtick fence would be closed by the page's own code blocks",
         );
+    }
+
+    fn vocab_of(names: &[&str], binding: &[&str]) -> ApiVocabulary {
+        let names: BTreeSet<String> = names.iter().map(|s| (*s).to_string()).collect();
+        ApiVocabulary {
+            folded: names.iter().map(|n| fold_name(n)).collect(),
+            names,
+            binding: binding.iter().map(|s| (*s).to_string()).collect(),
+            binding_source: (!binding.is_empty()).then(|| "target/codegen/azul.h".to_string()),
+        }
+    }
+
+    /// The bug this check existed to cause: a binding page spells the same
+    /// function its own way, and every one of those spellings was reported as
+    /// "not public API".
+    #[test]
+    fn a_bindings_spelling_of_a_real_function_is_not_a_finding() {
+        let v = vocab_of(&["Dom", "Dom::create_body", "Dom.create_body"], &[]);
+        // C, C#, Python, Rust — one function, four spellings.
+        for name in [
+            "AzDom_createBody",
+            "Dom.CreateBody",
+            "Dom.create_body",
+            "AzDom",
+        ] {
+            assert!(v.knows(name), "{name} should resolve to Dom::create_body");
+        }
+    }
+
+    /// Resolving manglings must not degrade into accepting everything: a
+    /// member the project does not have is still a finding, even when its type
+    /// exists.
+    #[test]
+    fn demangling_does_not_accept_an_invented_member() {
+        let v = vocab_of(&["Dom", "Dom::create_body"], &[]);
+        assert!(!v.knows("AzDom_thisWasNeverAFunction"));
+        assert!(!v.knows("AzFoo"), "a page's placeholder type is a finding");
+        assert!(!v.knows("Az"), "a bare namespace prefix is not a symbol");
+    }
+
+    /// `AzString_fromConstStr` is exported by the C header and has NO api.json
+    /// counterpart under that name (api.json calls it `String::from_c_str`), so
+    /// only the generated bindings can clear it.
+    #[test]
+    fn a_header_only_symbol_counts_as_public_api() {
+        let v = vocab_of(
+            &["String", "String::from_c_str"],
+            &["AzString_fromConstStr"],
+        );
+        assert!(v.knows("AzString_fromConstStr"));
+        assert!(!v.knows("AzString_fromWishfulThinking"));
+    }
+
+    /// Without the header, a C name that only the header could settle stays a
+    /// finding — and the bundle has to say the header was missing rather than
+    /// let the reader assume the name is wrong.
+    #[test]
+    fn a_missing_header_is_reported_not_papered_over() {
+        let v = vocab_of(&["String", "String::from_c_str"], &[]);
+        assert!(!v.knows("AzString_fromConstStr"));
+        assert!(
+            !v.reference_clause().contains("azul.h"),
+            "the clause must not name a file that was not read",
+        );
+    }
+
+    /// The scanner has to find both the comment markers and the two macros
+    /// that make a page's claim false at runtime.
+    #[test]
+    fn markers_are_found_with_their_line_numbers() {
+        let dir = std::env::temp_dir().join("az-assemble-context-markers");
+        fs::create_dir_all(&dir).unwrap();
+        let rel = "sample.rs";
+        fs::write(
+            dir.join(rel),
+            "fn a() {}\n// TODO: wire this up\nfn b() { todo!(\"later\") }\nfn c() {}\n",
+        )
+        .unwrap();
+        let found = scan_markers(&dir, rel);
+        assert_eq!(found.len(), 2);
+        assert_eq!(found[0].line, 2);
+        assert_eq!(found[0].text, "// TODO: wire this up");
+        assert_eq!(found[1].line, 3);
+        assert!(found[1].text.contains("todo!("));
+    }
+
+    /// The absence of markers is the signal the owner asked for, so it must be
+    /// stated out loud rather than left as an empty list.
+    #[test]
+    fn an_empty_marker_list_is_stated_explicitly() {
+        let fm: Frontmatter = serde_yaml::from_str(
+            "slug: x\ntitle: X\nmaturity: wip\ntracked_files: [core/src/a.rs]",
+        )
+        .unwrap();
+        let clean = MaturityReport {
+            page_maturity: Some("wip".to_string()),
+            wip_paragraph: None,
+            files_scanned: 1,
+            markers: Vec::new(),
+        };
+        let rendered = render_maturity_section(&fm, &clean);
+        assert!(rendered.contains("NO markers found"), "{rendered}");
+        assert!(rendered.contains("maturity: wip"), "{rendered}");
+    }
+
+    /// No page hits the cap today (the worst tracks 22 markers), which is
+    /// exactly why the branch needs a test: the first page that tracks a big
+    /// file would otherwise be the first to run it.
+    #[test]
+    fn a_long_marker_list_is_capped_and_says_what_it_elided() {
+        let fm: Frontmatter =
+            serde_yaml::from_str("slug: x\ntitle: X\nmaturity: wip\ntracked_files: [a.rs]")
+                .unwrap();
+        let rendered = render_maturity_section(
+            &fm,
+            &MaturityReport {
+                page_maturity: None,
+                wip_paragraph: Some("*WIP.* not done".to_string()),
+                files_scanned: 1,
+                markers: (1..=MARKER_CAP + 3)
+                    .map(|line| Marker {
+                        file: "a.rs".to_string(),
+                        line,
+                        text: "// TODO: x".to_string(),
+                    })
+                    .collect(),
+            },
+        );
+        assert_eq!(rendered.matches("// TODO: x").count(), MARKER_CAP);
+        assert!(
+            rendered.contains("3 further marker(s) not listed"),
+            "{rendered}"
+        );
+        assert!(rendered.contains("*WIP.* not done"), "{rendered}");
+    }
+
+    /// Section 5 is the writing model's only brief, and a model reads the end
+    /// of a long document best — so the bundle must END with it.
+    #[test]
+    fn the_bundle_ends_with_the_writing_brief() {
+        let guide = Guide {
+            title: "Hello World [C]".to_string(),
+            file_name: "hello-world/c".to_string(),
+            content: String::new(),
+            audience: Some("external".to_string()),
+            guide_order: Some(12),
+            description: None,
+            default_search_keys: Vec::new(),
+        };
+        let fm: Frontmatter = serde_yaml::from_str("slug: x\ntitle: X\nmaturity: wip").unwrap();
+        let head = Head {
+            sha: "abc123".to_string(),
+            date: "2026-01-01T00:00:00Z".to_string(),
+            dirty: true,
+        };
+        let m = MaturityReport {
+            page_maturity: Some("wip".to_string()),
+            wip_paragraph: None,
+            files_scanned: 0,
+            markers: Vec::new(),
+        };
+        let out = render_bundle(
+            &guide,
+            "doc/guide/en/x.md",
+            "# X\n",
+            &fm,
+            &head,
+            &[],
+            &m,
+            true,
+        );
+        assert!(out.trim_end().ends_with(WRITING_INSTRUCTIONS.trim_end()));
+        assert!(out.contains("## 5. How to write this page"));
+        assert!(out.contains("## 2b. Unfinished work behind this page"));
+        // A dirty tree cannot be a footnote: the bundle names a commit its
+        // excerpts did not come from.
+        assert!(out.contains("UNCOMMITTED CHANGES"), "{out}");
+        // Section 4 must still come before section 5, or the agent's excerpts
+        // would land after the brief.
+        let (s4, s5) = (out.find("## 4. Sources"), out.find("## 5. How to write"));
+        assert!(s4 < s5 && s4.is_some());
+    }
+
+    /// The prompt is the agent's only instruction sheet; if the tree is dirty
+    /// and the prompt does not say so, the agent pins line numbers to a commit
+    /// that does not have them.
+    #[test]
+    fn the_prompt_admits_a_dirty_tree() {
+        let guide = Guide {
+            title: "X".to_string(),
+            file_name: "x".to_string(),
+            content: String::new(),
+            audience: None,
+            guide_order: None,
+            description: None,
+            default_search_keys: Vec::new(),
+        };
+        let root = Path::new("/tmp/x");
+        let dirty = Head {
+            sha: "abc".to_string(),
+            date: String::new(),
+            dirty: true,
+        };
+        let clean = Head {
+            sha: "abc".to_string(),
+            date: String::new(),
+            dirty: false,
+        };
+        assert!(render_prompt(root, &guide, "p.md", &dirty).contains("UNCOMMITTED CHANGES"));
+        assert!(!render_prompt(root, &guide, "p.md", &clean).contains("UNCOMMITTED CHANGES"));
     }
 
     /// A nested page keeps its directory in the bundle name, so two pages


### PR DESCRIPTION
`azul-doc assemble-context` turns each shipping guide page into a self-contained bundle a tool-free writing model can rewrite from. Five changes, all in `doc/src/assemble_context.rs`.

## The public-API check was noise on every binding page

`public_api_names` collected api.json's unmangled spellings while the pages use each binding's own. On the C hello-world page that flagged **17 names as "not public API"**, including `AzApp_run`, `AzDom_createBody`, `AzString_fromConstStr` and `AzUpdate_RefreshDom` — all four exist in the generated `target/codegen/azul.h`. A fact-check agent reading that would chase 17 phantoms.

A name now resolves if it matches api.json verbatim, matches after folding case and separators, demangles as `Az<Type>_<member>`, or appears among the identifiers scanned from the generated header. Both mechanisms are needed: the header cannot settle C#/Python spellings, and demangling cannot settle a symbol whose api.json counterpart carries a different name.

**C page: 17 findings → 3**, and the three survivors are real (two invented by the page's own example, one a bare Rust term). Swift 22 → 5, C++ 20 → 10, C# 18 → 12, Python 2 → 0.

## The bundle claimed a commit it could not vouch for

The run printed "(dirty tree)" but the bundle still asserted "at commit <sha>" and told the agent line numbers must match it. With uncommitted edits, excerpts come from the working tree. The header and the prompt now say so plainly.

## Section 2b — unfinished work behind the page

The writing model could not tell a shipped feature from an aspirational one. Each bundle now lists the page's `maturity` marker, its `*WIP.*` paragraph, and every `TODO`, `FIXME`, `todo!(` and `unimplemented!(` in the files that page tracks, capped at 40. Across the 82 pages, **54 have markers and 28 are clean**. The fact-check treats "the page says this works, the source says `todo!`" as a WRONG finding, and hedging with no marker behind it as wrong too.

## Section 5 — the writing brief

Bundles ended after the sources, so the writer got no instructions. Each now closes with a brief: output the page and nothing else, never mention the bundle or the process, short sentences and plain words, say what a thing does before how to call it, never invent an API beyond the excerpts, and fix every finding. On maturity it is explicit — if no markers back the page, the WIP label goes; if markers remain, one plain sentence names what is unfinished.

## A usable summary

The run ends with `pbcopy` commands per bundle, collapsing to a directory and a paste-one-at-a-time loop above twelve.

## Notes

- `maturity` is a required field with no serde default, so the brief tells the writer to change its value rather than delete the key, which would make the page unparsable.
- Fixes a latent panic on unparsable front matter.
- 12 unit tests pass; `cargo build --release -p azul-doc` and a full 82-page run both exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018R3yhfRdgMASn2sbdrsMBy