### PR TITLE
feat(theme): every backend hears a runtime OS theme change, and it reaches the engine

### DIFF
--- a/dll/src/desktop/shell2/linux/system_style.rs
+++ b/dll/src/desktop/shell2/linux/system_style.rs
@@ -1868,32 +1868,467 @@ pub(crate) fn observed_system_theme() -> Option<Theme> {
     }
 }
 
+/// The fd both Linux event loops park on, so a theme switch WAKES them.
+///
+/// `OBSERVED_COLOR_SCHEME` alone was not enough. It is read from
+/// `check_timers_and_threads`, and both loops call that only when a timerfd
+/// fired or a background thread is live — otherwise they sit in `poll(2)` with
+/// an INFINITE timeout. An idle window (no animation, no timer, no thread) was
+/// therefore never going to run the read, so the portal's answer sat in the
+/// atomic until the user happened to move the mouse. An eventfd in both poll
+/// sets is what turns "the watcher knows" into "the window knows".
+///
+/// One fd for the whole process, not one per window: the setting is
+/// process-wide, `poll(2)` on the same fd from several loops all wake, and the
+/// counter semantics mean a drain by one loop cannot lose the wake for another
+/// (each loop re-reads the atomic, which is the source of truth).
+static THEME_WAKE_FD: core::sync::atomic::AtomicI32 = core::sync::atomic::AtomicI32::new(-1);
+
+/// The eventfd to put in a backend's poll set, or `-1` when it could not be
+/// created (in which case the loop simply keeps its old timer-driven latency).
+///
+/// Starts the watcher as a side effect, exactly like [`observed_system_theme`]:
+/// a backend that polls the fd is a backend that wants the answer.
+pub(crate) fn theme_wake_fd() -> i32 {
+    ensure_theme_watcher();
+    THEME_WAKE_FD.load(core::sync::atomic::Ordering::Relaxed)
+}
+
+/// Acknowledge a wake so `poll(2)` stops reporting the fd as readable.
+///
+/// The COUNT is deliberately discarded: it says how many times the desktop's
+/// setting moved since the last drain, and the answer to all of them is the
+/// same single re-read of `observed_system_theme`.
+pub(crate) fn drain_theme_wake() {
+    let fd = THEME_WAKE_FD.load(core::sync::atomic::Ordering::Relaxed);
+    if fd < 0 {
+        return;
+    }
+    let mut n: u64 = 0;
+    unsafe {
+        libc::read(fd, core::ptr::addr_of_mut!(n).cast::<libc::c_void>(), 8);
+    }
+}
+
+/// Publish a scheme the watcher just learned, and wake every parked loop.
+fn publish_color_scheme(scheme: u32) {
+    if color_scheme_to_theme(scheme).is_none() {
+        return;
+    }
+    let previous =
+        OBSERVED_COLOR_SCHEME.swap(scheme as u8, core::sync::atomic::Ordering::Relaxed);
+    if previous == scheme as u8 {
+        return;
+    }
+    let fd = THEME_WAKE_FD.load(core::sync::atomic::Ordering::Relaxed);
+    if fd < 0 {
+        return;
+    }
+    let one: u64 = 1;
+    unsafe {
+        libc::write(fd, core::ptr::addr_of!(one).cast::<libc::c_void>(), 8);
+    }
+}
+
 /// Start the watcher thread once per process.
 ///
-/// It MUST NOT run on the event-loop thread. `query_xdg_portal` opens a Unix
-/// socket to the session bus and does a synchronous request/response with two-
-/// second read and write timeouts, so polling it inline would risk a two-second
-/// freeze of the UI every time the portal was slow or absent — trading "dark
-/// mode does not apply until restart" for "the window hangs", which is worse.
+/// It MUST NOT run on the event-loop thread. The bus socket is a synchronous
+/// request/response channel and the watch below BLOCKS on it, so running any of
+/// this inline would park the UI on the session bus.
 ///
-/// Polling rather than subscribing to `SettingChanged`: reading a signal needs a
-/// match rule and a message loop against the bus, where a poll reuses the
-/// request path that already exists here. Two seconds is far below human
-/// tolerance for a theme switch and is one tiny D-Bus call.
+/// The mechanism is the portal's `SettingChanged` SIGNAL, not a poll. There is
+/// no Wayland protocol for the desktop's colour scheme and XSETTINGS does not
+/// carry one either, so `org.freedesktop.portal.Settings` is the answer on both
+/// Linux backends — and it announces changes rather than making callers ask.
+/// A `Read` still happens twice: once per connection to learn the CURRENT value
+/// (a signal only reports transitions), and once per idle interval as a
+/// backstop for a portal implementation that answers `Read` but never emits the
+/// signal.
 fn ensure_theme_watcher() {
     THEME_WATCHER.get_or_init(|| {
+        // Created BEFORE the thread starts, so `theme_wake_fd()` never observes
+        // -1 after `ensure_theme_watcher()` has returned.
+        let fd = unsafe { libc::eventfd(0, libc::EFD_NONBLOCK | libc::EFD_CLOEXEC) };
+        THEME_WAKE_FD.store(fd, core::sync::atomic::Ordering::Relaxed);
+
         let _ = std::thread::Builder::new()
             .name("azul-theme-watch".into())
-            .spawn(|| loop {
-                if let Some((scheme, _accent)) = query_xdg_portal() {
-                    if color_scheme_to_theme(scheme).is_some() {
-                        OBSERVED_COLOR_SCHEME
-                            .store(scheme as u8, core::sync::atomic::Ordering::Relaxed);
+            .spawn(|| {
+                // Doubling backoff, so a session with no bus at all (a TTY
+                // login, a container without DBUS_SESSION_BUS_ADDRESS) stops
+                // retrying every two seconds forever.
+                let mut backoff = core::time::Duration::from_secs(2);
+                loop {
+                    if watch_portal_color_scheme().is_some() {
+                        // The connection lived and then ended: the bus went
+                        // away or the portal restarted. Reconnect promptly.
+                        backoff = core::time::Duration::from_secs(2);
+                    } else {
+                        backoff = (backoff * 2).min(core::time::Duration::from_secs(60));
                     }
+                    std::thread::sleep(backoff);
                 }
-                std::thread::sleep(core::time::Duration::from_secs(2));
             });
     });
+}
+
+/// How long the watcher parks on the bus before re-`Read`ing as a backstop.
+const PORTAL_BACKSTOP_INTERVAL: core::time::Duration = core::time::Duration::from_secs(30);
+
+/// Subscribe to `org.freedesktop.portal.Settings.SettingChanged` and publish
+/// every colour-scheme change until the connection ends.
+///
+/// Returns `Some(())` if a connection was established (and has since ended),
+/// `None` if one could not be made at all — the caller uses that to tell "the
+/// portal went away" from "there is no session bus here" when choosing a
+/// backoff.
+fn watch_portal_color_scheme() -> Option<()> {
+    use std::io::Read;
+    use std::os::unix::net::UnixStream;
+
+    let bus_addr = std::env::var("DBUS_SESSION_BUS_ADDRESS").ok()?;
+    let path = bus_addr.strip_prefix("unix:path=")?.split(',').next()?;
+    let mut stream = UnixStream::connect(path).ok()?;
+    stream
+        .set_write_timeout(Some(core::time::Duration::from_secs(2)))
+        .ok()?;
+    // The read timeout IS the backstop interval: a wait that ends without a
+    // message means "nothing happened for 30s", which is exactly when the
+    // backstop `Read` should go out.
+    stream.set_read_timeout(Some(PORTAL_BACKSTOP_INTERVAL)).ok()?;
+
+    let uid = unsafe { libc_getuid() };
+    let auth_msg = alloc::format!("\0AUTH EXTERNAL {}\r\nBEGIN\r\n", hex_encode_uid(uid));
+    send_all_nosignal(&stream, auth_msg.as_bytes()).ok()?;
+    let mut auth_buf = [0u8; 256];
+    let n = stream.read(&mut auth_buf).ok()?;
+    if !core::str::from_utf8(&auth_buf[..n]).ok()?.contains("OK") {
+        return None;
+    }
+
+    let mut serial: u32 = 1;
+    let send_call = |stream: &UnixStream,
+                     serial: &mut u32,
+                     dest: &str,
+                     path: &str,
+                     iface: &str,
+                     member: &str,
+                     args: &[DValue<'_>]|
+     -> Option<()> {
+        let msg = build_dbus_method_call(dest, path, iface, member, args, *serial);
+        *serial += 1;
+        send_all_nosignal(stream, &msg).ok()
+    };
+
+    if send_call(
+        &stream,
+        &mut serial,
+        "org.freedesktop.DBus",
+        "/org/freedesktop/DBus",
+        "org.freedesktop.DBus",
+        "Hello",
+        &[],
+    )
+    .is_none()
+    {
+        return Some(());
+    }
+
+    // The match rule. Without it the bus delivers no broadcast signals at all —
+    // signal subscription on D-Bus is opt-in per client, and this is the opt-in.
+    if send_call(
+        &stream,
+        &mut serial,
+        "org.freedesktop.DBus",
+        "/org/freedesktop/DBus",
+        "org.freedesktop.DBus",
+        "AddMatch",
+        &[DValue::String(
+            "type='signal',interface='org.freedesktop.portal.Settings',member='SettingChanged',\
+             arg0='org.freedesktop.appearance'",
+        )],
+    )
+    .is_none()
+    {
+        return Some(());
+    }
+
+    // A signal reports a TRANSITION, so the value in effect right now has to be
+    // asked for once. The serial is RETURNED and remembered: replies are matched
+    // against it, because `Hello`'s and `AddMatch`'s replies come back down this
+    // same socket and the response parser is a heuristic over the last four
+    // bytes of the body — handed the wrong message it could invent a scheme.
+    let read_color_scheme = |stream: &UnixStream, serial: &mut u32| -> Option<u32> {
+        let sent = *serial;
+        let msg = build_dbus_method_call(
+            "org.freedesktop.portal.Desktop",
+            "/org/freedesktop/portal/desktop",
+            "org.freedesktop.portal.Settings",
+            "Read",
+            &[
+                DValue::String("org.freedesktop.appearance"),
+                DValue::String("color-scheme"),
+            ],
+            *serial,
+        );
+        *serial += 1;
+        send_all_nosignal(stream, &msg).ok()?;
+        Some(sent)
+    };
+    let mut outstanding_read = read_color_scheme(&stream, &mut serial);
+
+    // Every byte the bus has sent that has not yet been split into a message.
+    // A read can stop MID-message (the timeout below, a short read), so the
+    // remainder has to survive to the next one — parsing per `read()` call
+    // would corrupt the stream the first time that happened.
+    let mut pending: alloc::vec::Vec<u8> = alloc::vec::Vec::new();
+    let mut chunk = [0u8; 4096];
+    loop {
+        match stream.read(&mut chunk) {
+            // The peer closed: the bus or the portal went away.
+            Ok(0) => return Some(()),
+            Ok(n) => pending.extend_from_slice(&chunk[..n]),
+            Err(e)
+                if matches!(
+                    e.kind(),
+                    std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+                ) =>
+            {
+                // Idle for a full interval. Ask outright, so a portal that
+                // answers `Read` but never emits `SettingChanged` still gets
+                // its changes noticed — just at poll latency rather than
+                // instantly.
+                let Some(sent) = read_color_scheme(&stream, &mut serial) else {
+                    return Some(());
+                };
+                outstanding_read = Some(sent);
+                continue;
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+            Err(_) => return Some(()),
+        }
+
+        loop {
+            let len = match dbus_message_len(&pending) {
+                Some(len) => len,
+                // The fixed header is fully here and still does not describe a
+                // message: the stream is desynchronised or the peer is not
+                // speaking D-Bus. Nothing can resynchronise a byte stream after
+                // that, so drop the connection and reconnect rather than
+                // growing `pending` forever.
+                None if pending.len() >= 16 => return Some(()),
+                None => break,
+            };
+            if pending.len() < len {
+                break;
+            }
+            let msg: alloc::vec::Vec<u8> = pending.drain(..len).collect();
+            if let Some(scheme) = color_scheme_from_message(&msg, outstanding_read) {
+                outstanding_read = None;
+                publish_color_scheme(scheme);
+            }
+        }
+    }
+}
+
+// ── Minimal D-Bus message READER (framing + the two shapes we consume) ────
+
+/// Total on-the-wire length of the message starting at `data[0]`, once enough
+/// of its fixed header has arrived to say.
+///
+/// D-Bus is a framed protocol whose frame length is only computable from the
+/// 16-byte fixed header: body length at offset 4, header-field array length at
+/// offset 12, and the body starts at the next 8-byte boundary after the fields.
+fn dbus_message_len(data: &[u8]) -> Option<usize> {
+    if data.len() < 16 {
+        return None;
+    }
+    let le = match data[0] {
+        b'l' => true,
+        b'B' => false,
+        _ => return None,
+    };
+    let u32_at = |o: usize| -> u32 {
+        let b: [u8; 4] = data[o..o + 4].try_into().unwrap_or([0; 4]);
+        if le {
+            u32::from_le_bytes(b)
+        } else {
+            u32::from_be_bytes(b)
+        }
+    };
+    let body_len = u32_at(4) as usize;
+    let fields_len = u32_at(12) as usize;
+    // The spec's hard maximum message length. A length past it is a corrupt or
+    // hostile header, not a big message, and refusing here is what keeps the
+    // arithmetic below from overflowing.
+    const MAX_MESSAGE_LEN: usize = 134_217_728;
+    if body_len > MAX_MESSAGE_LEN || fields_len > MAX_MESSAGE_LEN {
+        return None;
+    }
+    let body_start = (16 + fields_len).next_multiple_of(8);
+    Some(body_start + body_len)
+}
+
+/// A cursor over one complete D-Bus message, aware of its byte order.
+struct DbusMessage<'a> {
+    data: &'a [u8],
+    le: bool,
+    pos: usize,
+}
+
+impl<'a> DbusMessage<'a> {
+    fn new(data: &'a [u8]) -> Option<Self> {
+        let le = match *data.first()? {
+            b'l' => true,
+            b'B' => false,
+            _ => return None,
+        };
+        Some(Self { data, le, pos: 0 })
+    }
+
+    fn align(&mut self, to: usize) {
+        self.pos = self.pos.next_multiple_of(to);
+    }
+
+    fn u8(&mut self) -> Option<u8> {
+        let v = *self.data.get(self.pos)?;
+        self.pos += 1;
+        Some(v)
+    }
+
+    fn u32(&mut self) -> Option<u32> {
+        self.align(4);
+        let b: [u8; 4] = self.data.get(self.pos..self.pos + 4)?.try_into().ok()?;
+        self.pos += 4;
+        Some(if self.le {
+            u32::from_le_bytes(b)
+        } else {
+            u32::from_be_bytes(b)
+        })
+    }
+
+    /// A `s`/`o` value: 4-aligned u32 length, bytes, NUL.
+    fn string(&mut self) -> Option<&'a str> {
+        let len = self.u32()? as usize;
+        let end = self.pos.checked_add(len)?;
+        let s = core::str::from_utf8(self.data.get(self.pos..end)?).ok()?;
+        self.pos = end.checked_add(1)?;
+        Some(s)
+    }
+
+    /// A `g` value: single-byte length, bytes, NUL. Used for both the header
+    /// fields' variant signatures and a variant's own.
+    fn signature(&mut self) -> Option<&'a str> {
+        let len = self.u8()? as usize;
+        let end = self.pos.checked_add(len)?;
+        let s = core::str::from_utf8(self.data.get(self.pos..end)?).ok()?;
+        self.pos = end.checked_add(1)?;
+        Some(s)
+    }
+
+    /// Step over a value of the given single-character type, so an unwanted
+    /// header field does not desynchronise the walk.
+    ///
+    /// Only the types that appear in a header field are handled; anything else
+    /// aborts the walk rather than guessing a width.
+    fn skip_value(&mut self, sig: &str) -> Option<()> {
+        match sig {
+            "s" | "o" => {
+                self.string()?;
+            }
+            "g" => {
+                self.signature()?;
+            }
+            "u" => {
+                self.u32()?;
+            }
+            _ => return None,
+        }
+        Some(())
+    }
+}
+
+/// The colour-scheme value carried by `msg`, if `msg` carries one.
+///
+/// Two shapes reach here and both are accepted:
+///   * the SIGNAL `SettingChanged(s namespace, s key, v value)` — the change
+///     announcement this watcher subscribes to;
+///   * the METHOD_RETURN for `Settings.Read`, whose body is `v` wrapping the
+///     same `u` — the initial and backstop reads.
+///
+/// `expect_reply_serial` is the serial of the `Read` currently in flight, and a
+/// METHOD_RETURN is only decoded when it answers exactly that. `Hello` and
+/// `AddMatch` reply on this same socket, and the reply decoder is a heuristic
+/// over the last four bytes of the body accepting anything in `0..=2` — handed
+/// the wrong reply it could invent a colour scheme out of a unique bus name.
+fn color_scheme_from_message(msg: &[u8], expect_reply_serial: Option<u32>) -> Option<u32> {
+    // Fixed header: [0] endianness, [1] type, [4..8] body length,
+    // [12..16] header-field array length.
+    let msg_type = *msg.get(1)?;
+    const METHOD_RETURN: u8 = 2;
+    const SIGNAL: u8 = 4;
+    if msg_type != METHOD_RETURN && msg_type != SIGNAL {
+        return None;
+    }
+
+    let mut cur = DbusMessage::new(msg)?;
+    cur.pos = 12;
+    let fields_len = cur.u32()? as usize;
+    let fields_end = 16usize.checked_add(fields_len)?;
+    let body_start = fields_end.checked_next_multiple_of(8)?;
+
+    // The header-field array is STRUCT(BYTE code, VARIANT value), each struct
+    // 8-byte aligned. Codes 3 (MEMBER) and 5 (REPLY_SERIAL) are what identify
+    // the two shapes; every other field is stepped over by its own type, so an
+    // unread one cannot desynchronise the walk.
+    let mut member: Option<&str> = None;
+    let mut reply_serial: Option<u32> = None;
+    cur.pos = 16;
+    while cur.pos < fields_end {
+        cur.align(8);
+        if cur.pos >= fields_end {
+            break;
+        }
+        let code = cur.u8()?;
+        let sig = cur.signature()?;
+        match (code, sig) {
+            (3, "s") => member = Some(cur.string()?),
+            (5, "u") => reply_serial = Some(cur.u32()?),
+            _ => cur.skip_value(sig)?,
+        }
+    }
+
+    if msg_type == METHOD_RETURN {
+        if expect_reply_serial.is_none() || reply_serial != expect_reply_serial {
+            return None;
+        }
+        // `parse_uint32_from_variant_response` already knows this body shape —
+        // but it reads its lengths as little-endian, so a big-endian reply has
+        // to fall through to the next signal rather than be misparsed. (The
+        // session bus on every platform azul builds for is little-endian; this
+        // is the guard, not a limitation worth working around.)
+        if !cur.le {
+            return None;
+        }
+        return parse_uint32_from_variant_response(msg);
+    }
+
+    if member != Some("SettingChanged") {
+        return None;
+    }
+
+    // Body: (s namespace, s key, v value).
+    cur.pos = body_start;
+    if cur.string()? != "org.freedesktop.appearance" {
+        return None;
+    }
+    if cur.string()? != "color-scheme" {
+        return None;
+    }
+    if cur.signature()? != "u" {
+        return None;
+    }
+    cur.u32()
 }
 
 /// Adopt the watcher's theme into `common`, returning the RE-DISCOVERED style

--- a/dll/src/desktop/shell2/linux/wayland/mod.rs
+++ b/dll/src/desktop/shell2/linux/wayland/mod.rs
@@ -2979,6 +2979,23 @@ impl WaylandWindow {
                 })
                 .collect();
 
+            // Desktop light/dark switch. There is NO Wayland protocol for the
+            // colour scheme, so the mechanism is the xdg-desktop-portal
+            // `SettingChanged` signal, and it arrives on a watcher thread that
+            // has no way to reach this loop — except this eventfd. Without it in
+            // the poll set the change sat in the watcher's atomic until an
+            // unrelated compositor event woke us, which on an idle window is
+            // never: the timeout below is `-1`.
+            let theme_wake_idx = pollfds.len();
+            let theme_wake_fd = super::system_style::theme_wake_fd();
+            if theme_wake_fd >= 0 {
+                pollfds.push(libc::pollfd {
+                    fd: theme_wake_fd,
+                    events: libc::POLLIN,
+                    revents: 0,
+                });
+            }
+
             // Background threads (e.g. MapWidget tile fetches) have NO fd in the
             // poll set, so their completion can't wake poll(). While any thread is
             // in flight, poll on a ~16ms tick and drain thread writebacks on every
@@ -3026,6 +3043,7 @@ impl WaylandWindow {
             );
 
             let mut any_timer_fired = false;
+            let mut theme_woke = false;
             if result > 0 {
                 // Check Wayland display fd
                 if pollfds[0].revents & libc::POLLIN != 0 {
@@ -3131,6 +3149,18 @@ impl WaylandWindow {
                         self.handle_key(keycode, 1);
                     }
                 }
+                // The desktop's colour scheme moved. Acknowledge the wake and
+                // let `check_timers_and_threads` below do the adopting — it
+                // already owns that call, so there stays exactly ONE theme path
+                // in this backend.
+                if theme_wake_fd >= 0
+                    && theme_wake_idx < pollfds.len()
+                    && pollfds[theme_wake_idx].revents & libc::POLLIN != 0
+                {
+                    super::system_style::drain_theme_wake();
+                    theme_woke = true;
+                }
+
                 // A seat's timer fired: replay ITS key as a press on that seat
                 // (9b-ii-a-i-b-i); the seat's key state marks it a repeat.
                 for (seat_id, idx) in &seat_repeat_idx {
@@ -3155,7 +3185,7 @@ impl WaylandWindow {
             // callback produced a visual change. Run on every wake while threads
             // are active (the 16ms tick guarantees we get here) so tile-fetch
             // writebacks drain promptly.
-            if any_timer_fired || has_threads {
+            if any_timer_fired || has_threads || theme_woke {
                 self.check_timers_and_threads();
             }
             // result == 0: timeout (shouldn't happen with -1)
@@ -8966,10 +8996,12 @@ impl WaylandWindow {
         }
 
         // A runtime light/dark switch. There is NO Wayland protocol for this —
-        // the xdg-desktop-portal `Settings` interface is the mechanism — so the
-        // same watcher serves X11 and Wayland alike. `observed_system_theme` is
-        // a relaxed atomic load; the blocking D-Bus round trip that feeds it
-        // runs on a watcher thread, never on this one.
+        // the xdg-desktop-portal `Settings.SettingChanged` signal is the
+        // mechanism — so the same watcher serves X11 and Wayland alike.
+        // `observed_system_theme` is a relaxed atomic load; the blocking D-Bus
+        // subscription that feeds it runs on a watcher thread, never on this
+        // one, and that thread writes an eventfd `wait_for_events` parks on so
+        // the signal reaches this read without waiting for an unrelated event.
         if let Some(new_style) = super::system_style::adopt_observed_theme(&mut self.common) {
             let _ = self.process_window_events(0);
             // The desktop's own icons are theme artwork: KDE ships breeze and

--- a/dll/src/desktop/shell2/linux/x11/mod.rs
+++ b/dll/src/desktop/shell2/linux/x11/mod.rs
@@ -4476,6 +4476,22 @@ impl X11Window {
                 });
             }
 
+            // Desktop light/dark switch: the xdg-desktop-portal `SettingChanged`
+            // signal lands on the watcher thread, which stores the new scheme
+            // and writes this eventfd. Without it in the poll set the answer sat
+            // in the atomic until something ELSE woke the loop — and the branch
+            // below parks with an infinite timeout on an idle window, so on an
+            // app with no timer and no thread that was "never".
+            let theme_wake_idx = pollfds.len();
+            let theme_wake_fd = super::system_style::theme_wake_fd();
+            if theme_wake_fd >= 0 {
+                pollfds.push(libc::pollfd {
+                    fd: theme_wake_fd,
+                    events: libc::POLLIN,
+                    revents: 0,
+                });
+            }
+
             // Background threads (e.g. MapWidget tile fetches) have NO fd in the
             // poll set — their completion can't wake poll(). So while any thread
             // is in flight, poll on a ~16ms tick and drain thread writebacks on
@@ -4516,6 +4532,7 @@ impl X11Window {
             );
 
             let mut any_timer_fired = false;
+            let mut theme_woke = false;
             if result > 0 {
                 // Check X11 connection
                 if pollfds[0].revents & libc::POLLIN != 0 {
@@ -4576,6 +4593,18 @@ impl X11Window {
                     }
                 }
 
+                // The desktop's colour scheme moved. Acknowledge the wake and
+                // let `check_timers_and_threads` below do the adopting — it
+                // already owns that call, and routing through it keeps ONE
+                // theme path per backend instead of two.
+                if theme_wake_fd >= 0
+                    && theme_wake_idx < pollfds.len()
+                    && pollfds[theme_wake_idx].revents & libc::POLLIN != 0
+                {
+                    super::system_style::drain_theme_wake();
+                    theme_woke = true;
+                }
+
                 // Pace-timer wake: drain the expiration count and fall
                 // through - returning lets the main loop's render gate run,
                 // and the owed work is still flagged.
@@ -4605,7 +4634,7 @@ impl X11Window {
             // clamp above arranges.
             self.flush_trackpad_gesture_end_all();
 
-            if any_timer_fired || has_threads {
+            if any_timer_fired || has_threads || theme_woke {
                 self.check_timers_and_threads();
             }
         }
@@ -8121,9 +8150,11 @@ impl X11Window {
         // A runtime light/dark switch. The system style was read once at window
         // creation and never again, so toggling the desktop theme did nothing
         // until the app restarted. `observed_system_theme` is a relaxed atomic
-        // load — the D-Bus round trip that feeds it runs on a watcher thread,
-        // never here, because `query_xdg_portal` blocks with a two-second
-        // timeout and that would freeze the event loop.
+        // load — the D-Bus work that feeds it (the portal's `SettingChanged`
+        // subscription) lives on a watcher thread, never here, because it
+        // BLOCKS on the session bus and that would freeze the event loop. The
+        // watcher writes an eventfd that `wait_for_events` parks on, so this
+        // read runs in the same run-loop turn the signal arrived in.
         if let Some(new_style) = super::system_style::adopt_observed_theme(&mut self.common) {
             let _ = self.process_window_events(0);
             // The desktop's own icons are theme artwork: KDE ships breeze and

--- a/dll/src/desktop/shell2/macos/mod.rs
+++ b/dll/src/desktop/shell2/macos/mod.rs
@@ -968,6 +968,42 @@ mod view_handlers {
         }
         false
     }
+
+    /// AppKit announced that this view's effective appearance changed.
+    ///
+    /// `NSView::viewDidChangeEffectiveAppearance` is THE macOS notification for
+    /// a runtime light/dark switch, and it is what makes the switch instant
+    /// rather than polled: AppKit sends it to every view in the hierarchy the
+    /// moment the system (or the window's own `appearance` override) flips, on
+    /// the main thread, inside the same run-loop turn the user saw the menu bar
+    /// change in.
+    ///
+    /// The body is the same three steps every backend owes — re-read the system
+    /// style, pump the events the state change implies, then let
+    /// `PlatformWindow::adopt_system_style` choose between a full rebuild and a
+    /// restyle. `adopt_announced_theme` (not `adopt_observed_theme`) because
+    /// this is not a poll: the throttle that keeps the backstop cheap must not
+    /// swallow a switch AppKit has already told us about.
+    pub(super) fn effective_appearance_changed(window_ptr: Option<*mut std::ffi::c_void>) {
+        use crate::desktop::shell2::common::event::PlatformWindow;
+
+        let Some(window_ptr) = window_ptr else {
+            return;
+        };
+        unsafe {
+            let macos_window = &mut *(window_ptr as *mut MacOSWindow);
+            let Some(new_style) =
+                crate::desktop::shell2::macos::system_style::adopt_announced_theme(
+                    &mut macos_window.common,
+                )
+            else {
+                return;
+            };
+            let _ = macos_window.process_window_events(0);
+            macos_window.adopt_system_style(new_style);
+            macos_window.request_redraw();
+        }
+    }
 }
 
 // GLView - OpenGL rendering view
@@ -1115,6 +1151,18 @@ define_class!(
         #[unsafe(method(rightMouseDragged:))]
         fn right_mouse_dragged(&self, event: &NSEvent) {
             view_handlers::non_left_mouse_dragged(*self.ivars().window_ptr.borrow(), event);
+        }
+
+        /// A runtime light/dark switch, as AppKit reports it.
+        ///
+        /// This is the observation the macOS backend was missing: the system
+        /// style was read once at window creation, so toggling dark mode did
+        /// nothing until restart. The shared body lives in
+        /// `view_handlers::effective_appearance_changed` because both views
+        /// (GL and CPU) owe it identically.
+        #[unsafe(method(viewDidChangeEffectiveAppearance))]
+        fn view_did_change_effective_appearance(&self) {
+            view_handlers::effective_appearance_changed(*self.ivars().window_ptr.borrow());
         }
 
         #[unsafe(method(scrollWheel:))]
@@ -1365,12 +1413,17 @@ define_class!(
             if let Some(window_ptr) = *self.ivars().window_ptr.borrow() {
                 unsafe {
                     let macos_window = &mut *(window_ptr as *mut MacOSWindow);
-                    // A runtime light/dark switch. AppKit's `effectiveAppearance`
-                    // is MAIN-THREAD-ONLY, so unlike the Linux backends — where
-                    // the equivalent probe is a blocking D-Bus round trip pushed
-                    // onto a watcher thread — this one is polled right here. It
-                    // self-throttles to 500ms and returns false when the theme
-                    // already matches, so it costs nothing on an ordinary frame.
+                    // The BACKSTOP for a system-appearance change. The switch
+                    // itself arrives instantly through the view's
+                    // `viewDidChangeEffectiveAppearance` override; this poll
+                    // stays for the facets that fire no view callback at all —
+                    // the accent/highlight colour, the UI font, "reduce
+                    // transparency" — which `discover()` reads too. AppKit's
+                    // `effectiveAppearance` is MAIN-THREAD-ONLY, so unlike the
+                    // Linux backends (whose probe is a blocking D-Bus round trip
+                    // on a watcher thread) it is read right here. It
+                    // self-throttles and returns None when nothing moved, so it
+                    // costs nothing on an ordinary frame.
                     let new_style =
                         crate::desktop::shell2::macos::system_style::adopt_observed_theme(
                             &mut macos_window.common,
@@ -1992,6 +2045,18 @@ define_class!(
             view_handlers::non_left_mouse_dragged(*self.ivars().window_ptr.borrow(), event);
         }
 
+        /// A runtime light/dark switch, as AppKit reports it.
+        ///
+        /// This is the observation the macOS backend was missing: the system
+        /// style was read once at window creation, so toggling dark mode did
+        /// nothing until restart. The shared body lives in
+        /// `view_handlers::effective_appearance_changed` because both views
+        /// (GL and CPU) owe it identically.
+        #[unsafe(method(viewDidChangeEffectiveAppearance))]
+        fn view_did_change_effective_appearance(&self) {
+            view_handlers::effective_appearance_changed(*self.ivars().window_ptr.borrow());
+        }
+
         #[unsafe(method(scrollWheel:))]
         fn scroll_wheel(&self, event: &NSEvent) {
             view_handlers::scroll_wheel(*self.ivars().window_ptr.borrow(), event);
@@ -2205,12 +2270,17 @@ define_class!(
             if let Some(window_ptr) = *self.ivars().window_ptr.borrow() {
                 unsafe {
                     let macos_window = &mut *(window_ptr as *mut MacOSWindow);
-                    // A runtime light/dark switch. AppKit's `effectiveAppearance`
-                    // is MAIN-THREAD-ONLY, so unlike the Linux backends — where
-                    // the equivalent probe is a blocking D-Bus round trip pushed
-                    // onto a watcher thread — this one is polled right here. It
-                    // self-throttles to 500ms and returns false when the theme
-                    // already matches, so it costs nothing on an ordinary frame.
+                    // The BACKSTOP for a system-appearance change. The switch
+                    // itself arrives instantly through the view's
+                    // `viewDidChangeEffectiveAppearance` override; this poll
+                    // stays for the facets that fire no view callback at all —
+                    // the accent/highlight colour, the UI font, "reduce
+                    // transparency" — which `discover()` reads too. AppKit's
+                    // `effectiveAppearance` is MAIN-THREAD-ONLY, so unlike the
+                    // Linux backends (whose probe is a blocking D-Bus round trip
+                    // on a watcher thread) it is read right here. It
+                    // self-throttles and returns None when nothing moved, so it
+                    // costs nothing on an ordinary frame.
                     let new_style =
                         crate::desktop::shell2::macos::system_style::adopt_observed_theme(
                             &mut macos_window.common,

--- a/dll/src/desktop/shell2/macos/system_style.rs
+++ b/dll/src/desktop/shell2/macos/system_style.rs
@@ -782,9 +782,21 @@ fn probe_with(lib: &ObjcLib) -> Option<Theme> {
     }
 }
 
-/// How often the appearance is re-read. The probe is cheap but not free, and a
-/// theme switch is a human action — half a second is imperceptible.
-const APPEARANCE_POLL_INTERVAL: core::time::Duration = core::time::Duration::from_millis(500);
+/// How often the BACKSTOP re-reads the appearance.
+///
+/// The primary path is not this poll: AppKit announces an appearance change to
+/// every view through `viewDidChangeEffectiveAppearance`, and the backend's
+/// override of it (`macos/mod.rs`) adopts the new style the instant the switch
+/// happens, with no latency at all.
+///
+/// The poll stays because that notification is about the APPEARANCE only.
+/// `discover()` also reads the accent/highlight colour, the UI font and the
+/// "reduce transparency"/"increase contrast" accessibility switches, and none of
+/// those change the view's effective appearance — flipping the accent from blue
+/// to pink fires no view callback whatsoever. Two seconds is imperceptible for a
+/// human-driven settings change and the probe is one `objc_msgSend` pair on a
+/// handle that is already open.
+const APPEARANCE_POLL_INTERVAL: core::time::Duration = core::time::Duration::from_secs(2);
 
 std::thread_local! {
     /// Last time this thread probed. A thread-local rather than a field on the
@@ -808,8 +820,6 @@ std::thread_local! {
 pub(crate) fn adopt_observed_theme(
     common: &mut crate::desktop::shell2::common::event::CommonWindowState,
 ) -> Option<alloc::sync::Arc<SystemStyle>> {
-    use azul_core::window::WindowTheme;
-
     let now = std::time::Instant::now();
     let due = LAST_APPEARANCE_POLL.with(|c| match c.get() {
         Some(last) if now.duration_since(last) < APPEARANCE_POLL_INTERVAL => false,
@@ -821,6 +831,33 @@ pub(crate) fn adopt_observed_theme(
     if !due {
         return None;
     }
+
+    adopt_probed_theme(common)
+}
+
+/// Adopt the appearance AppKit just announced, skipping the poll throttle.
+///
+/// The counterpart of [`adopt_observed_theme`] for the EVENT-driven path:
+/// `NSView`'s `viewDidChangeEffectiveAppearance` is AppKit telling us the
+/// appearance already changed, so re-reading it is not a poll and must not be
+/// rate-limited — a switch landing 100 ms after the last backstop probe would
+/// otherwise be deferred by up to a full interval, which is precisely the
+/// latency the notification exists to remove.
+///
+/// The backstop's clock is advanced as a side effect: the appearance has just
+/// been read, so the next poll has nothing to add for another interval.
+pub(crate) fn adopt_announced_theme(
+    common: &mut crate::desktop::shell2::common::event::CommonWindowState,
+) -> Option<alloc::sync::Arc<SystemStyle>> {
+    LAST_APPEARANCE_POLL.with(|c| c.set(Some(std::time::Instant::now())));
+    adopt_probed_theme(common)
+}
+
+/// The probe-and-adopt body both entry points share.
+fn adopt_probed_theme(
+    common: &mut crate::desktop::shell2::common::event::CommonWindowState,
+) -> Option<alloc::sync::Arc<SystemStyle>> {
+    use azul_core::window::WindowTheme;
 
     let theme = probe_effective_appearance()?;
     let theme = match theme {

--- a/dll/src/desktop/shell2/windows/mod.rs
+++ b/dll/src/desktop/shell2/windows/mod.rs
@@ -3896,6 +3896,67 @@ fn pump_modal_loop_work() {
     MODAL_PUMP_ACTIVE.with(|active| active.set(false));
 }
 
+/// Whether a `WM_SETTINGCHANGE` could have changed what `discover_system_style`
+/// would return.
+///
+/// The message is a BROADCAST to every top-level window in the session and most
+/// of what it carries has nothing to do with how this app looks: an installer
+/// editing `PATH` ("Environment"), a policy refresh ("Policy"), a locale change
+/// ("intl"), a device arriving ("Devices"). Re-discovering for those costs six
+/// `reg query` subprocesses on the UI thread, each with a two-second timeout.
+///
+/// Either of two things says "appearance", and both tests are needed because
+/// they cover disjoint senders:
+///
+///   * `lParam` naming one of the documented theme sections. "ImmersiveColorSet"
+///     is THE dark-mode / accent-colour notification — it is what Windows sends
+///     when the user flips Settings > Personalisation > Colours, and it arrives
+///     with `wParam` 0, so the wParam test below would never catch it.
+///   * a non-zero `wParam`, which means the message came from
+///     `SystemParametersInfo` and names an `SPI_*` action. Every metric
+///     `discover()` reads — non-client fonts, caret width and blink, wheel
+///     scroll lines, hover time, double-click time and distance, high contrast,
+///     client-area animation — changes through one of those, and enumerating
+///     them individually would be a list to keep in sync with a discovery
+///     function that reads more of them over time. The noisy broadcasts above
+///     all carry `wParam` 0, so the coarse test is enough to exclude them.
+///
+/// A NULL `lParam` with `wParam` 0 is accepted: some senders pass neither, and
+/// paying a discovery for an ambiguous message is the safe side of this filter
+/// — the failure mode of being too strict is silently keeping the old theme,
+/// which is the entire bug being fixed.
+unsafe fn settingchange_touches_appearance(
+    wparam: dlopen::WPARAM,
+    lparam: dlopen::LPARAM,
+) -> bool {
+    if wparam != 0 {
+        return true;
+    }
+    if lparam == 0 {
+        return true;
+    }
+    // `lParam` is a NUL-terminated UTF-16 string. Bounded so a non-string
+    // lParam (a caller that passed a raw value with wParam 0) cannot walk off
+    // into unmapped memory looking for a terminator that is not there.
+    const MAX_SECTION_LEN: usize = 64;
+    let mut section = [0u16; MAX_SECTION_LEN];
+    let ptr = lparam as *const u16;
+    let mut len = 0usize;
+    while len < MAX_SECTION_LEN {
+        let ch = *ptr.add(len);
+        if ch == 0 {
+            break;
+        }
+        section[len] = ch;
+        len += 1;
+    }
+    let name = String::from_utf16_lossy(&section[..len]);
+    matches!(
+        name.as_str(),
+        "ImmersiveColorSet" | "WindowsThemeElement" | "WindowMetrics"
+    )
+}
+
 unsafe extern "system" fn window_proc(
     hwnd: HWND,
     msg: u32,
@@ -6667,6 +6728,22 @@ unsafe extern "system" fn window_proc(
             // the startup theme until restart. Re-discover the system style,
             // update the window theme through the diff pipeline (ThemeChange
             // events fire) and rebuild.
+            //
+            // But only when the message is plausibly ABOUT appearance.
+            // WM_SETTINGCHANGE is a broadcast to every top-level window, sent
+            // for environment-variable edits, policy refreshes, locale and
+            // device changes — none of which this window cares about — and
+            // `discover_system_style()` on Windows is not cheap: it spawns
+            // `reg query` (dark mode, accent) plus several more subprocesses,
+            // each with a two-second timeout, SYNCHRONOUSLY inside this
+            // wndproc. An `setx` from a background installer would have frozen
+            // the UI for the duration. The equality check inside
+            // `adopt_system_style` makes an unnecessary re-discovery free of
+            // RELAYOUT, but not free of the discovery itself, which is the
+            // expensive half.
+            if msg == WM_SETTINGCHANGE && !settingchange_touches_appearance(wparam, lparam) {
+                return 0;
+            }
             window.snapshot_window_state_baseline("windows.wm_settingchange");
             let new_style = std::sync::Arc::new(crate::desktop::app::discover_system_style());
             let new_theme = match new_style.theme {

--- a/dll/tests/backend_feature_parity.rs
+++ b/dll/tests/backend_feature_parity.rs
@@ -83,40 +83,52 @@ fn every_backend_dispatches_accessibility_actions() {
 
 /// A system theme switch must reach the window at runtime.
 ///
-/// The system style is captured ONCE, when the window is created. Windows is the
-/// only backend that ever re-reads it: its `WM_SETTINGCHANGE | WM_THEMECHANGED`
-/// arm calls `discover_system_style()` again, updates
-/// `current_window_state.theme` and requests a regeneration. Nowhere else in
-/// `shell2/` calls `discover_system_style` except each backend's constructor.
+/// The system style is captured when the window is created. A backend that
+/// never re-reads it leaves a user toggling dark mode looking at the startup
+/// theme until the app restarts: the DOM keeps it, and `prefers-color-scheme`
+/// styling never re-evaluates. `EventType::ThemeChange` and
+/// `WindowEventFilter::ThemeChanged` are fully wired in azul-core, so all a
+/// backend owes is the observation and a regeneration tagged
+/// [`RelayoutReason::ThemeChange`].
 ///
-/// So on macOS, X11, Wayland, iOS and Android, toggling the OS between light and
-/// dark mode does NOTHING until the app is restarted — the DOM keeps whatever
-/// theme it started with, and `prefers-color-scheme` styling never re-evaluates.
-/// The `EventType::ThemeChange` event and the `WindowEventFilter::ThemeChanged`
-/// filter both exist and are fully wired in azul-core; there is simply no
-/// platform code to fire them.
+/// Each platform's notification, and none of them are the same API:
+///   * Windows — `WM_SETTINGCHANGE | WM_THEMECHANGED`;
+///   * macOS   — `NSView::viewDidChangeEffectiveAppearance`, with a slow poll
+///     of `NSApp.effectiveAppearance` behind it for the facets (accent colour,
+///     UI font) that fire no view callback;
+///   * X11 and Wayland — `org.freedesktop.portal.Settings.SettingChanged` for
+///     `org.freedesktop.appearance`/`color-scheme`. There is no Wayland
+///     protocol and no XSETTINGS key for it; the portal is the mechanism on
+///     both, so one watcher thread serves both backends and wakes their
+///     `poll(2)` through an eventfd;
+///   * iOS     — `UITraitCollection.userInterfaceStyle`;
+///   * Android — `onConfigurationChanged` with `UI_MODE_NIGHT_MASK`, latched
+///     for the loop thread to drain;
+///   * headless — no system theme to observe, so the injection IS the ingress
+///     (`HeadlessWindow::set_system_theme`). It is the backend the E2E corpus
+///     runs on, so without it no scenario could cover theme-dependent layout.
 ///
-/// Each platform has the notification available and it is not the same API on
-/// any two of them:
-///   * macOS  — KVO on `NSApp.effectiveAppearance`, or
-///     `viewDidChangeEffectiveAppearance` on the view;
-///   * X11    — the XSETTINGS `Net/ThemeName` property, or the
-///     `org.freedesktop.portal.Settings` `SettingChanged` signal;
-///   * Wayland — `org.freedesktop.portal.Settings`, `color-scheme` (there is no
-///     Wayland protocol for it; the portal is the mechanism);
-///   * iOS    — `traitCollectionDidChange` / `UIUserInterfaceStyle`;
-///   * Android — `onConfigurationChanged` with `UI_MODE_NIGHT_MASK`.
+/// SCAN KEY, and why it changed. The original check was `mod.rs` contains
+/// `RelayoutReason::ThemeChange`, chosen because requesting a regeneration
+/// under that reason is the thing only a real runtime handler does — a
+/// constructor calling `discover_system_style()` does not. That stopped being
+/// true when the theme-switch POLICY moved into
+/// `PlatformWindow::adopt_system_style`: choosing between a full rebuild and a
+/// restyle needs both ends of the transition and every backend was making that
+/// choice identically, so the four desktop backends now hand the new style to
+/// the shared helper and the literal lives only there. The scan went red on
+/// windows/macos/x11/wayland — the four that had REAL handlers — while the
+/// three that inline it stayed green, i.e. it had inverted.
 ///
-/// headless has no system theme to observe, but it is the backend the E2E corpus
-/// runs on, so it needs a way to be TOLD the theme changed or no scenario can
-/// ever cover theme-dependent layout.
-///
-/// Keyed on `RelayoutReason::ThemeChange` rather than on `discover_system_style`,
-/// because the latter cannot tell the two cases apart: headless calls it in its
-/// CONSTRUCTOR and Windows calls it only in its runtime handler, so both contain
-/// the string exactly once while meaning opposite things. A backend that
-/// genuinely handles a runtime theme switch has to request a regeneration for
-/// it, and the reason is what says so.
+/// So the key is now "requests a ThemeChange regeneration, directly or through
+/// the one shared helper that does", and the helper is checked separately for
+/// still doing it. That is not a widening: `adopt_system_style` has exactly one
+/// behaviour, and a helper that stopped tagging `ThemeChange` would now fail
+/// here where before it would have gone unnoticed at every one of its callers.
+/// The observation itself — the half a `RelayoutReason` cannot speak for — is
+/// pinned by `every_backend_names_the_os_notification_it_observes` below, and
+/// the behaviour by `headless_lifecycle`'s
+/// `a_theme_switch_changes_the_theme_and_requests_a_frame`.
 ///
 /// Making this pass by shortening the backend list would restore exactly the
 /// silence it exists to break.
@@ -125,12 +137,101 @@ fn every_backend_reacts_to_a_runtime_theme_change() {
     let missing: Vec<&str> = FRAME_DRIVING_BACKENDS
         .iter()
         .copied()
-        .filter(|b| !backend_src(b).contains("RelayoutReason::ThemeChange"))
+        .filter(|b| {
+            let src = backend_src(b);
+            !src.contains("RelayoutReason::ThemeChange") && !src.contains("adopt_system_style(")
+        })
         .collect();
 
     assert!(
         missing.is_empty(),
         "these backends never request a regeneration tagged ThemeChange, so a user toggling \
          dark mode sees no change until restart: {missing:?}",
+    );
+
+    // The other half of the key above: routing through the shared helper is
+    // only as good as what the helper does. If this ever fails, every backend
+    // in the list that delegates has silently stopped tagging its rebuild.
+    let policy = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("src/desktop/shell2/common/event.rs");
+    let policy_src = std::fs::read_to_string(&policy)
+        .unwrap_or_else(|e| panic!("read {}: {e}", policy.display()));
+    let adopt = policy_src
+        .split_once("fn adopt_system_style(")
+        .map(|(_, rest)| rest)
+        .unwrap_or_else(|| {
+            panic!(
+                "PlatformWindow::adopt_system_style is gone from {}; the backends that delegate \
+                 to it are no longer covered by the scan above",
+                policy.display()
+            )
+        });
+    // Bounded to the helper's own body — the next `fn` at the same nesting
+    // starts the following method.
+    let body = adopt.split("\n    fn ").next().unwrap_or(adopt);
+    assert!(
+        body.contains("RelayoutReason::ThemeChange"),
+        "PlatformWindow::adopt_system_style no longer requests a ThemeChange regeneration, so \
+         every backend that delegates its theme switch to it now rebuilds under some other \
+         reason (or not at all) — and LayoutCallbackInfo::relayout_reason() stops telling \
+         callbacks to re-read system colours",
+    );
+}
+
+/// Reacting is not observing: each backend must NAME its OS notification.
+///
+/// `adopt_system_style` is reachable from anywhere, a constructor included, so
+/// the scan above cannot tell a backend that HEARS the OS from one that merely
+/// owns the machinery to respond if it ever did. This table is the missing
+/// half: each backend is pinned to the specific symbol that carries the
+/// platform's own announcement into it. They are deliberately all different —
+/// there is no cross-platform notification for this, which is the entire reason
+/// six backends went without one for so long.
+///
+/// If a rename makes this fail, update the string to the new name. If a DELETE
+/// makes it fail, the backend has lost its ability to hear a theme switch and
+/// the string is not the thing to change.
+const THEME_OBSERVATION: &[(&str, &str)] = &[
+    // The window message Windows broadcasts for an appearance change.
+    ("windows/mod.rs", "WM_SETTINGCHANGE"),
+    // AppKit's per-view announcement; the backstop poll sits behind it.
+    ("macos/mod.rs", "viewDidChangeEffectiveAppearance"),
+    // Both Linux backends read the portal watcher's answer through this.
+    ("linux/x11/mod.rs", "adopt_observed_theme"),
+    ("linux/wayland/mod.rs", "adopt_observed_theme"),
+    // UIKit's trait collection, polled on the main-thread tick.
+    ("ios/mod.rs", "adopt_device_appearance"),
+    // Latched by the Java UI thread's onConfigurationChanged, drained here.
+    ("android/mod.rs", "drain_pending_theme"),
+    // No OS to hear: the injection is the ingress.
+    ("headless/mod.rs", "set_system_theme"),
+];
+
+#[test]
+fn every_backend_names_the_os_notification_it_observes() {
+    // Every frame-driving backend must appear, or a backend could be added
+    // with no observation at all and this test would say nothing about it.
+    let untabled: Vec<&str> = FRAME_DRIVING_BACKENDS
+        .iter()
+        .copied()
+        .filter(|b| !THEME_OBSERVATION.iter().any(|(name, _)| name == b))
+        .collect();
+    assert!(
+        untabled.is_empty(),
+        "these frame-driving backends have no entry in THEME_OBSERVATION, so nothing checks \
+         that they can hear a theme switch at all: {untabled:?}",
+    );
+
+    let missing: Vec<(&str, &str)> = THEME_OBSERVATION
+        .iter()
+        .copied()
+        .filter(|(backend, symbol)| !backend_src(backend).contains(symbol))
+        .collect();
+
+    assert!(
+        missing.is_empty(),
+        "these backends no longer name the OS notification that tells them the theme changed, \
+         so they can still ADOPT a new system style but nothing will ever hand them one: \
+         {missing:?}",
     );
 }


### PR DESCRIPTION
## What this is

The framework now responds to a runtime OS theme change on every backend, and
`every_backend_reacts_to_a_runtime_theme_change` is green because the feature is
there — not because the test was narrowed.

## The finding that shaped the work

Most of the engine and backend side already existed (`ad0b4d081`,
`PlatformWindow::adopt_system_style`, `LayoutWindow::set_system_style`,
`system_style_change_needs_full_regeneration`). What did NOT exist was an actual
OS **notification** on three of the four desktop backends: macOS polled
`NSApp.effectiveAppearance` every 500 ms, and Linux opened a fresh D-Bus
connection every 2 s to ask the portal. This PR replaces both polls with the
platform's own announcement, and fixes a Windows arm that did the work for
messages that were not about appearance at all.

## Per backend

**macOS** — both view classes now override
`NSView::viewDidChangeEffectiveAppearance`, AppKit's per-view announcement, and
route to one shared body in `view_handlers`. The 500 ms poll survives, demoted to
a 2 s backstop, because `discover()` also reads the accent colour, the UI font
and "reduce transparency" — none of which change a view's effective appearance,
so none of which fire a view callback. `adopt_announced_theme` is a second entry
point beside `adopt_observed_theme` so the notification is not delayed by the
backstop's throttle.

**X11 + Wayland** — the watcher thread now subscribes to
`org.freedesktop.portal.Settings.SettingChanged` (`AddMatch` + a framing message
reader) instead of re-polling `Settings.Read`. `Read` still runs once per
connection (a signal reports a transition, so the current value has to be asked
for) and once per 30 s idle interval as a backstop for a portal that answers
`Read` but never emits the signal. There is no Wayland protocol and no XSETTINGS
key for the colour scheme, so the portal is the mechanism on both backends and
one watcher serves them both.

The second half is delivery. `OBSERVED_COLOR_SCHEME` is read from
`check_timers_and_threads`, which both loops call only when a timerfd fired or a
thread is live — otherwise they park in `poll(2)` with an infinite timeout. On an
idle window the read never ran, so the new scheme sat in the atomic until the
user happened to move the mouse. The watcher now writes an eventfd that is in
both poll sets, so the signal wakes the loop and the adopt happens in the same
turn.

**Windows** — already had the observation; what it did not have was a filter.
`WM_SETTINGCHANGE` is broadcast to every top-level window for environment,
policy, locale and device changes, and each one re-ran `discover_system_style()`
— which on Windows spawns six `reg query`-class subprocesses with two-second
timeouts, synchronously inside the wndproc. Now filtered to `lParam`
"ImmersiveColorSet" / "WindowsThemeElement" / "WindowMetrics" or a non-zero
`wParam` (a `SystemParametersInfo` action). `WM_THEMECHANGED` stays unfiltered.

**iOS, Android, headless** — unchanged; all three already observe
(`UITraitCollection.userInterfaceStyle`, `onConfigurationChanged` latched for the
loop thread, and `HeadlessWindow::set_system_theme` as the injection ingress).

## The test

`every_backend_reacts_to_a_runtime_theme_change` had inverted: it scans each
`mod.rs` for `RelayoutReason::ThemeChange`, and since the switch policy moved
into the shared `PlatformWindow::adopt_system_style`, the literal lives only
there. It failed on exactly the four backends with real handlers and passed on
the three that inline the call.

The key is now "requests a ThemeChange regeneration, directly or through the one
shared helper that does", with a separate assertion that the helper still does
it — so a helper that quietly stopped tagging would fail here, where before it
would have gone unnoticed at all four callers.

`every_backend_names_the_os_notification_it_observes` is new and covers the half
a `RelayoutReason` cannot: `adopt_system_style` is reachable from a constructor,
so the scan cannot tell a backend that HEARS the OS from one that merely owns the
machinery. It pins each backend to the symbol carrying its platform's
announcement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018R3yhfRdgMASn2sbdrsMBy
