### PR TITLE
Linux/X11: the desktop's own settings, its icons, and a title bar that can actually be dragged

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -986,6 +986,20 @@ jobs:
                  target/${{ matrix.target }}/prod-release/azul*.lib
           bash scripts/strip_staticlib.sh --optional "$@"
 
+      # The sizes were already printed in half a dozen places and nothing ever
+      # failed on them, so a size regression could only be caught by someone
+      # downloading a release. Budgets live in scripts/artifact_size_budgets.txt;
+      # raising one is a deliberate, reviewable commit.
+      - name: Artifact size gate
+        if: steps.cache-valid.outputs.skip != 'true' && (success() || matrix.experimental)
+        shell: bash
+        run: |
+          shopt -s nullglob
+          bash scripts/check_artifact_size.sh --target ${{ matrix.target }} \
+            target/${{ matrix.target }}/prod-release/*azul*.${{ matrix.artifact_ext }} \
+            target/${{ matrix.target }}/prod-release/*azul*.a \
+            target/${{ matrix.target }}/prod-release/azul*.lib
+
       - name: Upload Artifacts
         if: ${{ success() || matrix.experimental }}
         uses: actions/upload-artifact@v7
@@ -2297,6 +2311,19 @@ jobs:
           ls -la target/prod-release/ 2>/dev/null | head -30 || echo "Not found"
           echo "=== target/codegen ==="
           ls -la target/codegen/ 2>/dev/null | head -20 || echo "Not found"
+
+      # Same gate as the cross-compile matrix, on the host-built artifacts.
+      # Budgets: scripts/artifact_size_budgets.txt.
+      - name: Artifact size gate
+        shell: bash
+        run: |
+          shopt -s nullglob
+          bash scripts/check_artifact_size.sh \
+            target/prod-release/libazul.so target/prod-release/libazuldbg.so \
+            target/prod-release/azul.so target/prod-release/libazul.a \
+            target/prod-release/libazul.dylib target/prod-release/libazuldbg.dylib \
+            target/prod-release/azul.dll target/prod-release/azuldbg.dll \
+            target/prod-release/azul.lib target/prod-release/azul.pyd
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v7

--- a/dll/src/desktop/shell2/android/mod.rs
+++ b/dll/src/desktop/shell2/android/mod.rs
@@ -528,6 +528,10 @@ impl PlatformWindow for AndroidWindow {
     /// "requested on API 26+", the closest this backend can answer
     /// synchronously, corrected by the framework's answer within a frame. A
     /// release always leaves no lock held.
+    /// Mobile windows are managed by the system shell and are never dragged
+    /// by the application.
+    fn handle_begin_interactive_move(&mut self) {}
+
     fn handle_set_pointer_lock(&mut self, locked: bool) -> bool {
         let dispatched = set_pointer_capture(locked);
         locked && dispatched

--- a/dll/src/desktop/shell2/common/event.rs
+++ b/dll/src/desktop/shell2/common/event.rs
@@ -4196,10 +4196,36 @@ pub trait PlatformWindow {
     /// compositor manage the window move. This is the only way to move windows on Wayland.
     /// On other platforms: no-op (use `set_window_position` via `ModifyWindowState` instead).
     ///
-    /// Default implementation does nothing (appropriate for macOS, Win32, X11).
-    fn handle_begin_interactive_move(&mut self) {
-        // No-op on non-Wayland platforms
+    /// Hand a title-bar drag to the window manager AND close the gesture
+    /// session that started it.
+    ///
+    /// Both halves are mandatory. The WM takes its own pointer grab, so the
+    /// `ButtonRelease` that ends the drag goes to IT and never comes back
+    /// here - the session opened by the press would stay open forever, and
+    /// the next press on the bar was folded into that stale session instead
+    /// of starting a new gesture. Dragging then worked only every OTHER
+    /// attempt (measured on Mint XFCE at a fixed x: y=4 dragged, y=10 dead,
+    /// y=14 dragged, y=18 dead, ...), which reads to a user as "only some
+    /// parts of the title bar are draggable". The backends already clear the
+    /// button flags at the hand-off for exactly this reason; the session is
+    /// the piece they missed.
+    fn hand_drag_to_window_manager(&mut self) {
+        if let Some(lw) = self.get_layout_window_mut() {
+            lw.gesture_drag_manager.end_current_session();
+        }
+        self.handle_begin_interactive_move();
     }
+
+    /// REQUIRED, deliberately: this had a `{}` default and it silently ate
+    /// two backends. X11 and Win32 both WROTE the method - `x11/mod.rs` and
+    /// `windows/mod.rs` each have a full `_NET_WM_MOVERESIZE` /
+    /// `WM_NCLBUTTONDOWN` implementation - but put it in their INHERENT
+    /// `impl` block instead of their `impl PlatformWindow`, so the call in
+    /// `dispatch_events_propagated` resolved to this default, dragging a
+    /// window by its client-drawn titlebar did nothing on both, and the dead
+    /// code sat there looking correct. With no default, a backend that
+    /// forgets does not compile.
+    fn handle_begin_interactive_move(&mut self);
 
     /// Drop the pointer lock because the window lost focus.
     ///
@@ -6133,7 +6159,7 @@ pub trait PlatformWindow {
 
             // === Window Move ===
             CallbackChange::BeginInteractiveMove => {
-                self.handle_begin_interactive_move();
+                self.hand_drag_to_window_manager();
                 ProcessEventResult::DoNothing
             }
 
@@ -8182,7 +8208,7 @@ pub trait PlatformWindow {
                         continue;
                     }
                 }
-                self.handle_begin_interactive_move();
+                self.hand_drag_to_window_manager();
             } else {
                 // Double-click on a drag region toggles the frame, the way
                 // double-clicking a native title bar does.
@@ -8192,8 +8218,16 @@ pub trait PlatformWindow {
                 } else {
                     azul_core::window::WindowFrame::Maximized
                 };
+                // `flags` is an OS-SYNCED field (see `os_synced_fields`), so
+                // this has to go through `update_window_state`, which advances
+                // the baseline and lets `sync_window_state` actually send the
+                // `_NET_WM_STATE` request. The old call was
+                // `update_unsynced_state`, whose own assert forbids exactly
+                // this write - so a debug build (or any run with AZ_VALIDATE)
+                // PANICKED on a titlebar double-click, and release builds
+                // changed the belief without telling the window manager.
                 self.get_common_mut()
-                    .update_unsynced_state(|ws| ws.flags.frame = next);
+                    .update_window_state(WindowStateSource::App, |ws| ws.flags.frame = next);
             }
         }
 

--- a/dll/src/desktop/shell2/headless/mod.rs
+++ b/dll/src/desktop/shell2/headless/mod.rs
@@ -2938,6 +2938,9 @@ impl HeadlessWindow {
 // === PlatformWindow Trait Implementation ===
 
 impl PlatformWindow for HeadlessWindow {
+    /// Headless has no window manager to hand a drag to.
+    fn handle_begin_interactive_move(&mut self) {}
+
     fn regenerate_layout_once(
         &mut self,
     ) -> Result<crate::desktop::shell2::common::layout::LayoutRegenerateResult, String> {

--- a/dll/src/desktop/shell2/ios/mod.rs
+++ b/dll/src/desktop/shell2/ios/mod.rs
@@ -1926,6 +1926,10 @@ impl IOSWindow {
 }
 
 impl PlatformWindow for IOSWindow {
+    /// Mobile windows are managed by the system shell and are never dragged
+    /// by the application.
+    fn handle_begin_interactive_move(&mut self) {}
+
     fn regenerate_layout_once(
         &mut self,
     ) -> Result<crate::desktop::shell2::common::layout::LayoutRegenerateResult, String> {

--- a/dll/src/desktop/shell2/linux/system_icons.rs
+++ b/dll/src/desktop/shell2/linux/system_icons.rs
@@ -76,13 +76,28 @@ fn icon_theme_dirs(theme: &str) -> Vec<(String, u32)> {
     ] {
         // The sizes a UI indicator is drawn at. 16 first: these are pixel-hinted
         // designs, and the 16px variant is the one drawn beside 10-11pt text.
+        //
+        // BOTH directory orders, and the symbolic/scalable trees, because real
+        // themes disagree and we only read SVG. Breeze puts SVGs in
+        // `actions/16`; Mint-Y's `actions/{16,22,24}` are PNG-ONLY and its
+        // only SVGs are in `actions/symbolic`; Adwaita inverts the nesting
+        // entirely (`symbolic/actions`, `scalable/actions`, `16x16/actions`).
+        // Looking only in `{theme}/actions/{16,22,24,scalable}` found nothing
+        // at all in a Mint session, so every system icon silently fell back to
+        // the app's built-ins - at a different nominal size, which is what
+        // "the icons are scaled 2x" looks like.
         for (size, nominal) in [
             ("16", 16),
+            ("16x16", 16),
             ("22", 22),
+            ("22x22", 22),
             ("24", 24),
+            ("24x24", 24),
+            ("symbolic", SCALABLE_NOMINAL_PX),
             ("scalable", SCALABLE_NOMINAL_PX),
         ] {
             out.push((alloc::format!("{root}/{theme}/actions/{size}"), nominal));
+            out.push((alloc::format!("{root}/{theme}/{size}/actions"), nominal));
         }
     }
     out
@@ -96,25 +111,108 @@ fn icon_theme_dirs(theme: &str) -> Vec<(String, u32)> {
 /// than that for crispness, so the nominal size has to travel with it or the
 /// icon lays out at its oversampled bitmap size (see
 /// `azul_layout::icon::register_image_icon_sized`).
+/// What OTHER desktops call the same indicator.
+///
+/// [`WANTED`] uses the freedesktop/Breeze spellings, and GNOME-lineage themes
+/// - which is what a Mint, Ubuntu or Fedora desktop actually ships - name half
+/// of them differently. On Mint 22.2 that cost 7 of 17 icons: `arrow-up` does
+/// not exist anywhere in the Mint-Y -> Adwaita chain, `go-up` does; `checkmark`
+/// does not, `object-select` does; `application-menu` does not, `open-menu`
+/// does. Each list is tried in order after the canonical name.
+fn icon_name_aliases(name: &str) -> &'static [&'static str] {
+    match name {
+        "arrow-up" => &["go-up", "pan-up"],
+        "arrow-down" => &["go-down", "pan-down"],
+        "arrow-left" => &["go-previous", "pan-start", "pan-left"],
+        "arrow-right" => &["go-next", "pan-end", "pan-right"],
+        "checkmark" => &["object-select", "emblem-ok", "checkbox-checked"],
+        "dialog-ok" => &["emblem-ok", "object-select", "gtk-ok"],
+        "dialog-close" => &["window-close", "gtk-close"],
+        "application-menu" => &["open-menu", "view-more", "gtk-menu"],
+        "edit-find" => &["system-search"],
+        "window-restore" => &["view-restore"],
+        _ => &[],
+    }
+}
+
 fn read_icon_svg(theme: &str, name: &str) -> Option<(Vec<u8>, u32)> {
-    for (dir, nominal) in icon_theme_dirs(theme) {
-        let path = alloc::format!("{dir}/{name}.svg");
-        if let Ok(bytes) = std::fs::read(&path) {
-            return Some((bytes, nominal));
+    // The WHOLE inheritance chain, not one level. Mint-Y-Sand inherits
+    // `Mint-Y,Adwaita,gnome,hicolor` and ships no `actions` icons of its own,
+    // so stopping at the first parent stopped exactly one theme short of the
+    // one that has the file. Bounded and visited-checked: `Inherits=` is
+    // user-editable and can be cyclic.
+    // EVERY name on the `Inherits=` line, breadth-first - not just the first.
+    // Mint-Y-Sand inherits `Mint-Y,Adwaita,gnome,hicolor`, and the icons its
+    // own tree lacks are in Adwaita, the SECOND entry: following only the
+    // first left 7 of 17 indicators unresolved.
+    let mut chain = alloc::vec![theme.to_string()];
+    let mut seen = alloc::vec![theme.to_ascii_lowercase()];
+    let mut cursor = 0usize;
+    while cursor < chain.len() && chain.len() < 16 {
+        let step = chain[cursor].clone();
+        cursor += 1;
+        for parent in icon_theme_parents(&step) {
+            let key = parent.to_ascii_lowercase();
+            if seen.contains(&key) {
+                continue;
+            }
+            seen.push(key);
+            chain.push(parent);
         }
     }
-    // One level of inheritance, read straight out of index.theme.
-    let parent = icon_theme_parent(theme)?;
-    for (dir, nominal) in icon_theme_dirs(&parent) {
-        let path = alloc::format!("{dir}/{name}.svg");
-        if let Ok(bytes) = std::fs::read(&path) {
-            return Some((bytes, nominal));
+
+    // The canonical name first, everywhere, before any alias: a theme that
+    // ships `checkmark` must win over one further down the chain that only
+    // has `object-select`.
+    for candidate in core::iter::once(name).chain(icon_name_aliases(name).iter().copied()) {
+        for step in &chain {
+            for (dir, nominal) in icon_theme_dirs(step) {
+                // `foo-symbolic.svg` is how the symbolic trees spell `foo`, and
+                // a symbolic icon is the one meant for exactly this job: a
+                // small, single-colour UI indicator that takes the desktop's
+                // foreground.
+                for file in [
+                    alloc::format!("{dir}/{candidate}.svg"),
+                    alloc::format!("{dir}/{candidate}-symbolic.svg"),
+                ] {
+                    if let Ok(bytes) = std::fs::read(&file) {
+                        return Some((bytes, nominal));
+                    }
+                }
+            }
         }
     }
     None
 }
 
+/// Every entry of a theme's `Inherits=` line, in order.
+fn icon_theme_parents(theme: &str) -> Vec<String> {
+    let home = std::env::var("HOME").unwrap_or_default();
+    for root in [
+        alloc::format!("{home}/.local/share/icons"),
+        alloc::format!("{home}/.icons"),
+        "/usr/share/icons".to_string(),
+        "/usr/local/share/icons".to_string(),
+    ] {
+        let Ok(text) = std::fs::read_to_string(alloc::format!("{root}/{theme}/index.theme")) else {
+            continue;
+        };
+        for line in text.lines() {
+            if let Some(rest) = line.trim().strip_prefix("Inherits=") {
+                return rest
+                    .split(',')
+                    .map(str::trim)
+                    .filter(|s| !s.is_empty())
+                    .map(alloc::string::ToString::to_string)
+                    .collect();
+            }
+        }
+    }
+    Vec::new()
+}
+
 /// The first entry of a theme's `Inherits=` line, if it has one.
+#[allow(dead_code)]
 fn icon_theme_parent(theme: &str) -> Option<String> {
     let home = std::env::var("HOME").unwrap_or_default();
     for root in [
@@ -865,18 +963,60 @@ mod tests {
     #[test]
     fn every_size_directory_reports_the_size_it_is_named_after() {
         for (dir, nominal) in icon_theme_dirs("breeze") {
-            let leaf = dir.rsplit('/').next().unwrap_or("");
-            match leaf {
-                "scalable" => assert_eq!(
+            // Both nestings are searched - `{theme}/actions/16` (Breeze) and
+            // `{theme}/16x16/actions` (Adwaita) - so the SIZE segment is
+            // whichever of the last two is not the category.
+            let mut tail = dir.rsplit('/');
+            let last = tail.next().unwrap_or("");
+            let prev = tail.next().unwrap_or("");
+            let size_seg = if last == "actions" { prev } else { last };
+            match size_seg {
+                "scalable" | "symbolic" => assert_eq!(
                     nominal, SCALABLE_NOMINAL_PX,
-                    "a scalable icon has no stated size; the indicator default stands in"
+                    "a scalable/symbolic icon has no stated size; the indicator default stands in"
                 ),
                 px => assert_eq!(
-                    px.parse::<u32>().ok(),
+                    px.trim_end_matches(|c: char| !c.is_ascii_digit())
+                        .split('x')
+                        .next()
+                        .and_then(|n| n.parse::<u32>().ok()),
                     Some(nominal),
                     "{dir} must report {px}, not {nominal}"
                 ),
             }
         }
+    }
+
+    /// Every indicator [`WANTED`] asks for must be reachable under SOME name a
+    /// GNOME-lineage theme actually ships, or it silently falls back to the
+    /// app's own icon at a different size.
+    #[test]
+    fn the_gnome_spellings_are_reachable_for_every_breeze_name() {
+        for name in ["arrow-up", "arrow-down", "checkmark", "application-menu", "dialog-close"] {
+            assert!(
+                !icon_name_aliases(name).is_empty(),
+                "{name} is a Breeze spelling with no GNOME alias - it will not resolve on Mint, \
+                 Ubuntu or Fedora"
+            );
+        }
+        // The aliases are real freedesktop names, not invented ones.
+        assert!(icon_name_aliases("arrow-up").contains(&"go-up"));
+        assert!(icon_name_aliases("checkmark").contains(&"object-select"));
+        assert!(icon_name_aliases("application-menu").contains(&"open-menu"));
+    }
+
+    /// The lookup only reads SVG, and themes disagree wildly about where SVGs
+    /// live. Mint-Y's `actions/{16,22,24}` are PNG-only and its SVGs are in
+    /// `actions/symbolic`; Adwaita nests the other way round. Searching one
+    /// layout found nothing on a Mint desktop.
+    #[test]
+    fn the_search_covers_both_directory_nestings_and_the_symbolic_trees() {
+        let dirs: Vec<String> = icon_theme_dirs("Mint-Y").into_iter().map(|(d, _)| d).collect();
+        let has = |suffix: &str| dirs.iter().any(|d| d.ends_with(suffix));
+        assert!(has("/Mint-Y/actions/16"), "Breeze-style sized actions dir");
+        assert!(has("/Mint-Y/actions/symbolic"), "Mint-Y keeps its SVGs here");
+        assert!(has("/Mint-Y/symbolic/actions"), "Adwaita-style nesting");
+        assert!(has("/Mint-Y/scalable/actions"), "Adwaita-style scalable");
+        assert!(has("/Mint-Y/16x16/actions"), "Adwaita-style size dir");
     }
 }

--- a/dll/src/desktop/shell2/linux/system_style.rs
+++ b/dll/src/desktop/shell2/linux/system_style.rs
@@ -27,7 +27,7 @@ use azul_css::props::basic::color::{parse_css_color, ColorU, OptionColorU};
 use azul_css::props::basic::pixel::{OptionPixelValue, PixelValue};
 use azul_css::system::{
     defaults, DesktopEnvironment, Platform, ScrollbarTrackClick, ScrollbarVisibility, SubpixelType,
-    SystemStyle, Theme, TitlebarButtonSide, ToolbarStyle,
+    SystemStyle, Theme, TitlebarButtonSide, TitlebarButtons, ToolbarStyle,
 };
 
 // ── D-Bus wire-protocol helpers (minimal, read-only) ─────────────────────
@@ -454,6 +454,17 @@ fn gsettings_get(schema: &str, key: &str) -> Option<String> {
 /// Populate additional Linux-specific fields in `style` via `gsettings` CLI
 /// queries and environment-variable fallbacks.
 fn discover_linux_extras(style: &mut SystemStyle) {
+    // Ask the desktop's OWN store first. XFCE keeps none of this in
+    // gsettings, and a machine that once ran KDE or GNOME still has THEIR
+    // schemas populated - reading those is how an XFCE desktop themed
+    // Mint-Y-Aqua ended up rendering as Breeze dark with breeze-dark icons.
+    let source = linux_settings_source(&azul_css::system::detect_linux_desktop_env());
+    if source == LinuxSettingsSource::Xfconf && xfce_extras(style) {
+        apply_env_cursor_fallbacks(style);
+        gtk_ini_extras(style);
+        return;
+    }
+
     // Icon theme
     if let Some(icon) = gsettings_get("org.gnome.desktop.interface", "icon-theme") {
         style.linux.icon_theme = OptionString::Some(icon.into());
@@ -489,18 +500,9 @@ fn discover_linux_extras(style: &mut SystemStyle) {
         style.linux.titlebar_button_layout = OptionString::Some(layout.into());
     }
     // Env-var fallbacks (work on ALL Linux WMs)
-    if style.linux.cursor_theme.is_none() {
-        if let Ok(t) = std::env::var("XCURSOR_THEME") {
-            style.linux.cursor_theme = OptionString::Some(t.into());
-        }
-    }
-    if style.linux.cursor_size == 0 {
-        if let Ok(s) = std::env::var("XCURSOR_SIZE") {
-            if let Ok(sz) = s.parse::<u32>() {
-                style.linux.cursor_size = sz;
-            }
-        }
-    }
+    apply_env_cursor_fallbacks(style);
+    // The GTK config file is the floor under every desktop and every bare WM.
+    gtk_ini_extras(style);
 
     // ── Animation metrics ────────────────────────────────────────────
     if let Some(anim_s) = gsettings_get("org.gnome.desktop.interface", "enable-animations") {
@@ -768,12 +770,324 @@ fn kde_color_sources() -> Vec<KdeIni> {
 /// and the controls are on the RIGHT — so "is the left half non-empty" and
 /// "does the string start with ':'" both answer LEFT for a desktop whose
 /// buttons are plainly on the right.
+/// Which store this desktop keeps its appearance settings in.
+///
+/// Detection used to know the desktop and then ask a DIFFERENT desktop's
+/// store anyway: on Linux Mint XFCE the dump read
+/// `platform Linux(Other("XFCE"))` and `settings_source gsettings:gnome` on
+/// the next line, because the GNOME schemas were installed and still held
+/// what a KDE session had written months earlier. The result was Breeze DARK
+/// with Noto Sans and breeze-dark icons on a desktop themed Mint-Y-Aqua LIGHT
+/// with Ubuntu 10. A desktop's own store is the only authority on it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum LinuxSettingsSource {
+    /// KDE Plasma: `kdeglobals` + the `*.colors` scheme files.
+    KdeConfig,
+    /// GNOME and the forks that kept its KEYS and renamed its SCHEMAS -
+    /// Cinnamon, MATE, Unity, Budgie. See [`schema_family`].
+    Gsettings,
+    /// XFCE: xfconf, which is what `xfsettingsd` publishes to the session as
+    /// XSETTINGS and therefore what every GTK app on that desktop obeys.
+    Xfconf,
+    /// LXQt: `~/.config/lxqt/lxqt.conf`.
+    LxqtConfig,
+    /// Tiling and riced sessions (Hyprland, Sway, i3, river, ...). They have
+    /// no settings daemon of their own; the chain ends at the GTK config
+    /// file and the environment, which is exactly what their users set.
+    Riced,
+}
+
+/// The desktops whose settings live in GNOME's schemas under another name.
+const GSETTINGS_DESKTOPS: &[&str] = &[
+    "cinnamon", "mate", "unity", "budgie", "gnome-classic", "gnome-flashback", "pantheon",
+];
+
+/// Riced/tiling sessions - no settings daemon, so the GTK file and the
+/// environment are the whole story.
+const RICED_DESKTOPS: &[&str] = &[
+    "hyprland", "sway", "i3", "river", "wayfire", "awesome", "bspwm", "dwm", "qtile", "xmonad",
+    "openbox", "fluxbox", "icewm", "herbstluftwm", "spectrwm", "niri", "labwc", "none+i3",
+];
+
+/// Resolve the store from the DESKTOP, not from whichever store happens to
+/// answer first.
+pub(crate) fn linux_settings_source(de: &DesktopEnvironment) -> LinuxSettingsSource {
+    match de {
+        DesktopEnvironment::Kde => LinuxSettingsSource::KdeConfig,
+        DesktopEnvironment::Gnome => LinuxSettingsSource::Gsettings,
+        DesktopEnvironment::Other(name) => {
+            let n = name.as_str().to_ascii_lowercase();
+            if n.contains("xfce") {
+                LinuxSettingsSource::Xfconf
+            } else if n.contains("lxqt") {
+                LinuxSettingsSource::LxqtConfig
+            } else if GSETTINGS_DESKTOPS.iter().any(|d| n.contains(d)) {
+                LinuxSettingsSource::Gsettings
+            } else if RICED_DESKTOPS.iter().any(|d| n.contains(d)) {
+                LinuxSettingsSource::Riced
+            } else {
+                // An unknown session still gets a native answer: the riced
+                // chain ends at the GTK config file, which is where a user
+                // on an unknown WM sets the theme.
+                LinuxSettingsSource::Riced
+            }
+        }
+    }
+}
+
+/// Is this GTK/Qt theme name a dark theme?
+///
+/// The rule every toolkit uses: the name says so. `Mint-Y-Aqua` is light,
+/// `Mint-Y-Dark-Aqua` is dark; matching on anything looser (an "a" in
+/// "Adwaita") would flip half the light themes.
+pub(crate) fn theme_name_is_dark(name: &str) -> bool {
+    name.to_ascii_lowercase().contains("dark")
+}
+
+/// Read one xfconf property. `xfconf-query` prints the bare value and exits
+/// non-zero when the property does not exist.
+fn xfconf_get(channel: &str, prop: &str) -> Option<String> {
+    use std::process::{Command, Stdio};
+
+    let out = Command::new("xfconf-query")
+        .args(["-c", channel, "-p", prop])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let v = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if v.is_empty() || v.contains("does not exist") {
+        None
+    } else {
+        Some(v)
+    }
+}
+
+/// xfwm4 writes its button layout as single LETTERS split by `|`, the title
+/// filler: `O`=window menu, `H`=hide (minimize), `M`=maximize, `C`=close,
+/// `S`=shade, `T`=stick. The stock layout is `O|HMC` - menu on the left,
+/// controls on the right. [`titlebar_side_from_layout`] looks for the WORD
+/// "close" (GNOME's `icon:minimize,maximize,close`) and so reports every
+/// xfwm4 layout as the default side, whatever the user set.
+pub(crate) fn titlebar_from_xfwm_layout(layout: &str) -> (TitlebarButtonSide, TitlebarButtons) {
+    let (left, _right) = layout.split_once('|').unwrap_or((layout, ""));
+    let side = if left.contains('C') {
+        TitlebarButtonSide::Left
+    } else {
+        TitlebarButtonSide::Right
+    };
+    let buttons = TitlebarButtons {
+        has_close: layout.contains('C'),
+        has_minimize: layout.contains('H'),
+        has_maximize: layout.contains('M'),
+        ..TitlebarButtons::default()
+    };
+    (side, buttons)
+}
+
+/// The GTK config file every desktop and every bare WM shares.
+///
+/// This is the universal floor under the DE-specific stores: a Hyprland or
+/// Sway user with no settings daemon still has `gtk-theme-name` here, and so
+/// does a session whose daemon we cannot reach. Parsed once.
+fn gtk_settings_ini() -> &'static alloc::collections::BTreeMap<String, String> {
+    static CACHE: std::sync::OnceLock<alloc::collections::BTreeMap<String, String>> =
+        std::sync::OnceLock::new();
+    CACHE.get_or_init(|| {
+        let mut map = alloc::collections::BTreeMap::new();
+        let home = std::env::var("HOME").unwrap_or_default();
+        let candidates = [
+            std::env::var("GTK_CONFIG_HOME").unwrap_or_default(),
+            alloc::format!("{home}/.config/gtk-4.0/settings.ini"),
+            alloc::format!("{home}/.config/gtk-3.0/settings.ini"),
+        ];
+        for path in candidates.iter().filter(|p| !p.is_empty()) {
+            let Ok(text) = std::fs::read_to_string(path) else {
+                continue;
+            };
+            for line in text.lines() {
+                let line = line.trim();
+                if line.starts_with('[') || line.starts_with('#') {
+                    continue;
+                }
+                if let Some((k, v)) = line.split_once('=') {
+                    // First file wins: gtk-4.0 is more specific than gtk-3.0.
+                    map.entry(k.trim().to_string())
+                        .or_insert_with(|| v.trim().to_string());
+                }
+            }
+        }
+        map
+    })
+}
+
+fn gtk_ini_get(key: &str) -> Option<String> {
+    gtk_settings_ini().get(key).cloned()
+}
+
 fn titlebar_side_from_layout(layout: &str) -> TitlebarButtonSide {
     let (left, _right) = layout.split_once(':').unwrap_or((layout, ""));
     if left.contains("close") {
         TitlebarButtonSide::Left
     } else {
         TitlebarButtonSide::Right
+    }
+}
+
+/// XFCE's own store.
+///
+/// `xfsettingsd` publishes these to the session as XSETTINGS, so they are
+/// what every GTK app on an XFCE desktop actually renders with - and none of
+/// them are in gsettings. Returns `Err` when xfconf does not answer at all
+/// (no `xfconf-query`, no daemon), so the caller can fall through.
+fn discover_xfce_style() -> Result<SystemStyle, ()> {
+    // The theme name is the probe: if xfconf cannot answer this, it is not
+    // answering anything and a fallback is honest.
+    let theme_name = xfconf_get("xsettings", "/Net/ThemeName").ok_or(())?;
+
+    // WHICH theme decides light vs dark: the WINDOW MANAGER's, i.e. the one
+    // drawing the titlebar (USER RULING, 2026-09-04 - "azwriter should use
+    // what the titlebar uses"). These disagree in practice: this Mint 22.2
+    // XFCE session runs xfwm4 `Mint-Y-Aqua` (light titlebars) while
+    // `gtk-application-prefer-dark-theme=true` and gsettings `color-scheme`
+    // still say prefer-dark, left over from a KDE session. An app that
+    // followed the GTK flag would paint a dark window under a light titlebar.
+    let polarity_theme =
+        xfconf_get("xfwm4", "/general/theme").unwrap_or_else(|| theme_name.clone());
+
+    let mut style = if theme_name_is_dark(&polarity_theme) {
+        defaults::gnome_adwaita_dark()
+    } else {
+        defaults::gnome_adwaita_light()
+    };
+
+    if let Some(font) = xfconf_get("xsettings", "/Gtk/FontName") {
+        if let Some((name, size)) = parse_font_name_and_size(&font) {
+            style.fonts.ui_font = OptionString::Some(name.into());
+            style.fonts.ui_font_size = OptionF32::Some(size);
+        } else {
+            style.fonts.ui_font = OptionString::Some(font.into());
+        }
+    }
+    if let Some(mono) = xfconf_get("xsettings", "/Gtk/MonospaceFontName") {
+        if let Some((name, size)) = parse_font_name_and_size(&mono) {
+            style.fonts.monospace_font = OptionString::Some(name.into());
+            style.fonts.monospace_font_size = OptionF32::Some(size);
+        } else {
+            style.fonts.monospace_font = OptionString::Some(mono.into());
+        }
+    }
+    // The titlebar font is xfwm4's, not xsettings'.
+    if let Some(title) = xfconf_get("xfwm4", "/general/title_font") {
+        if let Some((name, size)) = parse_font_name_and_size(&title) {
+            style.fonts.title_font = OptionString::Some(name.into());
+            style.fonts.title_font_size = OptionF32::Some(size);
+        } else {
+            style.fonts.title_font = OptionString::Some(title.into());
+        }
+    }
+
+    Ok(style)
+}
+
+/// The XFCE half of [`discover_linux_extras`] - icon theme, cursor and the
+/// titlebar buttons, all from xfconf.
+///
+/// Returns `false` when xfconf answered nothing, so the caller can fall back.
+fn xfce_extras(style: &mut SystemStyle) -> bool {
+    let mut answered = false;
+
+    if let Some(icon) = xfconf_get("xsettings", "/Net/IconThemeName") {
+        style.linux.icon_theme = OptionString::Some(icon.into());
+        answered = true;
+    }
+    if let Some(theme) = xfconf_get("xsettings", "/Net/ThemeName") {
+        style.linux.gtk_theme = OptionString::Some(theme.into());
+        answered = true;
+    }
+    if let Some(cursor) = xfconf_get("xsettings", "/Gtk/CursorThemeName") {
+        style.linux.cursor_theme = OptionString::Some(cursor.into());
+        answered = true;
+    }
+    if let Some(size) = xfconf_get("xsettings", "/Gtk/CursorThemeSize") {
+        if let Ok(sz) = size.parse::<u32>() {
+            if sz > 0 {
+                style.linux.cursor_size = sz;
+            }
+        }
+    }
+    if let Some(layout) = xfconf_get("xfwm4", "/general/button_layout") {
+        let (side, buttons) = titlebar_from_xfwm_layout(&layout);
+        style.metrics.titlebar.button_side = side;
+        style.metrics.titlebar.buttons = buttons;
+        style.linux.titlebar_button_layout = OptionString::Some(layout.into());
+        answered = true;
+    }
+
+    answered
+}
+
+/// `XCURSOR_THEME` / `XCURSOR_SIZE` - honoured by every Linux WM, and the
+/// only cursor answer a bare tiling session gives.
+fn apply_env_cursor_fallbacks(style: &mut SystemStyle) {
+    if style.linux.cursor_theme.is_none() {
+        if let Ok(t) = std::env::var("XCURSOR_THEME") {
+            style.linux.cursor_theme = OptionString::Some(t.into());
+        }
+    }
+    if style.linux.cursor_size == 0 {
+        if let Ok(s) = std::env::var("XCURSOR_SIZE") {
+            if let Ok(sz) = s.parse::<u32>() {
+                style.linux.cursor_size = sz;
+            }
+        }
+    }
+}
+
+/// The universal floor: whatever the GTK config file says, for the fields
+/// nothing above it answered. This is what makes a bare WM - Hyprland, Sway,
+/// i3, or an unknown session - load natively instead of falling back to a
+/// hardcoded Adwaita.
+fn gtk_ini_extras(style: &mut SystemStyle) {
+    if style.linux.icon_theme.is_none() {
+        if let Some(v) = gtk_ini_get("gtk-icon-theme-name") {
+            style.linux.icon_theme = OptionString::Some(v.into());
+        }
+    }
+    if style.linux.gtk_theme.is_none() {
+        if let Some(v) = gtk_ini_get("gtk-theme-name") {
+            style.linux.gtk_theme = OptionString::Some(v.into());
+        }
+    }
+    if style.linux.cursor_theme.is_none() {
+        if let Some(v) = gtk_ini_get("gtk-cursor-theme-name") {
+            style.linux.cursor_theme = OptionString::Some(v.into());
+        }
+    }
+    if style.linux.cursor_size == 0 {
+        if let Some(sz) = gtk_ini_get("gtk-cursor-theme-size").and_then(|v| v.parse::<u32>().ok()) {
+            style.linux.cursor_size = sz;
+        }
+    }
+    if style.fonts.ui_font.is_none() {
+        if let Some(font) = gtk_ini_get("gtk-font-name") {
+            if let Some((name, size)) = parse_font_name_and_size(&font) {
+                style.fonts.ui_font = OptionString::Some(name.into());
+                style.fonts.ui_font_size = OptionF32::Some(size);
+            }
+        }
+    }
+    if style.linux.titlebar_button_layout.is_none() {
+        if let Some(layout) = gtk_ini_get("gtk-decoration-layout") {
+            style.metrics.titlebar.button_side = titlebar_side_from_layout(&layout);
+            style.metrics.titlebar.buttons.has_close = layout.contains("close");
+            style.metrics.titlebar.buttons.has_minimize = layout.contains("minimize");
+            style.metrics.titlebar.buttons.has_maximize = layout.contains("maximize");
+            style.linux.titlebar_button_layout = OptionString::Some(layout.into());
+        }
     }
 }
 
@@ -1736,41 +2050,25 @@ pub(crate) fn discover() -> SystemStyle {
     // ── 1. Try XDG Desktop Portal (D-Bus) ───────────────────────────
     let portal_result = query_xdg_portal();
 
-    if let Some((color_scheme, accent_rgb)) = portal_result {
+    if let Some((color_scheme, _)) = portal_result {
         crate::plog_debug!(
             "system style: xdg-desktop-portal color-scheme={}",
             color_scheme
         );
-        let mut style = match color_scheme {
-            1 => defaults::gnome_adwaita_dark(),  // prefer-dark
-            2 => defaults::gnome_adwaita_light(), // prefer-light
-            _ => defaults::gnome_adwaita_light(), // no preference
-        };
-
-        if let Some((r, g, b)) = accent_rgb {
-            style.colors.accent = OptionColorU::Some(ColorU::new_rgb(
-                (r.clamp(0.0, 1.0) * 255.0) as u8,
-                (g.clamp(0.0, 1.0) * 255.0) as u8,
-                (b.clamp(0.0, 1.0) * 255.0) as u8,
-            ));
-        }
-
-        // Even with portal success, fill in extras from gsettings
-        discover_linux_extras(&mut style);
-        style.platform = Platform::Linux(azul_css::system::detect_linux_desktop_env());
-        style.language = detect_language_linux();
-        style.os_version = detect_linux_version();
-        style.prefers_reduced_motion = detect_gnome_reduced_motion();
-        style.prefers_high_contrast = detect_gnome_high_contrast();
-        style.app_specific_stylesheet = load_app_specific_stylesheet().map(Box::new);
-        return style;
+    } else {
+        // Portal probe unavailable or rejected (e.g. the raw-D-Bus handshake) —
+        // non-fatal. Visible only with AZ_LOG on.
+        crate::plog_debug!(
+            "system style: xdg-desktop-portal unavailable; falling back to CLI/defaults"
+        );
     }
 
-    // Portal probe unavailable or rejected (e.g. the raw-D-Bus handshake) —
-    // non-fatal; fall back to CLI/defaults. Visible only with AZ_LOG on.
-    crate::plog_debug!(
-        "system style: xdg-desktop-portal unavailable; falling back to CLI/defaults"
-    );
+    // NOTE: the portal used to RETURN here with a stock Adwaita palette, so on
+    // any machine with an xdg-desktop-portal installed no desktop-specific
+    // discovery ever ran and every font, theme and colour was a GNOME default
+    // nobody had chosen. The portal answers exactly two questions - the
+    // light/dark preference and the accent - so it now refines the desktop's
+    // own answer (below) instead of replacing it.
 
     // ── 2. CLI-based discovery ──────────────────────────────────────
     // `AZ_RICING=force` reorders the chain so riced-desktop sources
@@ -1782,27 +2080,76 @@ pub(crate) fn discover() -> SystemStyle {
         azul_css::system::RicingMode::Force,
     );
 
+    // Did the desktop's own store answer, or are we on built-in defaults?
+    // The portal is only allowed to speak for the second case.
+    let mut desktop_answered = false;
     let mut style = if force_riced {
-        discover_riced_style()
+        let found = discover_riced_style()
             .or_else(|_| discover_kde_style())
-            .or_else(|_| discover_gnome_style())
-            .unwrap_or_else(|_| defaults::gnome_adwaita_light())
+            .or_else(|_| discover_gnome_style());
+        desktop_answered = found.is_ok();
+        found.unwrap_or_else(|_| defaults::gnome_adwaita_light())
     } else {
         // Normal priority: KDE > GNOME > riced > defaults
         let desktop_env = azul_css::system::detect_linux_desktop_env();
-        match &desktop_env {
-            DesktopEnvironment::Kde => discover_kde_style()
+        // The desktop's OWN store leads. Everything after it is a fallback
+        // for a desktop that did not answer - never a different desktop's
+        // settings winning over one that did. A machine that once ran KDE
+        // keeps `kdeglobals`, and one with GNOME installed keeps its
+        // schemas, both fully populated and both wrong for the session the
+        // user is actually in.
+        let found = match linux_settings_source(&desktop_env) {
+            LinuxSettingsSource::KdeConfig => {
+                discover_kde_style().or_else(|_| discover_gnome_style())
+            }
+            LinuxSettingsSource::Gsettings => {
+                discover_gnome_style().or_else(|_| discover_kde_style())
+            }
+            LinuxSettingsSource::Xfconf => discover_xfce_style()
                 .or_else(|_| discover_gnome_style())
-                .unwrap_or_else(|_| defaults::gnome_adwaita_light()),
-            DesktopEnvironment::Gnome => discover_gnome_style()
-                .or_else(|_| discover_kde_style())
-                .unwrap_or_else(|_| defaults::gnome_adwaita_light()),
-            DesktopEnvironment::Other(_) => discover_riced_style()
+                .or_else(|_| discover_riced_style()),
+            LinuxSettingsSource::LxqtConfig | LinuxSettingsSource::Riced => discover_riced_style()
                 .or_else(|_| discover_gnome_style())
-                .or_else(|_| discover_kde_style())
-                .unwrap_or_else(|_| defaults::gnome_adwaita_light()),
-        }
+                .or_else(|_| discover_kde_style()),
+        };
+        desktop_answered = found.is_ok();
+        found.unwrap_or_else(|_| defaults::gnome_adwaita_light())
     };
+
+    // The portal refines only what the desktop did NOT answer for itself.
+    // Every desktop store above reads its own light/dark switch, and on XFCE
+    // the titlebar theme is the ruling one - a portal that reports
+    // "prefer-dark" from a stale GTK flag must not repaint a light session.
+    if let Some((color_scheme, accent_rgb)) = portal_result.filter(|_| !desktop_answered) {
+        match color_scheme {
+            1 if style.theme != Theme::Dark => {
+                let fonts = style.fonts.clone();
+                let linux = style.linux.clone();
+                let metrics = style.metrics.clone();
+                style = defaults::gnome_adwaita_dark();
+                style.fonts = fonts;
+                style.linux = linux;
+                style.metrics = metrics;
+            }
+            2 if style.theme != Theme::Light => {
+                let fonts = style.fonts.clone();
+                let linux = style.linux.clone();
+                let metrics = style.metrics.clone();
+                style = defaults::gnome_adwaita_light();
+                style.fonts = fonts;
+                style.linux = linux;
+                style.metrics = metrics;
+            }
+            _ => {}
+        }
+        if let Some((r, g, b)) = accent_rgb {
+            style.colors.accent = OptionColorU::Some(ColorU::new_rgb(
+                (r.clamp(0.0, 1.0) * 255.0) as u8,
+                (g.clamp(0.0, 1.0) * 255.0) as u8,
+                (b.clamp(0.0, 1.0) * 255.0) as u8,
+            ));
+        }
+    }
 
     // ── 3. Fill in extras and metadata ──────────────────────────────
     discover_linux_extras(&mut style);
@@ -2445,15 +2792,29 @@ pub fn dump_discovered_style() -> String {
     // Which desktop-settings family actually answered. A Cinnamon/MATE
     // session answers on its OWN schemas; probing with a key that exists in
     // only one of them is what distinguishes "detected" from "fell back".
-    let settings_source = if gsettings_get_raw("org.gnome.desktop.interface", "font-name").is_some()
-    {
-        "gsettings:gnome"
-    } else if gsettings_get_raw("org.cinnamon.desktop.interface", "font-name").is_some() {
-        "gsettings:cinnamon"
-    } else if gsettings_get_raw("org.mate.interface", "font-name").is_some() {
-        "gsettings:mate"
-    } else {
-        "none"
+    let resolved = linux_settings_source(&azul_css::system::detect_linux_desktop_env());
+    let settings_source = match resolved {
+        LinuxSettingsSource::KdeConfig => "kdeglobals".to_string(),
+        LinuxSettingsSource::Xfconf => {
+            if xfconf_get("xsettings", "/Net/ThemeName").is_some() {
+                "xfconf".to_string()
+            } else {
+                "xfconf (no answer -> fallback)".to_string()
+            }
+        }
+        LinuxSettingsSource::LxqtConfig => "lxqt".to_string(),
+        LinuxSettingsSource::Riced => "riced/gtk-ini".to_string(),
+        LinuxSettingsSource::Gsettings => {
+            if gsettings_get_raw("org.gnome.desktop.interface", "font-name").is_some() {
+                "gsettings:gnome".to_string()
+            } else if gsettings_get_raw("org.cinnamon.desktop.interface", "font-name").is_some() {
+                "gsettings:cinnamon".to_string()
+            } else if gsettings_get_raw("org.mate.interface", "font-name").is_some() {
+                "gsettings:mate".to_string()
+            } else {
+                "none".to_string()
+            }
+        }
     };
     let _ = writeln!(o, "platform            {:?}", s.platform);
     let _ = writeln!(o, "settings_source     {settings_source}");
@@ -2729,5 +3090,78 @@ mod kde_ini_tests {
         let wm = schema_family("org.gnome.desktop.wm.preferences");
         assert!(wm.contains(&"org.cinnamon.desktop.wm.preferences".to_string()));
         assert!(wm.contains(&"org.mate.Marco.general".to_string()));
+    }
+
+    // ── XFCE / xfconf ────────────────────────────────────────────────
+    //
+    // Observed on Linux Mint 22.2 XFCE (Xorg 21.1.11), 2026-09-04: the dump
+    // said `platform Linux(Other("XFCE"))` and, on the very next line,
+    // `settings_source gsettings:gnome`. Detection KNEW the desktop and then
+    // read a different desktop's settings — the machine still had KDE's
+    // schemas populated, so azul rendered Breeze DARK with Noto Sans and
+    // breeze-dark icons on a desktop themed Mint-Y-Aqua LIGHT with Ubuntu 10.
+    // XFCE keeps none of that in gsettings; xfconf is its store.
+
+    #[test]
+    fn a_theme_name_says_whether_it_is_dark() {
+        // The real theme on the test machine - light, and NOT dark just
+        // because a fuzzy match found some substring.
+        assert!(!theme_name_is_dark("Mint-Y-Aqua"));
+        assert!(!theme_name_is_dark("Breeze"));
+        assert!(!theme_name_is_dark("Adwaita"));
+        // The dark spellings XFCE themes actually ship.
+        assert!(theme_name_is_dark("Mint-Y-Dark-Aqua"));
+        assert!(theme_name_is_dark("Adwaita-dark"));
+        assert!(theme_name_is_dark("Breeze-Dark"));
+    }
+
+    #[test]
+    fn the_xfwm4_button_layout_is_not_the_gnome_one() {
+        // xfwm4 writes single LETTERS split by `|` (the title filler):
+        // O=menu, H=hide/minimize, M=maximize, C=close, S=shade, T=stick.
+        // `titlebar_side_from_layout` looks for the WORD "close" and would
+        // report every xfwm4 layout as buttons-on-the-right by default.
+        let (side, buttons) = titlebar_from_xfwm_layout("O|HMC");
+        assert_eq!(side, TitlebarButtonSide::Right);
+        assert!(buttons.has_close && buttons.has_minimize && buttons.has_maximize);
+
+        // Buttons moved to the left: close is left of the filler.
+        let (side, _) = titlebar_from_xfwm_layout("CMH|O");
+        assert_eq!(side, TitlebarButtonSide::Left);
+
+        // A layout that drops maximize must not draw one.
+        let (_, buttons) = titlebar_from_xfwm_layout("O|HC");
+        assert!(buttons.has_close && buttons.has_minimize && !buttons.has_maximize);
+    }
+
+    #[test]
+    fn xfce_reads_xfconf_and_not_the_gnome_schemas() {
+        // The whole defect in one assertion: on an XFCE desktop the settings
+        // source must be xfconf. It is what xfsettingsd publishes and what
+        // every GTK app on that session actually obeys; the GNOME schemas may
+        // be present and populated by a DIFFERENT desktop the user once ran.
+        assert_eq!(
+            linux_settings_source(&DesktopEnvironment::Other("XFCE".into())),
+            LinuxSettingsSource::Xfconf
+        );
+        assert_eq!(
+            linux_settings_source(&DesktopEnvironment::Other("xfce".into())),
+            LinuxSettingsSource::Xfconf,
+            "the desktop name is not case-normalised anywhere upstream"
+        );
+        // The desktops that DO answer on gsettings keep answering there.
+        assert_eq!(
+            linux_settings_source(&DesktopEnvironment::Gnome),
+            LinuxSettingsSource::Gsettings
+        );
+        assert_eq!(
+            linux_settings_source(&DesktopEnvironment::Other("Cinnamon".into())),
+            LinuxSettingsSource::Gsettings,
+            "Cinnamon is a GNOME fork - schema_family already maps its names"
+        );
+        assert_eq!(
+            linux_settings_source(&DesktopEnvironment::Kde),
+            LinuxSettingsSource::KdeConfig
+        );
     }
 }

--- a/dll/src/desktop/shell2/linux/wayland/mod.rs
+++ b/dll/src/desktop/shell2/linux/wayland/mod.rs
@@ -9861,6 +9861,9 @@ impl WaylandPopup {
 }
 
 impl PlatformWindow for WaylandPopup {
+    /// A popup is positioned by its parent surface, never dragged by a user.
+    fn handle_begin_interactive_move(&mut self) {}
+
     fn capture_screen_for_eyedropper(&mut self) -> Option<crate::desktop::eyedropper::Screenshot> {
         let scale = self
             .common

--- a/dll/src/desktop/shell2/linux/x11/events.rs
+++ b/dll/src/desktop/shell2/linux/x11/events.rs
@@ -558,8 +558,22 @@ impl X11Window {
         // to the WM via _NET_WM_MOVERESIZE (root coords come straight from
         // the button event; the implicit grab must be released first or the
         // WM cannot take over the pointer).
+        // ...but NOT while maximized or fullscreen. A maximized window has no
+        // resizable edge, so the request is a no-op at the WM - while the
+        // `return` below still swallows the press before it can reach
+        // `record_input_sample`, killing the DragStart AND the DoubleClick
+        // the titlebar needs. Maximized, the band's top 8 px sit at screen
+        // y = 0, which is exactly where a user aims for the titlebar: every
+        // drag and every double-click on AzWriter (it starts maximized and
+        // undecorated) was eaten here.
+        let frame_is_resizable = !matches!(
+            self.common.current_window_state().flags.frame,
+            azul_core::window::WindowFrame::Maximized
+                | azul_core::window::WindowFrame::Fullscreen
+        );
         if is_down
             && button == MouseButton::Left
+            && frame_is_resizable
             && self.common.current_window_state().flags.decorations
                 == azul_core::window::WindowDecorations::None
         {

--- a/dll/src/desktop/shell2/linux/x11/mod.rs
+++ b/dll/src/desktop/shell2/linux/x11/mod.rs
@@ -7692,6 +7692,17 @@ impl PlatformWindow for X11Window {
     fn sync_window_state(&mut self) {
         X11Window::sync_window_state(self);
     }
+
+    /// Hand the drag to the window manager via `_NET_WM_MOVERESIZE`.
+    ///
+    /// The implementation is the inherent one below; this forwarder is what
+    /// makes it REACHABLE. Without it the call in `dispatch_events_propagated`
+    /// bound to the trait's old no-op default and dragging an AzWriter window
+    /// by its titlebar did nothing, while the real code sat here looking
+    /// finished. Same shape as `sync_window_state` above.
+    fn handle_begin_interactive_move(&mut self) {
+        X11Window::handle_begin_interactive_move(self);
+    }
 }
 
 impl X11Window {

--- a/dll/src/desktop/shell2/windows/mod.rs
+++ b/dll/src/desktop/shell2/windows/mod.rs
@@ -7165,6 +7165,17 @@ impl Win32Window {
 // PlatformWindow Trait Implementation
 
 impl PlatformWindow for Win32Window {
+    /// Hand the drag to the window manager (`WM_NCLBUTTONDOWN` + `HTCAPTION`).
+    ///
+    /// Forwarder to the inherent implementation, which was unreachable for
+    /// exactly the same reason X11's was - written into `impl Win32Window`
+    /// instead of here, so the trait's old no-op default ran and a CSD
+    /// titlebar drag did nothing. NOT verified on a Windows box (found by the
+    /// X11 audit and fixed for parity).
+    fn handle_begin_interactive_move(&mut self) {
+        Win32Window::handle_begin_interactive_move(self);
+    }
+
     fn capture_screen_for_eyedropper(&mut self) -> Option<crate::desktop::eyedropper::Screenshot> {
         crate::desktop::eyedropper::windows::capture(self)
     }

--- a/examples/azul-writer/src/palette.rs
+++ b/examples/azul-writer/src/palette.rs
@@ -159,6 +159,22 @@ impl std::fmt::Debug for Palette {
     }
 }
 
+/// A document ink, lifted until it is legible on THIS palette's chrome.
+///
+/// The in-ribbon style gallery previews document styles, and a document style
+/// is a fixed thing: Heading 1 is `#2e74b5` whatever the desktop looks like.
+/// That ruling stands - the preview has to show what the style will actually
+/// be - but on a dark session those inks were being painted onto charcoal,
+/// and dark blue on dark grey is not a preview of anything. So the hue is
+/// kept and only the lightness moves, and only as far as WCAG AA needs, which
+/// is what [`Palette::brand_text`] already does by hand for the brand.
+///
+/// On a light chrome every one of these inks already passes, so this returns
+/// them unchanged and the light theme is pixel-identical to before.
+pub fn sample_ink(ink: ColorU, pal: &Palette) -> ColorU {
+    ink.ensure_contrast(pal.chrome, 4.5)
+}
+
 /// The Office-2013 palette, used verbatim when the desktop reports nothing.
 const OFFICE_2013: Palette = Palette {
     dark: false,
@@ -634,6 +650,67 @@ mod tests {
         assert_eq!(Palette::hex(rgb(43, 87, 154)), "#2b579a");
         assert_eq!(Palette::hex(rgb(0, 0, 0)), "#000000");
         assert_eq!(Palette::hex(rgb(255, 255, 255)), "#ffffff");
+    }
+
+    /// Observed on Linux Mint 22.2 XFCE, 2026-09-04: with the chrome dark,
+    /// the in-ribbon style gallery painted Word's document inks - `#2e74b5`
+    /// for Heading 1/2, `#262626` for Title, `#444444` for Normal - straight
+    /// onto the charcoal ribbon. Dark blue on dark grey: the Title sample was
+    /// invisible in the screenshot. The gallery previews are deliberately NOT
+    /// themed (they have to show what the style really is), and that ruling
+    /// stands - but "unthemed" cannot mean "unreadable", so the ink keeps its
+    /// hue and is lifted until it is legible, exactly as `brand_text` is.
+    #[test]
+    fn every_gallery_ink_is_legible_on_its_own_chrome() {
+        // The inks the ribbon's style gallery actually paints.
+        const INKS: &[ColorU] = &[
+            rgb(68, 68, 68),    // Normal / No Spacing
+            rgb(46, 116, 181),  // Heading 1 + 2
+            rgb(38, 38, 38),    // Title
+            rgb(90, 90, 90),    // Subtitle
+            rgb(128, 128, 128), // Subtle Emphasis
+            rgb(68, 114, 196),  // Emphasis
+        ];
+
+        for pal in [&OFFICE_2013, &OFFICE_2013_DARK] {
+            for ink in INKS {
+                let shown = sample_ink(*ink, pal);
+                let ratio = shown.contrast_ratio(pal.chrome);
+                assert!(
+                    ratio >= 4.5,
+                    "ink {} on chrome {} reads at {ratio:.2}:1 (need 4.5:1)",
+                    Palette::hex(shown),
+                    Palette::hex(pal.chrome),
+                );
+            }
+        }
+    }
+
+    /// The lift must be a LIFT, not a repaint: a blue stays blue, or the
+    /// preview stops previewing the style it names.
+    #[test]
+    fn lifting_an_ink_keeps_its_hue() {
+        // The FFI `ColorU` derives neither PartialEq nor Debug, so identity
+        // is compared channel-wise here.
+        let same = |a: ColorU, b: ColorU| a.r == b.r && a.g == b.g && a.b == b.b && a.a == b.a;
+
+        let heading = rgb(46, 116, 181);
+        let lifted = sample_ink(heading, &OFFICE_2013_DARK);
+        assert!(
+            !same(lifted, heading),
+            "on charcoal this ink has to move at all"
+        );
+        assert!(
+            lifted.b > lifted.r && lifted.b > lifted.g,
+            "still a blue: {}",
+            Palette::hex(lifted)
+        );
+        // On the light palette the same ink already passes and must be
+        // returned untouched - the previews are not re-tinted for fun.
+        assert!(
+            same(sample_ink(heading, &OFFICE_2013), heading),
+            "a light chrome must leave the document ink exactly as it is"
+        );
     }
 }
 

--- a/examples/azul-writer/src/ribbon_ui.rs
+++ b/examples/azul-writer/src/ribbon_ui.rs
@@ -17,7 +17,7 @@ use azul::widgets::{
     RibbonGallery, RibbonGalleryCell, RibbonGroup, RibbonItem, RibbonRow, RibbonTab,
 };
 
-use azul::css::SystemStyle;
+use azul::css::{ColorU, SystemStyle};
 
 use crate::palette::Palette;
 use crate::AppState;
@@ -326,40 +326,48 @@ fn home_tab(state: &AppState, data: &RefAny, pal: &Palette, sys: &SystemStyle) -
     // else because the desktop theme did. They are the one part of this app's
     // chrome that is deliberately NOT themed (user ruling) - the preview has
     // to show what the style will actually be.
+    //
+    // What that ruling does NOT license is illegibility: on a dark session
+    // these inks were painted straight onto the charcoal ribbon and the Title
+    // sample vanished into it. `sample_ink` keeps the hue and lifts only the
+    // lightness, and only until it clears WCAG AA against this palette's
+    // chrome - so on a light desktop every preview is byte-identical to before.
+    let ink =
+        |r: u8, g: u8, b: u8| Palette::hex(crate::palette::sample_ink(ColorU { r, g, b, a: 255 }, pal));
     let cells = vec![
         cell(
-            "font-size: 14px; color: #444444;".to_string(),
+            format!("font-size: 14px; color: {};", ink(68, 68, 68)),
             "AaBbCcDc",
             "\u{00b6} Normal",
         ),
         cell(
-            "font-size: 14px; color: #444444;".to_string(),
+            format!("font-size: 14px; color: {};", ink(68, 68, 68)),
             "AaBbCcDc",
             "\u{00b6} No Spac...",
         ),
         cell(
-            "font-size: 15px; color: #2e74b5;".to_string(),
+            format!("font-size: 15px; color: {};", ink(46, 116, 181)),
             "AaBbCc",
             "Heading 1",
         ),
         cell(
-            "font-size: 14px; color: #2e74b5;".to_string(),
+            format!("font-size: 14px; color: {};", ink(46, 116, 181)),
             "AaBbCcD",
             "Heading 2",
         ),
-        cell("font-size: 19px; color: #262626;".to_string(), "AaB", "Title"),
+        cell(format!("font-size: 19px; color: {};", ink(38, 38, 38)), "AaB", "Title"),
         cell(
-            "font-size: 13px; color: #5a5a5a;".to_string(),
+            format!("font-size: 13px; color: {};", ink(90, 90, 90)),
             "AaBbCcD",
             "Subtitle",
         ),
         cell(
-            "font-size: 13px; color: #808080;".to_string(),
+            format!("font-size: 13px; color: {};", ink(128, 128, 128)),
             "AaBbCcDi",
             "Subtle Em...",
         ),
         cell(
-            "font-size: 13px; color: #4472c4;".to_string(),
+            format!("font-size: 13px; color: {};", ink(68, 114, 196)),
             "AaBbCcDi",
             "Emphasis",
         ),

--- a/scripts/PHYSICAL_TESTING_LINUX_X11_2026_09_04.md
+++ b/scripts/PHYSICAL_TESTING_LINUX_X11_2026_09_04.md
@@ -35,7 +35,7 @@ Binary under test: `feat/rust-fontconfig-5` + the commits in this PR,
 | gallery contrast | ribbon style previews are readable | **BROKEN -> FIXED** | dark blue `#2e74b5` / `#262626` on charcoal; Title sample invisible. Now lifted to WCAG AA against the chrome, hue kept, light theme byte-identical |
 | `headless_window_features` | the target builds | **BROKEN -> FIXED** | had not compiled since `TouchPoint` gained `seat_id`; 7/7 now |
 | resize smoothness | interactive resize repaints at refresh rate | **BROKEN — not root-caused** | **44.2 ms median between frames (min 40.3, max 70.3) = ~23 fps on a 60 Hz display**, measured from the app's own ConfigureNotify timestamps over 28 consecutive resize steps. The FAST PATH IS TAKEN (no "boundary crossed" lines, so no full DOM regeneration), and `detect_frame_interval` reads the CRTC's real 60 Hz — so the cost is inside render/present, not relayout or pacing. Next step: instrument `render_and_present` |
-| library size | — | **NOT A DEFECT** | `libazul.so` is 402 MB because `[profile.release]` sets `debug = 1, strip = false` deliberately ("so samply can resolve them"). `strip --strip-debug` -> **70 MB** |
+| library size | — | **NOT A DEFECT** | The 402 MB `libazul.so` is a LOCAL `release` build: that profile deliberately keeps `debug = 1, strip = false` "so samply can resolve them" (`strip --strip-debug` -> **70 MB**). **CI does not ship this.** Dist artifacts build with `--profile prod-release` (`rust.yml:926-930`), which sets `strip = "symbols"`, `debug = 0`, thin LTO and `codegen-units = 1`; the `.a` gets `scripts/strip_staticlib.sh` on top, because cargo's `strip` only touches final linked outputs, never archives |
 
 ## Not tested (no hardware / not reached)
 
@@ -67,6 +67,13 @@ under "Device verification owed" remains owed.
 6. **`| head` on a running GUI kills it.** Closing the stderr pipe makes the
    diagnostics sink panic — "failed printing to stderr: Broken pipe" — and the
    app aborts. A library must not die because stderr went away; still open.
+
+## Worth a follow-up (not a defect)
+
+CI **reports** artifact sizes (`after local-symbol strip:`, `$before -> $after
+bytes`, and into the release HTML) but nothing **fails** on a size regression.
+Given how much of this repo's history is size work, a threshold gate on the
+shipped `.so`/`.a` would turn that reporting into a ratchet.
 
 ## Still open
 

--- a/scripts/PHYSICAL_TESTING_LINUX_X11_2026_09_04.md
+++ b/scripts/PHYSICAL_TESTING_LINUX_X11_2026_09_04.md
@@ -1,0 +1,79 @@
+# Physical testing — Linux / X11 — 2026-09-04
+
+**Device.** Linux Mint 22.2 "Zara", XFCE 4 on **Xorg 21.1.11**, `DISPLAY=:0.0`,
+`XDG_SESSION_TYPE=x11`, `XDG_CURRENT_DESKTOP=XFCE`. Single 1920x1080 @ 60 Hz.
+NOT Cinnamon — the session is XFCE, which matters because it decides which
+settings store is authoritative.
+
+Desktop's own settings, for reference (`xfconf-query`):
+
+    xsettings /Net/ThemeName     Mint-Y-Aqua      (light)
+    xsettings /Net/IconThemeName Mint-Y-Sand
+    xsettings /Gtk/FontName      Ubuntu 10
+    xfwm4     /general/theme     Mint-Y-Aqua      (light titlebars)
+    xfwm4     /general/button_layout  O|HMC
+
+The machine also still holds a **KDE session's leftovers**: gsettings
+`gtk-theme=Breeze`, `icon-theme=breeze-dark`, `color-scheme=prefer-dark`, and
+`~/.config/gtk-3.0/settings.ini` with `gtk-application-prefer-dark-theme=true`.
+That contradiction is what made the bugs below visible, and it is not exotic —
+any machine that has ever run another desktop is in this state.
+
+Binary under test: `feat/rust-fontconfig-5` + the commits in this PR,
+`cargo build -p azul-dll --release --features build-dll`, app = AzWriter
+(`link-dynamic`).
+
+## Results
+
+| id | promise (one line) | verdict | evidence |
+|----|--------------------|---------|----------|
+| system style | the app matches the desktop's fonts/colours/theme | **BROKEN -> FIXED** | dump said `platform Linux(Other("XFCE"))` and `settings_source gsettings:gnome` on the next line; theme Dark on a light desktop, `Noto Sans 10` for `Ubuntu 10`. After: `settings_source xfconf`, theme Light, ui `Ubuntu 10`, gtk theme `Mint-Y-Aqua` |
+| icon theme | the app draws the desktop's icons | **BROKEN -> FIXED** | `icon_theme breeze-dark` (a theme this desktop does not use). After the source fix it read `Mint-Y-Sand` but registered **0** icons; three lookup defects later, **18/17** |
+| titlebar drag | dragging a client-drawn titlebar moves the window | **BROKEN -> FIXED** | dead code in the wrong `impl` block + a gesture session never closed. Sweep at fixed x: y=4 DRAG, 10 dead, 14 DRAG, 18 dead, 21 DRAG, 24 dead, 27 DRAG. After: all 7 DRAG |
+| double-click maximize | double-clicking the titlebar toggles maximize/restore | **BROKEN -> FIXED** | `1920x1047@0,0` + `_NET_WM_STATE_MAXIMIZED_{VERT,HORZ}` -> `1280x800@320,140`, atoms cleared; and back. Debug builds PANICKED here (`update_unsynced_state` assert) |
+| CSD resize band | the 8 px edge band resizes | **PARTIAL -> FIXED** | it also ran while maximized, where there is no resizable edge, and swallowed the press before the gesture manager saw it |
+| gallery contrast | ribbon style previews are readable | **BROKEN -> FIXED** | dark blue `#2e74b5` / `#262626` on charcoal; Title sample invisible. Now lifted to WCAG AA against the chrome, hue kept, light theme byte-identical |
+| `headless_window_features` | the target builds | **BROKEN -> FIXED** | had not compiled since `TouchPoint` gained `seat_id`; 7/7 now |
+| resize smoothness | interactive resize repaints at refresh rate | **BROKEN — not root-caused** | **44.2 ms median between frames (min 40.3, max 70.3) = ~23 fps on a 60 Hz display**, measured from the app's own ConfigureNotify timestamps over 28 consecutive resize steps. The FAST PATH IS TAKEN (no "boundary crossed" lines, so no full DOM regeneration), and `detect_frame_interval` reads the CRTC's real 60 Hz — so the cost is inside render/present, not relayout or pacing. Next step: instrument `render_and_present` |
+| library size | — | **NOT A DEFECT** | `libazul.so` is 402 MB because `[profile.release]` sets `debug = 1, strip = false` deliberately ("so samply can resolve them"). `strip --strip-debug` -> **70 MB** |
+
+## Not tested (no hardware / not reached)
+
+Multi-seat (needs a second master pointer pair), pen/tablet, gamepad rumble,
+touch, IME/XIM composition, RandR hotplug, pointer lock. Every ledger item
+under "Device verification owed" remains owed.
+
+## Traps found (each cost >10 min)
+
+1. **The app links the STALE system library.** `ldd target/release/AzWriter`
+   resolves `libazul.so` to `/lib/libazul.so` — a 41 MB copy from June 1. A
+   plain run tests three-month-old code. Run with `LD_LIBRARY_PATH` pointing at
+   the freshly built one.
+2. **Two feature sets fight over one output path.** `cargo build -p azul-dll
+   --features build-dll` and `cargo build -p AzWriter` (which wants
+   `link-dynamic`) both write `target/release/libazul.so`; building the app
+   after the library replaces the 402 MB library with a 5.6 MB one, and the app
+   then fails to start with "file too short". Build the library LAST, or keep a
+   copy outside `target/release`.
+3. **Setting `RUSTFLAGS` to help the linker forces a full azul-dll rebuild**
+   (it changes every fingerprint). Combined with `earlyoom`, configured on this
+   box to *prefer* killing `rustc|cargo|lld|ld`, that produced a **0-byte
+   `libazul.so` from a build that reported success**. Use `LIBRARY_PATH`.
+4. **`cargo` reports success for a truncated link.** Always check
+   `ls -la target/release/libazul.so` after a build here.
+5. **A lint that lies costs more than no lint.** The bare-text lint claimed a
+   text node's callbacks were "INERT"; it pointed at the test's DOM while the
+   real fault was a missing filter family. (Fixed earlier in this branch.)
+6. **`| head` on a running GUI kills it.** Closing the stderr pipe makes the
+   diagnostics sink panic — "failed printing to stderr: Broken pipe" — and the
+   app aborts. A library must not die because stderr went away; still open.
+
+## Still open
+
+- Resize repaint at ~23 fps (above) — measured, not root-caused.
+- Broken-pipe stderr panic in `azul_core::diagnostics::default_sink`.
+- The X11 audit's remaining P1/P2/P3: no `PropertyChangeMask`/`PropertyNotify`
+  handler, so a WM-initiated maximize (Alt+F10, edge-snap) is never observed;
+  no `_NET_FRAME_EXTENTS`/`_GTK_FRAME_EXTENTS`; `XI_KeyPress` is selected on
+  `XIAllMasterDevices` while primary-seat keys are dropped; pointer lock uses
+  `XGrabPointer` under XI2.

--- a/scripts/artifact_size_budgets.txt
+++ b/scripts/artifact_size_budgets.txt
@@ -1,0 +1,52 @@
+# Size budgets for the SHIPPED libazul artifacts, in bytes.
+#
+# WHY THIS FILE EXISTS: CI already printed artifact sizes in half a dozen
+# places - `after local-symbol strip:`, `$before -> $after bytes`, and into the
+# release HTML - but nothing ever FAILED on a size regression. Reporting is not
+# a ratchet: a change that adds 40 MB to libazul.so lands green and is found
+# months later. This file turns the reporting into a gate.
+#
+# FORMAT:  <target-triple-or-*>  <basename-glob>  <max_bytes>
+# The first line whose target AND glob both match wins, so put specific
+# targets above `*`. Blank lines and `#` comments are ignored.
+#
+# PROVENANCE: every number below is 1.5x the size that artifact actually had in
+# the shipped 0.2.0 release (queried from the GitHub release assets), rounded
+# up. 1.5x is deliberately loose for a FIRST gate: the tree has moved several
+# hundred commits since 0.2.0, so these are a ceiling that catches a runaway
+# regression without failing honest growth. `check_artifact_size.sh` prints
+# each artifact as a percentage of its budget - once a few CI runs have
+# reported real current numbers, tighten these to ~1.15x and this becomes a
+# real ratchet.
+#
+# RAISING A BUDGET IS A DELIBERATE, REVIEWABLE COMMIT. That is the point: the
+# size change shows up in the diff with a reason next to it, instead of
+# silently in a release artifact.
+
+# --- Linux, cross-compiled (the `build_binaries` matrix) -------------------
+i686-unknown-linux-gnu          *azul*.so       62000000   # 0.2.0: 40810244
+aarch64-unknown-linux-gnu       *azul*.so       52000000   # 0.2.0: 34228712
+armv7-unknown-linux-gnueabihf   *azul*.so       53000000   # 0.2.0: 35047524
+powerpc64-unknown-linux-gnu     *azul*.so       76000000   # 0.2.0: 50546888
+s390x-unknown-linux-gnu         *azul*.so       66000000   # 0.2.0: 43603672
+riscv64gc-unknown-linux-gnu     *azul*.so       52000000   # 0.2.0: 34506720
+
+# --- Windows / macOS -------------------------------------------------------
+i686-pc-windows-msvc            *azul*.dll      51000000   # 0.2.0 azuldbg.dll: 33751552
+x86_64-apple-darwin             *azul*.dylib    45000000   # 0.2.0 libazuldbg.dylib: 29570896
+
+# --- Host builds (x86_64 linux), for jobs that opt in ----------------------
+*                               libazuldbg.so   66000000   # 0.2.0: 43543648
+*                               libazul.so      51000000   # 0.2.0 azul.so: 33970016
+*                               libazuldbg.dylib 45000000  # 0.2.0: 29570896
+*                               libazul.dylib   45000000
+*                               azul.so         51000000   # 0.2.0: 33970016 (the C lib)
+*                               azuldbg.dll     51000000   # 0.2.0: 33751552
+*                               azul.dll        51000000   # sized against azuldbg.dll
+*                               azul.pyd        59000000   # 0.2.0: 38763008
+*                               azul.cpython*.so 75000000  # 0.2.0: 49466680
+
+# The static archives (`*azul*.a` / `azul*.lib`) are NOT gated yet: the 0.2.0
+# release only published them gzipped, so there is no honest raw number to set
+# a budget from. `check_artifact_size.sh` reports them as UNGATED with their
+# real size - take those numbers from a CI run and add lines here.

--- a/scripts/check_artifact_size.sh
+++ b/scripts/check_artifact_size.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+#
+# Fail the build when a shipped artifact outgrows its budget.
+#
+# Sizes were already reported all over CI and nothing acted on them, so a size
+# regression could only be noticed by someone downloading a release. This makes
+# the budget explicit (scripts/artifact_size_budgets.txt) and the failure loud,
+# and prints every artifact as a percentage of its budget so the numbers stay
+# visible even when everything passes.
+#
+# Usage:
+#   scripts/check_artifact_size.sh --target <triple> <file>...
+#
+# An artifact with no matching budget line is REPORTED, not failed: a new
+# artifact should not break CI the day it appears - but its size is printed so
+# a budget can be added deliberately.
+#
+# Escape hatch: AZ_SIZE_GATE=report downgrades every breach to a warning (for
+# a branch that is knowingly mid-refactor). It does not silence the output.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BUDGETS="${AZ_SIZE_BUDGETS:-${SCRIPT_DIR}/artifact_size_budgets.txt}"
+TARGET="*"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --target) TARGET="${2:-*}"; shift 2 ;;
+        --budgets) BUDGETS="$2"; shift 2 ;;
+        --) shift; break ;;
+        *) break ;;
+    esac
+done
+
+if [[ ! -f "${BUDGETS}" ]]; then
+    echo "[size-gate] no budget file at ${BUDGETS}" >&2
+    exit 1
+fi
+if [[ $# -eq 0 ]]; then
+    echo "[size-gate] no artifacts given (nothing built?) — nothing to check"
+    exit 0
+fi
+
+# Longest match wins over the `*` fallback: budget lines are read in order and
+# the first line whose target AND glob both match is used.
+budget_for() {
+    local target="$1" base="$2" line btarget bglob bmax
+    while read -r btarget bglob bmax _; do
+        [[ -z "${btarget:-}" || "${btarget}" == \#* ]] && continue
+        [[ "${btarget}" != "*" && "${btarget}" != "${target}" ]] && continue
+        # shellcheck disable=SC2053  # glob match is intended
+        [[ "${base}" == ${bglob} ]] || continue
+        echo "${bmax}"
+        return 0
+    done < <(grep -vE '^\s*(#|$)' "${BUDGETS}")
+    return 1
+}
+
+human() { numfmt --to=iec --suffix=B "$1" 2>/dev/null || echo "$1 bytes"; }
+
+FAILED=0
+CHECKED=0
+UNGATED=0
+echo "[size-gate] target=${TARGET} budgets=${BUDGETS}"
+for f in "$@"; do
+    [[ -f "$f" ]] || continue
+    base="$(basename "$f")"
+    size="$(wc -c < "$f" | tr -d ' ')"
+    CHECKED=$((CHECKED + 1))
+    if max="$(budget_for "${TARGET}" "${base}")"; then
+        pct=$(( size * 100 / max ))
+        if (( size > max )); then
+            over=$(( size - max ))
+            echo "[size-gate] FAIL ${base}: $(human "${size}") > budget $(human "${max}") (+$(human "${over}"), ${pct}% of budget)"
+            FAILED=$((FAILED + 1))
+        else
+            echo "[size-gate]   ok ${base}: $(human "${size}") of $(human "${max}") (${pct}%)"
+        fi
+    else
+        echo "[size-gate] UNGATED ${base}: $(human "${size}") — no budget line; add one to $(basename "${BUDGETS}")"
+        UNGATED=$((UNGATED + 1))
+    fi
+done
+
+if (( CHECKED == 0 )); then
+    echo "[size-gate] none of the given paths existed — nothing to check"
+    exit 0
+fi
+if (( FAILED > 0 )); then
+    if [[ "${AZ_SIZE_GATE:-}" == "report" ]]; then
+        echo "[size-gate] ${FAILED} over budget, but AZ_SIZE_GATE=report — not failing"
+        exit 0
+    fi
+    echo "[size-gate] ${FAILED} artifact(s) over budget."
+    echo "[size-gate] If the growth is intended, raise the number in"
+    echo "[size-gate] scripts/artifact_size_budgets.txt in the SAME commit, with a reason."
+    exit 1
+fi
+GATED=$(( CHECKED - UNGATED ))
+if (( UNGATED > 0 )); then
+    echo "[size-gate] ${GATED} artifact(s) within budget, ${UNGATED} ungated."
+else
+    echo "[size-gate] all ${GATED} artifact(s) within budget."
+fi
+exit 0


### PR DESCRIPTION
Found and fixed on real hardware: **Linux Mint 22.2 XFCE, Xorg 21.1.11**, with a real pointer. Full evidence in `scripts/PHYSICAL_TESTING_LINUX_X11_2026_09_04.md`.

The machine still carries a previous KDE session's leftovers (`gsettings gtk-theme=Breeze`, `icon-theme=breeze-dark`, `color-scheme=prefer-dark`) while the live desktop is XFCE themed Mint-Y-Aqua. That contradiction is what made these visible — and it is not exotic: any machine that has ever run another desktop is in that state.

## 1. The style discovery knew the desktop and then read a different one

`AZ_DUMP_SYSTEM_STYLE=1` contradicted itself on two consecutive lines:

```
platform            Linux(Other("XFCE"))     <- knows the desktop
settings_source     gsettings:gnome          <- reads a different one
theme               Dark                     <- desktop is Mint-Y-Aqua, LIGHT
icon_theme          breeze-dark              <- desktop is Mint-Y-Sand
ui                  Noto Sans 10             <- xfconf says Ubuntu 10
```

XFCE keeps none of this in gsettings; **xfconf** is its store, and what `xfsettingsd` publishes there is what every GTK app on the session obeys.

- `LinuxSettingsSource` now resolves the store **from the detected desktop**: KDE → kdeglobals, GNOME and its forks → gsettings, XFCE → xfconf, LXQt, and the riced/tiling chain for Hyprland, Sway, i3, river and anything unknown.
- `~/.config/gtk-{4,3}.0/settings.ini` becomes the floor under every desktop *and* every bare WM, so a session with no settings daemon still loads natively instead of a hardcoded Adwaita.
- **The xdg-desktop-portal no longer short-circuits discovery.** It used to `return` a stock Adwaita palette before any desktop-specific code ran, so on any machine with a portal installed, nothing below it ever executed. It answers two questions — light/dark preference and accent — and now only fills what the desktop did not answer itself.
- Light/dark follows the **window manager's** theme (user ruling: "azwriter should use what the titlebar uses"). These genuinely disagree here: xfwm4 runs `Mint-Y-Aqua` (light titlebars) while `gtk-application-prefer-dark-theme` and gsettings `color-scheme` both say prefer-dark.

After: `settings_source xfconf`, theme Light, ui `Ubuntu 10`, gtk theme `Mint-Y-Aqua`, icons `Mint-Y-Sand`, cursor `Bibata-Modern-Classic`, titlebar layout `O|HMC` — every value matching what the desktop reports.

## 2. …and then could not find that theme's icons

With the correct theme name, Mint-Y-Sand registered **zero** icons where breeze-dark had registered 18, so every indicator fell back to the app's built-in at a different nominal size — which is what "the icons are scaled 2x" looks like. Three independent defects:

1. **Layout.** We read SVG, and searched only `{theme}/actions/{16,22,24,scalable}`. Mint-Y's `actions/{16,22,24}` are **PNG-only**; its SVGs live in `actions/symbolic`. Adwaita inverts the nesting entirely (`symbolic/actions`, `scalable/actions`, `16x16/actions`).
2. **Inheritance.** Only the *first* parent was followed, one level. Mint-Y-Sand inherits `Mint-Y,Adwaita,gnome,hicolor` and ships no `actions` icons of its own; what Mint-Y lacks is in Adwaita, the **second** entry.
3. **Names.** `WANTED` uses Breeze spellings; GNOME-lineage themes name half of them differently — `arrow-up` exists nowhere in that chain but `go-up` does, `checkmark` → `object-select`, `application-menu` → `open-menu`.

Mint-Y-Sand: 0 → 10 → **18/17** registered.

## 3. The title bar could not be dragged — four defects on one path

1. **The drag was dead code in the wrong `impl` block.** X11 and Win32 both *wrote* `handle_begin_interactive_move` — a complete `_NET_WM_MOVERESIZE` / `WM_NCLBUTTONDOWN` implementation — into their **inherent** `impl` instead of their `impl PlatformWindow`. The call resolves through the trait, so it bound to the trait's `{}` default: dragging did nothing on **both** backends while the real code sat there looking finished. Fixed by forwarding, and by **removing the default** so a backend that forgets does not compile. (The compiler immediately named X11, WaylandPopup and headless.)
2. **The gesture session was never closed** at the hand-off. The WM takes its own pointer grab, so the ButtonRelease goes to *it* and never returns — the session stayed open and the next press was folded into it. Dragging therefore worked every **other** attempt: at fixed x, `y=4 DRAG, 10 dead, 14 DRAG, 18 dead, 21 DRAG, 24 dead`. That alternation is what "the drag only works if you click the text" actually was. After: all 7 sampled points drag.
3. **The CSD resize band ate title-bar presses.** It ran even while maximized, where there is no resizable edge, and its `return` precedes `record_input_sample` — so the press produced neither DragStart nor DoubleClick. Maximized, that band's top 8 px sit at screen y=0, exactly where users aim.
4. **The maximize toggle used the forbidden door.** `flags` is OS-synced and the toggle wrote it via `update_unsynced_state`, whose own assert forbids exactly that whenever `validation_enabled()` — true under `debug_assertions`. **Debug builds panicked on title-bar double-click**; release builds changed the belief without telling the WM.

Verified: double-click restores (`1920x1047@0,0` + `MAXIMIZED_{VERT,HORZ}` → `1280x800@320,140`, atoms cleared) and re-maximizes; drag tracks the pointer exactly.

## 4. The style gallery painted document ink onto the chrome

Dark blue `#2e74b5` / `#262626` on charcoal; the Title sample was invisible. The ruling that previews are *not* themed stands — but "unthemed" cannot mean "unreadable". `sample_ink` keeps the hue and lifts only the lightness, only until it clears WCAG AA against the chrome. Light theme is byte-identical. The engine already had `ColorU::ensure_contrast`; the app simply wasn't calling it.

## 5. `headless_window_features` had not compiled since `TouchPoint` grew `seat_id`

The target failed to **build**, the same way `major`/`minor`/`orientation_rad`/`tool_type` broke it before. 7/7 again.

## Tests

Every fix is pinned by a test that was RED first: `theme_name_is_dark`, `titlebar_from_xfwm_layout` (xfwm4's `O|HMC` letters are not GNOME's words), `xfce_reads_xfconf_and_not_the_gnome_schemas`, the icon directory/alias tests, `every_gallery_ink_is_legible_on_its_own_chrome`, `lifting_an_ink_keeps_its_hue`. For the drag, the compiler is the test — the trait method is now required.

Green: `azul-dll --lib system_style::/system_icons::` 23/23, `headless_lifecycle` 7/7, `headless_window_features` 7/7, `text_changed_headless` 4/4, `AzWriter --lib palette::` 11/11.

## Known, measured, NOT fixed here

**Interactive resize repaints at ~23 fps on a 60 Hz display** — 44.2 ms median between frames (min 40.3, max 70.3) over 28 consecutive resize steps, from the app's own ConfigureNotify timestamps. The fast path *is* taken (no full DOM regeneration) and `detect_frame_interval` reads the real 60 Hz, so the cost is inside render/present. Next step: instrument `render_and_present`. Also open: the diagnostics sink panics when stderr is a closed pipe (`| head` on a running app kills it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FMzrTzd13njBVrULePteNJ