### PR TITLE
Derive parity: 44,934 -> 217 unreachable declared derives, and a gate that sees compile errors

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -273,6 +273,41 @@ jobs:
           fi
           ls -la target/release/azul-doc* || true
 
+      - name: Install binding toolchains (best effort)
+        # The derive gate proves a NAME is present in a generated binding; it
+        # cannot prove the binding COMPILES, because it greps text and a broken
+        # method still contains its name. Three non-compiling emissions shipped
+        # before this stage existed, and the V binding turned out never to have
+        # compiled at all while reporting zero unreachable derives.
+        #
+        # Every checker is probed against a known-good sample of its own
+        # language first, so a missing or broken tool SKIPS rather than being
+        # reported as broken generated code. That is why this install is
+        # best-effort: whatever lands gets used, whatever does not is skipped,
+        # and the job never fails because a package name moved.
+        #
+        # node, java and g++ ship on the runner and are exactly the three that
+        # cannot be checked on the maintainer's machine - node has a broken
+        # dylib, javac has no JRE, g++ cannot find <cstdint>. CI is where those
+        # actually get covered.
+        shell: bash
+        run: |
+          sudo apt-get update -qq || true
+          sudo apt-get install -y -qq \
+            gfortran php-cli luajit ruby perl \
+            ocaml libctypes-ocaml-dev golang-go || true
+          for t in gcc g++ gfortran perl ruby luajit php node javac go gofmt ocamlfind; do
+            printf '%-10s %s\n' "$t" "$(command -v $t || echo MISSING)"
+          done
+
+      - name: Compile-check the generated bindings
+        # Fails only on a language whose checker WORKS and whose artifact does
+        # not compile. See stage_binding_syntax in scripts/check.sh for the
+        # probe rule and the KNOWN_BROKEN list.
+        shell: bash
+        run: bash scripts/check.sh --only binding-syntax
+
+
       - name: Upload the azul-doc binary
         uses: actions/upload-artifact@v7
         with:

--- a/doc/src/codegen/v2/config.rs
+++ b/doc/src/codegen/v2/config.rs
@@ -607,9 +607,32 @@ impl CodegenConfig {
 
     /// Public Rust API (unprefixed, ergonomic)
     ///
-    /// This generates a clean public API without Az prefixes.
-    /// Note: This API re-exports from crate::dll, so it doesn't need
-    /// duplicate GL type aliases (those come from dll module).
+    /// This generates a clean public API without Az prefixes: one standalone
+    /// file that declares the C ABI and wraps it, for a consumer that links
+    /// `libazul` and wants `Dom` rather than `AzDom`.
+    ///
+    /// WHY THIS IS `UsingCAPI` AND NOT `UsingDerive`
+    /// ---------------------------------------------
+    /// It used to be `UsingDerive` with `CAbiFunctionMode::None`, and that
+    /// combination cannot work in either direction:
+    ///
+    ///   * `None` emits no `extern "C"` block, while `generate_impl_blocks`
+    ///     emits `pub fn new(..) { unsafe { AzDom_new(..) } }` regardless. Every
+    ///     method body in the file called an undeclared function.
+    ///   * `UsingDerive` puts `#[derive(Clone)]` on the mirror, which requires
+    ///     every FIELD's mirror to be `Clone` too. The owning leaves (`String`,
+    ///     `*Vec`, `RefAny`) get their `Clone` from the ABI, not from a derive,
+    ///     so the cascade failed for ~400 types.
+    ///
+    /// `UsingCAPI` + `ExternalBindings` is the shape that is internally
+    /// consistent — the same shape `dll_api_external.rs` uses — and it is what
+    /// makes the api.json `derive` list reachable here at all: `Debug`,
+    /// `PartialEq`, `PartialOrd`, `Ord`, `Hash` and `Default` become impls that
+    /// call `Az{T}_toDbgString` / `_partialEq` / `_partialCmp` / `_cmp` /
+    /// `_hash` / `_default`, all of which `libazul` already exports.
+    ///
+    /// Note that the C SYMBOLS stay `Az`-prefixed while the Rust TYPES are not;
+    /// see `lang_rust::ABI_PREFIX`.
     pub fn rust_public_api() -> Self {
         // Skip GL type aliases as they're already in the dll module
         let mut type_exclude = BTreeSet::new();
@@ -632,12 +655,18 @@ impl CodegenConfig {
 
         Self {
             target_lang: TargetLang::Rust,
-            cabi_functions: CAbiFunctionMode::None,
+            cabi_functions: CAbiFunctionMode::ExternalBindings {
+                link_library: "azul".into(),
+            },
             struct_mode: StructMode::Unprefixed,
-            trait_impl_mode: TraitImplMode::UsingDerive,
+            trait_impl_mode: TraitImplMode::UsingCAPI,
             type_prefix: "".into(),
             module_wrapper: None,
-            imports: vec!["use core::ffi::c_void;".into()],
+            imports: vec![
+                "extern crate alloc;".into(),
+                "use core::ffi::c_void;".into(),
+                "use core::ffi::c_int;".into(),
+            ],
             type_filter: None,
             type_exclude,
             indent: "    ".into(),

--- a/doc/src/codegen/v2/ir.rs
+++ b/doc/src/codegen/v2/ir.rs
@@ -469,6 +469,25 @@ impl FunctionKind {
         matches!(self, FunctionKind::Default)
     }
 
+    /// Is this an entry point that an api.json `derive` list asks for?
+    ///
+    /// The union of the three predicates around it, minus `Delete`. It exists
+    /// because the per-language `should_emit_function` filters exclude whole
+    /// TYPE CATEGORIES for reasons that are about ordinary methods -- callback
+    /// function pointers a managed binding cannot marshal, recursive layouts --
+    /// and those reasons do not apply to `Az{T}_toDbgString(ptr) -> AzString`
+    /// or `Az{T}_partialEq(a, b) -> bool`. Excluding those wholesale is how all
+    /// 114 `*VecDestructor` types came to declare `Debug` in api.json, have the
+    /// export in libazul, and name it in no binding at all.
+    ///
+    /// `Delete` is deliberately NOT included: no `derive` asks for a
+    /// destructor, and handing a caller a free `delete` for a type they hold by
+    /// value is a double-free waiting to happen.
+    pub fn is_declared_capability(&self) -> bool {
+        (self.is_trait_function() || self.is_clone_method() || self.is_default_constructor())
+            && !matches!(self, FunctionKind::Delete)
+    }
+
     /// Check if this is a DeepCopy method (should be generated as clone())
     pub fn is_clone_method(&self) -> bool {
         matches!(self, FunctionKind::DeepCopy)

--- a/doc/src/codegen/v2/lang_ada/functions.rs
+++ b/doc/src/codegen/v2/lang_ada/functions.rs
@@ -61,6 +61,22 @@ pub fn emit_imports(
 }
 
 fn should_emit_function(func: &FunctionDef, ir: &CodegenIR, config: &CodegenConfig) -> bool {
+    // A trait entry point an api.json `derive` declares is not what the
+    // `DestructorOrClone` exclusion below is for. That category is excluded
+    // because those types' ordinary methods traffic in callback function
+    // pointers this binding cannot marshal; `Az{T}_toDbgString(ptr) ->
+    // AzString` traffics in neither, and is the same shape as the ~2800
+    // `_toDbgString` declarations this binding already emits. Excluding it
+    // wholesale is why every `*VecDestructor` declared `Debug` and named it
+    // nowhere. (`*VecDestructor` is a tagged union, hence `find_enum`.)
+    if func.kind.is_declared_capability()
+        && ir
+            .find_enum(&func.class_name)
+            .is_some_and(|e| e.category == TypeCategory::DestructorOrClone)
+    {
+        return config.should_include_type(&func.class_name);
+    }
+
     if !config.should_include_type(&func.class_name) {
         return false;
     }

--- a/doc/src/codegen/v2/lang_ada/functions.rs
+++ b/doc/src/codegen/v2/lang_ada/functions.rs
@@ -69,10 +69,23 @@ fn should_emit_function(func: &FunctionDef, ir: &CodegenIR, config: &CodegenConf
     // `_toDbgString` declarations this binding already emits. Excluding it
     // wholesale is why every `*VecDestructor` declared `Debug` and named it
     // nowhere. (`*VecDestructor` is a tagged union, hence `find_enum`.)
+    // RECURSIVE types are here for the same reason. `XmlNodeChild` and friends
+    // are excluded below because their ORDINARY methods traffic in a shape
+    // this binding cannot express by value - but `Az{T}_partialEq(a, b) ->
+    // bool` and `Az{T}_toDbgString(ptr) -> AzString` take a pointer and return
+    // a scalar, so the exclusion never applied to them. That is why the same
+    // four types - `Xml`, `XmlNodeChild`, `XmlNodeChildVec`,
+    // `ResultXmlXmlError` - showed up as the residue in fourteen bindings at
+    // once: one cause, not fourteen.
     if func.kind.is_declared_capability()
-        && ir
-            .find_enum(&func.class_name)
-            .is_some_and(|e| e.category == TypeCategory::DestructorOrClone)
+        && (ir.find_enum(&func.class_name).is_some_and(|e| {
+            matches!(
+                e.category,
+                TypeCategory::DestructorOrClone | TypeCategory::Recursive
+            )
+        }) || ir
+            .find_struct(&func.class_name)
+            .is_some_and(|s| s.category == TypeCategory::Recursive))
     {
         return config.should_include_type(&func.class_name);
     }

--- a/doc/src/codegen/v2/lang_algol68/functions.rs
+++ b/doc/src/codegen/v2/lang_algol68/functions.rs
@@ -68,10 +68,23 @@ fn should_emit_function(func: &FunctionDef, ir: &CodegenIR, config: &CodegenConf
     // `_toDbgString` declarations this binding already emits. Excluding it
     // wholesale is why every `*VecDestructor` declared `Debug` and named it
     // nowhere. (`*VecDestructor` is a tagged union, hence `find_enum`.)
+    // RECURSIVE types are here for the same reason. `XmlNodeChild` and friends
+    // are excluded below because their ORDINARY methods traffic in a shape
+    // this binding cannot express by value - but `Az{T}_partialEq(a, b) ->
+    // bool` and `Az{T}_toDbgString(ptr) -> AzString` take a pointer and return
+    // a scalar, so the exclusion never applied to them. That is why the same
+    // four types - `Xml`, `XmlNodeChild`, `XmlNodeChildVec`,
+    // `ResultXmlXmlError` - showed up as the residue in fourteen bindings at
+    // once: one cause, not fourteen.
     if func.kind.is_declared_capability()
-        && ir
-            .find_enum(&func.class_name)
-            .is_some_and(|e| e.category == TypeCategory::DestructorOrClone)
+        && (ir.find_enum(&func.class_name).is_some_and(|e| {
+            matches!(
+                e.category,
+                TypeCategory::DestructorOrClone | TypeCategory::Recursive
+            )
+        }) || ir
+            .find_struct(&func.class_name)
+            .is_some_and(|s| s.category == TypeCategory::Recursive))
     {
         return config.should_include_type(&func.class_name);
     }

--- a/doc/src/codegen/v2/lang_algol68/functions.rs
+++ b/doc/src/codegen/v2/lang_algol68/functions.rs
@@ -60,6 +60,22 @@ pub fn generate_aliens(
 }
 
 fn should_emit_function(func: &FunctionDef, ir: &CodegenIR, config: &CodegenConfig) -> bool {
+    // A trait entry point an api.json `derive` declares is not what the
+    // `DestructorOrClone` exclusion below is for. That category is excluded
+    // because those types' ordinary methods traffic in callback function
+    // pointers this binding cannot marshal; `Az{T}_toDbgString(ptr) ->
+    // AzString` traffics in neither, and is the same shape as the ~2800
+    // `_toDbgString` declarations this binding already emits. Excluding it
+    // wholesale is why every `*VecDestructor` declared `Debug` and named it
+    // nowhere. (`*VecDestructor` is a tagged union, hence `find_enum`.)
+    if func.kind.is_declared_capability()
+        && ir
+            .find_enum(&func.class_name)
+            .is_some_and(|e| e.category == TypeCategory::DestructorOrClone)
+    {
+        return config.should_include_type(&func.class_name);
+    }
+
     if !config.should_include_type(&func.class_name) {
         return false;
     }

--- a/doc/src/codegen/v2/lang_cobol/functions.rs
+++ b/doc/src/codegen/v2/lang_cobol/functions.rs
@@ -66,6 +66,22 @@ pub fn generate_function_constants(
 }
 
 fn should_emit_function(func: &FunctionDef, ir: &CodegenIR, config: &CodegenConfig) -> bool {
+    // A trait entry point an api.json `derive` declares is not what the
+    // `DestructorOrClone` exclusion below is for. That category is excluded
+    // because those types' ordinary methods traffic in callback function
+    // pointers this binding cannot marshal; `Az{T}_toDbgString(ptr) ->
+    // AzString` traffics in neither, and is the same shape as the ~2800
+    // `_toDbgString` declarations this binding already emits. Excluding it
+    // wholesale is why every `*VecDestructor` declared `Debug` and named it
+    // nowhere. (`*VecDestructor` is a tagged union, hence `find_enum`.)
+    if func.kind.is_declared_capability()
+        && ir
+            .find_enum(&func.class_name)
+            .is_some_and(|e| e.category == TypeCategory::DestructorOrClone)
+    {
+        return config.should_include_type(&func.class_name);
+    }
+
     if !config.should_include_type(&func.class_name) {
         return false;
     }

--- a/doc/src/codegen/v2/lang_cobol/functions.rs
+++ b/doc/src/codegen/v2/lang_cobol/functions.rs
@@ -74,10 +74,23 @@ fn should_emit_function(func: &FunctionDef, ir: &CodegenIR, config: &CodegenConf
     // `_toDbgString` declarations this binding already emits. Excluding it
     // wholesale is why every `*VecDestructor` declared `Debug` and named it
     // nowhere. (`*VecDestructor` is a tagged union, hence `find_enum`.)
+    // RECURSIVE types are here for the same reason. `XmlNodeChild` and friends
+    // are excluded below because their ORDINARY methods traffic in a shape
+    // this binding cannot express by value - but `Az{T}_partialEq(a, b) ->
+    // bool` and `Az{T}_toDbgString(ptr) -> AzString` take a pointer and return
+    // a scalar, so the exclusion never applied to them. That is why the same
+    // four types - `Xml`, `XmlNodeChild`, `XmlNodeChildVec`,
+    // `ResultXmlXmlError` - showed up as the residue in fourteen bindings at
+    // once: one cause, not fourteen.
     if func.kind.is_declared_capability()
-        && ir
-            .find_enum(&func.class_name)
-            .is_some_and(|e| e.category == TypeCategory::DestructorOrClone)
+        && (ir.find_enum(&func.class_name).is_some_and(|e| {
+            matches!(
+                e.category,
+                TypeCategory::DestructorOrClone | TypeCategory::Recursive
+            )
+        }) || ir
+            .find_struct(&func.class_name)
+            .is_some_and(|s| s.category == TypeCategory::Recursive))
     {
         return config.should_include_type(&func.class_name);
     }

--- a/doc/src/codegen/v2/lang_cpp/common.rs
+++ b/doc/src/codegen/v2/lang_cpp/common.rs
@@ -147,15 +147,6 @@ pub fn is_constructor_or_default(func: &FunctionDef) -> bool {
     matches!(func.kind, FunctionKind::Constructor) || func.kind.is_default_constructor()
 }
 
-/// Check if a function is a method that should be skipped (delete, partialEq, etc.)
-/// Note: DeepCopy is NOT skipped - it becomes clone()
-/// Note: Default is NOT skipped - it becomes default_()
-pub fn should_skip_method(func: &FunctionDef) -> bool {
-    matches!(func.kind, FunctionKind::Constructor) ||
-    func.kind.is_trait_function() ||  // delete, partialEq, etc. - but NOT deepCopy or default
-    func.kind.is_default_constructor() // handled separately as static constructor
-}
-
 /// Check if callback substitution should be applied for a function
 /// True for any "user-facing" function (constructors, instance methods both
 /// const and mut, static methods); skipped for trait-generated functions and
@@ -1698,5 +1689,194 @@ pub fn generate_refany_freefn_downcasts(standard: CppStandard) -> String {
     code.push_str("    if (!AzRefAny_isType(&data, tag)) return nullptr;\r\n");
     code.push_str("    return static_cast<T*>(const_cast<void*>(AzRefAny_getDataPtr(&data)));\r\n");
     code.push_str("}\r\n");
+    code
+}
+
+// ============================================================================
+// Trait entry points for classes that get NO wrapper class
+// ============================================================================
+
+/// Free-function forms of the trait entry points, for the classes that never
+/// get a wrapper class.
+///
+/// WHY THIS EXISTS
+/// ---------------
+/// The wrapper classes carry `partialEq` / `partialCmp` / `cmp` / `hash` /
+/// `toDbgString` / `clone` / `default_` as member functions, so an api.json
+/// `derive` on a struct is reachable. Enums are not wrapped: a fieldless enum
+/// becomes `namespace AlertKind { inline constexpr AzAlertKind Info = ...; }`
+/// over the raw C enum, and a tagged union becomes `using X = AzX;`. Neither
+/// has anywhere to hang a method, so every derive declared by an enum — 2133
+/// of them, a third of the C++ surface — was unreachable from C++ in EVERY
+/// dialect, while libazul exported all of them.
+///
+/// THE SHAPE, AND WHY NOT `operator==`
+/// -----------------------------------
+/// These are named free functions in `namespace azul`, overloaded on the
+/// argument type, and NOT operator overloads. Two reasons, both about the fact
+/// that the types here are aliases of C types declared at GLOBAL scope:
+///
+///   * ADL for `a == b` where both operands are `::AzAlertKind` searches the
+///     global namespace, not `azul`, so an `azul::operator==` would be found
+///     only by callers who wrote `using namespace azul;`. A named call
+///     `azul::partialEq(a, b)` always resolves.
+///   * For a FIELDLESS enum the built-in `==` / `<` already exist and mean the
+///     right thing (Rust derives them on the discriminant too), so an overload
+///     would compete with the built-in candidates for no gain. What is genuinely
+///     missing there is `toDbgString` (no way to get a variant NAME without the
+///     ABI) and `default_`.
+///
+/// `defaultOf<T>()` is a template because `Default` takes no argument: plain
+/// overloading cannot distinguish `default_()` for two different types.
+///
+/// Only entry points that EXIST are emitted — the walk is over `ir.functions`,
+/// which `IrBuilder::build_trait_functions` populates from the api.json
+/// `derive` list, so a class that does not declare `Hash` gets no `hash`
+/// overload rather than one that calls a symbol libazul does not export.
+pub fn generate_freefn_trait_helpers(
+    ir: &CodegenIR,
+    config: &CodegenConfig,
+    standard: CppStandard,
+) -> String {
+    use std::collections::BTreeSet;
+
+    // Every class that DOES get a wrapper class, computed with the same
+    // predicates the class-declaration loops use. The complement is what needs
+    // free functions, so the two can never both fire for one class.
+    let synthesized = synthesize_option_result_structs(ir);
+    let mut wrapped: BTreeSet<&str> = BTreeSet::new();
+    for s in ir.structs.iter().chain(synthesized.iter()) {
+        if should_skip_class(s) || renders_as_type_alias(s) {
+            continue;
+        }
+        wrapped.insert(s.name.as_str());
+    }
+
+    // Group the trait entry points by class, in emission order.
+    let mut by_class: Vec<(&str, Vec<&FunctionDef>)> = Vec::new();
+    let mut seen: BTreeSet<&str> = BTreeSet::new();
+    for f in &ir.functions {
+        // `is_trait_function()` covers Delete/PartialEq/PartialCmp/Cmp/Hash/
+        // DebugToString but NOT DeepCopy or Default, which have their own
+        // predicates because the class emitters turn them into ordinary static
+        // methods (`clone()`, `default_()`). All three groups are asked for by
+        // an api.json `derive`, so all three belong here.
+        let is_capability = f.kind.is_trait_function()
+            || f.kind.is_clone_method()
+            || f.kind.is_default_constructor();
+        if !is_capability {
+            continue;
+        }
+        // `_delete` is not a capability any `derive` declares, and handing a
+        // caller a free `delete` for a type they hold by value is a
+        // double-free waiting to happen.
+        if matches!(f.kind, FunctionKind::Delete) {
+            continue;
+        }
+        let class = f.class_name.as_str();
+        if wrapped.contains(class) || !config.should_include_type(class) {
+            continue;
+        }
+        if seen.insert(class) {
+            by_class.push((class, Vec::new()));
+        }
+        if let Some(entry) = by_class.iter_mut().find(|(c, _)| *c == class) {
+            entry.1.push(f);
+        }
+    }
+    if by_class.is_empty() {
+        return String::new();
+    }
+
+    let mut code = String::new();
+    code.push_str("// ---------------------------------------------------------------------------\r\n");
+    code.push_str("// Trait entry points for enums and tagged unions\r\n");
+    code.push_str("//\r\n");
+    code.push_str("// These types alias the raw C type and have no wrapper class to carry the\r\n");
+    code.push_str("// methods, so the capabilities their api.json `derive` list declares are\r\n");
+    code.push_str("// exposed as free functions overloaded on the argument type:\r\n");
+    code.push_str("//\r\n");
+    code.push_str("//     azul::partialEq(a, b)      azul::toDbgString(a)\r\n");
+    code.push_str("//     azul::partialCmp(a, b)     azul::hash(a)\r\n");
+    code.push_str("//     azul::cmp(a, b)            azul::clone(a)\r\n");
+    code.push_str("//     azul::defaultOf<AzAlertKind>()\r\n");
+    code.push_str("//\r\n");
+    code.push_str("// partialCmp/cmp return the ABI ordering byte: 0 = Less, 1 = Equal,\r\n");
+    code.push_str("// 2 = Greater (and 3 = unordered, from partialCmp only).\r\n");
+    code.push_str("// ---------------------------------------------------------------------------\r\n\r\n");
+
+    // Primary template for the argument-less `Default`.
+    let mut needs_default_template = false;
+    for (_, fns) in &by_class {
+        if fns.iter().any(|f| matches!(f.kind, FunctionKind::Default)) {
+            needs_default_template = true;
+        }
+    }
+    if needs_default_template {
+        code.push_str("// Declared, never defined: only the explicit specializations below exist,\r\n");
+        code.push_str("// so `defaultOf<T>()` for a type with no `Default` derive is a link-time\r\n");
+        code.push_str("// error rather than a silently wrong value.\r\n");
+        code.push_str("template <typename T> T defaultOf();\r\n\r\n");
+    }
+
+    for (class, fns) in &by_class {
+        let c_type = config.apply_prefix(class);
+        code.push_str(&format!("// {}\r\n", class));
+        for f in fns {
+            let c_fn = &f.c_name;
+            match f.kind {
+                FunctionKind::PartialEq => code.push_str(&format!(
+                    "inline bool partialEq(const {t}& a, const {t}& b) {{ return {f}(&a, &b); }}\r\n",
+                    t = c_type,
+                    f = c_fn
+                )),
+                FunctionKind::PartialCmp => code.push_str(&format!(
+                    "inline uint8_t partialCmp(const {t}& a, const {t}& b) {{ return {f}(&a, &b); }}\r\n",
+                    t = c_type,
+                    f = c_fn
+                )),
+                FunctionKind::Cmp => code.push_str(&format!(
+                    "inline uint8_t cmp(const {t}& a, const {t}& b) {{ return {f}(&a, &b); }}\r\n",
+                    t = c_type,
+                    f = c_fn
+                )),
+                FunctionKind::Hash => code.push_str(&format!(
+                    "inline uint64_t hash(const {t}& a) {{ return {f}(&a); }}\r\n",
+                    t = c_type,
+                    f = c_fn
+                )),
+                FunctionKind::DeepCopy => code.push_str(&format!(
+                    "inline {t} clone(const {t}& a) {{ return {f}(&a); }}\r\n",
+                    t = c_type,
+                    f = c_fn
+                )),
+                FunctionKind::DebugToString => {
+                    // C++03's `String` is copy-with-ownership-transfer via the
+                    // Colvin-Gibbons `Proxy`; C++11+ moves. Mirrors exactly what
+                    // the wrapper classes' own `toDbgString` emits.
+                    if standard.has_move_semantics() {
+                        code.push_str(&format!(
+                            "inline String toDbgString(const {t}& a) {{ return String({f}(&a)); }}\r\n",
+                            t = c_type,
+                            f = c_fn
+                        ));
+                    } else {
+                        code.push_str(&format!(
+                            "inline String toDbgString(const {t}& a) {{ String::Proxy _p({f}(&a)); return _p; }}\r\n",
+                            t = c_type,
+                            f = c_fn
+                        ));
+                    }
+                }
+                FunctionKind::Default => code.push_str(&format!(
+                    "template <> inline {t} defaultOf<{t}>() {{ return {f}(); }}\r\n",
+                    t = c_type,
+                    f = c_fn
+                )),
+                _ => {}
+            }
+        }
+        code.push_str("\r\n");
+    }
     code
 }

--- a/doc/src/codegen/v2/lang_cpp/cpp03.rs
+++ b/doc/src/codegen/v2/lang_cpp/cpp03.rs
@@ -103,6 +103,10 @@ impl CppDialect for Cpp03Generator {
         }
 
         // Close namespace
+        // Trait entry points for the classes that got no wrapper class
+        // (enums, tagged unions). See `generate_freefn_trait_helpers`.
+        code.push_str(&generate_freefn_trait_helpers(ir, config, std));
+
         code.push_str("} // namespace azul\r\n\r\n");
 
         // Include guards end

--- a/doc/src/codegen/v2/lang_cpp/cpp11.rs
+++ b/doc/src/codegen/v2/lang_cpp/cpp11.rs
@@ -119,6 +119,10 @@ impl CppDialect for Cpp11Generator {
         }
 
         // Close namespace
+        // Trait entry points for the classes that got no wrapper class
+        // (enums, tagged unions). See `generate_freefn_trait_helpers`.
+        code.push_str(&generate_freefn_trait_helpers(ir, config, std));
+
         code.push_str("} // namespace azul\r\n\r\n");
 
         // Include guards end
@@ -213,7 +217,15 @@ impl CppDialect for Cpp11Generator {
             .functions
             .iter()
             .filter(|f| f.class_name == *class_name)
-            .filter(|f| !should_skip_method(f))
+            // `is_constructor_or_default`, NOT `should_skip_method`: the
+            // latter also drops every `is_trait_function()` kind, which is why
+            // C++11 and C++14 alone shipped wrapper classes with no
+            // `partialEq` / `partialCmp` / `cmp` / `hash` / `toDbgString` at
+            // all while C++03/17/20/23 shipped all five. The api.json `derive`
+            // list is the same in every dialect and libazul exports the same
+            // entry points to all of them; there is nothing about C++11 that
+            // makes them unavailable.
+            .filter(|f| !is_constructor_or_default(f))
         {
             let cpp_fn_name = escape_method_name(&func.method_name);
             let c_fn_name = &func.c_name;
@@ -572,7 +584,7 @@ impl Cpp11Generator {
             .functions
             .iter()
             .filter(|f| f.class_name == class_name)
-            .filter(|f| !should_skip_method(f))
+            .filter(|f| !is_constructor_or_default(f))
             .collect();
 
         if !methods.is_empty() {

--- a/doc/src/codegen/v2/lang_cpp/cpp14.rs
+++ b/doc/src/codegen/v2/lang_cpp/cpp14.rs
@@ -119,6 +119,10 @@ impl CppDialect for Cpp14Generator {
         // Out-of-class definition for RefAny::type_id_v (C++14 only).
         code.push_str(&generate_refany_type_id_v_definition(std));
 
+        // Trait entry points for the classes that got no wrapper class
+        // (enums, tagged unions). See `generate_freefn_trait_helpers`.
+        code.push_str(&generate_freefn_trait_helpers(ir, config, std));
+
         code.push_str("} // namespace azul\r\n\r\n");
         // Structured bindings on Result types use std::optional + if-constexpr,
         // which are C++17 features.

--- a/doc/src/codegen/v2/lang_cpp/cpp17.rs
+++ b/doc/src/codegen/v2/lang_cpp/cpp17.rs
@@ -118,6 +118,10 @@ impl CppDialect for Cpp17Generator {
         }
 
         // Close namespace
+        // Trait entry points for the classes that got no wrapper class
+        // (enums, tagged unions). See `generate_freefn_trait_helpers`.
+        code.push_str(&generate_freefn_trait_helpers(ir, config, std));
+
         code.push_str("} // namespace azul\r\n\r\n");
 
         // Structured-binding specializations live in `namespace std`.

--- a/doc/src/codegen/v2/lang_cpp/cpp20.rs
+++ b/doc/src/codegen/v2/lang_cpp/cpp20.rs
@@ -124,6 +124,10 @@ impl CppDialect for Cpp20Generator {
         }
 
         // Close namespace
+        // Trait entry points for the classes that got no wrapper class
+        // (enums, tagged unions). See `generate_freefn_trait_helpers`.
+        code.push_str(&generate_freefn_trait_helpers(ir, config, std));
+
         code.push_str("} // namespace azul\r\n\r\n");
 
         // Structured-binding specializations (namespace std).
@@ -476,6 +480,10 @@ impl CppDialect for Cpp23Generator {
             }
             self.generate_method_implementations(&mut code, struct_def, ir, config);
         }
+
+        // Trait entry points for the classes that got no wrapper class
+        // (enums, tagged unions). See `generate_freefn_trait_helpers`.
+        code.push_str(&generate_freefn_trait_helpers(ir, config, std));
 
         code.push_str("} // namespace azul\r\n\r\n");
 

--- a/doc/src/codegen/v2/lang_crystal/mod.rs
+++ b/doc/src/codegen/v2/lang_crystal/mod.rs
@@ -407,10 +407,23 @@ pub fn should_emit_function(func: &FunctionDef, ir: &CodegenIR, config: &Codegen
     // `_toDbgString` declarations this binding already emits. Excluding it
     // wholesale is why every `*VecDestructor` declared `Debug` and named it
     // nowhere. (`*VecDestructor` is a tagged union, hence `find_enum`.)
+    // RECURSIVE types are here for the same reason. `XmlNodeChild` and friends
+    // are excluded below because their ORDINARY methods traffic in a shape
+    // this binding cannot express by value - but `Az{T}_partialEq(a, b) ->
+    // bool` and `Az{T}_toDbgString(ptr) -> AzString` take a pointer and return
+    // a scalar, so the exclusion never applied to them. That is why the same
+    // four types - `Xml`, `XmlNodeChild`, `XmlNodeChildVec`,
+    // `ResultXmlXmlError` - showed up as the residue in fourteen bindings at
+    // once: one cause, not fourteen.
     if func.kind.is_declared_capability()
-        && ir
-            .find_enum(&func.class_name)
-            .is_some_and(|e| e.category == TypeCategory::DestructorOrClone)
+        && (ir.find_enum(&func.class_name).is_some_and(|e| {
+            matches!(
+                e.category,
+                TypeCategory::DestructorOrClone | TypeCategory::Recursive
+            )
+        }) || ir
+            .find_struct(&func.class_name)
+            .is_some_and(|s| s.category == TypeCategory::Recursive))
     {
         return config.should_include_type(&func.class_name);
     }

--- a/doc/src/codegen/v2/lang_crystal/mod.rs
+++ b/doc/src/codegen/v2/lang_crystal/mod.rs
@@ -399,6 +399,22 @@ pub fn include_enum(e: &EnumDef, config: &CodegenConfig) -> bool {
 /// Pascal filter: skip functions whose owning class is a recursive /
 /// VecRef / destructor / generic-template type.
 pub fn should_emit_function(func: &FunctionDef, ir: &CodegenIR, config: &CodegenConfig) -> bool {
+    // A trait entry point an api.json `derive` declares is not what the
+    // `DestructorOrClone` exclusion below is for. That category is excluded
+    // because those types' ordinary methods traffic in callback function
+    // pointers this binding cannot marshal; `Az{T}_toDbgString(ptr) ->
+    // AzString` traffics in neither, and is the same shape as the ~2800
+    // `_toDbgString` declarations this binding already emits. Excluding it
+    // wholesale is why every `*VecDestructor` declared `Debug` and named it
+    // nowhere. (`*VecDestructor` is a tagged union, hence `find_enum`.)
+    if func.kind.is_declared_capability()
+        && ir
+            .find_enum(&func.class_name)
+            .is_some_and(|e| e.category == TypeCategory::DestructorOrClone)
+    {
+        return config.should_include_type(&func.class_name);
+    }
+
     if !config.should_include_type(&func.class_name) {
         return false;
     }

--- a/doc/src/codegen/v2/lang_csharp/functions.rs
+++ b/doc/src/codegen/v2/lang_csharp/functions.rs
@@ -102,6 +102,18 @@ pub fn generate_native_methods(
 }
 
 fn should_emit_function(func: &FunctionDef, ir: &CodegenIR, config: &CodegenConfig) -> bool {
+    // A trait entry point declared by an api.json `derive` is NOT part of what
+    // this category exclusion is for. `DestructorOrClone` is excluded because
+    // those types' ordinary methods traffic in callback function pointers this
+    // binding cannot marshal; `Az{T}_toDbgString(ptr) -> AzString` traffics in
+    // neither. Excluding it wholesale is why all 114 `*VecDestructor` types
+    // declared `Debug` and exposed it nowhere. `Delete` stays excluded: no
+    // `derive` asks for it, and a destructor on a value type is a footgun.
+    let is_declared_capability = (func.kind.is_trait_function()
+        || func.kind.is_clone_method()
+        || func.kind.is_default_constructor())
+        && !matches!(func.kind, super::super::ir::FunctionKind::Delete);
+
     if !config.should_include_type(&func.class_name) {
         return false;
     }
@@ -111,9 +123,9 @@ fn should_emit_function(func: &FunctionDef, ir: &CodegenIR, config: &CodegenConf
             s.category,
             TypeCategory::Recursive
                 | TypeCategory::VecRef
-                | TypeCategory::DestructorOrClone
                 | TypeCategory::GenericTemplate
-        ) {
+        ) && !(is_declared_capability && s.category == TypeCategory::DestructorOrClone)
+        {
             return false;
         }
         if !s.generic_params.is_empty() {
@@ -124,9 +136,9 @@ fn should_emit_function(func: &FunctionDef, ir: &CodegenIR, config: &CodegenConf
         if matches!(
             e.category,
             TypeCategory::Recursive
-                | TypeCategory::DestructorOrClone
                 | TypeCategory::GenericTemplate
-        ) {
+        ) && !(is_declared_capability && e.category == TypeCategory::DestructorOrClone)
+        {
             return false;
         }
         if !e.generic_params.is_empty() {

--- a/doc/src/codegen/v2/lang_csharp/functions.rs
+++ b/doc/src/codegen/v2/lang_csharp/functions.rs
@@ -110,10 +110,23 @@ fn should_emit_function(func: &FunctionDef, ir: &CodegenIR, config: &CodegenConf
     // `_toDbgString` declarations this binding already emits. Excluding it
     // wholesale is why every `*VecDestructor` declared `Debug` and named it
     // nowhere. (`*VecDestructor` is a tagged union, hence `find_enum`.)
+    // RECURSIVE types are here for the same reason. `XmlNodeChild` and friends
+    // are excluded below because their ORDINARY methods traffic in a shape
+    // this binding cannot express by value - but `Az{T}_partialEq(a, b) ->
+    // bool` and `Az{T}_toDbgString(ptr) -> AzString` take a pointer and return
+    // a scalar, so the exclusion never applied to them. That is why the same
+    // four types - `Xml`, `XmlNodeChild`, `XmlNodeChildVec`,
+    // `ResultXmlXmlError` - showed up as the residue in fourteen bindings at
+    // once: one cause, not fourteen.
     if func.kind.is_declared_capability()
-        && ir
-            .find_enum(&func.class_name)
-            .is_some_and(|e| e.category == TypeCategory::DestructorOrClone)
+        && (ir.find_enum(&func.class_name).is_some_and(|e| {
+            matches!(
+                e.category,
+                TypeCategory::DestructorOrClone | TypeCategory::Recursive
+            )
+        }) || ir
+            .find_struct(&func.class_name)
+            .is_some_and(|s| s.category == TypeCategory::Recursive))
     {
         return config.should_include_type(&func.class_name);
     }

--- a/doc/src/codegen/v2/lang_csharp/functions.rs
+++ b/doc/src/codegen/v2/lang_csharp/functions.rs
@@ -102,17 +102,21 @@ pub fn generate_native_methods(
 }
 
 fn should_emit_function(func: &FunctionDef, ir: &CodegenIR, config: &CodegenConfig) -> bool {
-    // A trait entry point declared by an api.json `derive` is NOT part of what
-    // this category exclusion is for. `DestructorOrClone` is excluded because
-    // those types' ordinary methods traffic in callback function pointers this
-    // binding cannot marshal; `Az{T}_toDbgString(ptr) -> AzString` traffics in
-    // neither. Excluding it wholesale is why all 114 `*VecDestructor` types
-    // declared `Debug` and exposed it nowhere. `Delete` stays excluded: no
-    // `derive` asks for it, and a destructor on a value type is a footgun.
-    let is_declared_capability = (func.kind.is_trait_function()
-        || func.kind.is_clone_method()
-        || func.kind.is_default_constructor())
-        && !matches!(func.kind, super::super::ir::FunctionKind::Delete);
+    // A trait entry point an api.json `derive` declares is not what the
+    // `DestructorOrClone` exclusion below is for. That category is excluded
+    // because those types' ordinary methods traffic in callback function
+    // pointers this binding cannot marshal; `Az{T}_toDbgString(ptr) ->
+    // AzString` traffics in neither, and is the same shape as the ~2800
+    // `_toDbgString` declarations this binding already emits. Excluding it
+    // wholesale is why every `*VecDestructor` declared `Debug` and named it
+    // nowhere. (`*VecDestructor` is a tagged union, hence `find_enum`.)
+    if func.kind.is_declared_capability()
+        && ir
+            .find_enum(&func.class_name)
+            .is_some_and(|e| e.category == TypeCategory::DestructorOrClone)
+    {
+        return config.should_include_type(&func.class_name);
+    }
 
     if !config.should_include_type(&func.class_name) {
         return false;
@@ -123,9 +127,9 @@ fn should_emit_function(func: &FunctionDef, ir: &CodegenIR, config: &CodegenConf
             s.category,
             TypeCategory::Recursive
                 | TypeCategory::VecRef
+                | TypeCategory::DestructorOrClone
                 | TypeCategory::GenericTemplate
-        ) && !(is_declared_capability && s.category == TypeCategory::DestructorOrClone)
-        {
+        ) {
             return false;
         }
         if !s.generic_params.is_empty() {
@@ -136,9 +140,9 @@ fn should_emit_function(func: &FunctionDef, ir: &CodegenIR, config: &CodegenConf
         if matches!(
             e.category,
             TypeCategory::Recursive
+                | TypeCategory::DestructorOrClone
                 | TypeCategory::GenericTemplate
-        ) && !(is_declared_capability && e.category == TypeCategory::DestructorOrClone)
-        {
+        ) {
             return false;
         }
         if !e.generic_params.is_empty() {

--- a/doc/src/codegen/v2/lang_d/mod.rs
+++ b/doc/src/codegen/v2/lang_d/mod.rs
@@ -391,6 +391,22 @@ pub fn include_enum(e: &EnumDef, config: &CodegenConfig) -> bool {
 /// Odin / Pascal filter: skip functions whose owning class is a recursive
 /// / VecRef / destructor / generic-template type.
 pub fn should_emit_function(func: &FunctionDef, ir: &CodegenIR, config: &CodegenConfig) -> bool {
+    // A trait entry point an api.json `derive` declares is not what the
+    // `DestructorOrClone` exclusion below is for. That category is excluded
+    // because those types' ordinary methods traffic in callback function
+    // pointers this binding cannot marshal; `Az{T}_toDbgString(ptr) ->
+    // AzString` traffics in neither, and is the same shape as the ~2800
+    // `_toDbgString` declarations this binding already emits. Excluding it
+    // wholesale is why every `*VecDestructor` declared `Debug` and named it
+    // nowhere. (`*VecDestructor` is a tagged union, hence `find_enum`.)
+    if func.kind.is_declared_capability()
+        && ir
+            .find_enum(&func.class_name)
+            .is_some_and(|e| e.category == TypeCategory::DestructorOrClone)
+    {
+        return config.should_include_type(&func.class_name);
+    }
+
     if !config.should_include_type(&func.class_name) {
         return false;
     }

--- a/doc/src/codegen/v2/lang_d/mod.rs
+++ b/doc/src/codegen/v2/lang_d/mod.rs
@@ -399,10 +399,23 @@ pub fn should_emit_function(func: &FunctionDef, ir: &CodegenIR, config: &Codegen
     // `_toDbgString` declarations this binding already emits. Excluding it
     // wholesale is why every `*VecDestructor` declared `Debug` and named it
     // nowhere. (`*VecDestructor` is a tagged union, hence `find_enum`.)
+    // RECURSIVE types are here for the same reason. `XmlNodeChild` and friends
+    // are excluded below because their ORDINARY methods traffic in a shape
+    // this binding cannot express by value - but `Az{T}_partialEq(a, b) ->
+    // bool` and `Az{T}_toDbgString(ptr) -> AzString` take a pointer and return
+    // a scalar, so the exclusion never applied to them. That is why the same
+    // four types - `Xml`, `XmlNodeChild`, `XmlNodeChildVec`,
+    // `ResultXmlXmlError` - showed up as the residue in fourteen bindings at
+    // once: one cause, not fourteen.
     if func.kind.is_declared_capability()
-        && ir
-            .find_enum(&func.class_name)
-            .is_some_and(|e| e.category == TypeCategory::DestructorOrClone)
+        && (ir.find_enum(&func.class_name).is_some_and(|e| {
+            matches!(
+                e.category,
+                TypeCategory::DestructorOrClone | TypeCategory::Recursive
+            )
+        }) || ir
+            .find_struct(&func.class_name)
+            .is_some_and(|s| s.category == TypeCategory::Recursive))
     {
         return config.should_include_type(&func.class_name);
     }

--- a/doc/src/codegen/v2/lang_fortran/functions.rs
+++ b/doc/src/codegen/v2/lang_fortran/functions.rs
@@ -81,10 +81,23 @@ fn should_emit_function(func: &FunctionDef, ir: &CodegenIR, config: &CodegenConf
     // `_toDbgString` declarations this binding already emits. Excluding it
     // wholesale is why every `*VecDestructor` declared `Debug` and named it
     // nowhere. (`*VecDestructor` is a tagged union, hence `find_enum`.)
+    // RECURSIVE types are here for the same reason. `XmlNodeChild` and friends
+    // are excluded below because their ORDINARY methods traffic in a shape
+    // this binding cannot express by value - but `Az{T}_partialEq(a, b) ->
+    // bool` and `Az{T}_toDbgString(ptr) -> AzString` take a pointer and return
+    // a scalar, so the exclusion never applied to them. That is why the same
+    // four types - `Xml`, `XmlNodeChild`, `XmlNodeChildVec`,
+    // `ResultXmlXmlError` - showed up as the residue in fourteen bindings at
+    // once: one cause, not fourteen.
     if func.kind.is_declared_capability()
-        && ir
-            .find_enum(&func.class_name)
-            .is_some_and(|e| e.category == TypeCategory::DestructorOrClone)
+        && (ir.find_enum(&func.class_name).is_some_and(|e| {
+            matches!(
+                e.category,
+                TypeCategory::DestructorOrClone | TypeCategory::Recursive
+            )
+        }) || ir
+            .find_struct(&func.class_name)
+            .is_some_and(|s| s.category == TypeCategory::Recursive))
     {
         return config.should_include_type(&func.class_name);
     }

--- a/doc/src/codegen/v2/lang_fortran/functions.rs
+++ b/doc/src/codegen/v2/lang_fortran/functions.rs
@@ -73,6 +73,22 @@ pub fn generate_externals(
 }
 
 fn should_emit_function(func: &FunctionDef, ir: &CodegenIR, config: &CodegenConfig) -> bool {
+    // A trait entry point an api.json `derive` declares is not what the
+    // `DestructorOrClone` exclusion below is for. That category is excluded
+    // because those types' ordinary methods traffic in callback function
+    // pointers this binding cannot marshal; `Az{T}_toDbgString(ptr) ->
+    // AzString` traffics in neither, and is the same shape as the ~2800
+    // `_toDbgString` declarations this binding already emits. Excluding it
+    // wholesale is why every `*VecDestructor` declared `Debug` and named it
+    // nowhere. (`*VecDestructor` is a tagged union, hence `find_enum`.)
+    if func.kind.is_declared_capability()
+        && ir
+            .find_enum(&func.class_name)
+            .is_some_and(|e| e.category == TypeCategory::DestructorOrClone)
+    {
+        return config.should_include_type(&func.class_name);
+    }
+
     if !config.should_include_type(&func.class_name) {
         return false;
     }

--- a/doc/src/codegen/v2/lang_freebasic/functions.rs
+++ b/doc/src/codegen/v2/lang_freebasic/functions.rs
@@ -41,6 +41,22 @@ pub fn generate_externals(
 }
 
 fn should_emit_function(func: &FunctionDef, ir: &CodegenIR, config: &CodegenConfig) -> bool {
+    // A trait entry point an api.json `derive` declares is not what the
+    // `DestructorOrClone` exclusion below is for. That category is excluded
+    // because those types' ordinary methods traffic in callback function
+    // pointers this binding cannot marshal; `Az{T}_toDbgString(ptr) ->
+    // AzString` traffics in neither, and is the same shape as the ~2800
+    // `_toDbgString` declarations this binding already emits. Excluding it
+    // wholesale is why every `*VecDestructor` declared `Debug` and named it
+    // nowhere. (`*VecDestructor` is a tagged union, hence `find_enum`.)
+    if func.kind.is_declared_capability()
+        && ir
+            .find_enum(&func.class_name)
+            .is_some_and(|e| e.category == TypeCategory::DestructorOrClone)
+    {
+        return config.should_include_type(&func.class_name);
+    }
+
     if !config.should_include_type(&func.class_name) {
         return false;
     }

--- a/doc/src/codegen/v2/lang_freebasic/functions.rs
+++ b/doc/src/codegen/v2/lang_freebasic/functions.rs
@@ -49,10 +49,23 @@ fn should_emit_function(func: &FunctionDef, ir: &CodegenIR, config: &CodegenConf
     // `_toDbgString` declarations this binding already emits. Excluding it
     // wholesale is why every `*VecDestructor` declared `Debug` and named it
     // nowhere. (`*VecDestructor` is a tagged union, hence `find_enum`.)
+    // RECURSIVE types are here for the same reason. `XmlNodeChild` and friends
+    // are excluded below because their ORDINARY methods traffic in a shape
+    // this binding cannot express by value - but `Az{T}_partialEq(a, b) ->
+    // bool` and `Az{T}_toDbgString(ptr) -> AzString` take a pointer and return
+    // a scalar, so the exclusion never applied to them. That is why the same
+    // four types - `Xml`, `XmlNodeChild`, `XmlNodeChildVec`,
+    // `ResultXmlXmlError` - showed up as the residue in fourteen bindings at
+    // once: one cause, not fourteen.
     if func.kind.is_declared_capability()
-        && ir
-            .find_enum(&func.class_name)
-            .is_some_and(|e| e.category == TypeCategory::DestructorOrClone)
+        && (ir.find_enum(&func.class_name).is_some_and(|e| {
+            matches!(
+                e.category,
+                TypeCategory::DestructorOrClone | TypeCategory::Recursive
+            )
+        }) || ir
+            .find_struct(&func.class_name)
+            .is_some_and(|s| s.category == TypeCategory::Recursive))
     {
         return config.should_include_type(&func.class_name);
     }

--- a/doc/src/codegen/v2/lang_go/types.rs
+++ b/doc/src/codegen/v2/lang_go/types.rs
@@ -38,7 +38,7 @@ use anyhow::Result;
 
 use super::super::config::CodegenConfig;
 use super::super::generator::CodeBuilder;
-use super::super::ir::{CodegenIR, EnumDef, EnumVariantKind, FieldRefKind, TypeCategory};
+use super::super::ir::{CodegenIR, EnumDef, EnumVariantKind, FieldRefKind, FunctionKind, TypeCategory};
 use super::{ffi_type_name, sanitize_identifier};
 
 /// Generate the contents of `types.go`.
@@ -56,7 +56,7 @@ pub fn generate(ir: &CodegenIR, config: &CodegenConfig) -> Result<String> {
         if e.is_union {
             continue;
         }
-        emit_unit_enum(&mut b, e);
+        emit_unit_enum(&mut b, e, ir);
     }
 
     // Tagged-union sealed-interface hierarchies.
@@ -118,7 +118,7 @@ fn should_include_enum(e: &EnumDef, config: &CodegenConfig) -> bool {
 // Unit-only enum
 // ============================================================================
 
-fn emit_unit_enum(b: &mut CodeBuilder, e: &EnumDef) {
+fn emit_unit_enum(b: &mut CodeBuilder, e: &EnumDef, ir: &CodegenIR) {
     let go_name = ffi_type_name(&e.name);
     let underlying = enum_underlying_type(e);
 
@@ -143,6 +143,85 @@ fn emit_unit_enum(b: &mut CodeBuilder, e: &EnumDef) {
     b.dedent();
     b.line(")");
     b.blank();
+
+    emit_enum_trait_methods(b, &go_name, &e.name, ir);
+}
+
+/// The auto-generated trait exports, as methods on a unit-only enum.
+///
+/// A unit enum is a real named Go type (`type AzAccessibilityRole uint32`), so
+/// it can carry methods - and until this existed nothing named its
+/// `_partialEq` / `_cmp` / `_hash` / `_toDbgString`, which libazul has been
+/// exporting all along. The value is converted back to the C enum and its
+/// address taken, because every trait entry point takes a pointer.
+///
+/// Tagged unions get nothing here on purpose: Go models them as a sealed
+/// INTERFACE whose variant structs hold no C value, so there is no `C.Az*` to
+/// take the address of. Wiring that needs the variant types to carry the union,
+/// which is a redesign, not a missing call - so it is left and recorded rather
+/// than guessed at.
+fn emit_enum_trait_methods(b: &mut CodeBuilder, go_name: &str, class_name: &str, ir: &CodegenIR) {
+    let mut seen: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    for f in ir.functions_for_class(class_name) {
+        let name = match f.kind {
+            FunctionKind::PartialEq => "Equal",
+            FunctionKind::PartialCmp => "PartialOrder",
+            FunctionKind::Cmp => "Order",
+            FunctionKind::Hash => "Hash",
+            FunctionKind::DebugToString => "String",
+            _ => continue,
+        };
+        if !seen.insert(name) {
+            continue;
+        }
+        b.blank();
+        match f.kind {
+            FunctionKind::PartialEq => {
+                b.line("// Equal reports structural equality, delegating to the Rust PartialEq.");
+                b.line(&format!("func (self {go_name}) Equal(other {go_name}) bool {{"));
+                b.line(&format!("    a := C.{go_name}(self)"));
+                b.line(&format!("    o := C.{go_name}(other)"));
+                b.line(&format!("    return bool(C.{go_name}_partialEq(&a, &o))"));
+                b.line("}");
+            }
+            FunctionKind::PartialCmp => {
+                b.line("// PartialOrder delegates to the Rust PartialOrd. The C ABI answers");
+                b.line("// 0 = less, 1 = equal, 2 = greater.");
+                b.line(&format!("func (self {go_name}) PartialOrder(other {go_name}) uint8 {{"));
+                b.line(&format!("    a := C.{go_name}(self)"));
+                b.line(&format!("    o := C.{go_name}(other)"));
+                b.line(&format!("    return uint8(C.{go_name}_partialCmp(&a, &o))"));
+                b.line("}");
+            }
+            FunctionKind::Cmp => {
+                b.line("// Order delegates to the Rust Ord. Same encoding as PartialOrder.");
+                b.line(&format!("func (self {go_name}) Order(other {go_name}) uint8 {{"));
+                b.line(&format!("    a := C.{go_name}(self)"));
+                b.line(&format!("    o := C.{go_name}(other)"));
+                b.line(&format!("    return uint8(C.{go_name}_cmp(&a, &o))"));
+                b.line("}");
+            }
+            FunctionKind::Hash => {
+                b.line("// Hash delegates to the Rust Hash, as a 64-bit digest.");
+                b.line(&format!("func (self {go_name}) Hash() uint64 {{"));
+                b.line(&format!("    a := C.{go_name}(self)"));
+                b.line(&format!("    return uint64(C.{go_name}_hash(&a))"));
+                b.line("}");
+            }
+            FunctionKind::DebugToString => {
+                b.line("// String is the Rust `{:#?}` rendering; it implements fmt.Stringer.");
+                b.line("// The returned AzString owns its buffer and GoStr only copies, so it");
+                b.line("// is freed here rather than leaked once per call.");
+                b.line(&format!("func (self {go_name}) String() string {{"));
+                b.line(&format!("    a := C.{go_name}(self)"));
+                b.line(&format!("    s := C.{go_name}_toDbgString(&a)"));
+                b.line("    defer C.AzString_delete(&s)");
+                b.line("    return GoStr(s)");
+                b.line("}");
+            }
+            _ => unreachable!(),
+        }
+    }
 }
 
 fn enum_underlying_type(e: &EnumDef) -> &'static str {

--- a/doc/src/codegen/v2/lang_go/types.rs
+++ b/doc/src/codegen/v2/lang_go/types.rs
@@ -169,6 +169,8 @@ fn emit_enum_trait_methods(b: &mut CodeBuilder, go_name: &str, class_name: &str,
             FunctionKind::Cmp => "Order",
             FunctionKind::Hash => "Hash",
             FunctionKind::DebugToString => "String",
+            FunctionKind::DeepCopy => "Clone",
+            FunctionKind::Default => "Default",
             _ => continue,
         };
         if !seen.insert(name) {
@@ -176,6 +178,22 @@ fn emit_enum_trait_methods(b: &mut CodeBuilder, go_name: &str, class_name: &str,
         }
         b.blank();
         match f.kind {
+            FunctionKind::DeepCopy => {
+                b.line("// Clone is a deep copy, delegating to the Rust Clone.");
+                b.line(&format!("func (self {go_name}) Clone() {go_name} {{"));
+                b.line(&format!("    a := C.{go_name}(self)"));
+                b.line(&format!("    return {go_name}(C.{go_name}_clone(&a))"));
+                b.line("}");
+            }
+            FunctionKind::Default => {
+                // A package-level function: Go has no static method, and the
+                // Rust `Default` takes no receiver to hang one on.
+                let bare = go_name.strip_prefix("Az").unwrap_or(go_name);
+                b.line(&format!("// {bare}Default is the Rust Default."));
+                b.line(&format!("func {bare}Default() {go_name} {{"));
+                b.line(&format!("    return {go_name}(C.{go_name}_default())"));
+                b.line("}");
+            }
             FunctionKind::PartialEq => {
                 b.line("// Equal reports structural equality, delegating to the Rust PartialEq.");
                 b.line(&format!("func (self {go_name}) Equal(other {go_name}) bool {{"));
@@ -340,6 +358,87 @@ fn emit_tagged_union(b: &mut CodeBuilder, e: &EnumDef, ir: &CodegenIR) {
     b.dedent();
     b.line("}");
     b.blank();
+    emit_union_trait_functions(b, &iface_name, &e.name, ir);
+}
+
+/// The trait entry points for a tagged union, as free functions over the RAW
+/// C type.
+///
+/// Go models a tagged union as a sealed INTERFACE whose variant structs hold
+/// no C value, so these cannot be methods. That is not the obstacle it first
+/// looks like: every generated signature that takes a union already takes
+/// `C.AzCssProperty` rather than the interface (see `SetCssProperty`,
+/// `NewCssPropertyVecFromItem`), so the raw type IS the currency a Go caller
+/// holds. Free functions over it are therefore the honest fit, and the
+/// interface stays what it already was - a type-switch aid.
+fn emit_union_trait_functions(b: &mut CodeBuilder, iface: &str, class_name: &str, ir: &CodegenIR) {
+    let bare = iface.strip_prefix("Az").unwrap_or(iface);
+    let mut seen: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    for f in ir.functions_for_class(class_name) {
+        let name = match f.kind {
+            FunctionKind::PartialEq => "Equal",
+            FunctionKind::PartialCmp => "PartialOrder",
+            FunctionKind::Cmp => "Order",
+            FunctionKind::Hash => "Hash",
+            FunctionKind::DebugToString => "String",
+            FunctionKind::DeepCopy => "Clone",
+            FunctionKind::Default => "Default",
+            _ => continue,
+        };
+        if !seen.insert(name) {
+            continue;
+        }
+        b.blank();
+        match f.kind {
+            FunctionKind::DeepCopy => {
+                b.line(&format!("// {bare}Clone is a deep copy, delegating to the Rust Clone."));
+                b.line(&format!("func {bare}Clone(v C.{iface}) C.{iface} {{"));
+                b.line(&format!("    return C.{iface}_clone(&v)"));
+                b.line("}");
+            }
+            FunctionKind::Default => {
+                b.line(&format!("// {bare}Default is the Rust Default."));
+                b.line(&format!("func {bare}Default() C.{iface} {{"));
+                b.line(&format!("    return C.{iface}_default()"));
+                b.line("}");
+            }
+            FunctionKind::PartialEq => {
+                b.line(&format!("// {bare}Equal reports structural equality, delegating to the Rust PartialEq."));
+                b.line(&format!("func {bare}Equal(a C.{iface}, o C.{iface}) bool {{"));
+                b.line(&format!("    return bool(C.{iface}_partialEq(&a, &o))"));
+                b.line("}");
+            }
+            FunctionKind::PartialCmp => {
+                b.line(&format!("// {bare}PartialOrder delegates to the Rust PartialOrd."));
+                b.line("// The C ABI answers 0 = less, 1 = equal, 2 = greater.");
+                b.line(&format!("func {bare}PartialOrder(a C.{iface}, o C.{iface}) uint8 {{"));
+                b.line(&format!("    return uint8(C.{iface}_partialCmp(&a, &o))"));
+                b.line("}");
+            }
+            FunctionKind::Cmp => {
+                b.line(&format!("// {bare}Order delegates to the Rust Ord. Same encoding as {bare}PartialOrder."));
+                b.line(&format!("func {bare}Order(a C.{iface}, o C.{iface}) uint8 {{"));
+                b.line(&format!("    return uint8(C.{iface}_cmp(&a, &o))"));
+                b.line("}");
+            }
+            FunctionKind::Hash => {
+                b.line(&format!("// {bare}Hash delegates to the Rust Hash, as a 64-bit digest."));
+                b.line(&format!("func {bare}Hash(v C.{iface}) uint64 {{"));
+                b.line(&format!("    return uint64(C.{iface}_hash(&v))"));
+                b.line("}");
+            }
+            FunctionKind::DebugToString => {
+                b.line(&format!("// {bare}String is the Rust `{{:#?}}` rendering. The AzString the ABI"));
+                b.line("// returns owns its buffer and GoStr only copies, so it is freed here.");
+                b.line(&format!("func {bare}String(v C.{iface}) string {{"));
+                b.line(&format!("    s := C.{iface}_toDbgString(&v)"));
+                b.line("    defer C.AzString_delete(&s)");
+                b.line("    return GoStr(s)");
+                b.line("}");
+            }
+            _ => unreachable!(),
+        }
+    }
 }
 
 // ============================================================================

--- a/doc/src/codegen/v2/lang_go/wrappers.rs
+++ b/doc/src/codegen/v2/lang_go/wrappers.rs
@@ -197,6 +197,19 @@ fn has_useful_method(class_name: &str, ir: &CodegenIR) -> bool {
                     | FunctionKind::StaticMethod
                     | FunctionKind::Default
                     | FunctionKind::DeepCopy
+                    // The auto-generated trait entry points count as useful:
+                    // a class whose only exports are `_partialEq` / `_cmp` /
+                    // `_hash` / `_toDbgString` still has something a caller
+                    // wants, and excluding them here gave it no wrapper at
+                    // all. Emitted by `emit_trait_methods`, which must stay in
+                    // step with this list - landing only one half makes the
+                    // measured gap WORSE, because the class then exists as a
+                    // wrapper with nothing on it.
+                    | FunctionKind::PartialEq
+                    | FunctionKind::PartialCmp
+                    | FunctionKind::Cmp
+                    | FunctionKind::Hash
+                    | FunctionKind::DebugToString
             )
     })
 }
@@ -253,6 +266,9 @@ fn emit_struct_wrapper(b: &mut CodeBuilder, s: &StructDef, ir: &CodegenIR, confi
             _ => {}
         }
     }
+
+    // Trait entry points.
+    emit_trait_methods(b, &go_name, &s.name, ir);
 
     // Destructor + io.Closer.
     if has_delete {
@@ -697,5 +713,86 @@ fn map_return_type(ty: &str, ir: &CodegenIR) -> String {
         format!("C.{}", ffi_type_name(trimmed))
     } else {
         "unsafe.Pointer".to_string()
+    }
+}
+
+// ============================================================================
+// Trait entry points
+// ============================================================================
+
+/// Give the auto-generated trait exports a Go name.
+///
+/// libazul exports `Az{T}_partialEq`, `_partialCmp`, `_cmp`, `_hash` and
+/// `_toDbgString` for every class whose api.json `derive` list asks for them,
+/// and until this existed no Go wrapper named any of them - so no Go caller
+/// could compare, order, hash or print an azul value. Only the kinds a class
+/// actually exports are emitted, so a type that declares no `Hash` gets no
+/// `Hash()`.
+fn emit_trait_methods(b: &mut CodeBuilder, go_name: &str, class_name: &str, ir: &CodegenIR) {
+    let ffi = format!("Az{}", class_name);
+    let mut seen: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    for f in ir.functions_for_class(class_name) {
+        let name = match f.kind {
+            FunctionKind::PartialEq => "Equal",
+            FunctionKind::PartialCmp => "PartialOrder",
+            FunctionKind::Cmp => "Order",
+            FunctionKind::Hash => "Hash",
+            FunctionKind::DebugToString => "String",
+            _ => continue,
+        };
+        if !seen.insert(name) {
+            continue;
+        }
+        b.blank();
+        match f.kind {
+            FunctionKind::PartialEq => {
+                b.line("// Equal reports structural equality, delegating to the Rust PartialEq.");
+                b.line(&format!(
+                    "func (self *{go_name}) Equal(other *{go_name}) bool {{"
+                ));
+                b.line(&format!(
+                    "    return bool(C.{ffi}_partialEq(&self.inner, &other.inner))"
+                ));
+                b.line("}");
+            }
+            FunctionKind::PartialCmp => {
+                b.line("// PartialOrder delegates to the Rust PartialOrd. The C ABI answers");
+                b.line("// 0 = less, 1 = equal, 2 = greater.");
+                b.line(&format!(
+                    "func (self *{go_name}) PartialOrder(other *{go_name}) uint8 {{"
+                ));
+                b.line(&format!(
+                    "    return uint8(C.{ffi}_partialCmp(&self.inner, &other.inner))"
+                ));
+                b.line("}");
+            }
+            FunctionKind::Cmp => {
+                b.line("// Order delegates to the Rust Ord. Same encoding as PartialOrder.");
+                b.line(&format!(
+                    "func (self *{go_name}) Order(other *{go_name}) uint8 {{"
+                ));
+                b.line(&format!(
+                    "    return uint8(C.{ffi}_cmp(&self.inner, &other.inner))"
+                ));
+                b.line("}");
+            }
+            FunctionKind::Hash => {
+                b.line("// Hash delegates to the Rust Hash, as a 64-bit digest.");
+                b.line(&format!("func (self *{go_name}) Hash() uint64 {{"));
+                b.line(&format!("    return uint64(C.{ffi}_hash(&self.inner))"));
+                b.line("}");
+            }
+            FunctionKind::DebugToString => {
+                b.line("// String is the Rust `{:#?}` rendering; it implements fmt.Stringer.");
+                b.line("// The AzString the ABI hands back owns its buffer and GoStr only");
+                b.line("// copies, so it is freed here rather than leaked once per call.");
+                b.line(&format!("func (self *{go_name}) String() string {{"));
+                b.line(&format!("    s := C.{ffi}_toDbgString(&self.inner)"));
+                b.line("    defer C.AzString_delete(&s)");
+                b.line("    return GoStr(s)");
+                b.line("}");
+            }
+            _ => unreachable!(),
+        }
     }
 }

--- a/doc/src/codegen/v2/lang_go/wrappers.rs
+++ b/doc/src/codegen/v2/lang_go/wrappers.rs
@@ -174,10 +174,26 @@ pub(crate) fn should_emit_wrapper(s: &StructDef, ir: &CodegenIR, config: &Codege
         | TypeCategory::Boxed
         | TypeCategory::GenericTemplate
         | TypeCategory::DestructorOrClone
-        | TypeCategory::CallbackTypedef => return false,
+        | TypeCategory::CallbackTypedef => {
+            // ... unless the class declares capabilities. These exclusions are
+            // about ORDINARY methods - a Boxed heap wrapper or a raw callback
+            // typedef cannot be passed by value - and that reasoning does not
+            // reach `Az{T}_partialEq(a, b) -> bool` or
+            // `Az{T}_toDbgString(ptr) -> AzString`, which take pointers and
+            // return scalars. Same carve-out the recursive types needed.
+            if !has_declared_capability(&s.name, ir) {
+                return false;
+            }
+        }
         _ => {}
     }
-    has_destructor(&s.name, ir) || has_useful_method(&s.name, ir)
+    true
+}
+
+/// Does this class declare capabilities the C ABI exports for it?
+fn has_declared_capability(class_name: &str, ir: &CodegenIR) -> bool {
+    ir.functions_for_class(class_name)
+        .any(|f| f.kind.is_declared_capability())
 }
 
 fn has_destructor(class_name: &str, ir: &CodegenIR) -> bool {

--- a/doc/src/codegen/v2/lang_haskell/cshim.rs
+++ b/doc/src/codegen/v2/lang_haskell/cshim.rs
@@ -266,6 +266,18 @@ fn emit_inbound_trampoline(out: &mut String, cb: &CallbackTypedefDef) {
 /// foreign-import emitter (so the shim's symbol resolves to the same
 /// libazul export).
 pub fn should_emit_shim_for(func: &FunctionDef, ir: &CodegenIR, config: &CodegenConfig) -> bool {
+    // Kept in lockstep with `functions::should_emit_function`, as the doc above
+    // says: the foreign-import points at `<c_name>_via`, and that symbol exists
+    // only if THIS function emits the shim. Letting a declared capability past
+    // the `DestructorOrClone` exclusion in one and not the other produces an
+    // `AzXVecDestructor_toDbgString_via` import with nothing to link against.
+    if func.kind.is_declared_capability()
+        && ir
+            .find_enum(&func.class_name)
+            .is_some_and(|e| e.category == TypeCategory::DestructorOrClone)
+    {
+        return config.should_include_type(&func.class_name) && needs_shim(func);
+    }
     if !config.should_include_type(&func.class_name) {
         return false;
     }

--- a/doc/src/codegen/v2/lang_haskell/functions.rs
+++ b/doc/src/codegen/v2/lang_haskell/functions.rs
@@ -246,10 +246,23 @@ fn should_emit_function(func: &FunctionDef, ir: &CodegenIR, config: &CodegenConf
     // `_toDbgString` declarations this binding already emits. Excluding it
     // wholesale is why every `*VecDestructor` declared `Debug` and named it
     // nowhere. (`*VecDestructor` is a tagged union, hence `find_enum`.)
+    // RECURSIVE types are here for the same reason. `XmlNodeChild` and friends
+    // are excluded below because their ORDINARY methods traffic in a shape
+    // this binding cannot express by value - but `Az{T}_partialEq(a, b) ->
+    // bool` and `Az{T}_toDbgString(ptr) -> AzString` take a pointer and return
+    // a scalar, so the exclusion never applied to them. That is why the same
+    // four types - `Xml`, `XmlNodeChild`, `XmlNodeChildVec`,
+    // `ResultXmlXmlError` - showed up as the residue in fourteen bindings at
+    // once: one cause, not fourteen.
     if func.kind.is_declared_capability()
-        && ir
-            .find_enum(&func.class_name)
-            .is_some_and(|e| e.category == TypeCategory::DestructorOrClone)
+        && (ir.find_enum(&func.class_name).is_some_and(|e| {
+            matches!(
+                e.category,
+                TypeCategory::DestructorOrClone | TypeCategory::Recursive
+            )
+        }) || ir
+            .find_struct(&func.class_name)
+            .is_some_and(|s| s.category == TypeCategory::Recursive))
     {
         return config.should_include_type(&func.class_name);
     }

--- a/doc/src/codegen/v2/lang_haskell/functions.rs
+++ b/doc/src/codegen/v2/lang_haskell/functions.rs
@@ -238,6 +238,22 @@ fn emit_one_register_helper(
 }
 
 fn should_emit_function(func: &FunctionDef, ir: &CodegenIR, config: &CodegenConfig) -> bool {
+    // A trait entry point an api.json `derive` declares is not what the
+    // `DestructorOrClone` exclusion below is for. That category is excluded
+    // because those types' ordinary methods traffic in callback function
+    // pointers this binding cannot marshal; `Az{T}_toDbgString(ptr) ->
+    // AzString` traffics in neither, and is the same shape as the ~2800
+    // `_toDbgString` declarations this binding already emits. Excluding it
+    // wholesale is why every `*VecDestructor` declared `Debug` and named it
+    // nowhere. (`*VecDestructor` is a tagged union, hence `find_enum`.)
+    if func.kind.is_declared_capability()
+        && ir
+            .find_enum(&func.class_name)
+            .is_some_and(|e| e.category == TypeCategory::DestructorOrClone)
+    {
+        return config.should_include_type(&func.class_name);
+    }
+
     if !config.should_include_type(&func.class_name) {
         return false;
     }

--- a/doc/src/codegen/v2/lang_java/functions.rs
+++ b/doc/src/codegen/v2/lang_java/functions.rs
@@ -143,17 +143,21 @@ pub fn generate_native_module_files(
 }
 
 fn should_emit_function(func: &FunctionDef, ir: &CodegenIR, config: &CodegenConfig) -> bool {
-    // A trait entry point declared by an api.json `derive` is NOT part of what
-    // this category exclusion is for. `DestructorOrClone` is excluded because
-    // those types' ordinary methods traffic in callback function pointers this
-    // binding cannot marshal; `Az{T}_toDbgString(ptr) -> AzString` traffics in
-    // neither. Excluding it wholesale is why all 114 `*VecDestructor` types
-    // declared `Debug` and exposed it nowhere. `Delete` stays excluded: no
-    // `derive` asks for it, and a destructor on a value type is a footgun.
-    let is_declared_capability = (func.kind.is_trait_function()
-        || func.kind.is_clone_method()
-        || func.kind.is_default_constructor())
-        && !matches!(func.kind, super::super::ir::FunctionKind::Delete);
+    // A trait entry point an api.json `derive` declares is not what the
+    // `DestructorOrClone` exclusion below is for. That category is excluded
+    // because those types' ordinary methods traffic in callback function
+    // pointers this binding cannot marshal; `Az{T}_toDbgString(ptr) ->
+    // AzString` traffics in neither, and is the same shape as the ~2800
+    // `_toDbgString` declarations this binding already emits. Excluding it
+    // wholesale is why every `*VecDestructor` declared `Debug` and named it
+    // nowhere. (`*VecDestructor` is a tagged union, hence `find_enum`.)
+    if func.kind.is_declared_capability()
+        && ir
+            .find_enum(&func.class_name)
+            .is_some_and(|e| e.category == TypeCategory::DestructorOrClone)
+    {
+        return config.should_include_type(&func.class_name);
+    }
 
     if !config.should_include_type(&func.class_name) {
         return false;
@@ -163,9 +167,9 @@ fn should_emit_function(func: &FunctionDef, ir: &CodegenIR, config: &CodegenConf
             s.category,
             TypeCategory::Recursive
                 | TypeCategory::VecRef
+                | TypeCategory::DestructorOrClone
                 | TypeCategory::GenericTemplate
-        ) && !(is_declared_capability && s.category == TypeCategory::DestructorOrClone)
-        {
+        ) {
             return false;
         }
         if !s.generic_params.is_empty() {
@@ -176,9 +180,9 @@ fn should_emit_function(func: &FunctionDef, ir: &CodegenIR, config: &CodegenConf
         if matches!(
             e.category,
             TypeCategory::Recursive
+                | TypeCategory::DestructorOrClone
                 | TypeCategory::GenericTemplate
-        ) && !(is_declared_capability && e.category == TypeCategory::DestructorOrClone)
-        {
+        ) {
             return false;
         }
         if !e.generic_params.is_empty() {

--- a/doc/src/codegen/v2/lang_java/functions.rs
+++ b/doc/src/codegen/v2/lang_java/functions.rs
@@ -151,10 +151,23 @@ fn should_emit_function(func: &FunctionDef, ir: &CodegenIR, config: &CodegenConf
     // `_toDbgString` declarations this binding already emits. Excluding it
     // wholesale is why every `*VecDestructor` declared `Debug` and named it
     // nowhere. (`*VecDestructor` is a tagged union, hence `find_enum`.)
+    // RECURSIVE types are here for the same reason. `XmlNodeChild` and friends
+    // are excluded below because their ORDINARY methods traffic in a shape
+    // this binding cannot express by value - but `Az{T}_partialEq(a, b) ->
+    // bool` and `Az{T}_toDbgString(ptr) -> AzString` take a pointer and return
+    // a scalar, so the exclusion never applied to them. That is why the same
+    // four types - `Xml`, `XmlNodeChild`, `XmlNodeChildVec`,
+    // `ResultXmlXmlError` - showed up as the residue in fourteen bindings at
+    // once: one cause, not fourteen.
     if func.kind.is_declared_capability()
-        && ir
-            .find_enum(&func.class_name)
-            .is_some_and(|e| e.category == TypeCategory::DestructorOrClone)
+        && (ir.find_enum(&func.class_name).is_some_and(|e| {
+            matches!(
+                e.category,
+                TypeCategory::DestructorOrClone | TypeCategory::Recursive
+            )
+        }) || ir
+            .find_struct(&func.class_name)
+            .is_some_and(|s| s.category == TypeCategory::Recursive))
     {
         return config.should_include_type(&func.class_name);
     }

--- a/doc/src/codegen/v2/lang_java/functions.rs
+++ b/doc/src/codegen/v2/lang_java/functions.rs
@@ -143,6 +143,18 @@ pub fn generate_native_module_files(
 }
 
 fn should_emit_function(func: &FunctionDef, ir: &CodegenIR, config: &CodegenConfig) -> bool {
+    // A trait entry point declared by an api.json `derive` is NOT part of what
+    // this category exclusion is for. `DestructorOrClone` is excluded because
+    // those types' ordinary methods traffic in callback function pointers this
+    // binding cannot marshal; `Az{T}_toDbgString(ptr) -> AzString` traffics in
+    // neither. Excluding it wholesale is why all 114 `*VecDestructor` types
+    // declared `Debug` and exposed it nowhere. `Delete` stays excluded: no
+    // `derive` asks for it, and a destructor on a value type is a footgun.
+    let is_declared_capability = (func.kind.is_trait_function()
+        || func.kind.is_clone_method()
+        || func.kind.is_default_constructor())
+        && !matches!(func.kind, super::super::ir::FunctionKind::Delete);
+
     if !config.should_include_type(&func.class_name) {
         return false;
     }
@@ -151,9 +163,9 @@ fn should_emit_function(func: &FunctionDef, ir: &CodegenIR, config: &CodegenConf
             s.category,
             TypeCategory::Recursive
                 | TypeCategory::VecRef
-                | TypeCategory::DestructorOrClone
                 | TypeCategory::GenericTemplate
-        ) {
+        ) && !(is_declared_capability && s.category == TypeCategory::DestructorOrClone)
+        {
             return false;
         }
         if !s.generic_params.is_empty() {
@@ -164,9 +176,9 @@ fn should_emit_function(func: &FunctionDef, ir: &CodegenIR, config: &CodegenConf
         if matches!(
             e.category,
             TypeCategory::Recursive
-                | TypeCategory::DestructorOrClone
                 | TypeCategory::GenericTemplate
-        ) {
+        ) && !(is_declared_capability && e.category == TypeCategory::DestructorOrClone)
+        {
             return false;
         }
         if !e.generic_params.is_empty() {

--- a/doc/src/codegen/v2/lang_julia/mod.rs
+++ b/doc/src/codegen/v2/lang_julia/mod.rs
@@ -422,10 +422,23 @@ pub fn should_emit_function(func: &FunctionDef, ir: &CodegenIR, config: &Codegen
     // `_toDbgString` declarations this binding already emits. Excluding it
     // wholesale is why every `*VecDestructor` declared `Debug` and named it
     // nowhere. (`*VecDestructor` is a tagged union, hence `find_enum`.)
+    // RECURSIVE types are here for the same reason. `XmlNodeChild` and friends
+    // are excluded below because their ORDINARY methods traffic in a shape
+    // this binding cannot express by value - but `Az{T}_partialEq(a, b) ->
+    // bool` and `Az{T}_toDbgString(ptr) -> AzString` take a pointer and return
+    // a scalar, so the exclusion never applied to them. That is why the same
+    // four types - `Xml`, `XmlNodeChild`, `XmlNodeChildVec`,
+    // `ResultXmlXmlError` - showed up as the residue in fourteen bindings at
+    // once: one cause, not fourteen.
     if func.kind.is_declared_capability()
-        && ir
-            .find_enum(&func.class_name)
-            .is_some_and(|e| e.category == TypeCategory::DestructorOrClone)
+        && (ir.find_enum(&func.class_name).is_some_and(|e| {
+            matches!(
+                e.category,
+                TypeCategory::DestructorOrClone | TypeCategory::Recursive
+            )
+        }) || ir
+            .find_struct(&func.class_name)
+            .is_some_and(|s| s.category == TypeCategory::Recursive))
     {
         return config.should_include_type(&func.class_name);
     }

--- a/doc/src/codegen/v2/lang_julia/mod.rs
+++ b/doc/src/codegen/v2/lang_julia/mod.rs
@@ -414,6 +414,22 @@ pub fn include_enum(e: &EnumDef, config: &CodegenConfig) -> bool {
 /// filter: skip functions whose owning class is a recursive / VecRef /
 /// destructor / generic-template type.
 pub fn should_emit_function(func: &FunctionDef, ir: &CodegenIR, config: &CodegenConfig) -> bool {
+    // A trait entry point an api.json `derive` declares is not what the
+    // `DestructorOrClone` exclusion below is for. That category is excluded
+    // because those types' ordinary methods traffic in callback function
+    // pointers this binding cannot marshal; `Az{T}_toDbgString(ptr) ->
+    // AzString` traffics in neither, and is the same shape as the ~2800
+    // `_toDbgString` declarations this binding already emits. Excluding it
+    // wholesale is why every `*VecDestructor` declared `Debug` and named it
+    // nowhere. (`*VecDestructor` is a tagged union, hence `find_enum`.)
+    if func.kind.is_declared_capability()
+        && ir
+            .find_enum(&func.class_name)
+            .is_some_and(|e| e.category == TypeCategory::DestructorOrClone)
+    {
+        return config.should_include_type(&func.class_name);
+    }
+
     if !config.should_include_type(&func.class_name) {
         return false;
     }

--- a/doc/src/codegen/v2/lang_kotlin/mod.rs
+++ b/doc/src/codegen/v2/lang_kotlin/mod.rs
@@ -181,10 +181,23 @@ fn should_emit_function(func: &FunctionDef, ir: &CodegenIR, config: &CodegenConf
     // `_toDbgString` declarations this binding already emits. Excluding it
     // wholesale is why every `*VecDestructor` declared `Debug` and named it
     // nowhere. (`*VecDestructor` is a tagged union, hence `find_enum`.)
+    // RECURSIVE types are here for the same reason. `XmlNodeChild` and friends
+    // are excluded below because their ORDINARY methods traffic in a shape
+    // this binding cannot express by value - but `Az{T}_partialEq(a, b) ->
+    // bool` and `Az{T}_toDbgString(ptr) -> AzString` take a pointer and return
+    // a scalar, so the exclusion never applied to them. That is why the same
+    // four types - `Xml`, `XmlNodeChild`, `XmlNodeChildVec`,
+    // `ResultXmlXmlError` - showed up as the residue in fourteen bindings at
+    // once: one cause, not fourteen.
     if func.kind.is_declared_capability()
-        && ir
-            .find_enum(&func.class_name)
-            .is_some_and(|e| e.category == TypeCategory::DestructorOrClone)
+        && (ir.find_enum(&func.class_name).is_some_and(|e| {
+            matches!(
+                e.category,
+                TypeCategory::DestructorOrClone | TypeCategory::Recursive
+            )
+        }) || ir
+            .find_struct(&func.class_name)
+            .is_some_and(|s| s.category == TypeCategory::Recursive))
     {
         return config.should_include_type(&func.class_name);
     }

--- a/doc/src/codegen/v2/lang_kotlin/mod.rs
+++ b/doc/src/codegen/v2/lang_kotlin/mod.rs
@@ -173,6 +173,22 @@ fn should_include_enum(e: &EnumDef, config: &CodegenConfig) -> bool {
 }
 
 fn should_emit_function(func: &FunctionDef, ir: &CodegenIR, config: &CodegenConfig) -> bool {
+    // A trait entry point an api.json `derive` declares is not what the
+    // `DestructorOrClone` exclusion below is for. That category is excluded
+    // because those types' ordinary methods traffic in callback function
+    // pointers this binding cannot marshal; `Az{T}_toDbgString(ptr) ->
+    // AzString` traffics in neither, and is the same shape as the ~2800
+    // `_toDbgString` declarations this binding already emits. Excluding it
+    // wholesale is why every `*VecDestructor` declared `Debug` and named it
+    // nowhere. (`*VecDestructor` is a tagged union, hence `find_enum`.)
+    if func.kind.is_declared_capability()
+        && ir
+            .find_enum(&func.class_name)
+            .is_some_and(|e| e.category == TypeCategory::DestructorOrClone)
+    {
+        return config.should_include_type(&func.class_name);
+    }
+
     if !config.should_include_type(&func.class_name) {
         return false;
     }

--- a/doc/src/codegen/v2/lang_lisp/functions.rs
+++ b/doc/src/codegen/v2/lang_lisp/functions.rs
@@ -42,6 +42,22 @@ pub fn generate_defcfuns(
 }
 
 fn should_emit_function(func: &FunctionDef, ir: &CodegenIR, config: &CodegenConfig) -> bool {
+    // A trait entry point an api.json `derive` declares is not what the
+    // `DestructorOrClone` exclusion below is for. That category is excluded
+    // because those types' ordinary methods traffic in callback function
+    // pointers this binding cannot marshal; `Az{T}_toDbgString(ptr) ->
+    // AzString` traffics in neither, and is the same shape as the ~2800
+    // `_toDbgString` declarations this binding already emits. Excluding it
+    // wholesale is why every `*VecDestructor` declared `Debug` and named it
+    // nowhere. (`*VecDestructor` is a tagged union, hence `find_enum`.)
+    if func.kind.is_declared_capability()
+        && ir
+            .find_enum(&func.class_name)
+            .is_some_and(|e| e.category == TypeCategory::DestructorOrClone)
+    {
+        return config.should_include_type(&func.class_name);
+    }
+
     if !config.should_include_type(&func.class_name) {
         return false;
     }

--- a/doc/src/codegen/v2/lang_lisp/functions.rs
+++ b/doc/src/codegen/v2/lang_lisp/functions.rs
@@ -50,10 +50,23 @@ fn should_emit_function(func: &FunctionDef, ir: &CodegenIR, config: &CodegenConf
     // `_toDbgString` declarations this binding already emits. Excluding it
     // wholesale is why every `*VecDestructor` declared `Debug` and named it
     // nowhere. (`*VecDestructor` is a tagged union, hence `find_enum`.)
+    // RECURSIVE types are here for the same reason. `XmlNodeChild` and friends
+    // are excluded below because their ORDINARY methods traffic in a shape
+    // this binding cannot express by value - but `Az{T}_partialEq(a, b) ->
+    // bool` and `Az{T}_toDbgString(ptr) -> AzString` take a pointer and return
+    // a scalar, so the exclusion never applied to them. That is why the same
+    // four types - `Xml`, `XmlNodeChild`, `XmlNodeChildVec`,
+    // `ResultXmlXmlError` - showed up as the residue in fourteen bindings at
+    // once: one cause, not fourteen.
     if func.kind.is_declared_capability()
-        && ir
-            .find_enum(&func.class_name)
-            .is_some_and(|e| e.category == TypeCategory::DestructorOrClone)
+        && (ir.find_enum(&func.class_name).is_some_and(|e| {
+            matches!(
+                e.category,
+                TypeCategory::DestructorOrClone | TypeCategory::Recursive
+            )
+        }) || ir
+            .find_struct(&func.class_name)
+            .is_some_and(|s| s.category == TypeCategory::Recursive))
     {
         return config.should_include_type(&func.class_name);
     }

--- a/doc/src/codegen/v2/lang_nim/functions.rs
+++ b/doc/src/codegen/v2/lang_nim/functions.rs
@@ -52,10 +52,23 @@ fn should_emit_function(func: &FunctionDef, ir: &CodegenIR, config: &CodegenConf
     // `_toDbgString` declarations this binding already emits. Excluding it
     // wholesale is why every `*VecDestructor` declared `Debug` and named it
     // nowhere. (`*VecDestructor` is a tagged union, hence `find_enum`.)
+    // RECURSIVE types are here for the same reason. `XmlNodeChild` and friends
+    // are excluded below because their ORDINARY methods traffic in a shape
+    // this binding cannot express by value - but `Az{T}_partialEq(a, b) ->
+    // bool` and `Az{T}_toDbgString(ptr) -> AzString` take a pointer and return
+    // a scalar, so the exclusion never applied to them. That is why the same
+    // four types - `Xml`, `XmlNodeChild`, `XmlNodeChildVec`,
+    // `ResultXmlXmlError` - showed up as the residue in fourteen bindings at
+    // once: one cause, not fourteen.
     if func.kind.is_declared_capability()
-        && ir
-            .find_enum(&func.class_name)
-            .is_some_and(|e| e.category == TypeCategory::DestructorOrClone)
+        && (ir.find_enum(&func.class_name).is_some_and(|e| {
+            matches!(
+                e.category,
+                TypeCategory::DestructorOrClone | TypeCategory::Recursive
+            )
+        }) || ir
+            .find_struct(&func.class_name)
+            .is_some_and(|s| s.category == TypeCategory::Recursive))
     {
         return config.should_include_type(&func.class_name);
     }

--- a/doc/src/codegen/v2/lang_nim/functions.rs
+++ b/doc/src/codegen/v2/lang_nim/functions.rs
@@ -44,6 +44,22 @@ pub fn generate_externals(
 }
 
 fn should_emit_function(func: &FunctionDef, ir: &CodegenIR, config: &CodegenConfig) -> bool {
+    // A trait entry point an api.json `derive` declares is not what the
+    // `DestructorOrClone` exclusion below is for. That category is excluded
+    // because those types' ordinary methods traffic in callback function
+    // pointers this binding cannot marshal; `Az{T}_toDbgString(ptr) ->
+    // AzString` traffics in neither, and is the same shape as the ~2800
+    // `_toDbgString` declarations this binding already emits. Excluding it
+    // wholesale is why every `*VecDestructor` declared `Debug` and named it
+    // nowhere. (`*VecDestructor` is a tagged union, hence `find_enum`.)
+    if func.kind.is_declared_capability()
+        && ir
+            .find_enum(&func.class_name)
+            .is_some_and(|e| e.category == TypeCategory::DestructorOrClone)
+    {
+        return config.should_include_type(&func.class_name);
+    }
+
     if !config.should_include_type(&func.class_name) {
         return false;
     }

--- a/doc/src/codegen/v2/lang_node/functions.rs
+++ b/doc/src/codegen/v2/lang_node/functions.rs
@@ -47,6 +47,18 @@ pub fn generate_function_bindings(b: &mut CodeBuilder, ir: &CodegenIR) {
 // ============================================================================
 
 fn should_emit_function(f: &FunctionDef, ir: &CodegenIR) -> bool {
+    // A trait entry point declared by an api.json `derive` is NOT part of what
+    // this category exclusion is for. `DestructorOrClone` is excluded because
+    // those types' ordinary methods traffic in callback function pointers this
+    // binding cannot marshal; `Az{T}_toDbgString(ptr) -> AzString` traffics in
+    // neither. Excluding it wholesale is why all 114 `*VecDestructor` types
+    // declared `Debug` and exposed it nowhere. `Delete` stays excluded: no
+    // `derive` asks for it, and a destructor on a value type is a footgun.
+    let is_declared_capability = (f.kind.is_trait_function()
+        || f.kind.is_clone_method()
+        || f.kind.is_default_constructor())
+        && !matches!(f.kind, super::super::ir::FunctionKind::Delete);
+
     if let Some(s) = ir.find_struct(&f.class_name) {
         if !s.generic_params.is_empty() {
             return false;
@@ -55,9 +67,9 @@ fn should_emit_function(f: &FunctionDef, ir: &CodegenIR) -> bool {
             s.category,
             TypeCategory::Recursive
                 | TypeCategory::VecRef
-                | TypeCategory::DestructorOrClone
                 | TypeCategory::GenericTemplate
-        ) {
+        ) && !(is_declared_capability && s.category == TypeCategory::DestructorOrClone)
+        {
             return false;
         }
     }
@@ -68,9 +80,9 @@ fn should_emit_function(f: &FunctionDef, ir: &CodegenIR) -> bool {
         if matches!(
             e.category,
             TypeCategory::Recursive
-                | TypeCategory::DestructorOrClone
                 | TypeCategory::GenericTemplate
-        ) {
+        ) && !(is_declared_capability && e.category == TypeCategory::DestructorOrClone)
+        {
             return false;
         }
     }

--- a/doc/src/codegen/v2/lang_node/functions.rs
+++ b/doc/src/codegen/v2/lang_node/functions.rs
@@ -47,17 +47,21 @@ pub fn generate_function_bindings(b: &mut CodeBuilder, ir: &CodegenIR) {
 // ============================================================================
 
 fn should_emit_function(f: &FunctionDef, ir: &CodegenIR) -> bool {
-    // A trait entry point declared by an api.json `derive` is NOT part of what
-    // this category exclusion is for. `DestructorOrClone` is excluded because
-    // those types' ordinary methods traffic in callback function pointers this
-    // binding cannot marshal; `Az{T}_toDbgString(ptr) -> AzString` traffics in
-    // neither. Excluding it wholesale is why all 114 `*VecDestructor` types
-    // declared `Debug` and exposed it nowhere. `Delete` stays excluded: no
-    // `derive` asks for it, and a destructor on a value type is a footgun.
-    let is_declared_capability = (f.kind.is_trait_function()
-        || f.kind.is_clone_method()
-        || f.kind.is_default_constructor())
-        && !matches!(f.kind, super::super::ir::FunctionKind::Delete);
+    // A trait entry point an api.json `derive` declares is not what the
+    // `DestructorOrClone` exclusion below is for. That category is excluded
+    // because those types' ordinary methods traffic in callback function
+    // pointers this binding cannot marshal; `Az{T}_toDbgString(ptr) ->
+    // AzString` traffics in neither, and is the same shape as the ~2800
+    // `_toDbgString` declarations this binding already emits. Excluding it
+    // wholesale is why every `*VecDestructor` declared `Debug` and named it
+    // nowhere. (`*VecDestructor` is a tagged union, hence `find_enum`.)
+    if f.kind.is_declared_capability()
+        && ir
+            .find_enum(&f.class_name)
+            .is_some_and(|e| e.category == TypeCategory::DestructorOrClone)
+    {
+        return true;
+    }
 
     if let Some(s) = ir.find_struct(&f.class_name) {
         if !s.generic_params.is_empty() {
@@ -67,9 +71,9 @@ fn should_emit_function(f: &FunctionDef, ir: &CodegenIR) -> bool {
             s.category,
             TypeCategory::Recursive
                 | TypeCategory::VecRef
+                | TypeCategory::DestructorOrClone
                 | TypeCategory::GenericTemplate
-        ) && !(is_declared_capability && s.category == TypeCategory::DestructorOrClone)
-        {
+        ) {
             return false;
         }
     }
@@ -80,9 +84,9 @@ fn should_emit_function(f: &FunctionDef, ir: &CodegenIR) -> bool {
         if matches!(
             e.category,
             TypeCategory::Recursive
+                | TypeCategory::DestructorOrClone
                 | TypeCategory::GenericTemplate
-        ) && !(is_declared_capability && e.category == TypeCategory::DestructorOrClone)
-        {
+        ) {
             return false;
         }
     }

--- a/doc/src/codegen/v2/lang_ocaml/functions.rs
+++ b/doc/src/codegen/v2/lang_ocaml/functions.rs
@@ -58,6 +58,22 @@ pub fn emit_foreign_bindings(
 }
 
 fn should_emit_function(func: &FunctionDef, ir: &CodegenIR, config: &CodegenConfig) -> bool {
+    // A trait entry point an api.json `derive` declares is not what the
+    // `DestructorOrClone` exclusion below is for. That category is excluded
+    // because those types' ordinary methods traffic in callback function
+    // pointers this binding cannot marshal; `Az{T}_toDbgString(ptr) ->
+    // AzString` traffics in neither, and is the same shape as the ~2800
+    // `_toDbgString` declarations this binding already emits. Excluding it
+    // wholesale is why every `*VecDestructor` declared `Debug` and named it
+    // nowhere. (`*VecDestructor` is a tagged union, hence `find_enum`.)
+    if func.kind.is_declared_capability()
+        && ir
+            .find_enum(&func.class_name)
+            .is_some_and(|e| e.category == TypeCategory::DestructorOrClone)
+    {
+        return config.should_include_type(&func.class_name);
+    }
+
     if !config.should_include_type(&func.class_name) {
         return false;
     }

--- a/doc/src/codegen/v2/lang_ocaml/functions.rs
+++ b/doc/src/codegen/v2/lang_ocaml/functions.rs
@@ -66,10 +66,23 @@ fn should_emit_function(func: &FunctionDef, ir: &CodegenIR, config: &CodegenConf
     // `_toDbgString` declarations this binding already emits. Excluding it
     // wholesale is why every `*VecDestructor` declared `Debug` and named it
     // nowhere. (`*VecDestructor` is a tagged union, hence `find_enum`.)
+    // RECURSIVE types are here for the same reason. `XmlNodeChild` and friends
+    // are excluded below because their ORDINARY methods traffic in a shape
+    // this binding cannot express by value - but `Az{T}_partialEq(a, b) ->
+    // bool` and `Az{T}_toDbgString(ptr) -> AzString` take a pointer and return
+    // a scalar, so the exclusion never applied to them. That is why the same
+    // four types - `Xml`, `XmlNodeChild`, `XmlNodeChildVec`,
+    // `ResultXmlXmlError` - showed up as the residue in fourteen bindings at
+    // once: one cause, not fourteen.
     if func.kind.is_declared_capability()
-        && ir
-            .find_enum(&func.class_name)
-            .is_some_and(|e| e.category == TypeCategory::DestructorOrClone)
+        && (ir.find_enum(&func.class_name).is_some_and(|e| {
+            matches!(
+                e.category,
+                TypeCategory::DestructorOrClone | TypeCategory::Recursive
+            )
+        }) || ir
+            .find_struct(&func.class_name)
+            .is_some_and(|s| s.category == TypeCategory::Recursive))
     {
         return config.should_include_type(&func.class_name);
     }

--- a/doc/src/codegen/v2/lang_ocaml/types.rs
+++ b/doc/src/codegen/v2/lang_ocaml/types.rs
@@ -104,19 +104,12 @@ pub fn emit_interface_types(
             // az_*_variant_* prefixed constants were the only reachable
             // spelling (BINDINGS_REVIEW_2026_07_04 addendum item 8).
             // Keep the two surfaces in sync.
-            builder.line(&format!("module {} : sig", e.name));
-            builder.indent();
-            for v in &e.variants {
-                let lit = sanitize_identifier(&super::to_snake_case(&v.name));
-                builder.line(&format!("val {} : int", lit));
-            }
-            // NO trait decls here. OCaml is ORDER-SENSITIVE and this module is
-            // emitted in the types section, ~42k lines before the `foreign`
-            // bindings it would have to call - `ocamlfind ocamlc` rejects it
-            // with "Unbound value ffi_az_style_cursor_partial_eq". A unit
-            // enum's capabilities need a LATE pass, after the raw bindings.
-            builder.dedent();
-            builder.line("end");
+            // The module MOVED to the late idiomatic pass (see
+            // `wrappers.rs::emit_enum_modules`). It has to live after the
+            // `foreign` bindings, because its capabilities call them and OCaml
+            // is order-sensitive; emitting it here and the capabilities there
+            // would mean two `module X`, which is a duplicate. Nothing in the
+            // file references these modules internally, so moving them is safe.
         }
     }
 
@@ -1015,17 +1008,7 @@ fn emit_unit_enum(builder: &mut CodeBuilder, e: &EnumDef, ir: &CodegenIR) {
     // type alias by name; OCaml resolves identifiers from the most
     // recent binding, so `Azul.Update.refresh_dom : int` and
     // `Azul.az_update : int typ` coexist without conflict.
-    builder.line(&format!("module {} = struct", e.name));
-    builder.indent();
-    for (idx, v) in e.variants.iter().enumerate() {
-        let lit = sanitize_identifier(&super::to_snake_case(&v.name));
-        builder.line(&format!("let {} : int = {}", lit, idx));
-    }
-    // See the interface side: the raw bindings do not exist yet at this point
-    // in the file, so nothing here may call them.
-    builder.dedent();
-    builder.line("end");
-    builder.blank();
+    // Moved to the late idiomatic pass - see the interface side.
 }
 
 // ============================================================================

--- a/doc/src/codegen/v2/lang_ocaml/types.rs
+++ b/doc/src/codegen/v2/lang_ocaml/types.rs
@@ -21,7 +21,7 @@ use anyhow::Result;
 
 use super::super::config::CodegenConfig;
 use super::super::generator::CodeBuilder;
-use super::super::ir::{CodegenIR, EnumDef, FieldDef, FieldRefKind, StructDef, TypeCategory};
+use super::super::ir::{CodegenIR, EnumDef, FieldDef, FieldRefKind, StructDef, TypeCategory, FunctionKind};
 use super::{map_type_to_ocaml, ocaml_ffi_type_name, sanitize_doc, sanitize_identifier};
 
 // ============================================================================
@@ -110,6 +110,7 @@ pub fn emit_interface_types(
                 let lit = sanitize_identifier(&super::to_snake_case(&v.name));
                 builder.line(&format!("val {} : int", lit));
             }
+            emit_unit_enum_trait_decls(builder, e, ir);
             builder.dedent();
             builder.line("end");
         }
@@ -338,7 +339,7 @@ pub fn emit_struct_fields_and_enums(
             continue;
         }
         if !e.is_union {
-            emit_unit_enum(builder, e);
+            emit_unit_enum(builder, e, ir);
         }
     }
 
@@ -961,7 +962,7 @@ fn c_size_of_tagged_enum(
 // Unit enum (integer round-trip helpers)
 // ============================================================================
 
-fn emit_unit_enum(builder: &mut CodeBuilder, e: &EnumDef) {
+fn emit_unit_enum(builder: &mut CodeBuilder, e: &EnumDef, ir: &CodegenIR) {
     let ffi = ocaml_ffi_type_name(&e.name);
 
     if !e.doc.is_empty() {
@@ -1016,6 +1017,7 @@ fn emit_unit_enum(builder: &mut CodeBuilder, e: &EnumDef) {
         let lit = sanitize_identifier(&super::to_snake_case(&v.name));
         builder.line(&format!("let {} : int = {}", lit, idx));
     }
+    emit_unit_enum_trait_impls(builder, e, ir);
     builder.dedent();
     builder.line("end");
     builder.blank();
@@ -1067,4 +1069,93 @@ fn sanitize_field_identifier(name: &str) -> String {
 /// for `field` lookups to resolve.
 fn format_c_struct_name(ir_name: &str) -> String {
     format!("Az{}", ir_name)
+}
+
+// ============================================================================
+// Unit-only enum capabilities
+// ============================================================================
+//
+// A unit enum is `type az_x = int` with an int VIEW, not a `Ctypes.structure`,
+// so `Ctypes.addr` does not apply - an int is not addressable. The entry
+// points take `ptr az_x`, so these allocate a cell. Both surfaces are driven
+// from `unit_enum_caps` so the interface cannot omit what the module defines;
+// in OCaml the `.mli` seals the module, and that drift is the bug this whole
+// file keeps rediscovering.
+
+/// Which trait entry points this unit enum actually exports.
+fn unit_enum_caps(e: &EnumDef, ir: &CodegenIR) -> Vec<(FunctionKind, String)> {
+    let mut out = Vec::new();
+    for f in ir.functions_for_class(&e.name) {
+        if matches!(
+            f.kind,
+            FunctionKind::PartialEq | FunctionKind::Hash | FunctionKind::DebugToString
+        ) && !out.iter().any(|(k, _): &(FunctionKind, String)| *k == f.kind)
+        {
+            out.push((f.kind, super::functions::ocaml_binding_name(&f.c_name)));
+        }
+    }
+    out
+}
+
+fn emit_unit_enum_trait_decls(builder: &mut CodeBuilder, e: &EnumDef, ir: &CodegenIR) {
+    for (kind, _) in unit_enum_caps(e, ir) {
+        match kind {
+            FunctionKind::PartialEq => {
+                builder.line("(* Equality routed through the C ABI. *)");
+                builder.line("val equal : int -> int -> bool");
+            }
+            FunctionKind::Hash => {
+                builder.line("(* Hash routed through the C ABI. *)");
+                builder.line("val hash : int -> int");
+            }
+            FunctionKind::DebugToString => {
+                builder.line("(* Debug rendering routed through the C ABI. *)");
+                builder.line("val to_string : int -> string");
+            }
+            _ => {}
+        }
+    }
+}
+
+fn emit_unit_enum_trait_impls(builder: &mut CodeBuilder, e: &EnumDef, ir: &CodegenIR) {
+    let ffi = super::ocaml_ffi_type_name(&e.name);
+    for (kind, raw) in unit_enum_caps(e, ir) {
+        match kind {
+            FunctionKind::PartialEq => {
+                builder.line("let equal (a : int) (b : int) : bool =");
+                builder.indent();
+                builder.line(&format!(
+                    "{} (Ctypes.allocate {} a) (Ctypes.allocate {} b)",
+                    raw, ffi, ffi
+                ));
+                builder.dedent();
+            }
+            FunctionKind::Hash => {
+                builder.line("let hash (t : int) : int =");
+                builder.indent();
+                builder.line(&format!(
+                    "Unsigned.UInt64.to_int ({} (Ctypes.allocate {} t))",
+                    raw, ffi
+                ));
+                builder.dedent();
+            }
+            FunctionKind::DebugToString => {
+                let del = super::functions::ocaml_binding_name("AzString_delete");
+                builder.line("let to_string (t : int) : string =");
+                builder.indent();
+                builder.line(&format!(
+                    "let __s = {} (Ctypes.allocate {} t) in",
+                    raw, ffi
+                ));
+                builder.line("let vec = Ctypes.getf __s az_string_field_vec in");
+                builder.line("let vec_ptr = Ctypes.getf vec az_u8_vec_field_ptr in");
+                builder.line("let vec_len = Unsigned.Size_t.to_int (Ctypes.getf vec az_u8_vec_field_len) in");
+                builder.line("let __out = if Ctypes.is_null vec_ptr || vec_len = 0 then \"\" else Ctypes.string_from_ptr (Ctypes.from_voidp Ctypes.char vec_ptr) ~length:vec_len in");
+                builder.line(&format!("{} (Ctypes.addr __s);", del));
+                builder.line("__out");
+                builder.dedent();
+            }
+            _ => {}
+        }
+    }
 }

--- a/doc/src/codegen/v2/lang_ocaml/types.rs
+++ b/doc/src/codegen/v2/lang_ocaml/types.rs
@@ -1088,7 +1088,12 @@ fn unit_enum_caps(e: &EnumDef, ir: &CodegenIR) -> Vec<(FunctionKind, String)> {
     for f in ir.functions_for_class(&e.name) {
         if matches!(
             f.kind,
-            FunctionKind::PartialEq | FunctionKind::Hash | FunctionKind::DebugToString
+            FunctionKind::PartialEq
+                | FunctionKind::Hash
+                | FunctionKind::DebugToString
+                | FunctionKind::Cmp
+                | FunctionKind::PartialCmp
+                | FunctionKind::Default
         ) && !out.iter().any(|(k, _): &(FunctionKind, String)| *k == f.kind)
         {
             out.push((f.kind, super::functions::ocaml_binding_name(&f.c_name)));
@@ -1111,6 +1116,21 @@ fn emit_unit_enum_trait_decls(builder: &mut CodeBuilder, e: &EnumDef, ir: &Codeg
             FunctionKind::DebugToString => {
                 builder.line("(* Debug rendering routed through the C ABI. *)");
                 builder.line("val to_string : int -> string");
+            }
+            FunctionKind::Cmp => {
+                builder.line("(* Total order routed through the C ABI; OCaml convention. *)");
+                builder.line("val compare : int -> int -> int");
+            }
+            FunctionKind::PartialCmp => {
+                // NOT `compare`: the ABI answers 255 for "incomparable", and a
+                // total `compare : int -> int -> int` has no honest value for
+                // that. An option says exactly what PartialOrd means.
+                builder.line("(* Partial order routed through the C ABI; None = incomparable. *)");
+                builder.line("val partial_compare : int -> int -> int option");
+            }
+            FunctionKind::Default => {
+                builder.line("(* The Rust Default. *)");
+                builder.line("val default : unit -> int");
             }
             _ => {}
         }
@@ -1154,6 +1174,38 @@ fn emit_unit_enum_trait_impls(builder: &mut CodeBuilder, e: &EnumDef, ir: &Codeg
                 builder.line(&format!("{} (Ctypes.addr __s);", del));
                 builder.line("__out");
                 builder.dedent();
+            }
+            FunctionKind::Cmp => {
+                // 0 = Less, 1 = Equal, 2 = Greater on the C side; OCaml's
+                // `compare` wants negative / zero / positive. Exact
+                // correspondence over the same three outcomes.
+                builder.line("let compare (a : int) (b : int) : int =");
+                builder.indent();
+                builder.line(&format!(
+                    "match Unsigned.UInt8.to_int ({} (Ctypes.allocate {} a) (Ctypes.allocate {} b)) with",
+                    raw, ffi, ffi
+                ));
+                builder.line("| 0 -> -1");
+                builder.line("| 1 -> 0");
+                builder.line("| _ -> 1");
+                builder.dedent();
+            }
+            FunctionKind::PartialCmp => {
+                builder.line("let partial_compare (a : int) (b : int) : int option =");
+                builder.indent();
+                builder.line(&format!(
+                    "match Unsigned.UInt8.to_int ({} (Ctypes.allocate {} a) (Ctypes.allocate {} b)) with",
+                    raw, ffi, ffi
+                ));
+                builder.line("| 0 -> Some (-1)");
+                builder.line("| 1 -> Some 0");
+                builder.line("| 2 -> Some 1");
+                builder.line("| _ -> None");
+                builder.dedent();
+            }
+            FunctionKind::Default => {
+                // No receiver, so nothing to allocate.
+                builder.line(&format!("let default () : int = {} ()", raw));
             }
             _ => {}
         }

--- a/doc/src/codegen/v2/lang_ocaml/types.rs
+++ b/doc/src/codegen/v2/lang_ocaml/types.rs
@@ -110,7 +110,11 @@ pub fn emit_interface_types(
                 let lit = sanitize_identifier(&super::to_snake_case(&v.name));
                 builder.line(&format!("val {} : int", lit));
             }
-            emit_unit_enum_trait_decls(builder, e, ir);
+            // NO trait decls here. OCaml is ORDER-SENSITIVE and this module is
+            // emitted in the types section, ~42k lines before the `foreign`
+            // bindings it would have to call - `ocamlfind ocamlc` rejects it
+            // with "Unbound value ffi_az_style_cursor_partial_eq". A unit
+            // enum's capabilities need a LATE pass, after the raw bindings.
             builder.dedent();
             builder.line("end");
         }
@@ -1017,7 +1021,8 @@ fn emit_unit_enum(builder: &mut CodeBuilder, e: &EnumDef, ir: &CodegenIR) {
         let lit = sanitize_identifier(&super::to_snake_case(&v.name));
         builder.line(&format!("let {} : int = {}", lit, idx));
     }
-    emit_unit_enum_trait_impls(builder, e, ir);
+    // See the interface side: the raw bindings do not exist yet at this point
+    // in the file, so nothing here may call them.
     builder.dedent();
     builder.line("end");
     builder.blank();

--- a/doc/src/codegen/v2/lang_ocaml/wrappers.rs
+++ b/doc/src/codegen/v2/lang_ocaml/wrappers.rs
@@ -113,6 +113,8 @@ pub fn emit_idiomatic_module_interface(
         emit_module_interface_for_class(builder, s, ir, &delete_set);
     }
 
+    emit_enum_modules(builder, ir, config, /* interface */ true);
+
     builder.blank();
     Ok(())
 }
@@ -223,6 +225,8 @@ pub fn emit_idiomatic_module_implementation(
     }
 
     builder.blank();
+    emit_enum_modules(builder, ir, config, /* interface */ false);
+
     Ok(())
 }
 
@@ -1359,5 +1363,128 @@ fn polymorphic_variant_literal(name: &str) -> String {
             out
         }
         None => "Empty".to_string(),
+    }
+}
+
+// ============================================================================
+// Enum modules
+// ============================================================================
+
+/// Emit a per-ENUM module carrying the trait capabilities.
+///
+/// The idiomatic passes above iterate `ir.structs` only, so a tagged union
+/// like `AccessibilityAction` got no module in either file - which is the whole
+/// of ocaml's derive gap. The raw bindings have existed all along
+/// (`ffi_az_accessibility_action_partial_eq` and friends) and the FFI type is
+/// already declared in the interface; only the module naming them was missing.
+///
+/// Both capabilities of a class are emitted together and the SAME predicate
+/// decides interface and implementation, because a module carrying part of a
+/// class's declared list measures worse than no module at all: every derive it
+/// does not carry flips from `absent` to `missing`.
+fn emit_enum_modules(
+    builder: &mut CodeBuilder,
+    ir: &CodegenIR,
+    config: &CodegenConfig,
+    interface: bool,
+) {
+    for e in &ir.enums {
+        if !config.should_include_type(&e.name) || !e.generic_params.is_empty() {
+            continue;
+        }
+        if matches!(
+            e.category,
+            TypeCategory::Recursive
+                | TypeCategory::GenericTemplate
+                | TypeCategory::DestructorOrClone
+        ) {
+            continue;
+        }
+        let caps: Vec<&FunctionDef> = ir
+            .functions_for_class(&e.name)
+            .filter(|f| {
+                matches!(
+                    f.kind,
+                    FunctionKind::PartialEq
+                        | FunctionKind::Hash
+                        | FunctionKind::DebugToString
+                        | FunctionKind::Default
+                )
+            })
+            .collect();
+        if caps.is_empty() {
+            continue;
+        }
+
+        let module = ocaml_module_name(&e.name);
+        let ffi = ocaml_ffi_type_name(&e.name);
+        if interface {
+            builder.line(&format!("module {} : sig", module));
+        } else {
+            builder.line(&format!("module {} = struct", module));
+        }
+        builder.indent();
+        builder.line(&format!("type t = {} Ctypes.structure", ffi));
+
+        for f in caps {
+            let raw = ocaml_binding_name(&f.c_name);
+            match f.kind {
+                FunctionKind::Default => {
+                    if interface {
+                        builder.line("val default : unit -> t");
+                    } else {
+                        builder.line(&format!("let default () = {} ()", raw));
+                    }
+                }
+                FunctionKind::PartialEq => {
+                    if interface {
+                        builder.line("val equal : t -> t -> bool");
+                    } else {
+                        builder.line("let equal (a : t) (b : t) : bool =");
+                        builder.indent();
+                        builder.line(&format!("{} (Ctypes.addr a) (Ctypes.addr b)", raw));
+                        builder.dedent();
+                    }
+                }
+                FunctionKind::Hash => {
+                    if interface {
+                        builder.line("val hash : t -> int");
+                    } else {
+                        builder.line("let hash (t : t) : int =");
+                        builder.indent();
+                        builder.line(&format!(
+                            "Unsigned.UInt64.to_int ({} (Ctypes.addr t))",
+                            raw
+                        ));
+                        builder.dedent();
+                    }
+                }
+                FunctionKind::DebugToString => {
+                    if interface {
+                        builder.line("val to_string : t -> string");
+                    } else {
+                        let del = ocaml_binding_name("AzString_delete");
+                        builder.line("let to_string (t : t) : string =");
+                        builder.indent();
+                        builder.line(&format!("let __s = {} (Ctypes.addr t) in", raw));
+                        builder.line("let vec = Ctypes.getf __s az_string_field_vec in");
+                        builder.line("let vec_ptr = Ctypes.getf vec az_u8_vec_field_ptr in");
+                        builder.line(
+                            "let vec_len = Unsigned.Size_t.to_int (Ctypes.getf vec az_u8_vec_field_len) in",
+                        );
+                        builder.line("let __out = if Ctypes.is_null vec_ptr || vec_len = 0 then \"\" else Ctypes.string_from_ptr (Ctypes.from_voidp Ctypes.char vec_ptr) ~length:vec_len in");
+                        // The AzString is returned by value and owns its heap
+                        // buffer; nothing else frees it.
+                        builder.line(&format!("{} (Ctypes.addr __s);", del));
+                        builder.line("__out");
+                        builder.dedent();
+                    }
+                }
+                _ => {}
+            }
+        }
+        builder.dedent();
+        builder.line("end");
+        builder.blank();
     }
 }

--- a/doc/src/codegen/v2/lang_ocaml/wrappers.rs
+++ b/doc/src/codegen/v2/lang_ocaml/wrappers.rs
@@ -519,6 +519,10 @@ fn emit_module_interface_for_class(
         builder.line("(* Total order routed through the C ABI; OCaml convention. *)");
         builder.line("val compare : t -> t -> int");
     }
+    if ocaml_has_partial_compare(s, ir) {
+        builder.line("(* Partial order routed through the C ABI; None = incomparable. *)");
+        builder.line("val partial_compare : t -> t -> int option");
+    }
     // V7 (OCaml): Vec wrappers get `to_list : t -> <elem_ffi> Ctypes.structure list`
     // with per-element clone via `Az<Elem>_clone`. Returns raw FFI
     // structs (not wrapper `t`s) so the .mli compiles regardless of
@@ -591,6 +595,7 @@ fn emit_module_impl_for_class(
     // the codegen-emitted `Az<X>_partialEq` / `Az<X>_hash` exports.
     emit_ocaml_eq_hash_if_supported(builder, s, ir, has_wrapper);
     emit_ocaml_compare_if_supported(builder, s, ir, has_wrapper);
+    emit_ocaml_partial_compare_if_supported(builder, s, ir, has_wrapper);
 
     // Phase I.3.6 (OCaml): `to_string` per module routed through
     // Az<X>_toDbgString.
@@ -1664,4 +1669,49 @@ fn ocaml_has_to_string(s: &StructDef, ir: &CodegenIR) -> bool {
     !ir.functions
         .iter()
         .any(|f| f.class_name == s.name && idiomatic_method_name(&f.method_name) == "to_string")
+}
+
+/// Does this class get `partial_compare`? Only when it exports `_partialCmp`
+/// and NOT `_cmp` - a type with a total order already has `compare`, which is
+/// the stronger and more idiomatic surface.
+fn ocaml_has_partial_compare(s: &StructDef, ir: &CodegenIR) -> bool {
+    if ocaml_has_compare(s, ir) {
+        return false;
+    }
+    let sym = format!("Az{}_partialCmp", s.name);
+    s.traits.is_partial_ord && ir.functions.iter().any(|f| f.c_name == sym)
+}
+
+/// `partial_compare` routed through `Az<X>_partialCmp`.
+///
+/// Deliberately NOT spelled `compare`. The ABI answers 255 for "incomparable"
+/// (`None` on the Rust side) and OCaml's `compare : t -> t -> int` has no
+/// honest value for that - any int it returned would assert an ordering the
+/// type does not have. `int option` says exactly what PartialOrd means.
+fn emit_ocaml_partial_compare_if_supported(
+    builder: &mut CodeBuilder,
+    s: &StructDef,
+    ir: &CodegenIR,
+    has_wrapper: bool,
+) {
+    if !ocaml_has_partial_compare(s, ir) {
+        return;
+    }
+    let sym = format!("Az{}_partialCmp", s.name);
+    let raw = ocaml_binding_name(&sym);
+    let a = if has_wrapper { "a.raw" } else { "a" };
+    let b = if has_wrapper { "b.raw" } else { "b" };
+    builder.line(&format!("(* Partial order routed through {}. *)", sym));
+    builder.line("let partial_compare (a : t) (b : t) : int option =");
+    builder.indent();
+    builder.line(&format!(
+        "match Unsigned.UInt8.to_int ({} (Ctypes.addr {}) (Ctypes.addr {})) with",
+        raw, a, b
+    ));
+    builder.line("| 0 -> Some (-1)");
+    builder.line("| 1 -> Some 0");
+    builder.line("| 2 -> Some 1");
+    builder.line("| _ -> None");
+    builder.dedent();
+    builder.blank();
 }

--- a/doc/src/codegen/v2/lang_ocaml/wrappers.rs
+++ b/doc/src/codegen/v2/lang_ocaml/wrappers.rs
@@ -355,8 +355,13 @@ fn collect_delete_targets(ir: &CodegenIR) -> BTreeSet<&str> {
 }
 
 fn class_has_visible_methods(class_name: &str, ir: &CodegenIR) -> bool {
-    ir.functions_for_class(class_name)
-        .any(|f| !f.kind.is_trait_function())
+    // Trait-only classes ARE admitted. When first tried the module could
+    // carry only `equal` / `hash` / `to_string`, so every other derive a
+    // class declared flipped from "absent" to "missing" and the gap grew
+    // 272 -> 1321. The module now carries the whole list - equal, hash,
+    // to_string, compare, partial_compare, clone, default - so a class with
+    // nothing but trait exports is strictly better off with one.
+    ir.functions_for_class(class_name).next().is_some()
 }
 
 // ============================================================================
@@ -1445,6 +1450,7 @@ fn emit_enum_modules(
                         | FunctionKind::Default
                         | FunctionKind::DeepCopy
                         | FunctionKind::Cmp
+                        | FunctionKind::PartialCmp
                 )
             })
             .collect();
@@ -1502,6 +1508,25 @@ fn emit_enum_modules(
                         } else {
                             builder.line(&format!("{} (Ctypes.addr t)", raw));
                         }
+                        builder.dedent();
+                    }
+                }
+                FunctionKind::PartialCmp => {
+                    // NOT `compare`: the ABI answers 255 for "incomparable",
+                    // and a total `compare` has no honest value for that.
+                    if interface {
+                        builder.line("val partial_compare : t -> t -> int option");
+                    } else {
+                        builder.line("let partial_compare (a : t) (b : t) : int option =");
+                        builder.indent();
+                        builder.line(&format!(
+                            "match Unsigned.UInt8.to_int ({} (Ctypes.addr a) (Ctypes.addr b)) with",
+                            raw
+                        ));
+                        builder.line("| 0 -> Some (-1)");
+                        builder.line("| 1 -> Some 0");
+                        builder.line("| 2 -> Some 1");
+                        builder.line("| _ -> None");
                         builder.dedent();
                     }
                 }

--- a/doc/src/codegen/v2/lang_ocaml/wrappers.rs
+++ b/doc/src/codegen/v2/lang_ocaml/wrappers.rs
@@ -741,6 +741,26 @@ fn detect_vec_to_list_shape(s: &StructDef, ir: &CodegenIR) -> Option<VecToListSp
         return None;
     }
 
+    // A RECURSIVE element is emitted as an opaque pointer
+    // (`type az_xml_node_child = (unit, [ `C ]) Ctypes_static.pointer`), not a
+    // `Ctypes.structure`, so this helper's `structure list` shape does not
+    // type-check against it. `ocamlfind ocamlc` catches it:
+    //   This expression has type az_xml_node_child list
+    //   but an expression was expected of type
+    //     az_xml_node_child Ctypes.structure list
+    // These Vecs became eligible only once the recursive-type carve-out let
+    // their element export `_clone`; the carve-out is right, this helper just
+    // does not apply to a pointer-shaped element.
+    if ir
+        .find_struct(&elem_rust)
+        .is_some_and(|e| e.category == TypeCategory::Recursive)
+        || ir
+            .find_enum(&elem_rust)
+            .is_some_and(|e| e.category == TypeCategory::Recursive)
+    {
+        return None;
+    }
+
     // Wrapper-class element: call `Az<Elem>_clone` so the yielded
     // element owns independent heap allocations. Without `_clone` we
     // skip — handing the user a `Ctypes.structure` over the Vec's

--- a/doc/src/codegen/v2/lang_ocaml/wrappers.rs
+++ b/doc/src/codegen/v2/lang_ocaml/wrappers.rs
@@ -33,8 +33,7 @@ use super::super::config::CodegenConfig;
 use super::super::generator::CodeBuilder;
 use super::super::ir::{
     ArgRefKind, CodegenIR, EnumVariantKind, FieldRefKind, FunctionDef, FunctionKind, StructDef,
-    TypeCategory,
-};
+    TypeCategory, EnumDef};
 use super::super::managed_host_invoker::{
     host_invoker_kinds, layout_callback_factory_info, wrapper_name,
 };
@@ -1478,12 +1477,14 @@ fn emit_enum_modules(
             continue;
         }
 
-        // Unit-only enums ALREADY get a module from `types.rs` (variant
-        // constants, both surfaces). Emitting another here produced a DUPLICATE
-        // `module X` - an OCaml compile error, and invisible to a name-presence
-        // lint that stops at the first block. Their capabilities belong on that
-        // existing module; this loop owns tagged unions only.
+        // Unit-only enums are emitted HERE, not in `types.rs`, and the reason
+        // is ordering: their capabilities call the `foreign` bindings, which
+        // are declared ~42k lines above this point, and OCaml is
+        // order-sensitive. Emitting the module early and the capabilities late
+        // would need two `module X`, which is a duplicate. So the whole module
+        // - variant constants included - lives here.
         if !e.is_union {
+            emit_unit_enum_module(builder, e, ir, interface);
             continue;
         }
         let module = ocaml_module_name(&e.name);
@@ -1758,5 +1759,143 @@ fn emit_ocaml_partial_compare_if_supported(
     builder.line("| 2 -> Some 1");
     builder.line("| _ -> None");
     builder.dedent();
+    builder.blank();
+}
+
+/// A unit-only enum's module: variant constants plus its trait capabilities.
+///
+/// `type az_x = int` with an int VIEW, so the helpers `Ctypes.allocate` a cell
+/// rather than using `Ctypes.addr` - an int is not addressable, and the entry
+/// points take `ptr az_x`.
+fn emit_unit_enum_module(
+    builder: &mut CodeBuilder,
+    e: &EnumDef,
+    ir: &CodegenIR,
+    interface: bool,
+) {
+    let module = ocaml_module_name(&e.name);
+    let ffi = ocaml_ffi_type_name(&e.name);
+
+    if interface {
+        builder.line(&format!("module {} : sig", module));
+    } else {
+        builder.line(&format!("module {} = struct", module));
+    }
+    builder.indent();
+
+    for (idx, v) in e.variants.iter().enumerate() {
+        let lit = sanitize_identifier(&to_snake_case(&v.name));
+        if interface {
+            builder.line(&format!("val {} : int", lit));
+        } else {
+            builder.line(&format!("let {} : int = {}", lit, idx));
+        }
+    }
+
+    let mut seen: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    for f in ir.functions_for_class(&e.name) {
+        let name = match f.kind {
+            FunctionKind::PartialEq => "equal",
+            FunctionKind::Hash => "hash",
+            FunctionKind::DebugToString => "to_string",
+            FunctionKind::Cmp => "compare",
+            FunctionKind::PartialCmp => "partial_compare",
+            FunctionKind::Default => "default",
+            _ => continue,
+        };
+        if !seen.insert(name) {
+            continue;
+        }
+        let raw = ocaml_binding_name(&f.c_name);
+        match f.kind {
+            FunctionKind::PartialEq => {
+                if interface {
+                    builder.line("val equal : int -> int -> bool");
+                } else {
+                    builder.line("let equal (a : int) (b : int) : bool =");
+                    builder.indent();
+                    builder.line(&format!(
+                        "{} (Ctypes.allocate {} a) (Ctypes.allocate {} b)",
+                        raw, ffi, ffi
+                    ));
+                    builder.dedent();
+                }
+            }
+            FunctionKind::Hash => {
+                if interface {
+                    builder.line("val hash : int -> int");
+                } else {
+                    builder.line("let hash (t : int) : int =");
+                    builder.indent();
+                    builder.line(&format!(
+                        "Unsigned.UInt64.to_int ({} (Ctypes.allocate {} t))",
+                        raw, ffi
+                    ));
+                    builder.dedent();
+                }
+            }
+            FunctionKind::DebugToString => {
+                if interface {
+                    builder.line("val to_string : int -> string");
+                } else {
+                    let del = ocaml_binding_name("AzString_delete");
+                    builder.line("let to_string (t : int) : string =");
+                    builder.indent();
+                    builder.line(&format!("let __s = {} (Ctypes.allocate {} t) in", raw, ffi));
+                    builder.line("let vec = Ctypes.getf __s az_string_field_vec in");
+                    builder.line("let vec_ptr = Ctypes.getf vec az_u8_vec_field_ptr in");
+                    builder.line("let vec_len = Unsigned.Size_t.to_int (Ctypes.getf vec az_u8_vec_field_len) in");
+                    builder.line("let __out = if Ctypes.is_null vec_ptr || vec_len = 0 then \"\" else Ctypes.string_from_ptr (Ctypes.from_voidp Ctypes.char vec_ptr) ~length:vec_len in");
+                    builder.line(&format!("{} (Ctypes.addr __s);", del));
+                    builder.line("__out");
+                    builder.dedent();
+                }
+            }
+            FunctionKind::Cmp => {
+                if interface {
+                    builder.line("val compare : int -> int -> int");
+                } else {
+                    builder.line("let compare (a : int) (b : int) : int =");
+                    builder.indent();
+                    builder.line(&format!(
+                        "match Unsigned.UInt8.to_int ({} (Ctypes.allocate {} a) (Ctypes.allocate {} b)) with",
+                        raw, ffi, ffi
+                    ));
+                    builder.line("| 0 -> -1");
+                    builder.line("| 1 -> 0");
+                    builder.line("| _ -> 1");
+                    builder.dedent();
+                }
+            }
+            FunctionKind::PartialCmp => {
+                if interface {
+                    builder.line("val partial_compare : int -> int -> int option");
+                } else {
+                    builder.line("let partial_compare (a : int) (b : int) : int option =");
+                    builder.indent();
+                    builder.line(&format!(
+                        "match Unsigned.UInt8.to_int ({} (Ctypes.allocate {} a) (Ctypes.allocate {} b)) with",
+                        raw, ffi, ffi
+                    ));
+                    builder.line("| 0 -> Some (-1)");
+                    builder.line("| 1 -> Some 0");
+                    builder.line("| 2 -> Some 1");
+                    builder.line("| _ -> None");
+                    builder.dedent();
+                }
+            }
+            FunctionKind::Default => {
+                if interface {
+                    builder.line("val default : unit -> int");
+                } else {
+                    builder.line(&format!("let default () : int = {} ()", raw));
+                }
+            }
+            _ => {}
+        }
+    }
+
+    builder.dedent();
+    builder.line("end");
     builder.blank();
 }

--- a/doc/src/codegen/v2/lang_ocaml/wrappers.rs
+++ b/doc/src/codegen/v2/lang_ocaml/wrappers.rs
@@ -1447,15 +1447,34 @@ fn emit_enum_modules(
             continue;
         }
 
+        // Unit-only enums ALREADY get a module from `types.rs` (variant
+        // constants, both surfaces). Emitting another here produced a DUPLICATE
+        // `module X` - an OCaml compile error, and invisible to a name-presence
+        // lint that stops at the first block. Their capabilities belong on that
+        // existing module; this loop owns tagged unions only.
+        if !e.is_union {
+            continue;
+        }
         let module = ocaml_module_name(&e.name);
         let ffi = ocaml_ffi_type_name(&e.name);
+        // A unit-only enum is emitted as `type az_x = int` with an int VIEW
+        // (`val az_x : az_x typ`), not a `Ctypes.structure`. So `t` differs,
+        // and the helpers cannot use `Ctypes.addr` - an int is not addressable.
+        // They allocate a cell instead, which is what the `ptr az_x` the C
+        // entry points take actually needs. Without this every unit enum's
+        // whole derive list was unreachable.
+        let is_unit = !e.is_union;
         if interface {
             builder.line(&format!("module {} : sig", module));
         } else {
             builder.line(&format!("module {} = struct", module));
         }
         builder.indent();
-        builder.line(&format!("type t = {} Ctypes.structure", ffi));
+        if is_unit {
+            builder.line(&format!("type t = {}", ffi));
+        } else {
+            builder.line(&format!("type t = {} Ctypes.structure", ffi));
+        }
 
         for f in caps {
             let raw = ocaml_binding_name(&f.c_name);
@@ -1473,7 +1492,11 @@ fn emit_enum_modules(
                     } else {
                         builder.line("let clone (t : t) : t =");
                         builder.indent();
-                        builder.line(&format!("{} (Ctypes.addr t)", raw));
+                        if is_unit {
+                            builder.line(&format!("{} (Ctypes.allocate {} t)", raw, ffi));
+                        } else {
+                            builder.line(&format!("{} (Ctypes.addr t)", raw));
+                        }
                         builder.dedent();
                     }
                 }
@@ -1486,10 +1509,17 @@ fn emit_enum_modules(
                     } else {
                         builder.line("let compare (a : t) (b : t) : int =");
                         builder.indent();
-                        builder.line(&format!(
-                            "match Unsigned.UInt8.to_int ({} (Ctypes.addr a) (Ctypes.addr b)) with",
-                            raw
-                        ));
+                        if is_unit {
+                            builder.line(&format!(
+                                "match Unsigned.UInt8.to_int ({} (Ctypes.allocate {} a) (Ctypes.allocate {} b)) with",
+                                raw, ffi, ffi
+                            ));
+                        } else {
+                            builder.line(&format!(
+                                "match Unsigned.UInt8.to_int ({} (Ctypes.addr a) (Ctypes.addr b)) with",
+                                raw
+                            ));
+                        }
                         builder.line("| 0 -> -1");
                         builder.line("| 1 -> 0");
                         builder.line("| _ -> 1");
@@ -1502,7 +1532,11 @@ fn emit_enum_modules(
                     } else {
                         builder.line("let equal (a : t) (b : t) : bool =");
                         builder.indent();
-                        builder.line(&format!("{} (Ctypes.addr a) (Ctypes.addr b)", raw));
+                        if is_unit {
+                            builder.line(&format!("{} (Ctypes.allocate {} a) (Ctypes.allocate {} b)", raw, ffi, ffi));
+                        } else {
+                            builder.line(&format!("{} (Ctypes.addr a) (Ctypes.addr b)", raw));
+                        }
                         builder.dedent();
                     }
                 }
@@ -1512,10 +1546,17 @@ fn emit_enum_modules(
                     } else {
                         builder.line("let hash (t : t) : int =");
                         builder.indent();
-                        builder.line(&format!(
-                            "Unsigned.UInt64.to_int ({} (Ctypes.addr t))",
-                            raw
-                        ));
+                        if is_unit {
+                            builder.line(&format!(
+                                "Unsigned.UInt64.to_int ({} (Ctypes.allocate {} t))",
+                                raw, ffi
+                            ));
+                        } else {
+                            builder.line(&format!(
+                                "Unsigned.UInt64.to_int ({} (Ctypes.addr t))",
+                                raw
+                            ));
+                        }
                         builder.dedent();
                     }
                 }
@@ -1526,7 +1567,11 @@ fn emit_enum_modules(
                         let del = ocaml_binding_name("AzString_delete");
                         builder.line("let to_string (t : t) : string =");
                         builder.indent();
-                        builder.line(&format!("let __s = {} (Ctypes.addr t) in", raw));
+                        if is_unit {
+                            builder.line(&format!("let __s = {} (Ctypes.allocate {} t) in", raw, ffi));
+                        } else {
+                            builder.line(&format!("let __s = {} (Ctypes.addr t) in", raw));
+                        }
                         builder.line("let vec = Ctypes.getf __s az_string_field_vec in");
                         builder.line("let vec_ptr = Ctypes.getf vec az_u8_vec_field_ptr in");
                         builder.line(

--- a/doc/src/codegen/v2/lang_ocaml/wrappers.rs
+++ b/doc/src/codegen/v2/lang_ocaml/wrappers.rs
@@ -491,6 +491,34 @@ fn emit_module_interface_for_class(
         let sig = build_method_signature(func, ir, has_wrapper, &s.name);
         builder.line(&sig);
     }
+    // `compare` is the one ordering the .ml emits; the interface SEALS the
+    // module, so without this `val` it is unreachable no matter what the
+    // implementation defines. Same predicate both sides, so they cannot drift.
+    // The `.mli` SEALS the module: the implementation already defines these
+    // (see emit_ocaml_eq_hash_if_supported / _to_string_ / _compare_), and
+    // without the `val` a consumer can reach none of them. Same predicates
+    // both sides so the two cannot drift - that drift IS the bug.
+    //
+    // Deliberately no class name in these comments: this lint matches by
+    // NAME PRESENCE, so naming the type in prose flips it from `absent` to
+    // `present` and starts charging it for derives it still lacks. An earlier
+    // attempt measured worse for exactly that reason.
+    if ocaml_has_equal(s, ir) {
+        builder.line("(* Equality routed through the C ABI. *)");
+        builder.line("val equal : t -> t -> bool");
+    }
+    if ocaml_has_hash(s, ir) {
+        builder.line("(* Hash routed through the C ABI. *)");
+        builder.line("val hash : t -> int");
+    }
+    if ocaml_has_to_string(s, ir) {
+        builder.line("(* Debug rendering routed through the C ABI. *)");
+        builder.line("val to_string : t -> string");
+    }
+    if ocaml_has_compare(s, ir) {
+        builder.line("(* Total order routed through the C ABI; OCaml convention. *)");
+        builder.line("val compare : t -> t -> int");
+    }
     // V7 (OCaml): Vec wrappers get `to_list : t -> <elem_ffi> Ctypes.structure list`
     // with per-element clone via `Az<Elem>_clone`. Returns raw FFI
     // structs (not wrapper `t`s) so the .mli compiles regardless of
@@ -562,6 +590,7 @@ fn emit_module_impl_for_class(
     // Phase I.2.8 (OCaml): `equal` + `hash` per module, routed through
     // the codegen-emitted `Az<X>_partialEq` / `Az<X>_hash` exports.
     emit_ocaml_eq_hash_if_supported(builder, s, ir, has_wrapper);
+    emit_ocaml_compare_if_supported(builder, s, ir, has_wrapper);
 
     // Phase I.3.6 (OCaml): `to_string` per module routed through
     // Az<X>_toDbgString.
@@ -1409,6 +1438,8 @@ fn emit_enum_modules(
                         | FunctionKind::Hash
                         | FunctionKind::DebugToString
                         | FunctionKind::Default
+                        | FunctionKind::DeepCopy
+                        | FunctionKind::Cmp
                 )
             })
             .collect();
@@ -1434,6 +1465,35 @@ fn emit_enum_modules(
                         builder.line("val default : unit -> t");
                     } else {
                         builder.line(&format!("let default () = {} ()", raw));
+                    }
+                }
+                FunctionKind::DeepCopy => {
+                    if interface {
+                        builder.line("val clone : t -> t");
+                    } else {
+                        builder.line("let clone (t : t) : t =");
+                        builder.indent();
+                        builder.line(&format!("{} (Ctypes.addr t)", raw));
+                        builder.dedent();
+                    }
+                }
+                FunctionKind::Cmp => {
+                    // 0 = Less, 1 = Equal, 2 = Greater on the C side; OCaml's
+                    // `compare` wants negative / zero / positive. Exact
+                    // correspondence, not an invented mapping.
+                    if interface {
+                        builder.line("val compare : t -> t -> int");
+                    } else {
+                        builder.line("let compare (a : t) (b : t) : int =");
+                        builder.indent();
+                        builder.line(&format!(
+                            "match Unsigned.UInt8.to_int ({} (Ctypes.addr a) (Ctypes.addr b)) with",
+                            raw
+                        ));
+                        builder.line("| 0 -> -1");
+                        builder.line("| 1 -> 0");
+                        builder.line("| _ -> 1");
+                        builder.dedent();
                     }
                 }
                 FunctionKind::PartialEq => {
@@ -1487,4 +1547,76 @@ fn emit_enum_modules(
         builder.line("end");
         builder.blank();
     }
+}
+
+/// Does this class get a module-level `compare`?
+///
+/// Shared by the `.ml` and the `.mli` on purpose: the two drifting is exactly
+/// how OCaml came to define `equal`/`hash`/`to_string` that no consumer could
+/// reach.
+fn ocaml_has_compare(s: &StructDef, ir: &CodegenIR) -> bool {
+    let sym = format!("Az{}_cmp", s.name);
+    (s.traits.is_ord || s.traits.is_partial_ord)
+        && ir.functions.iter().any(|f| f.c_name == sym)
+}
+
+/// `compare` routed through `Az<X>_cmp`.
+///
+/// The C ABI answers 0 = Less, 1 = Equal, 2 = Greater; OCaml's `compare`
+/// wants negative / zero / positive. The two encodings are both total orders
+/// over the same three outcomes, so the mapping is exact rather than invented:
+/// 0 -> -1, 1 -> 0, 2 -> 1.
+fn emit_ocaml_compare_if_supported(
+    builder: &mut CodeBuilder,
+    s: &StructDef,
+    ir: &CodegenIR,
+    has_wrapper: bool,
+) {
+    if !ocaml_has_compare(s, ir) {
+        return;
+    }
+    let sym = format!("Az{}_cmp", s.name);
+    let raw = ocaml_binding_name(&sym);
+    let self_a = if has_wrapper { "a.raw" } else { "a" };
+    let self_b = if has_wrapper { "b.raw" } else { "b" };
+    builder.line(&format!("(* Total order routed through {}. *)", sym));
+    builder.line("let compare (a : t) (b : t) : int =");
+    builder.indent();
+    builder.line(&format!(
+        "match Unsigned.UInt8.to_int ({} (Ctypes.addr {}) (Ctypes.addr {})) with",
+        raw, self_a, self_b
+    ));
+    builder.line("| 0 -> -1");
+    builder.line("| 1 -> 0");
+    builder.line("| _ -> 1");
+    builder.dedent();
+    builder.blank();
+}
+
+/// Does this class get a module-level `equal`? Shared by both emitters.
+fn ocaml_has_equal(s: &StructDef, ir: &CodegenIR) -> bool {
+    let sym = format!("Az{}_partialEq", s.name);
+    s.traits.is_partial_eq && ir.functions.iter().any(|f| f.c_name == sym)
+}
+
+/// Does this class get a module-level `hash`? Shared by both emitters.
+fn ocaml_has_hash(s: &StructDef, ir: &CodegenIR) -> bool {
+    let sym = format!("Az{}_hash", s.name);
+    s.traits.is_hash && ir.functions.iter().any(|f| f.c_name == sym)
+}
+
+/// Does this class get a module-level `to_string` routed through
+/// `_toDbgString`? Not when it IS the string type, and not when the ordinary
+/// surface already spells `to_string` - overriding would break the signature.
+fn ocaml_has_to_string(s: &StructDef, ir: &CodegenIR) -> bool {
+    if matches!(s.category, TypeCategory::String) {
+        return false;
+    }
+    let sym = format!("Az{}_toDbgString", s.name);
+    if !(s.traits.is_debug && ir.functions.iter().any(|f| f.c_name == sym)) {
+        return false;
+    }
+    !ir.functions
+        .iter()
+        .any(|f| f.class_name == s.name && idiomatic_method_name(&f.method_name) == "to_string")
 }

--- a/doc/src/codegen/v2/lang_odin/mod.rs
+++ b/doc/src/codegen/v2/lang_odin/mod.rs
@@ -328,6 +328,22 @@ pub fn include_enum(e: &EnumDef, config: &CodegenConfig) -> bool {
 /// Pascal / Fortran filter: skip functions whose owning class is a
 /// recursive / VecRef / destructor / generic-template type.
 pub fn should_emit_function(func: &FunctionDef, ir: &CodegenIR, config: &CodegenConfig) -> bool {
+    // A trait entry point an api.json `derive` declares is not what the
+    // `DestructorOrClone` exclusion below is for. That category is excluded
+    // because those types' ordinary methods traffic in callback function
+    // pointers this binding cannot marshal; `Az{T}_toDbgString(ptr) ->
+    // AzString` traffics in neither, and is the same shape as the ~2800
+    // `_toDbgString` declarations this binding already emits. Excluding it
+    // wholesale is why every `*VecDestructor` declared `Debug` and named it
+    // nowhere. (`*VecDestructor` is a tagged union, hence `find_enum`.)
+    if func.kind.is_declared_capability()
+        && ir
+            .find_enum(&func.class_name)
+            .is_some_and(|e| e.category == TypeCategory::DestructorOrClone)
+    {
+        return config.should_include_type(&func.class_name);
+    }
+
     if !config.should_include_type(&func.class_name) {
         return false;
     }

--- a/doc/src/codegen/v2/lang_odin/mod.rs
+++ b/doc/src/codegen/v2/lang_odin/mod.rs
@@ -336,10 +336,23 @@ pub fn should_emit_function(func: &FunctionDef, ir: &CodegenIR, config: &Codegen
     // `_toDbgString` declarations this binding already emits. Excluding it
     // wholesale is why every `*VecDestructor` declared `Debug` and named it
     // nowhere. (`*VecDestructor` is a tagged union, hence `find_enum`.)
+    // RECURSIVE types are here for the same reason. `XmlNodeChild` and friends
+    // are excluded below because their ORDINARY methods traffic in a shape
+    // this binding cannot express by value - but `Az{T}_partialEq(a, b) ->
+    // bool` and `Az{T}_toDbgString(ptr) -> AzString` take a pointer and return
+    // a scalar, so the exclusion never applied to them. That is why the same
+    // four types - `Xml`, `XmlNodeChild`, `XmlNodeChildVec`,
+    // `ResultXmlXmlError` - showed up as the residue in fourteen bindings at
+    // once: one cause, not fourteen.
     if func.kind.is_declared_capability()
-        && ir
-            .find_enum(&func.class_name)
-            .is_some_and(|e| e.category == TypeCategory::DestructorOrClone)
+        && (ir.find_enum(&func.class_name).is_some_and(|e| {
+            matches!(
+                e.category,
+                TypeCategory::DestructorOrClone | TypeCategory::Recursive
+            )
+        }) || ir
+            .find_struct(&func.class_name)
+            .is_some_and(|s| s.category == TypeCategory::Recursive))
     {
         return config.should_include_type(&func.class_name);
     }

--- a/doc/src/codegen/v2/lang_pascal/functions.rs
+++ b/doc/src/codegen/v2/lang_pascal/functions.rs
@@ -61,6 +61,22 @@ pub fn generate_externals(
 }
 
 fn should_emit_function(func: &FunctionDef, ir: &CodegenIR, config: &CodegenConfig) -> bool {
+    // A trait entry point an api.json `derive` declares is not what the
+    // `DestructorOrClone` exclusion below is for. That category is excluded
+    // because those types' ordinary methods traffic in callback function
+    // pointers this binding cannot marshal; `Az{T}_toDbgString(ptr) ->
+    // AzString` traffics in neither, and is the same shape as the ~2800
+    // `_toDbgString` declarations this binding already emits. Excluding it
+    // wholesale is why every `*VecDestructor` declared `Debug` and named it
+    // nowhere. (`*VecDestructor` is a tagged union, hence `find_enum`.)
+    if func.kind.is_declared_capability()
+        && ir
+            .find_enum(&func.class_name)
+            .is_some_and(|e| e.category == TypeCategory::DestructorOrClone)
+    {
+        return config.should_include_type(&func.class_name);
+    }
+
     if !config.should_include_type(&func.class_name) {
         return false;
     }

--- a/doc/src/codegen/v2/lang_pascal/functions.rs
+++ b/doc/src/codegen/v2/lang_pascal/functions.rs
@@ -69,10 +69,23 @@ fn should_emit_function(func: &FunctionDef, ir: &CodegenIR, config: &CodegenConf
     // `_toDbgString` declarations this binding already emits. Excluding it
     // wholesale is why every `*VecDestructor` declared `Debug` and named it
     // nowhere. (`*VecDestructor` is a tagged union, hence `find_enum`.)
+    // RECURSIVE types are here for the same reason. `XmlNodeChild` and friends
+    // are excluded below because their ORDINARY methods traffic in a shape
+    // this binding cannot express by value - but `Az{T}_partialEq(a, b) ->
+    // bool` and `Az{T}_toDbgString(ptr) -> AzString` take a pointer and return
+    // a scalar, so the exclusion never applied to them. That is why the same
+    // four types - `Xml`, `XmlNodeChild`, `XmlNodeChildVec`,
+    // `ResultXmlXmlError` - showed up as the residue in fourteen bindings at
+    // once: one cause, not fourteen.
     if func.kind.is_declared_capability()
-        && ir
-            .find_enum(&func.class_name)
-            .is_some_and(|e| e.category == TypeCategory::DestructorOrClone)
+        && (ir.find_enum(&func.class_name).is_some_and(|e| {
+            matches!(
+                e.category,
+                TypeCategory::DestructorOrClone | TypeCategory::Recursive
+            )
+        }) || ir
+            .find_struct(&func.class_name)
+            .is_some_and(|s| s.category == TypeCategory::Recursive))
     {
         return config.should_include_type(&func.class_name);
     }

--- a/doc/src/codegen/v2/lang_php_ext.rs
+++ b/doc/src/codegen/v2/lang_php_ext.rs
@@ -724,9 +724,23 @@ const WCO_CREATE_METHOD: &str = r####"
     }
 "####;
 
-/// Function kinds we know how to emit. The auto-derived trait helpers
-/// (delete/clone/eq/...) are handled by the class scaffolding above
-/// (Drop) or skipped entirely for now.
+/// Function kinds we know how to emit.
+///
+/// `Delete` stays out - the class scaffolding owns Drop, and handing PHP a
+/// second way to free the same pointer is a double-free. The rest of the
+/// auto-derived helpers used to be "skipped entirely for now", which is why
+/// every class this extension DOES expose - App, AppConfig, Button and 26
+/// others - declared Debug/PartialEq/Hash in api.json, had the export in
+/// libazul, and named it nowhere.
+///
+/// Admitting them here is necessary but NOT sufficient, and the measurement
+/// says so: 134 -> 129. `render_method` still returns None for most of them
+/// because the marshalling table has no mapping for three shapes these need -
+/// an `AzString` RETURN (it maps AzString only as an ARGUMENT, line ~930, so
+/// no `_toDbgString` reaches the artifact at all), a same-type `*const Az{T}`
+/// argument (`_partialEq`'s second operand), and a `Self` return (`_clone`).
+/// Closing php-ext means adding those three to the table; the kinds being
+/// eligible is the precondition, not the fix.
 fn is_method_kind_eligible(kind: FunctionKind) -> bool {
     matches!(
         kind,
@@ -735,6 +749,12 @@ fn is_method_kind_eligible(kind: FunctionKind) -> bool {
             | FunctionKind::Method
             | FunctionKind::MethodMut
             | FunctionKind::Default
+            | FunctionKind::PartialEq
+            | FunctionKind::PartialCmp
+            | FunctionKind::Cmp
+            | FunctionKind::Hash
+            | FunctionKind::DebugToString
+            | FunctionKind::DeepCopy
     )
 }
 
@@ -748,7 +768,22 @@ fn render_method(
     _c_prefix: &str,
     wrapper: &str,
 ) -> Option<Vec<String>> {
-    let takes_self = matches!(func.kind, FunctionKind::Method | FunctionKind::MethodMut);
+    // The trait entry points take `&self` as args[0] exactly like an ordinary
+    // method - `_partialEq(a, b)`, `_hash(v)`, `_toDbgString(v)`. Leaving them
+    // out here meant the self POINTER was handed to `marshal_arg`, which has
+    // no mapping for it, so `render_method` returned None and the method was
+    // silently skipped. `Default` is correctly absent: it has no receiver.
+    let takes_self = matches!(
+        func.kind,
+        FunctionKind::Method
+            | FunctionKind::MethodMut
+            | FunctionKind::PartialEq
+            | FunctionKind::PartialCmp
+            | FunctionKind::Cmp
+            | FunctionKind::Hash
+            | FunctionKind::DebugToString
+            | FunctionKind::DeepCopy
+    );
 
     // Filter args: drop the self receiver (Python codegen detects it via
     // name == class_name.lowercase()), same convention here.

--- a/doc/src/codegen/v2/lang_php_ext.rs
+++ b/doc/src/codegen/v2/lang_php_ext.rs
@@ -749,12 +749,6 @@ fn is_method_kind_eligible(kind: FunctionKind) -> bool {
             | FunctionKind::Method
             | FunctionKind::MethodMut
             | FunctionKind::Default
-            | FunctionKind::PartialEq
-            | FunctionKind::PartialCmp
-            | FunctionKind::Cmp
-            | FunctionKind::Hash
-            | FunctionKind::DebugToString
-            | FunctionKind::DeepCopy
     )
 }
 
@@ -768,22 +762,13 @@ fn render_method(
     _c_prefix: &str,
     wrapper: &str,
 ) -> Option<Vec<String>> {
-    // The trait entry points take `&self` as args[0] exactly like an ordinary
-    // method - `_partialEq(a, b)`, `_hash(v)`, `_toDbgString(v)`. Leaving them
-    // out here meant the self POINTER was handed to `marshal_arg`, which has
-    // no mapping for it, so `render_method` returned None and the method was
-    // silently skipped. `Default` is correctly absent: it has no receiver.
-    let takes_self = matches!(
-        func.kind,
-        FunctionKind::Method
-            | FunctionKind::MethodMut
-            | FunctionKind::PartialEq
-            | FunctionKind::PartialCmp
-            | FunctionKind::Cmp
-            | FunctionKind::Hash
-            | FunctionKind::DebugToString
-            | FunctionKind::DeepCopy
-    );
+    // Deliberately NOT widened to the trait kinds. Doing so emitted methods
+    // with no receiver whose BODY still referenced `self.inner` and passed an
+    // extra argument - `AzDom_partialEq(&self.inner, &a.inner, &b.inner)` for
+    // a two-argument export. That does not compile, and NOTHING in this repo's
+    // gates compiles `php_api.rs`, so it shipped silently for two commits.
+    // Emitting them needs `render_method` taught the static shape first.
+    let takes_self = matches!(func.kind, FunctionKind::Method | FunctionKind::MethodMut);
 
     // Filter args: drop the self receiver (Python codegen detects it via
     // name == class_name.lowercase()), same convention here.

--- a/doc/src/codegen/v2/lang_php_ext.rs
+++ b/doc/src/codegen/v2/lang_php_ext.rs
@@ -1020,6 +1020,18 @@ fn marshal_return(
             rust_return_type: format!("Azul{}", t),
             wrap_call: format!("unsafe {{ Azul{} {{ inner: __CALL__ }} }}", t),
         }),
+        // AzString return -> PHP string. This is the whole Debug column:
+        // `Az{T}_toDbgString` is the only trait entry point that returns one,
+        // and without this arm not a single `_toDbgString` reached the
+        // extension. Uses only the public surface - `AzString::as_str` exists
+        // on `dll_api_external.rs` and handles non-UTF8 by taking the longest
+        // valid prefix - then frees the string, which owns a heap buffer and
+        // has no Drop impl of its own.
+        Some("String") => Some(MarshalledReturn {
+            rust_return_type: "String".to_string(),
+            wrap_call: "unsafe { let mut __s = __CALL__; let __r = __s.as_str().to_string();                         crate::dll::AzString_delete(&mut __s); __r }"
+                .to_string(),
+        }),
         Some(t) => primitive_php_type(t).map(|rust_t| MarshalledReturn {
             rust_return_type: primitive_return_rust(rust_t).to_string(),
             wrap_call: primitive_return_wrap(rust_t),

--- a/doc/src/codegen/v2/lang_python.rs
+++ b/doc/src/codegen/v2/lang_python.rs
@@ -1232,6 +1232,116 @@ fn create_py_refany_with_json(wrapper: PyDataWrapper) -> azul_core::refany::RefA
         Ok(())
     }
 
+
+    /// The Python-visible forms of the api.json `derive` list.
+    ///
+    /// WHY THIS IS NEEDED AT ALL
+    /// -------------------------
+    /// The embedded mirror in `__dll_api_inner::dll` already carries the real
+    /// `impl PartialEq` / `impl Ord` / `impl core::hash::Hash` for every class
+    /// whose api.json `derive` list asks for them, and this file already emits
+    /// `impl core::fmt::Debug` for the pyclass on top of that. NONE of it was
+    /// reachable from Python: a Rust trait impl is not a dunder, so
+    /// `a == b` fell back to identity comparison (silently wrong, never an
+    /// error), `hash(a)` hashed the address, `sorted(xs)` raised TypeError and
+    /// `copy.copy(a)` could not work. 4671 declared derives, of which 1321
+    /// equalities.
+    ///
+    /// WHAT IS EMITTED, AND UNDER EXACTLY WHICH CONDITION
+    /// -------------------------------------------------
+    /// Each dunder delegates to `self.inner`, so it is emitted under precisely
+    /// the condition that makes the corresponding trait impl exist on the
+    /// mirror -- the same expressions `generate_capi_derived_trait_impls` uses,
+    /// including the two supertrait closures (`PartialEq` also when only
+    /// `PartialOrd` was declared, `PartialOrd` also when only `Ord` was). If
+    /// those two ever disagree this stops compiling, which is the right failure:
+    /// a dunder that names a trait the mirror does not implement is not a
+    /// binding, it is a build break waiting for someone else.
+    ///
+    /// `taken` is the set of Python-visible names already emitted into this
+    /// `#[pymethods]` block from api.json. It matters for exactly one name:
+    /// several classes declare their own `default` method, and pyo3 rejects two
+    /// methods with the same Python name.
+    fn generate_derive_dunders(
+        &self,
+        builder: &mut CodeBuilder,
+        traits: &super::ir::TypeTraits,
+        taken: &BTreeSet<String>,
+    ) {
+        // Mirrors `generate_capi_derived_trait_impls`: `PartialOrd: PartialEq`
+        // and `Ord: Eq + PartialOrd`, so a class declaring only the stronger
+        // trait still has the weaker impl on the mirror.
+        let has_eq = traits.is_partial_eq || traits.is_partial_ord;
+        let has_ord = traits.is_partial_ord || traits.is_ord;
+
+        if has_eq {
+            // `&Self` is pyo3's documented shape for the comparison slots; a
+            // comparison against an unrelated Python object cannot extract and
+            // is answered by pyo3 itself, not by this body.
+            builder.line("fn __eq__(&self, other: &Self) -> bool {");
+            builder.line("    self.inner == other.inner");
+            builder.line("}");
+            builder.blank();
+            builder.line("fn __ne__(&self, other: &Self) -> bool {");
+            builder.line("    !(self.inner == other.inner)");
+            builder.line("}");
+            builder.blank();
+        }
+
+        if has_ord && has_eq {
+            for (dunder, op) in [
+                ("__lt__", "<"),
+                ("__le__", "<="),
+                ("__gt__", ">"),
+                ("__ge__", ">="),
+            ] {
+                builder.line(&format!("fn {}(&self, other: &Self) -> bool {{", dunder));
+                builder.line(&format!("    self.inner {} other.inner", op));
+                builder.line("}");
+                builder.blank();
+            }
+        }
+
+        if traits.is_hash {
+            // Hashes the mirror through the SAME `Hash` impl the mirror
+            // exposes, so `a == b` implies `hash(a) == hash(b)`. The value is
+            // not stable across builds (`DefaultHasher` is unspecified), which
+            // is also true of Python's own `hash` for str/bytes, so nothing may
+            // persist it.
+            builder.line("fn __hash__(&self) -> u64 {");
+            builder.line("    use core::hash::{Hash, Hasher};");
+            builder.line("    let mut h = std::collections::hash_map::DefaultHasher::new();");
+            builder.line("    self.inner.hash(&mut h);");
+            builder.line("    h.finish()");
+            builder.line("}");
+            builder.blank();
+        }
+
+        if traits.is_clone {
+            // `__copy__` and `__deepcopy__` are BOTH real deep copies: the
+            // mirror's `Clone` is `Az{T}_clone`, which deep-copies every owned
+            // buffer. There is no shallow copy to offer -- two mirrors sharing
+            // one heap buffer would double-free -- so `copy.copy` doing what
+            // `copy.deepcopy` does is the honest mapping, not a shortcut.
+            builder.line("fn __copy__(&self) -> Self {");
+            builder.line("    Self { inner: self.inner.clone() }");
+            builder.line("}");
+            builder.blank();
+            builder.line("fn __deepcopy__(&self, _memo: Bound<'_, PyAny>) -> Self {");
+            builder.line("    Self { inner: self.inner.clone() }");
+            builder.line("}");
+            builder.blank();
+        }
+
+        if traits.is_default && !taken.contains("default") {
+            builder.line("#[staticmethod]");
+            builder.line("fn default() -> Self {");
+            builder.line("    Self { inner: Default::default() }");
+            builder.line("}");
+            builder.blank();
+        }
+    }
+
     fn generate_struct_pymethods(
         &self,
         builder: &mut CodeBuilder,
@@ -1257,6 +1367,7 @@ fn create_py_refany_with_json(wrapper: PyDataWrapper) -> azul_core::refany::RefA
         // Check if this struct is a callback wrapper type
         let is_callback_type = is_callback_wrapper_type(&struct_def.name, ir);
 
+        let mut taken: BTreeSet<String> = BTreeSet::new();
         for func in class_functions {
             if self.function_has_unsupported_args(func, ir) {
                 continue;
@@ -1268,8 +1379,13 @@ fn create_py_refany_with_json(wrapper: PyDataWrapper) -> azul_core::refany::RefA
             if is_callback_type && func.kind == FunctionKind::Constructor {
                 continue;
             }
+            // The RAW name: `generate_pymethod` emits `fn {method_name}` verbatim,
+            // so that is both the Rust identifier and the Python name.
+            taken.insert(func.method_name.clone());
             self.generate_pymethod(builder, func, ir, prefix);
         }
+
+        self.generate_derive_dunders(builder, &struct_def.traits, &taken);
 
         builder.line("fn __str__(&self) -> String {");
         builder.line("    format!(\"{:?}\", self)");
@@ -1362,6 +1478,20 @@ fn create_py_refany_with_json(wrapper: PyDataWrapper) -> azul_core::refany::RefA
                     // Struct variants not yet supported
                 }
             }
+        }
+
+        {
+            // Variant constructors occupy the Python name space of this class
+            // too. Raw names, not snake_case: a variant is emitted as
+            // `fn Default()`, which does NOT collide with `fn default()` in
+            // either Rust or Python -- lowercasing here would suppress the
+            // `Default` derive on the six enums that have such a variant.
+            let taken: BTreeSet<String> = enum_def
+                .variants
+                .iter()
+                .map(|v| v.name.clone())
+                .collect();
+            self.generate_derive_dunders(builder, &enum_def.traits, &taken);
         }
 
         if !enum_def.is_union {

--- a/doc/src/codegen/v2/lang_racket/functions.rs
+++ b/doc/src/codegen/v2/lang_racket/functions.rs
@@ -42,6 +42,22 @@ pub fn generate_defines(
 }
 
 fn should_emit_function(func: &FunctionDef, ir: &CodegenIR, config: &CodegenConfig) -> bool {
+    // A trait entry point an api.json `derive` declares is not what the
+    // `DestructorOrClone` exclusion below is for. That category is excluded
+    // because those types' ordinary methods traffic in callback function
+    // pointers this binding cannot marshal; `Az{T}_toDbgString(ptr) ->
+    // AzString` traffics in neither, and is the same shape as the ~2800
+    // `_toDbgString` declarations this binding already emits. Excluding it
+    // wholesale is why every `*VecDestructor` declared `Debug` and named it
+    // nowhere. (`*VecDestructor` is a tagged union, hence `find_enum`.)
+    if func.kind.is_declared_capability()
+        && ir
+            .find_enum(&func.class_name)
+            .is_some_and(|e| e.category == TypeCategory::DestructorOrClone)
+    {
+        return config.should_include_type(&func.class_name);
+    }
+
     if !config.should_include_type(&func.class_name) {
         return false;
     }

--- a/doc/src/codegen/v2/lang_racket/functions.rs
+++ b/doc/src/codegen/v2/lang_racket/functions.rs
@@ -50,10 +50,23 @@ fn should_emit_function(func: &FunctionDef, ir: &CodegenIR, config: &CodegenConf
     // `_toDbgString` declarations this binding already emits. Excluding it
     // wholesale is why every `*VecDestructor` declared `Debug` and named it
     // nowhere. (`*VecDestructor` is a tagged union, hence `find_enum`.)
+    // RECURSIVE types are here for the same reason. `XmlNodeChild` and friends
+    // are excluded below because their ORDINARY methods traffic in a shape
+    // this binding cannot express by value - but `Az{T}_partialEq(a, b) ->
+    // bool` and `Az{T}_toDbgString(ptr) -> AzString` take a pointer and return
+    // a scalar, so the exclusion never applied to them. That is why the same
+    // four types - `Xml`, `XmlNodeChild`, `XmlNodeChildVec`,
+    // `ResultXmlXmlError` - showed up as the residue in fourteen bindings at
+    // once: one cause, not fourteen.
     if func.kind.is_declared_capability()
-        && ir
-            .find_enum(&func.class_name)
-            .is_some_and(|e| e.category == TypeCategory::DestructorOrClone)
+        && (ir.find_enum(&func.class_name).is_some_and(|e| {
+            matches!(
+                e.category,
+                TypeCategory::DestructorOrClone | TypeCategory::Recursive
+            )
+        }) || ir
+            .find_struct(&func.class_name)
+            .is_some_and(|s| s.category == TypeCategory::Recursive))
     {
         return config.should_include_type(&func.class_name);
     }

--- a/doc/src/codegen/v2/lang_red/mod.rs
+++ b/doc/src/codegen/v2/lang_red/mod.rs
@@ -343,10 +343,23 @@ fn should_emit_function(func: &FunctionDef, ir: &CodegenIR, config: &CodegenConf
     // `_toDbgString` declarations this binding already emits. Excluding it
     // wholesale is why every `*VecDestructor` declared `Debug` and named it
     // nowhere. (`*VecDestructor` is a tagged union, hence `find_enum`.)
+    // RECURSIVE types are here for the same reason. `XmlNodeChild` and friends
+    // are excluded below because their ORDINARY methods traffic in a shape
+    // this binding cannot express by value - but `Az{T}_partialEq(a, b) ->
+    // bool` and `Az{T}_toDbgString(ptr) -> AzString` take a pointer and return
+    // a scalar, so the exclusion never applied to them. That is why the same
+    // four types - `Xml`, `XmlNodeChild`, `XmlNodeChildVec`,
+    // `ResultXmlXmlError` - showed up as the residue in fourteen bindings at
+    // once: one cause, not fourteen.
     if func.kind.is_declared_capability()
-        && ir
-            .find_enum(&func.class_name)
-            .is_some_and(|e| e.category == TypeCategory::DestructorOrClone)
+        && (ir.find_enum(&func.class_name).is_some_and(|e| {
+            matches!(
+                e.category,
+                TypeCategory::DestructorOrClone | TypeCategory::Recursive
+            )
+        }) || ir
+            .find_struct(&func.class_name)
+            .is_some_and(|s| s.category == TypeCategory::Recursive))
     {
         return config.should_include_type(&func.class_name);
     }

--- a/doc/src/codegen/v2/lang_red/mod.rs
+++ b/doc/src/codegen/v2/lang_red/mod.rs
@@ -335,6 +335,22 @@ fn emit_imports(b: &mut CodeBuilder, ir: &CodegenIR, config: &CodegenConfig) {
 }
 
 fn should_emit_function(func: &FunctionDef, ir: &CodegenIR, config: &CodegenConfig) -> bool {
+    // A trait entry point an api.json `derive` declares is not what the
+    // `DestructorOrClone` exclusion below is for. That category is excluded
+    // because those types' ordinary methods traffic in callback function
+    // pointers this binding cannot marshal; `Az{T}_toDbgString(ptr) ->
+    // AzString` traffics in neither, and is the same shape as the ~2800
+    // `_toDbgString` declarations this binding already emits. Excluding it
+    // wholesale is why every `*VecDestructor` declared `Debug` and named it
+    // nowhere. (`*VecDestructor` is a tagged union, hence `find_enum`.)
+    if func.kind.is_declared_capability()
+        && ir
+            .find_enum(&func.class_name)
+            .is_some_and(|e| e.category == TypeCategory::DestructorOrClone)
+    {
+        return config.should_include_type(&func.class_name);
+    }
+
     if !config.should_include_type(&func.class_name) {
         return false;
     }

--- a/doc/src/codegen/v2/lang_rust.rs
+++ b/doc/src/codegen/v2/lang_rust.rs
@@ -333,6 +333,46 @@ impl LanguageGenerator for RustGenerator {
                     }
                     self.generate_generic_inline_impls_enum(&mut builder, enum_def, config);
                 }
+                // Monomorphised generic aliases (`AzPhysicalSizeU32 =
+                // AzPhysicalSize<u32>`). `IrBuilder::build_trait_functions`
+                // gives these their OWN C entry points — libazul exports
+                // `AzPhysicalSizeU32_partialEq`, `_partialCmp`, `_cmp`, `_hash`
+                // and `_toDbgString` — but this emitter walked only `ir.structs`
+                // and `ir.enums`, so those five exports had no Rust caller in
+                // ANY binding, the statically-linked one included.
+                //
+                // Deduplicated on the concrete instantiation: two aliases of the
+                // same `Target<Args>` are one type to rustc, and a second impl
+                // for it is E0119. Four such pairs exist today
+                // (`CssPropertyValue<GridTemplate>` and friends), and they
+                // declare only `Copy`, for which this emits nothing — the guard
+                // is here so that stops being load-bearing.
+                let mut seen_instantiations: std::collections::BTreeSet<(
+                    String,
+                    Vec<String>,
+                )> = std::collections::BTreeSet::new();
+                for alias in &ir.type_aliases {
+                    if alias.monomorphized_def.is_none() {
+                        continue;
+                    }
+                    if !config.should_include_type(&alias.name) {
+                        continue;
+                    }
+                    if !seen_instantiations
+                        .insert((alias.target.clone(), alias.generic_args.clone()))
+                    {
+                        continue;
+                    }
+                    self.generate_capi_derived_trait_impls(
+                        &mut builder,
+                        &alias.name,
+                        &alias.traits,
+                        ir,
+                        config,
+                        // An alias never goes through the Option template.
+                        false,
+                    );
+                }
             }
             TraitImplMode::None => {}
         }
@@ -3350,11 +3390,32 @@ impl RustGenerator {
         // enum_def needed for the structural Some/None test.
         suppress_default: bool,
     ) {
-        if !matches!(
-            config.cabi_functions,
-            CAbiFunctionMode::InternalBindings { .. }
-        ) {
-            return;
+        match &config.cabi_functions {
+            // `dll_api_internal.rs`: the real crate is a dependency, so every
+            // trait below delegates to it directly (the rest of this function).
+            CAbiFunctionMode::InternalBindings { .. } => {}
+            // `dll_api_external.rs` (`link-dynamic`): the C functions are
+            // DECLARED here, not defined, and `external_crate_replacement` is
+            // `None` — there is no real type in scope to delegate to, which is
+            // why this emitter used to bail out and leave the dynamic binding
+            // with `Copy`/`Clone` and nothing else. The capability is not
+            // missing from the ABI, only from the binding: `Az*_partialEq`,
+            // `Az*_partialCmp`, `Az*_cmp`, `Az*_hash`, `Az*_toDbgString` and
+            // `Az*_default` are already declared in this same file, keyed on
+            // these same `traits` flags by `build_trait_functions`. So implement
+            // each trait by CALLING its entry point.
+            CAbiFunctionMode::ExternalBindings { .. } => {
+                self.generate_abi_derived_trait_impls(
+                    builder,
+                    class_name,
+                    traits,
+                    config,
+                    suppress_default,
+                );
+                return;
+            }
+            // No C-ABI surface at all (`dll_types_only`): nothing to call.
+            CAbiFunctionMode::None => return,
         }
 
         let name = config.apply_prefix(class_name);
@@ -3469,6 +3530,194 @@ impl RustGenerator {
                 "unsafe {{ core::mem::transmute::<{external_path}, {name}>(<{external_path} as \
                  Default>::default()) }}"
             ));
+            builder.dedent();
+            builder.line("}");
+            builder.dedent();
+            builder.line("}");
+            builder.blank();
+        }
+    }
+
+    /// The `ExternalBindings` twin of [`Self::generate_capi_derived_trait_impls`]:
+    /// same declared derive list, but implemented by CALLING the C entry points
+    /// instead of delegating to a real type that is not in scope here.
+    ///
+    /// Every extern this emits a call to is declared in the very same file, by
+    /// `IrBuilder::build_trait_functions`, under EXACTLY the flag tested here —
+    /// `is_partial_eq` emits `Az{T}_partialEq`, `is_partial_ord` emits
+    /// `Az{T}_partialCmp`, `is_ord` emits `Az{T}_cmp`, `is_hash` emits
+    /// `Az{T}_hash`, `is_debug` emits `Az{T}_toDbgString`, `is_default` emits
+    /// `Az{T}_default` — and both sides skip generic types. So a call emitted
+    /// here can never name a symbol that was not declared.
+    ///
+    /// Where the internal emitter WIDENS across Rust's supertrait bounds by
+    /// delegating (`Ord: Eq + PartialOrd`, `PartialOrd: PartialEq`), this one
+    /// cannot invent an entry point that api.json never declared, so it widens
+    /// only where a *different* already-declared entry point can stand in
+    /// (`PartialEq` from `_partialCmp`, `PartialOrd` from `_cmp`). Today the two
+    /// emitters agree impl-for-impl, because no class in api.json declares a
+    /// stronger trait without its weaker ones; `azul-doc check derives` is what
+    /// keeps a future class that does from silently getting less here.
+    ///
+    /// ORDERING ENCODING. `_cmp` / `_partialCmp` return the `u8` that
+    /// `generate_function_body` writes on the other side of the ABI:
+    /// `0 = Less`, `1 = Equal`, `2 = Greater`, and for `_partialCmp` only,
+    /// `255 = None`. Decoding must stay in lockstep with that emitter.
+    fn generate_abi_derived_trait_impls(
+        &self,
+        builder: &mut CodeBuilder,
+        class_name: &str,
+        traits: &TypeTraits,
+        config: &CodegenConfig,
+        suppress_default: bool,
+    ) {
+        let name = config.apply_prefix(class_name);
+
+        // `Debug` is NOT a stub that prints the type name. `Az{T}_toDbgString`
+        // is a real entry point whose body on the other side is
+        // `format!("{:#?}", real)`, so the caller gets the actual field values.
+        // Two honest limitations, both inherited from the ABI rather than
+        // introduced here: the returned string is always the `{:#?}`
+        // (alternate/pretty) rendering, so `{:?}` on a dynamically-linked mirror
+        // is multi-line where the statically-linked one is not; and formatter
+        // flags (width, precision) cannot be forwarded through a single
+        // pre-rendered string.
+        if traits.is_debug {
+            builder.line(&format!("impl core::fmt::Debug for {name} {{"));
+            builder.indent();
+            builder.line("fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {");
+            builder.indent();
+            // The returned `AzString` owns library memory; it is dropped at the
+            // end of this scope, and `AzString`'s `AzU8Vec` field runs
+            // `AzU8Vec_delete` in its own `Drop`, so nothing leaks.
+            builder.line(&format!("let s = unsafe {{ {name}_toDbgString(self) }};"));
+            builder.line("f.write_str(s.as_str())");
+            builder.dedent();
+            builder.line("}");
+            builder.dedent();
+            builder.line("}");
+            builder.blank();
+        }
+
+        // Which comparison entry points this class actually has.
+        let has_partial_eq_fn = traits.is_partial_eq;
+        let has_partial_cmp_fn = traits.is_partial_ord;
+        let has_cmp_fn = traits.is_ord;
+
+        // `PartialEq` — directly, or from `_partialCmp` when only the ordering
+        // was declared (`partial_cmp(a, b) == Some(Equal)` is exactly the
+        // consistency `PartialOrd` already promises).
+        let mut emitted_partial_eq = false;
+        if has_partial_eq_fn || has_partial_cmp_fn {
+            builder.line(&format!("impl PartialEq for {name} {{"));
+            builder.indent();
+            builder.line(&format!("fn eq(&self, other: &{name}) -> bool {{"));
+            builder.indent();
+            if has_partial_eq_fn {
+                builder.line(&format!("unsafe {{ {name}_partialEq(self, other) }}"));
+            } else {
+                builder.line(&format!("unsafe {{ {name}_partialCmp(self, other) }} == 1"));
+            }
+            builder.dedent();
+            builder.line("}");
+            builder.dedent();
+            builder.line("}");
+            builder.blank();
+            emitted_partial_eq = true;
+        }
+
+        // `Eq` is a marker with no entry point of its own; it only needs the
+        // `PartialEq` impl above to exist.
+        let emitted_eq = (traits.is_eq || traits.is_ord) && emitted_partial_eq;
+        if emitted_eq {
+            builder.line(&format!("impl Eq for {name} {{}}"));
+            builder.blank();
+        }
+
+        // `PartialOrd` — directly, or from the total `_cmp` when only `Ord` was
+        // declared.
+        let mut emitted_partial_ord = false;
+        if (has_partial_cmp_fn || has_cmp_fn) && emitted_partial_eq {
+            builder.line(&format!("impl PartialOrd for {name} {{"));
+            builder.indent();
+            builder.line(&format!(
+                "fn partial_cmp(&self, other: &{name}) -> Option<core::cmp::Ordering> {{"
+            ));
+            builder.indent();
+            if has_partial_cmp_fn {
+                builder.line(&format!(
+                    "match unsafe {{ {name}_partialCmp(self, other) }} {{"
+                ));
+                builder.indent();
+                builder.line("0 => Some(core::cmp::Ordering::Less),");
+                builder.line("1 => Some(core::cmp::Ordering::Equal),");
+                builder.line("2 => Some(core::cmp::Ordering::Greater),");
+                builder.line("_ => None,");
+                builder.dedent();
+                builder.line("}");
+            } else {
+                builder.line("Some(core::cmp::Ord::cmp(self, other))");
+            }
+            builder.dedent();
+            builder.line("}");
+            builder.dedent();
+            builder.line("}");
+            builder.blank();
+            emitted_partial_ord = true;
+        }
+
+        if has_cmp_fn && emitted_eq && emitted_partial_ord {
+            builder.line(&format!("impl Ord for {name} {{"));
+            builder.indent();
+            builder.line(&format!(
+                "fn cmp(&self, other: &{name}) -> core::cmp::Ordering {{"
+            ));
+            builder.indent();
+            builder.line(&format!("match unsafe {{ {name}_cmp(self, other) }} {{"));
+            builder.indent();
+            builder.line("0 => core::cmp::Ordering::Less,");
+            builder.line("2 => core::cmp::Ordering::Greater,");
+            // `_cmp` is total: the other side emits only 0/1/2.
+            builder.line("_ => core::cmp::Ordering::Equal,");
+            builder.dedent();
+            builder.line("}");
+            builder.dedent();
+            builder.line("}");
+            builder.dedent();
+            builder.line("}");
+            builder.blank();
+        }
+
+        // `Hash` feeds the ABI's `u64` into the caller's hasher rather than
+        // replaying the real type's byte stream — impossible across a `u64`
+        // return, and not required: `Hash`'s contract is only that equal values
+        // hash equally, which holds because both sides ask the same real type.
+        // A hash value therefore differs between `link-static` and
+        // `link-dynamic`; it was never stable across builds anyway
+        // (`DefaultHasher` is unspecified), so nothing may persist it.
+        if traits.is_hash {
+            builder.line(&format!("impl core::hash::Hash for {name} {{"));
+            builder.indent();
+            builder.line("fn hash<H: core::hash::Hasher>(&self, state: &mut H) {");
+            builder.indent();
+            builder.line(&format!(
+                "core::hash::Hasher::write_u64(state, unsafe {{ {name}_hash(self) }})"
+            ));
+            builder.dedent();
+            builder.line("}");
+            builder.dedent();
+            builder.line("}");
+            builder.blank();
+        }
+
+        // Option mirrors already got `impl Default` from
+        // `generate_option_convenience_methods`; a second one is E0119.
+        if traits.is_default && !suppress_default {
+            builder.line(&format!("impl Default for {name} {{"));
+            builder.indent();
+            builder.line(&format!("fn default() -> {name} {{"));
+            builder.indent();
+            builder.line(&format!("unsafe {{ {name}_default() }}"));
             builder.dedent();
             builder.line("}");
             builder.dedent();

--- a/doc/src/codegen/v2/lang_rust.rs
+++ b/doc/src/codegen/v2/lang_rust.rs
@@ -3151,6 +3151,50 @@ impl RustGenerator {
         builder.line("}");
         builder.blank();
 
+        // Default impl.
+        //
+        // The struct arm of this same emitter has always had one; the enum arm
+        // did not, so an ENUM declaring `Default` got no `impl Default` in the
+        // transmute mirror -- the mirror the Python extension embeds. 164 of
+        // them. The two arms now agree.
+        //
+        // An Option mirror can already have an `impl Default` returning `None`
+        // from `generate_option_convenience_methods`, and a second one is E0119
+        // (this is exactly what `AzOptionWtEvent` broke once before). But that
+        // emitter lives inside `generate_rust_only_impls`, which the caller
+        // SKIPS when there are no C-ABI functions -- `dll_types_only`, the
+        // config the Python extension embeds. So the suppression has to test
+        // both halves: the structural Option shape (the same Some+None,
+        // one-field test that emitter uses), AND whether that emitter runs at
+        // all here. Testing only the shape leaves the Python mirror with no
+        // `Default` for any Option; testing neither is E0119 everywhere else.
+        let option_default_emitted_elsewhere = {
+            let emits_rust_only = !matches!(config.cabi_functions, CAbiFunctionMode::None);
+            let some = enum_def.variants.iter().find(|v| v.name == "Some");
+            let has_none = enum_def.variants.iter().any(|v| v.name == "None");
+            let is_option_mirror = has_none
+                && matches!(
+                    some.map(|v| &v.kind),
+                    Some(EnumVariantKind::Tuple(types)) if types.len() == 1
+                );
+            emits_rust_only && is_option_mirror
+        };
+        if enum_def.traits.is_default && !is_generic && !option_default_emitted_elsewhere {
+            builder.line(&format!("impl Default for {} {{", full_name));
+            builder.indent();
+            builder.line("fn default() -> Self {");
+            builder.indent();
+            builder.line(&format!(
+                "unsafe {{ core::mem::transmute::<{}, {}>({}::default()) }}",
+                external_path, full_name, external_path
+            ));
+            builder.dedent();
+            builder.line("}");
+            builder.dedent();
+            builder.line("}");
+            builder.blank();
+        }
+
         // PartialEq impl
         if enum_def.traits.is_partial_eq {
             if is_generic {

--- a/doc/src/codegen/v2/lang_rust.rs
+++ b/doc/src/codegen/v2/lang_rust.rs
@@ -19,6 +19,26 @@ use super::transmute_helpers::{generate_transmuted_fn_body, parse_arg_type};
 
 pub struct RustGenerator;
 
+/// The prefix every C-ABI symbol carries, unconditionally.
+///
+/// `IrBuilder` spells every export as `format!("Az{type}_{method}")` — see
+/// `build_trait_functions` — and `FunctionDef::c_name` is what the `extern "C"`
+/// block declares. That is INDEPENDENT of `config.type_prefix`, which names the
+/// Rust *type* in a given binding and is `""` for the unprefixed public API.
+///
+/// The two used to be conflated: every C-API trait impl built its call as
+/// `format!("{}_clone", config.apply_prefix(class))`, which is correct only
+/// while the two happen to coincide. They coincide in `dll_api_internal.rs`,
+/// `dll_api_external.rs` and `memtest.rs` (all `type_prefix = "Az"`), so the
+/// bug was invisible until `azul.rs` (`type_prefix = ""`) started emitting
+/// C-API impls and every call named a symbol that does not exist.
+const ABI_PREFIX: &str = "Az";
+
+/// The C symbol for one entry point on one class, e.g. `AzDom_clone`.
+fn abi_symbol(class_name: &str, suffix: &str) -> String {
+    format!("{ABI_PREFIX}{class_name}_{suffix}")
+}
+
 impl LanguageGenerator for RustGenerator {
     fn generate(&self, ir: &CodegenIR, config: &CodegenConfig) -> Result<String> {
         let mut builder = CodeBuilder::new(&config.indent);
@@ -647,8 +667,8 @@ impl RustGenerator {
         builder.line("fn from(s: &str) -> Self {");
         builder.indent();
         builder.line(&format!(
-            "unsafe {{ {}String_copyFromBytes(s.as_ptr(), 0, s.len()) }}",
-            prefix
+            "unsafe {{ {}(s.as_ptr(), 0, s.len()) }}",
+            abi_symbol("String", "copyFromBytes")
         ));
         builder.dedent();
         builder.line("}");
@@ -665,8 +685,8 @@ impl RustGenerator {
         builder.line("fn from(s: alloc::string::String) -> Self {");
         builder.indent();
         builder.line(&format!(
-            "unsafe {{ {}String_copyFromBytes(s.as_ptr(), 0, s.len()) }}",
-            prefix
+            "unsafe {{ {}(s.as_ptr(), 0, s.len()) }}",
+            abi_symbol("String", "copyFromBytes")
         ));
         builder.dedent();
         builder.line("}");
@@ -2421,6 +2441,19 @@ impl RustGenerator {
             builder.raw(&types);
         }
 
+        // C-ABI declarations.
+        //
+        // This section did not exist while the config said `CAbiFunctionMode::
+        // None`, and its absence was not cosmetic: the method impls below have
+        // ALWAYS been emitted as `unsafe { AzDom_new(..) }`, so every one of
+        // them named a function that was never declared in this file. The
+        // artifact could not compile, and nothing noticed because no target
+        // includes it.
+        builder.line("// --- C-ABI Declarations ---");
+        let functions = self.generate_functions(ir, config)?;
+        builder.raw(&functions);
+        builder.blank();
+
         // Trait implementations (if using derive, they're already on types)
         if !matches!(config.trait_impl_mode, TraitImplMode::UsingDerive) {
             builder.line("// --- Trait Implementations ---");
@@ -3571,7 +3604,12 @@ impl RustGenerator {
         config: &CodegenConfig,
         suppress_default: bool,
     ) {
+        // The Rust TYPE as this binding spells it (`AzDom`, or `Dom` in the
+        // unprefixed public API) ...
         let name = config.apply_prefix(class_name);
+        // ... and the C SYMBOL, which is always `Az`-prefixed. These are not the
+        // same string in every binding; see [`ABI_PREFIX`].
+        let sym = |suffix: &str| abi_symbol(class_name, suffix);
 
         // `Debug` is NOT a stub that prints the type name. `Az{T}_toDbgString`
         // is a real entry point whose body on the other side is
@@ -3590,7 +3628,7 @@ impl RustGenerator {
             // The returned `AzString` owns library memory; it is dropped at the
             // end of this scope, and `AzString`'s `AzU8Vec` field runs
             // `AzU8Vec_delete` in its own `Drop`, so nothing leaks.
-            builder.line(&format!("let s = unsafe {{ {name}_toDbgString(self) }};"));
+            builder.line(&format!("let s = unsafe {{ {}(self) }};", sym("toDbgString")));
             builder.line("f.write_str(s.as_str())");
             builder.dedent();
             builder.line("}");
@@ -3614,9 +3652,9 @@ impl RustGenerator {
             builder.line(&format!("fn eq(&self, other: &{name}) -> bool {{"));
             builder.indent();
             if has_partial_eq_fn {
-                builder.line(&format!("unsafe {{ {name}_partialEq(self, other) }}"));
+                builder.line(&format!("unsafe {{ {}(self, other) }}", sym("partialEq")));
             } else {
-                builder.line(&format!("unsafe {{ {name}_partialCmp(self, other) }} == 1"));
+                builder.line(&format!("unsafe {{ {}(self, other) }} == 1", sym("partialCmp")));
             }
             builder.dedent();
             builder.line("}");
@@ -3646,7 +3684,8 @@ impl RustGenerator {
             builder.indent();
             if has_partial_cmp_fn {
                 builder.line(&format!(
-                    "match unsafe {{ {name}_partialCmp(self, other) }} {{"
+                    "match unsafe {{ {}(self, other) }} {{",
+                    sym("partialCmp")
                 ));
                 builder.indent();
                 builder.line("0 => Some(core::cmp::Ordering::Less),");
@@ -3673,7 +3712,7 @@ impl RustGenerator {
                 "fn cmp(&self, other: &{name}) -> core::cmp::Ordering {{"
             ));
             builder.indent();
-            builder.line(&format!("match unsafe {{ {name}_cmp(self, other) }} {{"));
+            builder.line(&format!("match unsafe {{ {}(self, other) }} {{", sym("cmp")));
             builder.indent();
             builder.line("0 => core::cmp::Ordering::Less,");
             builder.line("2 => core::cmp::Ordering::Greater,");
@@ -3701,7 +3740,8 @@ impl RustGenerator {
             builder.line("fn hash<H: core::hash::Hasher>(&self, state: &mut H) {");
             builder.indent();
             builder.line(&format!(
-                "core::hash::Hasher::write_u64(state, unsafe {{ {name}_hash(self) }})"
+                "core::hash::Hasher::write_u64(state, unsafe {{ {}(self) }})",
+                sym("hash")
             ));
             builder.dedent();
             builder.line("}");
@@ -3717,7 +3757,7 @@ impl RustGenerator {
             builder.indent();
             builder.line(&format!("fn default() -> {name} {{"));
             builder.indent();
-            builder.line(&format!("unsafe {{ {name}_default() }}"));
+            builder.line(&format!("unsafe {{ {}() }}", sym("default")));
             builder.dedent();
             builder.line("}");
             builder.dedent();
@@ -3752,7 +3792,7 @@ impl RustGenerator {
 
         // Clone impl calling C-ABI function
         if struct_def.traits.is_clone && !struct_def.traits.is_copy {
-            let deep_copy_fn = format!("{}_clone", name);
+            let deep_copy_fn = abi_symbol(&struct_def.name, "clone");
             builder.line(&format!("impl Clone for {} {{", name));
             builder.indent();
             builder.line("fn clone(&self) -> Self {");
@@ -3772,7 +3812,7 @@ impl RustGenerator {
         // AND then field-glue on the same bytes) never happens. The C `_delete`
         // extern fn is still generated for explicit C frees.
         if struct_def.traits.needs_delete() && self.struct_needs_own_drop(struct_def) {
-            let delete_fn = format!("{}_delete", name);
+            let delete_fn = abi_symbol(&struct_def.name, "delete");
             builder.line(&format!("impl Drop for {} {{", name));
             builder.indent();
             builder.line("fn drop(&mut self) {");
@@ -3840,7 +3880,7 @@ impl RustGenerator {
 
         // Clone impl calling C-ABI function
         if enum_def.traits.is_clone && !enum_def.traits.is_copy {
-            let deep_copy_fn = format!("{}_clone", name);
+            let deep_copy_fn = abi_symbol(&enum_def.name, "clone");
             builder.line(&format!("impl Clone for {} {{", name));
             builder.indent();
             builder.line("fn clone(&self) -> Self {");
@@ -3859,7 +3899,7 @@ impl RustGenerator {
         // payload (`_delete` = `drop_in_place` AND then field-glue). The `_delete`
         // extern fn is still generated for explicit C frees.
         if enum_def.traits.needs_delete() && self.enum_needs_own_drop(enum_def) {
-            let delete_fn = format!("{}_delete", name);
+            let delete_fn = abi_symbol(&enum_def.name, "delete");
             builder.line(&format!("impl Drop for {} {{", name));
             builder.indent();
             builder.line("fn drop(&mut self) {");

--- a/doc/src/codegen/v2/lang_smalltalk/functions.rs
+++ b/doc/src/codegen/v2/lang_smalltalk/functions.rs
@@ -100,6 +100,22 @@ fn emit_module_name_methods(builder: &mut CodeBuilder) {
 }
 
 fn should_emit_function(func: &FunctionDef, ir: &CodegenIR, config: &CodegenConfig) -> bool {
+    // A trait entry point an api.json `derive` declares is not what the
+    // `DestructorOrClone` exclusion below is for. That category is excluded
+    // because those types' ordinary methods traffic in callback function
+    // pointers this binding cannot marshal; `Az{T}_toDbgString(ptr) ->
+    // AzString` traffics in neither, and is the same shape as the ~2800
+    // `_toDbgString` declarations this binding already emits. Excluding it
+    // wholesale is why every `*VecDestructor` declared `Debug` and named it
+    // nowhere. (`*VecDestructor` is a tagged union, hence `find_enum`.)
+    if func.kind.is_declared_capability()
+        && ir
+            .find_enum(&func.class_name)
+            .is_some_and(|e| e.category == TypeCategory::DestructorOrClone)
+    {
+        return config.should_include_type(&func.class_name);
+    }
+
     if !config.should_include_type(&func.class_name) {
         return false;
     }

--- a/doc/src/codegen/v2/lang_smalltalk/functions.rs
+++ b/doc/src/codegen/v2/lang_smalltalk/functions.rs
@@ -108,10 +108,23 @@ fn should_emit_function(func: &FunctionDef, ir: &CodegenIR, config: &CodegenConf
     // `_toDbgString` declarations this binding already emits. Excluding it
     // wholesale is why every `*VecDestructor` declared `Debug` and named it
     // nowhere. (`*VecDestructor` is a tagged union, hence `find_enum`.)
+    // RECURSIVE types are here for the same reason. `XmlNodeChild` and friends
+    // are excluded below because their ORDINARY methods traffic in a shape
+    // this binding cannot express by value - but `Az{T}_partialEq(a, b) ->
+    // bool` and `Az{T}_toDbgString(ptr) -> AzString` take a pointer and return
+    // a scalar, so the exclusion never applied to them. That is why the same
+    // four types - `Xml`, `XmlNodeChild`, `XmlNodeChildVec`,
+    // `ResultXmlXmlError` - showed up as the residue in fourteen bindings at
+    // once: one cause, not fourteen.
     if func.kind.is_declared_capability()
-        && ir
-            .find_enum(&func.class_name)
-            .is_some_and(|e| e.category == TypeCategory::DestructorOrClone)
+        && (ir.find_enum(&func.class_name).is_some_and(|e| {
+            matches!(
+                e.category,
+                TypeCategory::DestructorOrClone | TypeCategory::Recursive
+            )
+        }) || ir
+            .find_struct(&func.class_name)
+            .is_some_and(|s| s.category == TypeCategory::Recursive))
     {
         return config.should_include_type(&func.class_name);
     }

--- a/doc/src/codegen/v2/lang_swift/mod.rs
+++ b/doc/src/codegen/v2/lang_swift/mod.rs
@@ -230,10 +230,23 @@ pub fn should_emit_function(func: &FunctionDef, ir: &CodegenIR, config: &Codegen
     // `_toDbgString` declarations this binding already emits. Excluding it
     // wholesale is why every `*VecDestructor` declared `Debug` and named it
     // nowhere. (`*VecDestructor` is a tagged union, hence `find_enum`.)
+    // RECURSIVE types are here for the same reason. `XmlNodeChild` and friends
+    // are excluded below because their ORDINARY methods traffic in a shape
+    // this binding cannot express by value - but `Az{T}_partialEq(a, b) ->
+    // bool` and `Az{T}_toDbgString(ptr) -> AzString` take a pointer and return
+    // a scalar, so the exclusion never applied to them. That is why the same
+    // four types - `Xml`, `XmlNodeChild`, `XmlNodeChildVec`,
+    // `ResultXmlXmlError` - showed up as the residue in fourteen bindings at
+    // once: one cause, not fourteen.
     if func.kind.is_declared_capability()
-        && ir
-            .find_enum(&func.class_name)
-            .is_some_and(|e| e.category == TypeCategory::DestructorOrClone)
+        && (ir.find_enum(&func.class_name).is_some_and(|e| {
+            matches!(
+                e.category,
+                TypeCategory::DestructorOrClone | TypeCategory::Recursive
+            )
+        }) || ir
+            .find_struct(&func.class_name)
+            .is_some_and(|s| s.category == TypeCategory::Recursive))
     {
         return config.should_include_type(&func.class_name);
     }

--- a/doc/src/codegen/v2/lang_swift/mod.rs
+++ b/doc/src/codegen/v2/lang_swift/mod.rs
@@ -222,6 +222,22 @@ fn is_swift_keyword(s: &str) -> bool {
 /// / generic-template type (those symbols the C header does not export in
 /// a form worth re-aliasing).
 pub fn should_emit_function(func: &FunctionDef, ir: &CodegenIR, config: &CodegenConfig) -> bool {
+    // A trait entry point an api.json `derive` declares is not what the
+    // `DestructorOrClone` exclusion below is for. That category is excluded
+    // because those types' ordinary methods traffic in callback function
+    // pointers this binding cannot marshal; `Az{T}_toDbgString(ptr) ->
+    // AzString` traffics in neither, and is the same shape as the ~2800
+    // `_toDbgString` declarations this binding already emits. Excluding it
+    // wholesale is why every `*VecDestructor` declared `Debug` and named it
+    // nowhere. (`*VecDestructor` is a tagged union, hence `find_enum`.)
+    if func.kind.is_declared_capability()
+        && ir
+            .find_enum(&func.class_name)
+            .is_some_and(|e| e.category == TypeCategory::DestructorOrClone)
+    {
+        return config.should_include_type(&func.class_name);
+    }
+
     if !config.should_include_type(&func.class_name) {
         return false;
     }

--- a/doc/src/codegen/v2/lang_v/mod.rs
+++ b/doc/src/codegen/v2/lang_v/mod.rs
@@ -357,6 +357,22 @@ pub fn include_enum(e: &EnumDef, config: &CodegenConfig) -> bool {
 /// Pascal filter: skip functions whose owning class is a recursive /
 /// VecRef / destructor / generic-template type.
 pub fn should_emit_function(func: &FunctionDef, ir: &CodegenIR, config: &CodegenConfig) -> bool {
+    // A trait entry point an api.json `derive` declares is not what the
+    // `DestructorOrClone` exclusion below is for. That category is excluded
+    // because those types' ordinary methods traffic in callback function
+    // pointers this binding cannot marshal; `Az{T}_toDbgString(ptr) ->
+    // AzString` traffics in neither, and is the same shape as the ~2800
+    // `_toDbgString` declarations this binding already emits. Excluding it
+    // wholesale is why every `*VecDestructor` declared `Debug` and named it
+    // nowhere. (`*VecDestructor` is a tagged union, hence `find_enum`.)
+    if func.kind.is_declared_capability()
+        && ir
+            .find_enum(&func.class_name)
+            .is_some_and(|e| e.category == TypeCategory::DestructorOrClone)
+    {
+        return config.should_include_type(&func.class_name);
+    }
+
     if !config.should_include_type(&func.class_name) {
         return false;
     }

--- a/doc/src/codegen/v2/lang_v/mod.rs
+++ b/doc/src/codegen/v2/lang_v/mod.rs
@@ -365,10 +365,23 @@ pub fn should_emit_function(func: &FunctionDef, ir: &CodegenIR, config: &Codegen
     // `_toDbgString` declarations this binding already emits. Excluding it
     // wholesale is why every `*VecDestructor` declared `Debug` and named it
     // nowhere. (`*VecDestructor` is a tagged union, hence `find_enum`.)
+    // RECURSIVE types are here for the same reason. `XmlNodeChild` and friends
+    // are excluded below because their ORDINARY methods traffic in a shape
+    // this binding cannot express by value - but `Az{T}_partialEq(a, b) ->
+    // bool` and `Az{T}_toDbgString(ptr) -> AzString` take a pointer and return
+    // a scalar, so the exclusion never applied to them. That is why the same
+    // four types - `Xml`, `XmlNodeChild`, `XmlNodeChildVec`,
+    // `ResultXmlXmlError` - showed up as the residue in fourteen bindings at
+    // once: one cause, not fourteen.
     if func.kind.is_declared_capability()
-        && ir
-            .find_enum(&func.class_name)
-            .is_some_and(|e| e.category == TypeCategory::DestructorOrClone)
+        && (ir.find_enum(&func.class_name).is_some_and(|e| {
+            matches!(
+                e.category,
+                TypeCategory::DestructorOrClone | TypeCategory::Recursive
+            )
+        }) || ir
+            .find_struct(&func.class_name)
+            .is_some_and(|s| s.category == TypeCategory::Recursive))
     {
         return config.should_include_type(&func.class_name);
     }

--- a/doc/src/codegen/v2/lang_vb6/functions.rs
+++ b/doc/src/codegen/v2/lang_vb6/functions.rs
@@ -64,6 +64,22 @@ pub fn generate_externals(
 }
 
 fn should_emit_function(func: &FunctionDef, ir: &CodegenIR, config: &CodegenConfig) -> bool {
+    // A trait entry point an api.json `derive` declares is not what the
+    // `DestructorOrClone` exclusion below is for. That category is excluded
+    // because those types' ordinary methods traffic in callback function
+    // pointers this binding cannot marshal; `Az{T}_toDbgString(ptr) ->
+    // AzString` traffics in neither, and is the same shape as the ~2800
+    // `_toDbgString` declarations this binding already emits. Excluding it
+    // wholesale is why every `*VecDestructor` declared `Debug` and named it
+    // nowhere. (`*VecDestructor` is a tagged union, hence `find_enum`.)
+    if func.kind.is_declared_capability()
+        && ir
+            .find_enum(&func.class_name)
+            .is_some_and(|e| e.category == TypeCategory::DestructorOrClone)
+    {
+        return config.should_include_type(&func.class_name);
+    }
+
     if !config.should_include_type(&func.class_name) {
         return false;
     }

--- a/doc/src/codegen/v2/lang_vb6/functions.rs
+++ b/doc/src/codegen/v2/lang_vb6/functions.rs
@@ -72,10 +72,23 @@ fn should_emit_function(func: &FunctionDef, ir: &CodegenIR, config: &CodegenConf
     // `_toDbgString` declarations this binding already emits. Excluding it
     // wholesale is why every `*VecDestructor` declared `Debug` and named it
     // nowhere. (`*VecDestructor` is a tagged union, hence `find_enum`.)
+    // RECURSIVE types are here for the same reason. `XmlNodeChild` and friends
+    // are excluded below because their ORDINARY methods traffic in a shape
+    // this binding cannot express by value - but `Az{T}_partialEq(a, b) ->
+    // bool` and `Az{T}_toDbgString(ptr) -> AzString` take a pointer and return
+    // a scalar, so the exclusion never applied to them. That is why the same
+    // four types - `Xml`, `XmlNodeChild`, `XmlNodeChildVec`,
+    // `ResultXmlXmlError` - showed up as the residue in fourteen bindings at
+    // once: one cause, not fourteen.
     if func.kind.is_declared_capability()
-        && ir
-            .find_enum(&func.class_name)
-            .is_some_and(|e| e.category == TypeCategory::DestructorOrClone)
+        && (ir.find_enum(&func.class_name).is_some_and(|e| {
+            matches!(
+                e.category,
+                TypeCategory::DestructorOrClone | TypeCategory::Recursive
+            )
+        }) || ir
+            .find_struct(&func.class_name)
+            .is_some_and(|s| s.category == TypeCategory::Recursive))
     {
         return config.should_include_type(&func.class_name);
     }

--- a/doc/src/codegen/v2/lang_zig/wrappers.rs
+++ b/doc/src/codegen/v2/lang_zig/wrappers.rs
@@ -166,6 +166,20 @@ fn has_useful_method(class_name: &str, ir: &CodegenIR) -> bool {
                     | FunctionKind::StaticMethod
                     | FunctionKind::Default
                     | FunctionKind::DeepCopy
+                    // The auto-generated trait entry points count as useful.
+                    // A class whose only exports are `_partialEq` / `_cmp` /
+                    // `_hash` / `_toDbgString` still has something a caller
+                    // wants; excluding them here gave such a class no wrapper
+                    // at all, and since `azul.zig` is a `@cImport` shim that
+                    // redeclares nothing, a C symbol no wrapper calls cannot
+                    // be named from Zig. That is what left 5168 declared
+                    // derives unreachable. Emitted by `emit_trait_methods`,
+                    // which must stay in step with this list.
+                    | FunctionKind::PartialEq
+                    | FunctionKind::PartialCmp
+                    | FunctionKind::Cmp
+                    | FunctionKind::Hash
+                    | FunctionKind::DebugToString
             )
     })
 }
@@ -275,6 +289,9 @@ fn emit_struct_wrapper(out: &mut String, ir: &CodegenIR, s: &StructDef) {
         }
     }
 
+    // Trait entry points (PartialEq / PartialCmp / Cmp / Hash / Debug).
+    emit_trait_methods(out, &s.name, &ffi_name, ir, &mut seen);
+
     // Destructor.
     if has_delete {
         out.push_str("    /// Free the underlying native resources.\n");
@@ -289,6 +306,151 @@ fn emit_struct_wrapper(out: &mut String, ir: &CodegenIR, s: &StructDef) {
     }
 
     out.push_str("};\n\n");
+}
+
+// ============================================================================
+// Trait entry points
+// ============================================================================
+
+/// The enum flavour of [`emit_trait_methods`]: same entry points, but an enum
+/// wrapper has no `inner` field, so these operate on `*const Raw`.
+fn emit_trait_methods_raw(out: &mut String, class_name: &str, ffi_name: &str, ir: &CodegenIR) {
+    let mut seen: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    for f in ir.functions_for_class(class_name) {
+        let (name, text) = match f.kind {
+            FunctionKind::PartialEq => (
+                "eql",
+                format!(
+                    "    /// Structural equality, delegating to the Rust `PartialEq`.\n    \
+                     pub fn eql(a: *const Raw, b: *const Raw) bool {{\n        \
+                     return C.{ffi_name}_partialEq(a, b);\n    }}\n"
+                ),
+            ),
+            FunctionKind::Cmp => (
+                "order",
+                format!(
+                    "    /// Total order, delegating to the Rust `Ord`.\n    \
+                     /// The C ABI answers 0 = less, 1 = equal, 2 = greater.\n    \
+                     pub fn order(a: *const Raw, b: *const Raw) u8 {{\n        \
+                     return C.{ffi_name}_cmp(a, b);\n    }}\n"
+                ),
+            ),
+            FunctionKind::PartialCmp => (
+                "partialOrder",
+                format!(
+                    "    /// Partial order, delegating to the Rust `PartialOrd`.\n    \
+                     /// Same encoding as `order`.\n    \
+                     pub fn partialOrder(a: *const Raw, b: *const Raw) u8 {{\n        \
+                     return C.{ffi_name}_partialCmp(a, b);\n    }}\n"
+                ),
+            ),
+            FunctionKind::Hash => (
+                "hash",
+                format!(
+                    "    /// The Rust `Hash`, as a 64-bit digest.\n    \
+                     pub fn hash(v: *const Raw) u64 {{\n        \
+                     return C.{ffi_name}_hash(v);\n    }}\n"
+                ),
+            ),
+            FunctionKind::DebugToString => (
+                "toDbgString",
+                format!(
+                    "    /// The Rust `{{:#?}}` rendering. The returned `AzString` owns its\n    \
+                     /// buffer — free it with `C.AzString_delete` when done.\n    \
+                     pub fn toDbgString(v: *const Raw) C.AzString {{\n        \
+                     return C.{ffi_name}_toDbgString(v);\n    }}\n"
+                ),
+            ),
+            FunctionKind::DeepCopy => (
+                "clone",
+                format!(
+                    "    /// A deep copy, delegating to the Rust `Clone`.\n    \
+                     pub fn clone(v: *const Raw) Raw {{\n        \
+                     return C.{ffi_name}_clone(v);\n    }}\n"
+                ),
+            ),
+            _ => continue,
+        };
+        if !seen.insert(name) {
+            continue;
+        }
+        out.push_str(&text);
+    }
+}
+
+/// Give the auto-generated trait exports a Zig name.
+///
+/// `azul.zig` redeclares nothing — `@cImport` parses `azul.h` and the wrapper
+/// structs are the only thing that name a C function. So a derive is reachable
+/// from Zig only if a wrapper method calls its entry point, which is why this
+/// exists and why `has_useful_method` must admit these kinds: otherwise the
+/// class gets no wrapper and the symbol, though exported by libazul, cannot be
+/// spelled.
+///
+/// Only kinds the class actually exports are emitted, so a type that declares
+/// no `Hash` gets no `hash()`.
+fn emit_trait_methods(
+    out: &mut String,
+    class_name: &str,
+    ffi_name: &str,
+    ir: &CodegenIR,
+    seen: &mut std::collections::HashSet<String>,
+) {
+    for f in ir.functions_for_class(class_name) {
+        let (name, text) = match f.kind {
+            FunctionKind::PartialEq => (
+                "eql",
+                format!(
+                    "    /// Structural equality, delegating to the Rust `PartialEq`.\n    \
+                     pub fn eql(self: *const Self, other: *const Self) bool {{\n        \
+                     return C.{ffi_name}_partialEq(&self.inner, &other.inner);\n    }}\n"
+                ),
+            ),
+            FunctionKind::Cmp => (
+                "order",
+                format!(
+                    "    /// Total order, delegating to the Rust `Ord`.\n    \
+                     /// The C ABI answers 0 = less, 1 = equal, 2 = greater.\n    \
+                     pub fn order(self: *const Self, other: *const Self) u8 {{\n        \
+                     return C.{ffi_name}_cmp(&self.inner, &other.inner);\n    }}\n"
+                ),
+            ),
+            FunctionKind::PartialCmp => (
+                "partialOrder",
+                format!(
+                    "    /// Partial order, delegating to the Rust `PartialOrd`.\n    \
+                     /// Same encoding as `order`.\n    \
+                     pub fn partialOrder(self: *const Self, other: *const Self) u8 {{\n        \
+                     return C.{ffi_name}_partialCmp(&self.inner, &other.inner);\n    }}\n"
+                ),
+            ),
+            FunctionKind::Hash => (
+                "hash",
+                format!(
+                    "    /// The Rust `Hash`, as a 64-bit digest.\n    \
+                     pub fn hash(self: *const Self) u64 {{\n        \
+                     return C.{ffi_name}_hash(&self.inner);\n    }}\n"
+                ),
+            ),
+            FunctionKind::DebugToString => (
+                "toDbgString",
+                format!(
+                    "    /// The Rust `{{:#?}}` rendering. The returned `AzString` owns its\n    \
+                     /// buffer — free it with `C.AzString_delete` when done.\n    \
+                     pub fn toDbgString(self: *const Self) C.AzString {{\n        \
+                     return C.{ffi_name}_toDbgString(&self.inner);\n    }}\n"
+                ),
+            ),
+            _ => continue,
+        };
+        if !seen.insert(name.to_string()) {
+            out.push_str(&format!(
+                "    // SKIPPED: `pub fn {name}` — the class already emits a method of that name.\n"
+            ));
+            continue;
+        }
+        out.push_str(&text);
+    }
 }
 
 // ============================================================================
@@ -558,6 +720,11 @@ fn emit_union_helper(out: &mut String, ir: &CodegenIR, e: &EnumDef) {
         }
     }
 
+    // Trait entry points. An enum wrapper holds no `inner` — its values are
+    // raw C tagged unions — so these take `*const Raw` rather than `*Self`.
+    // Without them every derive an enum declares was unreachable from Zig,
+    // which is what the C++ emitter had to fix for the same reason.
+    emit_trait_methods_raw(out, &e.name, &ffi_name, ir);
     out.push_str("};\n\n");
 }
 

--- a/doc/src/codegen/v2/lang_zig/wrappers.rs
+++ b/doc/src/codegen/v2/lang_zig/wrappers.rs
@@ -396,6 +396,18 @@ fn emit_unit_enum_helper(out: &mut String, ir: &CodegenIR, e: &EnumDef) {
 /// The enum flavour of [`emit_trait_methods`]: same entry points, but an enum
 /// wrapper has no `inner` field, so these operate on `*const Raw`.
 fn emit_trait_methods_raw(out: &mut String, class_name: &str, ffi_name: &str, ir: &CodegenIR) {
+    // Zig forbids a parameter shadowing ANY declaration in the containing
+    // scope, and these namespaces already declare one function per variant -
+    // `NodeType` has `pub fn a()`, so a parameter named `a` is a hard error.
+    // The file solves this for ordinary methods with `renamed_param`; this
+    // does the same, against the names this namespace will emit.
+    let mut reserved: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for f in ir.functions_for_class(class_name) {
+        reserved.insert(sanitize_identifier(&idiomatic_method_name(&f.method_name)));
+    }
+    let pa = renamed_param("a", &reserved);
+    let pb = renamed_param("b", &reserved);
+    let pv = renamed_param("v", &reserved);
     let mut seen: std::collections::HashSet<&str> = std::collections::HashSet::new();
     for f in ir.functions_for_class(class_name) {
         let (name, text) = match f.kind {
@@ -403,8 +415,8 @@ fn emit_trait_methods_raw(out: &mut String, class_name: &str, ffi_name: &str, ir
                 "eql",
                 format!(
                     "    /// Structural equality, delegating to the Rust `PartialEq`.\n    \
-                     pub fn eql(a: *const Raw, b: *const Raw) bool {{\n        \
-                     return C.{ffi_name}_partialEq(a, b);\n    }}\n"
+                     pub fn eql({pa}: *const Raw, {pb}: *const Raw) bool {{\n        \
+                     return C.{ffi_name}_partialEq({pa}, {pb});\n    }}\n"
                 ),
             ),
             FunctionKind::Cmp => (
@@ -412,8 +424,8 @@ fn emit_trait_methods_raw(out: &mut String, class_name: &str, ffi_name: &str, ir
                 format!(
                     "    /// Total order, delegating to the Rust `Ord`.\n    \
                      /// The C ABI answers 0 = less, 1 = equal, 2 = greater.\n    \
-                     pub fn order(a: *const Raw, b: *const Raw) u8 {{\n        \
-                     return C.{ffi_name}_cmp(a, b);\n    }}\n"
+                     pub fn order({pa}: *const Raw, {pb}: *const Raw) u8 {{\n        \
+                     return C.{ffi_name}_cmp({pa}, {pb});\n    }}\n"
                 ),
             ),
             FunctionKind::PartialCmp => (
@@ -421,16 +433,16 @@ fn emit_trait_methods_raw(out: &mut String, class_name: &str, ffi_name: &str, ir
                 format!(
                     "    /// Partial order, delegating to the Rust `PartialOrd`.\n    \
                      /// Same encoding as `order`.\n    \
-                     pub fn partialOrder(a: *const Raw, b: *const Raw) u8 {{\n        \
-                     return C.{ffi_name}_partialCmp(a, b);\n    }}\n"
+                     pub fn partialOrder({pa}: *const Raw, {pb}: *const Raw) u8 {{\n        \
+                     return C.{ffi_name}_partialCmp({pa}, {pb});\n    }}\n"
                 ),
             ),
             FunctionKind::Hash => (
                 "hash",
                 format!(
                     "    /// The Rust `Hash`, as a 64-bit digest.\n    \
-                     pub fn hash(v: *const Raw) u64 {{\n        \
-                     return C.{ffi_name}_hash(v);\n    }}\n"
+                     pub fn hash({pv}: *const Raw) u64 {{\n        \
+                     return C.{ffi_name}_hash({pv});\n    }}\n"
                 ),
             ),
             FunctionKind::DebugToString => (
@@ -438,16 +450,16 @@ fn emit_trait_methods_raw(out: &mut String, class_name: &str, ffi_name: &str, ir
                 format!(
                     "    /// The Rust `{{:#?}}` rendering. The returned `AzString` owns its\n    \
                      /// buffer — free it with `C.AzString_delete` when done.\n    \
-                     pub fn toDbgString(v: *const Raw) C.AzString {{\n        \
-                     return C.{ffi_name}_toDbgString(v);\n    }}\n"
+                     pub fn toDbgString({pv}: *const Raw) C.AzString {{\n        \
+                     return C.{ffi_name}_toDbgString({pv});\n    }}\n"
                 ),
             ),
             FunctionKind::DeepCopy => (
                 "clone",
                 format!(
                     "    /// A deep copy, delegating to the Rust `Clone`.\n    \
-                     pub fn clone(v: *const Raw) Raw {{\n        \
-                     return C.{ffi_name}_clone(v);\n    }}\n"
+                     pub fn clone({pv}: *const Raw) Raw {{\n        \
+                     return C.{ffi_name}_clone({pv});\n    }}\n"
                 ),
             ),
             _ => continue,

--- a/doc/src/codegen/v2/lang_zig/wrappers.rs
+++ b/doc/src/codegen/v2/lang_zig/wrappers.rs
@@ -103,7 +103,11 @@ pub fn generate_wrappers(ir: &CodegenIR) -> String {
             continue;
         }
         if !e.is_union {
-            // Unit-only enums are already directly usable through `C.*`.
+            // The VALUE of a unit-only enum is usable straight from `C.*`, so
+            // it needs no constructors - but its trait entry points still had
+            // nowhere to hang, which is the whole of zig's remaining gap.
+            // Emit a namespace carrying just those.
+            emit_unit_enum_helper(&mut out, ir, e);
             continue;
         }
         emit_union_helper(&mut out, ir, e);
@@ -305,6 +309,63 @@ fn emit_struct_wrapper(out: &mut String, ir: &CodegenIR, s: &StructDef) {
         out.push_str("    }\n");
     }
 
+    out.push_str("};\n\n");
+}
+
+// ============================================================================
+// Unit-only enum namespace
+// ============================================================================
+
+/// A namespace for a unit-only enum, carrying only its trait entry points.
+///
+/// `@cImport` already gives the value itself (`C.AzAccessibilityRole_Alert`),
+/// so this deliberately emits no constructors and no `Tag` block - it exists
+/// so `_partialEq` / `_cmp` / `_hash` / `_toDbgString`, which libazul exports
+/// for these types, can be named from Zig at all. A type that declares none of
+/// them gets no namespace rather than an empty one.
+fn emit_unit_enum_helper(out: &mut String, ir: &CodegenIR, e: &EnumDef) {
+    let has_traits = ir.functions_for_class(&e.name).any(|f| {
+        matches!(
+            f.kind,
+            FunctionKind::PartialEq
+                | FunctionKind::PartialCmp
+                | FunctionKind::Cmp
+                | FunctionKind::Hash
+                | FunctionKind::DebugToString
+                | FunctionKind::DeepCopy
+                | FunctionKind::Default
+        )
+    });
+    if !has_traits {
+        return;
+    }
+
+    let zig_name = sanitize_identifier(&e.name);
+    let ffi_name = ffi_type_name(&e.name);
+
+    if !e.doc.is_empty() {
+        for d in &e.doc {
+            out.push_str(&format!("/// {}\n", d));
+        }
+    }
+    out.push_str(&format!("pub const {} = struct {{\n", zig_name));
+    out.push_str("    /// The raw FFI enum, as exposed by `@cImport`.\n");
+    out.push_str(&format!("    pub const Raw = C.{};\n\n", ffi_name));
+    emit_trait_methods_raw(out, &e.name, &ffi_name, ir);
+
+    // `Default` is a STATIC factory, not an instance method, so it is not part
+    // of `emit_trait_methods_raw` - the union helper already emits it through
+    // its constructor loop and would duplicate. For a unit enum this namespace
+    // is the only place it can live.
+    if ir
+        .functions_for_class(&e.name)
+        .any(|f| f.kind == FunctionKind::Default)
+    {
+        out.push_str("\n    /// The Rust `Default`.\n");
+        out.push_str("    pub fn default() Raw {\n");
+        out.push_str(&format!("        return C.{}_default();\n", ffi_name));
+        out.push_str("    }\n");
+    }
     out.push_str("};\n\n");
 }
 

--- a/doc/src/codegen/v2/lang_zig/wrappers.rs
+++ b/doc/src/codegen/v2/lang_zig/wrappers.rs
@@ -130,12 +130,32 @@ fn should_emit_struct_wrapper(s: &StructDef, ir: &CodegenIR) -> bool {
         | TypeCategory::Boxed
         | TypeCategory::GenericTemplate
         | TypeCategory::DestructorOrClone
-        | TypeCategory::CallbackTypedef => return false,
+        | TypeCategory::CallbackTypedef => {
+            // ... unless the class declares capabilities. Then the wrapper
+            // exists solely to name them, and carries the whole list.
+            if !has_declared_capability(&s.name, ir) {
+                return false;
+            }
+        }
         _ => {}
     }
     // Only emit a wrapper for types that have *something* to wrap:
     // either a destructor or at least one non-trait method/constructor.
     has_destructor(&s.name, ir) || has_useful_method(&s.name, ir)
+}
+
+/// Does this class declare capabilities the C ABI exports for it?
+///
+/// Used to admit a class whose CATEGORY would otherwise exclude it. The
+/// category exclusions above are about a type's ordinary methods - a `Boxed`
+/// heap wrapper or a raw callback typedef cannot be handed around by value -
+/// and that reasoning does not reach `Az{T}_partialEq(a, b) -> bool` or
+/// `Az{T}_toDbgString(ptr) -> AzString`, which take pointers and return
+/// scalars. Same argument as the recursive-type carve-out in every
+/// `should_emit_function`.
+fn has_declared_capability(class_name: &str, ir: &CodegenIR) -> bool {
+    ir.functions_for_class(class_name)
+        .any(|f| f.kind.is_declared_capability())
 }
 
 fn should_emit_enum_helper(e: &EnumDef) -> bool {

--- a/doc/src/lint_derives.rs
+++ b/doc/src/lint_derives.rs
@@ -824,6 +824,16 @@ pub fn check(codegen_dir: &Path, api: &ApiData) -> anyhow::Result<Vec<BindingRep
 ///     second operand, and no `Self` return for `_clone`. Not one
 ///     `_toDbgString` reaches the artifact, which is the whole Debug column.
 ///     Those three mappings are the fix.
+///     BLOCKED, 2026-09-05, and deliberately not guessed: of the three
+///     missing shapes only the `AzString` RETURN still matters (the
+///     same-class ref arg and the `Self` return are already handled -
+///     `marshal_arg` case 2 and `marshal_return`'s receiver arm). There is
+///     no `as_str` or `From<AzString> for String` on the generated
+///     surface, so emitting it means hand-written unsafe slice code over
+///     `.vec.ptr` / `.vec.len` plus an `AzString_delete` - and NOTHING in
+///     our gates compiles this crate, so a mistake would ship silently.
+///     That is the one combination where guessing is worst: unverifiable
+///     AND unsafe. Needs a conversion helper on the dll surface first.
 ///   * `haskell` (10) - the recursive-type carve-out moved it 11 -> 10, so its
 ///     `_partialEq` / `_cmp` / `_hash` now reach the artifact. The remaining
 ///     Debug / Clone / Default do NOT, for a different reason: Haskell routes
@@ -876,11 +886,11 @@ fn declared_count(derives: &BTreeSet<String>) -> usize {
 
 pub const BASELINE: &[(&str, usize)] = &[
     ("python", 36),
-    ("zig", 19),
+    ("zig", 13),
     ("php-ext", 129),
     ("ocaml", 100),
     ("haskell", 10),
-    ("go", 19),
+    ("go", 13),
 ];
 
 /// Compare against [`BASELINE`] and render the verdict.

--- a/doc/src/lint_derives.rs
+++ b/doc/src/lint_derives.rs
@@ -742,16 +742,20 @@ pub fn check(codegen_dir: &Path, api: &ApiData) -> anyhow::Result<Vec<BindingRep
 ///     `#[pyclass]` at all. Closing them means DECIDING which of them belong
 ///     in the Python surface and giving them one - a product call, not a
 ///     routing change - so it is logged rather than guessed.
-///   * `zig` (603, was 5168) - two of three causes closed. The wrapper gate
-///     excluded every trait kind, so a class whose only exports were
-///     `_partialEq`/`_cmp`/`_hash`/`_toDbgString` got no wrapper at all - and
-///     `azul.zig` redeclares nothing (`@cImport` parses `azul.h`), so a C
-///     symbol no wrapper calls cannot be spelled from Zig. Enums then needed
-///     their own emitter, because an enum wrapper holds a raw tagged union
-///     rather than an `inner` field. What is LEFT is the third case: a
-///     FIELDLESS C enum (`AccessibilityRole`) gets no wrapper of any kind - it
-///     appears only as a `C.Az*` parameter type - so its derives have nowhere
-///     to hang. Closing it means emitting a wrapper for plain enums.
+///   * `zig` (19, was 5168) - effectively closed. Three causes, all fixed:
+///     the wrapper gate excluded every trait kind (and `azul.zig` redeclares
+///     nothing, so a C symbol no wrapper calls cannot be spelled at all);
+///     enums needed their own emitter because an enum wrapper holds a raw
+///     tagged union rather than an `inner`; and unit-only enums were skipped
+///     entirely on the grounds that their VALUE is usable straight from `C.*`,
+///     which is true and left their trait entry points homeless. They now get
+///     a namespace carrying only those, plus `default()` - a static factory,
+///     so it sits outside the instance-method emitter that the union helper
+///     already covers.
+///     The last 19 are a handful of types the struct emitter excludes BY
+///     CATEGORY - `ImageRef`, `Svg`, `PhysicalSizeU32`, `GlVoidPtrConst`.
+///     Closing them means revisiting those category exclusions, which is a
+///     separate decision from routing a capability.
 ///   * `go` (2246, was 5648) - structs and unit-only enums are closed. The
 ///     struct half was the same gate-plus-emitter pair zig needed; unit enums
 ///     are real named Go types (`type AzAccessibilityRole uint32`), so they
@@ -812,7 +816,7 @@ fn declared_count(derives: &BTreeSet<String>) -> usize {
 pub const BASELINE: &[(&str, usize)] = &[
     ("python", 36),
     ("freebasic", 11),
-    ("zig", 603),
+    ("zig", 19),
     ("powershell", 4),
     ("php-ext", 134),
     ("ocaml", 272),

--- a/doc/src/lint_derives.rs
+++ b/doc/src/lint_derives.rs
@@ -823,22 +823,20 @@ pub fn check(codegen_dir: &Path, api: &ApiData) -> anyhow::Result<Vec<BindingRep
 ///     `ResultXmlXmlError`, three classes whose entry points these emitters
 ///     drop for a reason not yet established. Consistent across every binding
 ///     that has a residue at all, so it is one cause, not fourteen.
-///   * `ocaml` (1100) - BACK UP from 11, because two of the emissions that
-///     lowered it DID NOT TYPE-CHECK. `ocamlfind ocamlc` says so:
-///       1. Unit-enum capabilities were emitted in the TYPES section, ~42k
-///          lines before the `foreign` bindings they call. OCaml is
-///          order-sensitive: "Unbound value ffi_az_style_cursor_partial_eq".
-///          A unit enum's capabilities need a LATE pass, after the bindings -
-///          and it cannot simply reuse the late enum-module loop, because
-///          `types.rs` already emits `module X` and a second one is a
-///          duplicate. That is the open design question here.
-///       2. The recursive carve-out let `XmlNodeChildVec` reach the Vec
-///          `to_list` helper, whose `structure list` shape does not fit an
-///          element emitted as an opaque pointer. Fixed by skipping recursive
-///          elements - the carve-out is right, the helper just does not apply.
-///     Both were invisible to this lint, which greps for names. `azul.mli`
-///     and `azul.ml` now type-check clean, and `scripts/check.sh
-///     --only binding-syntax` keeps them that way.
+///   * `ocaml` (11) - and this 11 differs from the previous one: the code now
+///     TYPE-CHECKS. `ocamlfind ocamlc -package ctypes,ctypes.foreign` compiles
+///     both `azul.mli` and `azul.ml` clean, and `scripts/check.sh --only
+///     binding-syntax` runs it.
+///     The fix was ORDERING, not capability. OCaml is order-sensitive, so a
+///     unit enum's module cannot sit in the types section and call `foreign`
+///     bindings declared 42k lines later. The module could not be split either
+///     - two `module X` is a duplicate - so the WHOLE module, variant
+///     constants included, moved to the late idiomatic pass. Nothing in the
+///     file references these modules internally, which is what made the move
+///     safe; the type checker confirmed it.
+///     Everything else here was the same fault in different places: the `.mli`
+///     SEALS the module, so anything the interface omits is unreachable
+///     however complete `azul.ml` is.
 ///   * `php-ext` (134) - BACK UP from 125, because the change that lowered it
 ///     emitted code that does not compile. `is_method_kind_eligible` and
 ///     `takes_self` were widened to the trait kinds; the result was methods
@@ -912,7 +910,7 @@ pub const BASELINE: &[(&str, usize)] = &[
     ("python", 36),
     ("zig", 13),
     ("php-ext", 134),
-    ("ocaml", 1100),
+    ("ocaml", 11),
     ("haskell", 10),
     ("go", 13),
 ];

--- a/doc/src/lint_derives.rs
+++ b/doc/src/lint_derives.rs
@@ -184,6 +184,31 @@ const PYO3_PROFILE: &[(&str, Expect)] = &[
 
 const PY_BLOCK: &[&str] = &["#[pymethods]\nimpl {T} {"];
 
+/// OCaml (`azul.mli`).
+///
+/// The interface spells nothing the way the C ABI does: the FFI type is
+/// `az_accessibility_action`, the module is `AccessibilityAction`, and the C
+/// symbol appears only inside `azul.ml` as a `foreign "..."` string. Matching
+/// this binding against `Az{T}_partialEq` therefore measured NOTHING - it
+/// reported 0 honoured and 1703 absent, i.e. it could not see a single one of
+/// the 1718 modules the interface actually publishes. This profile asks the
+/// question in OCaml's own vocabulary instead.
+///
+/// `Ord`/`PartialOrd` both map to `val compare`, because OCaml has one
+/// comparison function and no separate partial order.
+const OCAML_BLOCK: &[&str] = &["module {T} : sig"];
+const OCAML_PROFILE: &[(&str, Expect)] = &[
+    ("Debug", Expect::Block { start: OCAML_BLOCK, markers: &["val to_string"] }),
+    ("Clone", Expect::Block { start: OCAML_BLOCK, markers: &["val clone"] }),
+    ("Copy", COPY_NA),
+    ("PartialEq", Expect::Block { start: OCAML_BLOCK, markers: &["val equal"] }),
+    ("Eq", EQ_NA),
+    ("PartialOrd", Expect::Block { start: OCAML_BLOCK, markers: &["val compare"] }),
+    ("Ord", Expect::Block { start: OCAML_BLOCK, markers: &["val compare"] }),
+    ("Hash", Expect::Block { start: OCAML_BLOCK, markers: &["val hash"] }),
+    ("Default", Expect::Block { start: OCAML_BLOCK, markers: &["val default"] }),
+];
+
 /// C++ (`azul03.hpp` … `azul23.hpp`, `azul.cppm`).
 ///
 /// The headers open with `extern "C" { #include "azul.h" }`, which under this
@@ -320,7 +345,7 @@ pub const BINDINGS: &[Binding] = &[
     Binding { name: "php", files: &["Azul.php"], prefix: "Az", block_end: "", expects: ABI_PROFILE, note: "FFI::cdef over the whole header" },
     Binding { name: "php-ext", files: &["php_api.rs"], prefix: "Az", block_end: "", expects: ABI_PROFILE, note: "Zend native extension (curated 5-class surface)" },
     Binding { name: "perl", files: &["Azul.pm"], prefix: "Az", block_end: "", expects: ABI_PROFILE, note: "FFI::Platypus attach" },
-    Binding { name: "ocaml", files: &["azul.mli"], prefix: "Az", block_end: "", expects: ABI_PROFILE, note: "the .mli SEALS the module - only what it lists is reachable" },
+    Binding { name: "ocaml", files: &["azul.mli"], prefix: "", block_end: "\nend\n", expects: OCAML_PROFILE, note: "the .mli SEALS the module - only what it lists is reachable" },
     Binding { name: "haskell", files: &["haskell"], prefix: "Az", block_end: "", expects: ABI_PROFILE, note: "foreign import ccall + idiomatic instances" },
     Binding { name: "java", files: &["java"], prefix: "Az", block_end: "", expects: ABI_PROFILE, note: "JNA/Panama" },
     Binding { name: "kotlin", files: &["kotlin"], prefix: "Az", block_end: "", expects: ABI_PROFILE, note: "JNA" },
@@ -773,24 +798,25 @@ pub fn check(codegen_dir: &Path, api: &ApiData) -> anyhow::Result<Vec<BindingRep
 ///     `ResultXmlXmlError`, three classes whose entry points these emitters
 ///     drop for a reason not yet established. Consistent across every binding
 ///     that has a residue at all, so it is one cause, not fourteen.
-///   * `ocaml` (272) - the capability IS generated: `azul.ml` defines `equal`,
-///     `hash` and `to_string` per module, and the raw `foreign` bindings name
-///     all 7893 trait symbols. The `.mli` declares none of them, and in OCaml
-///     the interface SEALS the module, so a consumer can reach nothing.
-///     ATTEMPTED AND REVERTED 2026-09-05, twice, both times making it WORSE.
-///     Recorded so the next attempt does not repeat it:
-///       1. Widening `class_has_visible_methods` to admit trait-only classes
-///          emits a module exposing only `equal`/`hash`/`to_string`, so every
-///          OTHER derive that class declares (Clone, Ord, PartialOrd, Default)
-///          flips from `absent` to `missing`: 272 -> 1321. A module is only an
-///          improvement once it carries the WHOLE declared list.
-///       2. Even the signature-only change measured worse (272 -> 1171),
-///          because this check is TEXT-based: the emitted comment
-///          `(* Equality routed through AzFoo_partialEq. *)` NAMES the class,
-///          so `class_is_named` counts previously-absent classes as present
-///          and starts charging them for derives they still lack. Any fix here
-///          must either carry the full list or avoid naming the class in prose
-///          - and that fragility is worth knowing about the checker itself.
+///   * `ocaml` (4010) - THIS NUMBER WENT UP, and nothing regressed. It was
+///     272 because the check could not see this binding at all: it matched
+///     `Az{T}_partialEq` against `azul.mli`, which spells the FFI type
+///     `az_accessibility_action`, the module `AccessibilityAction`, and never
+///     mentions a C symbol (those live in `azul.ml` as `foreign "..."`
+///     strings). It reported 0 honoured and 1703 absent - blind to all 1718
+///     modules the interface publishes. `OCAML_PROFILE` now asks in OCaml's
+///     own vocabulary (`val equal`, `val hash`, `val to_string`, `val clone`,
+///     `val default`, `val compare` inside `module {T} : sig`), and the real
+///     figure is 1770 honoured / 4010 missing.
+///     Most of the 4010 is `compare`: the interface publishes 704 `equal`,
+///     754 `to_string`, 560 `clone`, 496 `default`, 399 `hash` - and TWO
+///     `compare`, so nearly every declared Ord/PartialOrd is genuinely
+///     unreachable. Enums now get a module too (they had none, which was the
+///     original diagnosis and was real), carrying equal/hash/to_string/default.
+///     LESSON, worth more than the fix: a binding reporting a suspiciously
+///     SMALL gap deserves the same scrutiny as a large one. 0 honoured is not
+///     a good sign, it is the signature of a profile that does not match its
+///     artifact.
 ///   * `haskell` (10) - the recursive-type carve-out moved it 11 -> 10, so its
 ///     `_partialEq` / `_cmp` / `_hash` now reach the artifact. The remaining
 ///     Debug / Clone / Default do NOT, for a different reason: Haskell routes
@@ -845,7 +871,7 @@ pub const BASELINE: &[(&str, usize)] = &[
     ("python", 36),
     ("zig", 19),
     ("php-ext", 134),
-    ("ocaml", 272),
+    ("ocaml", 4010),
     ("haskell", 10),
     ("go", 19),
 ];

--- a/doc/src/lint_derives.rs
+++ b/doc/src/lint_derives.rs
@@ -717,10 +717,12 @@ pub fn check(codegen_dir: &Path, api: &ApiData) -> anyhow::Result<Vec<BindingRep
 /// Pascal, Ada, PHP, Perl, Common Lisp, Algol 68 and COBOL.
 ///
 /// WHAT EACH REMAINING NUMBER IS, IN ONE LINE (measured 2026-09-05):
-///   * `python` — `lang_python.rs` drops trait kinds, then `generate_pymethod`
-///     bails on `fn_body: None`, which every synthesised trait fn has. Only
-///     `__str__`/`__repr__` survive; there is no `__eq__`, `__hash__` or
-///     `__lt__` in the whole extension.
+///   * `python` (150) — every class that HAS a pyclass now honours its whole
+///     derive list. What is left is 185 classes that have no pyclass at all:
+///     the 114 `*VecDestructor`s (`DestructorOrClone`, excluded wholesale) and
+///     the monomorphised `*Value` aliases (`pub type LayoutWidthValue =
+///     AzCssPropertyValue<..>`, which cannot BE a pyclass). Closing it means
+///     giving those types a pyclass, not routing a capability differently.
 ///   * `zig` / `go` — the wrapper emitters whitelist
 ///     `Constructor | Method | MethodMut | StaticMethod | Default | DeepCopy`,
 ///     so the comparison and debug entry points reach the artifact zero times.
@@ -742,9 +744,14 @@ pub fn check(codegen_dir: &Path, api: &ApiData) -> anyhow::Result<Vec<BindingRep
 ///     to hang a method on, so their capabilities are now free functions
 ///     overloaded on the argument type; see
 ///     `lang_cpp::common::generate_freefn_trait_helpers`.
+///   * `python` (was 4671) — the PyO3 extension had no `__eq__`, `__lt__`,
+///     `__hash__`, `__copy__` or `default` anywhere: the mirror's Rust trait
+///     impls are not dunders, so `a == b` silently fell back to identity.
+///     `generate_derive_dunders` emits them under exactly the condition that
+///     makes the corresponding mirror impl exist.
 pub const BASELINE: &[(&str, usize)] = &[
     ("csharp", 114),
-    ("python", 4671),
+    ("python", 150),
     ("freebasic", 124),
     ("zig", 5168),
     ("powershell", 118),

--- a/doc/src/lint_derives.rs
+++ b/doc/src/lint_derives.rs
@@ -773,10 +773,24 @@ pub fn check(codegen_dir: &Path, api: &ApiData) -> anyhow::Result<Vec<BindingRep
 ///     `ResultXmlXmlError`, three classes whose entry points these emitters
 ///     drop for a reason not yet established. Consistent across every binding
 ///     that has a residue at all, so it is one cause, not fourteen.
-///   * `ocaml` — every capability IS generated in `azul.ml` and the `.mli`
-///     exports only `clone` and `default`, so a consumer can reach nothing else.
-///
-/// WHAT CAME OFF THIS TABLE, AND HOW:
+///   * `ocaml` (272) - the capability IS generated: `azul.ml` defines `equal`,
+///     `hash` and `to_string` per module, and the raw `foreign` bindings name
+///     all 7893 trait symbols. The `.mli` declares none of them, and in OCaml
+///     the interface SEALS the module, so a consumer can reach nothing.
+///     ATTEMPTED AND REVERTED 2026-09-05, twice, both times making it WORSE.
+///     Recorded so the next attempt does not repeat it:
+///       1. Widening `class_has_visible_methods` to admit trait-only classes
+///          emits a module exposing only `equal`/`hash`/`to_string`, so every
+///          OTHER derive that class declares (Clone, Ord, PartialOrd, Default)
+///          flips from `absent` to `missing`: 272 -> 1321. A module is only an
+///          improvement once it carries the WHOLE declared list.
+///       2. Even the signature-only change measured worse (272 -> 1171),
+///          because this check is TEXT-based: the emitted comment
+///          `(* Equality routed through AzFoo_partialEq. *)` NAMES the class,
+///          so `class_is_named` counts previously-absent classes as present
+///          and starts charging them for derives they still lack. Any fix here
+///          must either carry the full list or avoid naming the class in prose
+///          - and that fragility is worth knowing about the checker itself.
 ///   * `rust-public` (was 7122) — `azul.rs` was `UsingDerive` with no `extern`
 ///     block, a combination that could not compile in either direction. It is
 ///     now `UsingCAPI` + `ExternalBindings`, the same shape as

--- a/doc/src/lint_derives.rs
+++ b/doc/src/lint_derives.rs
@@ -712,9 +712,10 @@ pub fn check(codegen_dir: &Path, api: &ApiData) -> anyhow::Result<Vec<BindingRep
 /// a baseline that is only ever checked as an upper bound goes stale the day
 /// after it is written and then proves nothing.
 ///
-/// A binding absent from this table must have ZERO gaps. Twenty-three are
+/// A binding absent from this table must have ZERO gaps. Twenty-five are
 /// today: the three Rust mirrors, memtest, all six C++ dialects, C, C#, Java,
-/// Node, Ruby, Lua, Pascal, Ada, PHP, Perl, Common Lisp, Algol 68 and COBOL.
+/// Node, Kotlin, Racket, Ruby, Lua, Pascal, Ada, PHP, Perl, Common Lisp,
+/// Algol 68 and COBOL.
 ///
 /// WHAT EACH REMAINING NUMBER IS, IN ONE LINE (measured 2026-09-05):
 ///   * `python` (150) — every class that HAS a pyclass now honours its whole
@@ -726,13 +727,10 @@ pub fn check(codegen_dir: &Path, api: &ApiData) -> anyhow::Result<Vec<BindingRep
 ///   * `zig` / `go` — the wrapper emitters whitelist
 ///     `Constructor | Method | MethodMut | StaticMethod | Default | DeepCopy`,
 ///     so the comparison and debug entry points reach the artifact zero times.
-///   * `~114-134` in the remaining tail — the `*VecDestructor` types. Their
-///     `_toDbgString` is exported from libazul and those emitters skip the type
-///     wholesale. Fixed for C#/Java/Node/PowerShell; kotlin, racket, crystal,
-///     d, julia, nim, odin, v, fortran, red, smalltalk, vb6 and freebasic are
-///     the same one-line shape, untouched here.
-///   * `powershell` / `swift` (4 each) — one class, `Xml`, whose four entry
-///     points those two emitters drop for a reason not yet established.
+///   * `4-20` in the remaining tail — `Xml`, `XmlNodeChild` and
+///     `ResultXmlXmlError`, three classes whose entry points these emitters
+///     drop for a reason not yet established. Consistent across every binding
+///     that has a residue at all, so it is one cause, not fourteen.
 ///   * `ocaml` — every capability IS generated in `azul.ml` and the `.mli`
 ///     exports only `clone` and `default`, so a consumer can reach nothing else.
 ///
@@ -753,31 +751,34 @@ pub fn check(codegen_dir: &Path, api: &ApiData) -> anyhow::Result<Vec<BindingRep
 ///     impls are not dunders, so `a == b` silently fell back to identity.
 ///     `generate_derive_dunders` emits them under exactly the condition that
 ///     makes the corresponding mirror impl exist.
-///   * `csharp` / `java` / `node` (114 each) and `powershell` (118) — their
-///     `should_emit_function` excluded the whole `DestructorOrClone` category,
-///     including the one entry point a `derive` actually asks for.
+///   * the `*VecDestructor` tail, in twenty bindings at once (114 each in
+///     csharp/java/node/kotlin/racket, and the bulk of the 118-134 in
+///     powershell, crystal, d, julia, nim, odin, v, fortran, red, smalltalk,
+///     vb6, freebasic, haskell, plus 114 previously-ABSENT classes each in
+///     pascal/ada/lisp/algol68/cobol) — every one of those
+///     `should_emit_function` filters excluded the whole `DestructorOrClone`
+///     category, including the one entry point a `derive` actually asks for.
+///     They now share `FunctionKind::is_declared_capability`.
 pub const BASELINE: &[(&str, usize)] = &[
     ("python", 150),
-    ("freebasic", 124),
+    ("freebasic", 11),
     ("zig", 5168),
     ("powershell", 4),
     ("php-ext", 134),
     ("ocaml", 272),
     ("haskell", 11),
-    ("kotlin", 114),
-    ("fortran", 134),
+    ("fortran", 20),
     ("go", 5648),
-    ("smalltalk", 123),
-    ("vb6", 123),
-    ("crystal", 134),
-    ("d", 134),
-    ("julia", 134),
-    ("nim", 134),
-    ("odin", 134),
-    ("racket", 114),
-    ("red", 126),
+    ("smalltalk", 10),
+    ("vb6", 10),
+    ("crystal", 20),
+    ("d", 20),
+    ("julia", 20),
+    ("nim", 20),
+    ("odin", 20),
+    ("red", 12),
     ("swift", 4),
-    ("v", 134),
+    ("v", 20),
 ];
 
 /// Compare against [`BASELINE`] and render the verdict.

--- a/doc/src/lint_derives.rs
+++ b/doc/src/lint_derives.rs
@@ -196,6 +196,28 @@ const PY_BLOCK: &[&str] = &["#[pymethods]\nimpl {T} {"];
 ///
 /// `Ord`/`PartialOrd` both map to `val compare`, because OCaml has one
 /// comparison function and no separate partial order.
+/// php-ext (`php_api.rs`, the Zend native extension).
+///
+/// This extension curates FIVE classes - `PHP_CLASS_ALLOWLIST` - and declares
+/// `extern` blocks for everything else. Matching on the extern symbol
+/// therefore counted 1744 types as "present" that a PHP user cannot touch,
+/// and charged them for derives the extension never intended to expose. The
+/// user-visible surface is the `impl Azul{T}` block, so that is what this
+/// asks about; a type with no PHP class is `absent`, which is the honest
+/// verdict for a deliberate curation.
+const PHP_EXT_BLOCK: &[&str] = &["impl Azul{T} {"];
+const PHP_EXT_PROFILE: &[(&str, Expect)] = &[
+    ("Debug", Expect::Block { start: PHP_EXT_BLOCK, markers: &["fn toDbgString"] }),
+    ("Clone", Expect::Block { start: PHP_EXT_BLOCK, markers: &["fn clone"] }),
+    ("Copy", COPY_NA),
+    ("PartialEq", Expect::Block { start: PHP_EXT_BLOCK, markers: &["fn partialEq"] }),
+    ("Eq", EQ_NA),
+    ("PartialOrd", Expect::Block { start: PHP_EXT_BLOCK, markers: &["fn partialCmp"] }),
+    ("Ord", Expect::Block { start: PHP_EXT_BLOCK, markers: &["fn cmp"] }),
+    ("Hash", Expect::Block { start: PHP_EXT_BLOCK, markers: &["fn hash"] }),
+    ("Default", Expect::Block { start: PHP_EXT_BLOCK, markers: &["fn default"] }),
+];
+
 const OCAML_BLOCK: &[&str] = &["module {T} : sig"];
 const OCAML_PROFILE: &[(&str, Expect)] = &[
     ("Debug", Expect::Block { start: OCAML_BLOCK, markers: &["val to_string"] }),
@@ -816,23 +838,25 @@ pub fn check(codegen_dir: &Path, api: &ApiData) -> anyhow::Result<Vec<BindingRep
 ///     `compare`: the ABI answers 255 for "incomparable" and a total compare
 ///     has no honest value for it. Needed in all three emitters - struct,
 ///     tagged union, unit enum.
-///   * `php-ext` (125) - the `AzString` RETURN is now handled, which was the
-///     whole Debug column: `AzString::as_str` does exist on the external
-///     surface (it handles non-UTF8 by taking the longest valid prefix), so
-///     the arm needs no hand-written pointer code - just `as_str().to_string()`
-///     and an `AzString_delete`, since AzString owns a heap buffer and has no
-///     Drop of its own. An earlier pass recorded this as blocked on a missing
-///     helper; that was wrong, the helper was there.
-///     It only moved 129 -> 125, and the reason is NOT a marshalling gap:
-///     `PHP_CLASS_ALLOWLIST` is exactly five classes - Dom, App, AppConfig,
-///     WindowCreateOptions, Button - and everything else gets no PHP class at
-///     all. The remaining 125 are derives on types this extension
-///     DELIBERATELY does not expose; they count as present only because their
-///     `extern` declarations name them.
-///     NEXT STEP, and it is a MEASUREMENT fix rather than an emitter one:
-///     php-ext's presence test should key on the registered PHP class
-///     (`Azul{T}`), not the extern symbol - exactly the correction ocaml
-///     needed. Until then this number describes the curation, not a defect.
+///   * `php-ext` (134) - BACK UP from 125, because the change that lowered it
+///     emitted code that does not compile. `is_method_kind_eligible` and
+///     `takes_self` were widened to the trait kinds; the result was methods
+///     with no receiver whose bodies still said `self.inner` and passed an
+///     extra argument - `AzDom_partialEq(&self.inner, &a.inner, &b.inner)` for
+///     a two-argument export. Three of them shipped, across two commits,
+///     because NOTHING in this repo's gates compiles `php_api.rs`. The gate
+///     went green the whole time: it greps for names, and broken code still
+///     contains the name.
+///     Both widenings are reverted. Emitting these needs `render_method`
+///     taught the STATIC shape (no receiver, both operands as arguments)
+///     first; the eligibility flag is not the hard part.
+///     A profile fix was also attempted and reverted: keying presence on
+///     `impl Azul{T}` instead of the extern symbol gave 0 honoured, which is
+///     the same "blind profile" signature that made ocaml read 272 for weeks.
+///     The `AzString` RETURN arm in `marshal_return` is KEPT - it is correct
+///     and independent, and any ordinary method returning a string needs it.
+///     LESSON: a name-presence gate cannot see a compile error. For a target
+///     nothing builds, the gate is not evidence.
 ///   * `haskell` (10) - the recursive-type carve-out moved it 11 -> 10, so its
 ///     `_partialEq` / `_cmp` / `_hash` now reach the artifact. The remaining
 ///     Debug / Clone / Default do NOT, for a different reason: Haskell routes
@@ -886,7 +910,7 @@ fn declared_count(derives: &BTreeSet<String>) -> usize {
 pub const BASELINE: &[(&str, usize)] = &[
     ("python", 36),
     ("zig", 13),
-    ("php-ext", 125),
+    ("php-ext", 134),
     ("ocaml", 11),
     ("haskell", 10),
     ("go", 13),

--- a/doc/src/lint_derives.rs
+++ b/doc/src/lint_derives.rs
@@ -798,20 +798,22 @@ pub fn check(codegen_dir: &Path, api: &ApiData) -> anyhow::Result<Vec<BindingRep
 ///     `ResultXmlXmlError`, three classes whose entry points these emitters
 ///     drop for a reason not yet established. Consistent across every binding
 ///     that has a residue at all, so it is one cause, not fourteen.
-///   * `ocaml` (1233, was 4010 once measured properly) - three fixes, all the
-///     same fault in different places: the `.mli` SEALS the module, so a value
-///     the interface does not list is unreachable however complete the `.ml`
-///     is. (1) The implementation defined `equal` / `hash` / `to_string` and
-///     the interface declared none of them. (2) Nothing emitted `compare` at
-///     all: 2 in the whole file against 704 `equal`, so almost every declared
-///     Ord/PartialOrd was dead. It maps the ABI's 0/1/2 onto OCaml's
-///     negative/zero/positive - an exact correspondence, not an invention.
-///     (3) Enums had no module at all and now carry the same six.
-///     Every capability is decided by ONE predicate used by both emitters,
-///     because the two drifting is the whole bug.
-///     The residue is unit-only enums (`AccessibilityRole`): they are plain C
-///     enums with no `Ctypes.structure`, so the pointer-taking `Ctypes.addr`
-///     shape these helpers use does not apply. Different plumbing, logged.
+///   * `ocaml` (619, was 4010 once measured properly) - four fixes, one fault:
+///     the `.mli` SEALS the module, so a value the interface does not list is
+///     unreachable however complete `azul.ml` is. The implementation defined
+///     `equal`/`hash`/`to_string` that the interface never declared; nothing
+///     emitted `compare` at all (2 in the file against 704 `equal`); tagged
+///     unions got no module; and unit-only enums needed their capabilities on
+///     the module `types.rs` ALREADY emits - adding a second one produced a
+///     duplicate `module X`, which is an OCaml compile error AND invisible to
+///     a name-presence lint that stops at the first block.
+///     A unit enum is `type az_x = int` with an int view, so the helpers
+///     allocate a cell rather than using `Ctypes.addr`; an int is not
+///     addressable.
+///     Every capability is decided by ONE predicate both emitters call.
+///     The residue is ordering on unit enums (187 Ord + 275 PartialOrd) and
+///     121 Default: `unit_enum_caps` covers equality, hash and debug only, and
+///     `_cmp` / `_default` want the same allocate-a-cell treatment.
 ///   * `php-ext` (129, was 134) - correctly measured, unlike ocaml: the
 ///     artifact really does name `AzApp_*` symbols, and the 1744 absent are a
 ///     genuinely curated surface of 29 classes. `is_method_kind_eligible`
@@ -878,7 +880,7 @@ pub const BASELINE: &[(&str, usize)] = &[
     ("python", 36),
     ("zig", 19),
     ("php-ext", 129),
-    ("ocaml", 1233),
+    ("ocaml", 619),
     ("haskell", 10),
     ("go", 19),
 ];

--- a/doc/src/lint_derives.rs
+++ b/doc/src/lint_derives.rs
@@ -203,7 +203,10 @@ const OCAML_PROFILE: &[(&str, Expect)] = &[
     ("Copy", COPY_NA),
     ("PartialEq", Expect::Block { start: OCAML_BLOCK, markers: &["val equal"] }),
     ("Eq", EQ_NA),
-    ("PartialOrd", Expect::Block { start: OCAML_BLOCK, markers: &["val compare"] }),
+    // A PartialOrd-only type gets `partial_compare : t -> t -> int option`,
+    // not `compare`: the ABI answers 255 for "incomparable" and a total
+    // `compare` has no honest value for it. Either spelling satisfies it.
+    ("PartialOrd", Expect::Block { start: OCAML_BLOCK, markers: &["val compare", "val partial_compare"] }),
     ("Ord", Expect::Block { start: OCAML_BLOCK, markers: &["val compare"] }),
     ("Hash", Expect::Block { start: OCAML_BLOCK, markers: &["val hash"] }),
     ("Default", Expect::Block { start: OCAML_BLOCK, markers: &["val default"] }),
@@ -798,22 +801,17 @@ pub fn check(codegen_dir: &Path, api: &ApiData) -> anyhow::Result<Vec<BindingRep
 ///     `ResultXmlXmlError`, three classes whose entry points these emitters
 ///     drop for a reason not yet established. Consistent across every binding
 ///     that has a residue at all, so it is one cause, not fourteen.
-///   * `ocaml` (619, was 4010 once measured properly) - four fixes, one fault:
-///     the `.mli` SEALS the module, so a value the interface does not list is
-///     unreachable however complete `azul.ml` is. The implementation defined
-///     `equal`/`hash`/`to_string` that the interface never declared; nothing
-///     emitted `compare` at all (2 in the file against 704 `equal`); tagged
-///     unions got no module; and unit-only enums needed their capabilities on
-///     the module `types.rs` ALREADY emits - adding a second one produced a
-///     duplicate `module X`, which is an OCaml compile error AND invisible to
-///     a name-presence lint that stops at the first block.
-///     A unit enum is `type az_x = int` with an int view, so the helpers
-///     allocate a cell rather than using `Ctypes.addr`; an int is not
-///     addressable.
+///   * `ocaml` (100, was 4010 once measured properly) - the `.mli` SEALS the
+///     module, so anything the interface omits is unreachable however complete
+///     `azul.ml` is. Fixed: equal/hash/to_string were defined and never
+///     declared; `compare` was emitted nowhere (2 in the file against 704
+///     `equal`); tagged unions had no module; unit-only enums needed their
+///     capabilities on the module `types.rs` already emits, allocating a cell
+///     because an int view is not addressable.
+///     `PartialOrd` gets `partial_compare : t -> t -> int option`, NOT
+///     `compare`: the ABI answers 255 for "incomparable" and a total `compare`
+///     has no honest value for that. The profile accepts either spelling.
 ///     Every capability is decided by ONE predicate both emitters call.
-///     The residue is ordering on unit enums (187 Ord + 275 PartialOrd) and
-///     121 Default: `unit_enum_caps` covers equality, hash and debug only, and
-///     `_cmp` / `_default` want the same allocate-a-cell treatment.
 ///   * `php-ext` (129, was 134) - correctly measured, unlike ocaml: the
 ///     artifact really does name `AzApp_*` symbols, and the 1744 absent are a
 ///     genuinely curated surface of 29 classes. `is_method_kind_eligible`
@@ -880,7 +878,7 @@ pub const BASELINE: &[(&str, usize)] = &[
     ("python", 36),
     ("zig", 19),
     ("php-ext", 129),
-    ("ocaml", 619),
+    ("ocaml", 100),
     ("haskell", 10),
     ("go", 19),
 ];

--- a/doc/src/lint_derives.rs
+++ b/doc/src/lint_derives.rs
@@ -752,16 +752,19 @@ pub fn check(codegen_dir: &Path, api: &ApiData) -> anyhow::Result<Vec<BindingRep
 ///     FIELDLESS C enum (`AccessibilityRole`) gets no wrapper of any kind - it
 ///     appears only as a `C.Az*` parameter type - so its derives have nowhere
 ///     to hang. Closing it means emitting a wrapper for plain enums.
-///   * `go` (3217, was 5648) - the struct half is closed by the same pair that
-///     worked for zig: admit the trait kinds to `has_useful_method` AND emit
-///     the methods, in one change. Go gets idiomatic spellings - `Equal`,
-///     `Order`, `PartialOrder`, `Hash`, and a `String()` that implements
-///     fmt.Stringer. `String()` frees the `AzString` the ABI returns, because
-///     `GoStr` only copies and would otherwise leak one per call.
-///     What is LEFT is enums. Go carries them in `types.go` as real named
-///     types (`type AzAccessibilityRole uint32` plus constants, and an
-///     interface + marker methods for the tagged unions), so they CAN take
-///     methods - nothing emits them today. That is the next change.
+///   * `go` (2246, was 5648) - structs and unit-only enums are closed. The
+///     struct half was the same gate-plus-emitter pair zig needed; unit enums
+///     are real named Go types (`type AzAccessibilityRole uint32`), so they
+///     simply take methods. Go gets idiomatic spellings - `Equal`, `Order`,
+///     `PartialOrder`, `Hash`, and a `String()` implementing fmt.Stringer that
+///     frees the `AzString` (GoStr only copies, so it would otherwise leak one
+///     per call).
+///     What is LEFT is TAGGED UNIONS, and it is a redesign rather than a
+///     missing call: Go models them as a sealed INTERFACE
+///     (`type AzCssProperty interface { isAzCssProperty() }`) whose variant
+///     structs hold no C value, so there is no `C.Az*` whose address a trait
+///     entry point could take. Wiring it means having the variant types carry
+///     the union. Recorded, not guessed at.
 ///   * `4-20` in the remaining tail — `Xml`, `XmlNodeChild` and
 ///     `ResultXmlXmlError`, three classes whose entry points these emitters
 ///     drop for a reason not yet established. Consistent across every binding
@@ -815,7 +818,7 @@ pub const BASELINE: &[(&str, usize)] = &[
     ("ocaml", 272),
     ("haskell", 11),
     ("fortran", 20),
-    ("go", 3217),
+    ("go", 2246),
     ("smalltalk", 10),
     ("vb6", 10),
     ("crystal", 20),

--- a/doc/src/lint_derives.rs
+++ b/doc/src/lint_derives.rs
@@ -829,24 +829,11 @@ fn declared_count(derives: &BTreeSet<String>) -> usize {
 
 pub const BASELINE: &[(&str, usize)] = &[
     ("python", 36),
-    ("freebasic", 11),
     ("zig", 19),
-    ("powershell", 4),
     ("php-ext", 134),
     ("ocaml", 272),
-    ("haskell", 11),
-    ("fortran", 20),
+    ("haskell", 10),
     ("go", 2246),
-    ("smalltalk", 10),
-    ("vb6", 10),
-    ("crystal", 20),
-    ("d", 20),
-    ("julia", 20),
-    ("nim", 20),
-    ("odin", 20),
-    ("red", 12),
-    ("swift", 4),
-    ("v", 20),
 ];
 
 /// Compare against [`BASELINE`] and render the verdict.

--- a/doc/src/lint_derives.rs
+++ b/doc/src/lint_derives.rs
@@ -823,21 +823,22 @@ pub fn check(codegen_dir: &Path, api: &ApiData) -> anyhow::Result<Vec<BindingRep
 ///     `ResultXmlXmlError`, three classes whose entry points these emitters
 ///     drop for a reason not yet established. Consistent across every binding
 ///     that has a residue at all, so it is one cause, not fourteen.
-///   * `ocaml` (11, was 4010 once measured properly) - the `.mli` SEALS the
-///     module, so anything the interface omits is unreachable however complete
-///     `azul.ml` is. equal/hash/to_string were defined and never declared;
-///     `compare` was emitted nowhere; tagged unions and unit enums had no
-///     capabilities at all; and trait-only classes got no module.
-///     That last one FAILED the first time (272 -> 1321) and succeeded later,
-///     which is the useful lesson: a module carrying three of a class's seven
-///     derives makes the other four flip from `absent` to `missing`, so the
-///     change was not wrong, only premature. Once the module carried the whole
-///     list the same edit was a clean win. Record WHY a revert happened, not
-///     just that it did.
-///     `PartialOrd` gets `partial_compare : t -> t -> int option`, never
-///     `compare`: the ABI answers 255 for "incomparable" and a total compare
-///     has no honest value for it. Needed in all three emitters - struct,
-///     tagged union, unit enum.
+///   * `ocaml` (1100) - BACK UP from 11, because two of the emissions that
+///     lowered it DID NOT TYPE-CHECK. `ocamlfind ocamlc` says so:
+///       1. Unit-enum capabilities were emitted in the TYPES section, ~42k
+///          lines before the `foreign` bindings they call. OCaml is
+///          order-sensitive: "Unbound value ffi_az_style_cursor_partial_eq".
+///          A unit enum's capabilities need a LATE pass, after the bindings -
+///          and it cannot simply reuse the late enum-module loop, because
+///          `types.rs` already emits `module X` and a second one is a
+///          duplicate. That is the open design question here.
+///       2. The recursive carve-out let `XmlNodeChildVec` reach the Vec
+///          `to_list` helper, whose `structure list` shape does not fit an
+///          element emitted as an opaque pointer. Fixed by skipping recursive
+///          elements - the carve-out is right, the helper just does not apply.
+///     Both were invisible to this lint, which greps for names. `azul.mli`
+///     and `azul.ml` now type-check clean, and `scripts/check.sh
+///     --only binding-syntax` keeps them that way.
 ///   * `php-ext` (134) - BACK UP from 125, because the change that lowered it
 ///     emitted code that does not compile. `is_method_kind_eligible` and
 ///     `takes_self` were widened to the trait kinds; the result was methods
@@ -911,7 +912,7 @@ pub const BASELINE: &[(&str, usize)] = &[
     ("python", 36),
     ("zig", 13),
     ("php-ext", 134),
-    ("ocaml", 11),
+    ("ocaml", 1100),
     ("haskell", 10),
     ("go", 13),
 ];

--- a/doc/src/lint_derives.rs
+++ b/doc/src/lint_derives.rs
@@ -752,10 +752,16 @@ pub fn check(codegen_dir: &Path, api: &ApiData) -> anyhow::Result<Vec<BindingRep
 ///     FIELDLESS C enum (`AccessibilityRole`) gets no wrapper of any kind - it
 ///     appears only as a `C.Az*` parameter type - so its derives have nowhere
 ///     to hang. Closing it means emitting a wrapper for plain enums.
-///   * `go` (5648) - the same whitelist defect zig had, untouched. The fix is
-///     the pair that worked here: admit the trait kinds to `has_useful_method`
-///     AND emit the methods. Doing only the first makes the number WORSE,
-///     because the class then exists as a wrapper with nothing on it.
+///   * `go` (3217, was 5648) - the struct half is closed by the same pair that
+///     worked for zig: admit the trait kinds to `has_useful_method` AND emit
+///     the methods, in one change. Go gets idiomatic spellings - `Equal`,
+///     `Order`, `PartialOrder`, `Hash`, and a `String()` that implements
+///     fmt.Stringer. `String()` frees the `AzString` the ABI returns, because
+///     `GoStr` only copies and would otherwise leak one per call.
+///     What is LEFT is enums. Go carries them in `types.go` as real named
+///     types (`type AzAccessibilityRole uint32` plus constants, and an
+///     interface + marker methods for the tagged unions), so they CAN take
+///     methods - nothing emits them today. That is the next change.
 ///   * `4-20` in the remaining tail — `Xml`, `XmlNodeChild` and
 ///     `ResultXmlXmlError`, three classes whose entry points these emitters
 ///     drop for a reason not yet established. Consistent across every binding
@@ -809,7 +815,7 @@ pub const BASELINE: &[(&str, usize)] = &[
     ("ocaml", 272),
     ("haskell", 11),
     ("fortran", 20),
-    ("go", 5648),
+    ("go", 3217),
     ("smalltalk", 10),
     ("vb6", 10),
     ("crystal", 20),

--- a/doc/src/lint_derives.rs
+++ b/doc/src/lint_derives.rs
@@ -712,9 +712,9 @@ pub fn check(codegen_dir: &Path, api: &ApiData) -> anyhow::Result<Vec<BindingRep
 /// a baseline that is only ever checked as an upper bound goes stale the day
 /// after it is written and then proves nothing.
 ///
-/// A binding absent from this table must have ZERO gaps. Twenty are, today:
-/// the three Rust mirrors, memtest, all six C++ dialects, C, Ruby, Lua,
-/// Pascal, Ada, PHP, Perl, Common Lisp, Algol 68 and COBOL.
+/// A binding absent from this table must have ZERO gaps. Twenty-three are
+/// today: the three Rust mirrors, memtest, all six C++ dialects, C, C#, Java,
+/// Node, Ruby, Lua, Pascal, Ada, PHP, Perl, Common Lisp, Algol 68 and COBOL.
 ///
 /// WHAT EACH REMAINING NUMBER IS, IN ONE LINE (measured 2026-09-05):
 ///   * `python` (150) — every class that HAS a pyclass now honours its whole
@@ -726,9 +726,13 @@ pub fn check(codegen_dir: &Path, api: &ApiData) -> anyhow::Result<Vec<BindingRep
 ///   * `zig` / `go` — the wrapper emitters whitelist
 ///     `Constructor | Method | MethodMut | StaticMethod | Default | DeepCopy`,
 ///     so the comparison and debug entry points reach the artifact zero times.
-///   * `~114-134` in a dozen bindings — the `*VecDestructor` types. Their
+///   * `~114-134` in the remaining tail — the `*VecDestructor` types. Their
 ///     `_toDbgString` is exported from libazul and those emitters skip the type
-///     wholesale (C# emits no VecDestructor function at all, not just no debug).
+///     wholesale. Fixed for C#/Java/Node/PowerShell; kotlin, racket, crystal,
+///     d, julia, nim, odin, v, fortran, red, smalltalk, vb6 and freebasic are
+///     the same one-line shape, untouched here.
+///   * `powershell` / `swift` (4 each) — one class, `Xml`, whose four entry
+///     points those two emitters drop for a reason not yet established.
 ///   * `ocaml` — every capability IS generated in `azul.ml` and the `.mli`
 ///     exports only `clone` and `default`, so a consumer can reach nothing else.
 ///
@@ -749,22 +753,22 @@ pub fn check(codegen_dir: &Path, api: &ApiData) -> anyhow::Result<Vec<BindingRep
 ///     impls are not dunders, so `a == b` silently fell back to identity.
 ///     `generate_derive_dunders` emits them under exactly the condition that
 ///     makes the corresponding mirror impl exist.
+///   * `csharp` / `java` / `node` (114 each) and `powershell` (118) — their
+///     `should_emit_function` excluded the whole `DestructorOrClone` category,
+///     including the one entry point a `derive` actually asks for.
 pub const BASELINE: &[(&str, usize)] = &[
-    ("csharp", 114),
     ("python", 150),
     ("freebasic", 124),
     ("zig", 5168),
-    ("powershell", 118),
+    ("powershell", 4),
     ("php-ext", 134),
     ("ocaml", 272),
     ("haskell", 11),
-    ("java", 114),
     ("kotlin", 114),
     ("fortran", 134),
     ("go", 5648),
     ("smalltalk", 123),
     ("vb6", 123),
-    ("node", 114),
     ("crystal", 134),
     ("d", 134),
     ("julia", 134),

--- a/doc/src/lint_derives.rs
+++ b/doc/src/lint_derives.rs
@@ -817,6 +817,18 @@ pub fn check(codegen_dir: &Path, api: &ApiData) -> anyhow::Result<Vec<BindingRep
 ///     SMALL gap deserves the same scrutiny as a large one. 0 honoured is not
 ///     a good sign, it is the signature of a profile that does not match its
 ///     artifact.
+///   * `php-ext` (129, was 134) - correctly measured, unlike ocaml: the
+///     artifact really does name `AzApp_*` symbols, and the 1744 absent are a
+///     genuinely curated surface of 29 classes. `is_method_kind_eligible`
+///     said the trait helpers were "skipped entirely for now"; admitting them
+///     landed `_partialEq`, `_hash`, `_cmp` and `_clone` for Dom, Button and
+///     WindowCreateOptions, and NOTHING else - because eligibility is only the
+///     precondition. `render_method` still returns None for the rest: the
+///     marshalling table has no `AzString` RETURN (only the argument
+///     direction), no same-type `*const Az{T}` argument for `_partialEq`'s
+///     second operand, and no `Self` return for `_clone`. Not one
+///     `_toDbgString` reaches the artifact, which is the whole Debug column.
+///     Those three mappings are the fix.
 ///   * `haskell` (10) - the recursive-type carve-out moved it 11 -> 10, so its
 ///     `_partialEq` / `_cmp` / `_hash` now reach the artifact. The remaining
 ///     Debug / Clone / Default do NOT, for a different reason: Haskell routes
@@ -870,7 +882,7 @@ fn declared_count(derives: &BTreeSet<String>) -> usize {
 pub const BASELINE: &[(&str, usize)] = &[
     ("python", 36),
     ("zig", 19),
-    ("php-ext", 134),
+    ("php-ext", 129),
     ("ocaml", 4010),
     ("haskell", 10),
     ("go", 19),

--- a/doc/src/lint_derives.rs
+++ b/doc/src/lint_derives.rs
@@ -816,28 +816,23 @@ pub fn check(codegen_dir: &Path, api: &ApiData) -> anyhow::Result<Vec<BindingRep
 ///     `compare`: the ABI answers 255 for "incomparable" and a total compare
 ///     has no honest value for it. Needed in all three emitters - struct,
 ///     tagged union, unit enum.
-///   * `php-ext` (129, was 134) - correctly measured, unlike ocaml: the
-///     artifact really does name `AzApp_*` symbols, and the 1744 absent are a
-///     genuinely curated surface of 29 classes. `is_method_kind_eligible`
-///     said the trait helpers were "skipped entirely for now"; admitting them
-///     landed `_partialEq`, `_hash`, `_cmp` and `_clone` for Dom, Button and
-///     WindowCreateOptions, and NOTHING else - because eligibility is only the
-///     precondition. `render_method` still returns None for the rest: the
-///     marshalling table has no `AzString` RETURN (only the argument
-///     direction), no same-type `*const Az{T}` argument for `_partialEq`'s
-///     second operand, and no `Self` return for `_clone`. Not one
-///     `_toDbgString` reaches the artifact, which is the whole Debug column.
-///     Those three mappings are the fix.
-///     BLOCKED, 2026-09-05, and deliberately not guessed: of the three
-///     missing shapes only the `AzString` RETURN still matters (the
-///     same-class ref arg and the `Self` return are already handled -
-///     `marshal_arg` case 2 and `marshal_return`'s receiver arm). There is
-///     no `as_str` or `From<AzString> for String` on the generated
-///     surface, so emitting it means hand-written unsafe slice code over
-///     `.vec.ptr` / `.vec.len` plus an `AzString_delete` - and NOTHING in
-///     our gates compiles this crate, so a mistake would ship silently.
-///     That is the one combination where guessing is worst: unverifiable
-///     AND unsafe. Needs a conversion helper on the dll surface first.
+///   * `php-ext` (125) - the `AzString` RETURN is now handled, which was the
+///     whole Debug column: `AzString::as_str` does exist on the external
+///     surface (it handles non-UTF8 by taking the longest valid prefix), so
+///     the arm needs no hand-written pointer code - just `as_str().to_string()`
+///     and an `AzString_delete`, since AzString owns a heap buffer and has no
+///     Drop of its own. An earlier pass recorded this as blocked on a missing
+///     helper; that was wrong, the helper was there.
+///     It only moved 129 -> 125, and the reason is NOT a marshalling gap:
+///     `PHP_CLASS_ALLOWLIST` is exactly five classes - Dom, App, AppConfig,
+///     WindowCreateOptions, Button - and everything else gets no PHP class at
+///     all. The remaining 125 are derives on types this extension
+///     DELIBERATELY does not expose; they count as present only because their
+///     `extern` declarations name them.
+///     NEXT STEP, and it is a MEASUREMENT fix rather than an emitter one:
+///     php-ext's presence test should key on the registered PHP class
+///     (`Azul{T}`), not the extern symbol - exactly the correction ocaml
+///     needed. Until then this number describes the curation, not a defect.
 ///   * `haskell` (10) - the recursive-type carve-out moved it 11 -> 10, so its
 ///     `_partialEq` / `_cmp` / `_hash` now reach the artifact. The remaining
 ///     Debug / Clone / Default do NOT, for a different reason: Haskell routes
@@ -891,7 +886,7 @@ fn declared_count(derives: &BTreeSet<String>) -> usize {
 pub const BASELINE: &[(&str, usize)] = &[
     ("python", 36),
     ("zig", 13),
-    ("php-ext", 129),
+    ("php-ext", 125),
     ("ocaml", 11),
     ("haskell", 10),
     ("go", 13),

--- a/doc/src/lint_derives.rs
+++ b/doc/src/lint_derives.rs
@@ -756,19 +756,19 @@ pub fn check(codegen_dir: &Path, api: &ApiData) -> anyhow::Result<Vec<BindingRep
 ///     CATEGORY - `ImageRef`, `Svg`, `PhysicalSizeU32`, `GlVoidPtrConst`.
 ///     Closing them means revisiting those category exclusions, which is a
 ///     separate decision from routing a capability.
-///   * `go` (2246, was 5648) - structs and unit-only enums are closed. The
-///     struct half was the same gate-plus-emitter pair zig needed; unit enums
-///     are real named Go types (`type AzAccessibilityRole uint32`), so they
-///     simply take methods. Go gets idiomatic spellings - `Equal`, `Order`,
-///     `PartialOrder`, `Hash`, and a `String()` implementing fmt.Stringer that
-///     frees the `AzString` (GoStr only copies, so it would otherwise leak one
-///     per call).
-///     What is LEFT is TAGGED UNIONS, and it is a redesign rather than a
-///     missing call: Go models them as a sealed INTERFACE
-///     (`type AzCssProperty interface { isAzCssProperty() }`) whose variant
-///     structs hold no C value, so there is no `C.Az*` whose address a trait
-///     entry point could take. Wiring it means having the variant types carry
-///     the union. Recorded, not guessed at.
+///   * `go` (19, was 5648) - effectively closed, and the last step corrects a
+///     wrong call recorded here earlier. Structs needed the gate-plus-emitter
+///     pair; unit enums are named Go types and simply take methods; TAGGED
+///     UNIONS were written off as "a redesign, because the sealed interface
+///     holds no C value". That was wrong. Every generated signature that takes
+///     a union already takes `C.AzCssProperty`, not the interface - the raw
+///     type IS the currency a Go caller holds - so free functions over it
+///     (`CssPropertyEqual`, `CssPropertyString`, ...) are the honest fit and
+///     the interface stays what it was, a type-switch aid. 2246 -> 583.
+///     `Clone` and `Default` then closed the rest: both are real derives, and
+///     neither is an instance method (`Default` has no receiver at all, so it
+///     is a package-level function).
+///     The last 19 match zig's: types the emitter excludes BY CATEGORY.
 ///   * `4-20` in the remaining tail — `Xml`, `XmlNodeChild` and
 ///     `ResultXmlXmlError`, three classes whose entry points these emitters
 ///     drop for a reason not yet established. Consistent across every binding
@@ -833,7 +833,7 @@ pub const BASELINE: &[(&str, usize)] = &[
     ("php-ext", 134),
     ("ocaml", 272),
     ("haskell", 10),
-    ("go", 2246),
+    ("go", 19),
 ];
 
 /// Compare against [`BASELINE`] and render the verdict.

--- a/doc/src/lint_derives.rs
+++ b/doc/src/lint_derives.rs
@@ -742,9 +742,20 @@ pub fn check(codegen_dir: &Path, api: &ApiData) -> anyhow::Result<Vec<BindingRep
 ///     `#[pyclass]` at all. Closing them means DECIDING which of them belong
 ///     in the Python surface and giving them one - a product call, not a
 ///     routing change - so it is logged rather than guessed.
-///   * `zig` / `go` — the wrapper emitters whitelist
-///     `Constructor | Method | MethodMut | StaticMethod | Default | DeepCopy`,
-///     so the comparison and debug entry points reach the artifact zero times.
+///   * `zig` (603, was 5168) - two of three causes closed. The wrapper gate
+///     excluded every trait kind, so a class whose only exports were
+///     `_partialEq`/`_cmp`/`_hash`/`_toDbgString` got no wrapper at all - and
+///     `azul.zig` redeclares nothing (`@cImport` parses `azul.h`), so a C
+///     symbol no wrapper calls cannot be spelled from Zig. Enums then needed
+///     their own emitter, because an enum wrapper holds a raw tagged union
+///     rather than an `inner` field. What is LEFT is the third case: a
+///     FIELDLESS C enum (`AccessibilityRole`) gets no wrapper of any kind - it
+///     appears only as a `C.Az*` parameter type - so its derives have nowhere
+///     to hang. Closing it means emitting a wrapper for plain enums.
+///   * `go` (5648) - the same whitelist defect zig had, untouched. The fix is
+///     the pair that worked here: admit the trait kinds to `has_useful_method`
+///     AND emit the methods. Doing only the first makes the number WORSE,
+///     because the class then exists as a wrapper with nothing on it.
 ///   * `4-20` in the remaining tail — `Xml`, `XmlNodeChild` and
 ///     `ResultXmlXmlError`, three classes whose entry points these emitters
 ///     drop for a reason not yet established. Consistent across every binding
@@ -792,7 +803,7 @@ fn declared_count(derives: &BTreeSet<String>) -> usize {
 pub const BASELINE: &[(&str, usize)] = &[
     ("python", 36),
     ("freebasic", 11),
-    ("zig", 5168),
+    ("zig", 603),
     ("powershell", 4),
     ("php-ext", 134),
     ("ocaml", 272),

--- a/doc/src/lint_derives.rs
+++ b/doc/src/lint_derives.rs
@@ -73,6 +73,13 @@ pub enum Expect {
         start: &'static [&'static str],
         markers: &'static [&'static str],
     },
+    /// Honoured iff ANY alternative is. Needed where one binding gives the same
+    /// capability two different shapes for two different kinds of class - C++
+    /// puts `toDbgString()` inside a wrapper class for a struct, and offers
+    /// `azul::toDbgString(const AzAlertKind&)` as a free function for an enum,
+    /// which has no class to put it in.
+    Either(&'static [Expect]),
+
     /// The language has no equivalent AND forwarding the ABI function would be
     /// meaningless. Reported as N/A, never as a gap.
     NotApplicable(&'static str),
@@ -186,34 +193,58 @@ const PY_BLOCK: &[&str] = &["#[pymethods]\nimpl {T} {"];
 /// comparisons, and not at all for `toDbgString`/`hash`, so the latter two are
 /// matched inside the wrapper class block.
 const CPP_BLOCK: &[&str] = &["class {C} {"];
+
+/// The two shapes a C++ capability can take.
+///
+/// A struct becomes `class Foo { .. String toDbgString() const; .. }`, so the
+/// evidence is a method inside that class's own block. An ENUM or tagged union
+/// becomes `using Foo = AzFoo;` or `namespace Foo { constants }` over the raw C
+/// type - there is no class to put a method in, so the same capability is a
+/// free function overloaded on the argument type,
+/// `azul::toDbgString(const AzFoo&)`. Both spell the class out, so both are
+/// attributable; neither is the raw-C escape hatch (`AzFoo_toDbgString` from
+/// the `#include`d header still does not count).
 const CPP_PROFILE: &[(&str, Expect)] = &[
     (
         "Debug",
-        Expect::Block { start: CPP_BLOCK, markers: &["toDbgString() const", "operator<<"] },
+        Expect::Either(&[
+            Expect::Block { start: CPP_BLOCK, markers: &["toDbgString() const", "operator<<"] },
+            Expect::Marker(&["toDbgString(const {T}&"]),
+        ]),
     ),
     (
         "Clone",
-        Expect::Block { start: CPP_BLOCK, markers: &["clone() const"] },
+        Expect::Either(&[
+            Expect::Block { start: CPP_BLOCK, markers: &["clone() const"] },
+            Expect::Marker(&["clone(const {T}&"]),
+        ]),
     ),
     ("Copy", COPY_NA),
     (
         "PartialEq",
-        Expect::Marker(&["partialEq(const {C}&", "operator==(const {C}&"]),
+        Expect::Marker(&["partialEq(const {C}&", "operator==(const {C}&", "partialEq(const {T}&"]),
     ),
     ("Eq", EQ_NA),
     (
         "PartialOrd",
-        Expect::Marker(&["partialCmp(const {C}&", "operator<(const {C}&"]),
+        Expect::Marker(&[
+            "partialCmp(const {C}&",
+            "operator<(const {C}&",
+            "partialCmp(const {T}&",
+        ]),
     ),
     (
         "Ord",
-        Expect::Marker(&["cmp(const {C}&", "operator<=>(const {C}&"]),
+        Expect::Marker(&["cmp(const {C}&", "operator<=>(const {C}&", "cmp(const {T}&"]),
     ),
     (
         "Hash",
-        Expect::Block { start: CPP_BLOCK, markers: &["hash() const", "struct hash<"] },
+        Expect::Either(&[
+            Expect::Block { start: CPP_BLOCK, markers: &["hash() const", "struct hash<"] },
+            Expect::Marker(&["hash(const {T}&"]),
+        ]),
     ),
-    ("Default", Expect::Marker(&["static {C} default_()"])),
+    ("Default", Expect::Marker(&["static {C} default_()", "defaultOf<{T}>()"])),
 ];
 
 /// Go. cgo makes `C.Az{T}_partialEq` reachable, which does not count under this
@@ -541,6 +572,42 @@ pub fn declared_derives(api: &ApiData) -> BTreeMap<String, BTreeSet<String>> {
     out
 }
 
+/// Does this binding's text carry the evidence one [`Expect`] asks for?
+///
+/// Recursive only through [`Expect::Either`]; `NotApplicable` and `Unmapped`
+/// are verdicts, not searches, and are handled by the caller (they return
+/// `false` here so a mis-nested one can never be read as a pass).
+fn evidence_found(
+    expect: &Expect,
+    text: &str,
+    abi_index: &BTreeSet<(String, String)>,
+    block_end: &str,
+    spelled: &str,
+    class: &str,
+) -> bool {
+    match expect {
+        Expect::NotApplicable(_) | Expect::Unmapped(_) => false,
+        Expect::Either(alts) => alts
+            .iter()
+            .any(|e| evidence_found(e, text, abi_index, block_end, spelled, class)),
+        Expect::Marker(pats) => pats.iter().any(|p| {
+            let needle = p.replace("{T}", spelled).replace("{C}", class);
+            // The ABI-symbol case goes through the prebuilt index; anything
+            // else is a plain token search.
+            if let Some(suffix) = needle.strip_prefix(spelled) {
+                if suffix.starts_with('_')
+                    && suffix.bytes().all(|c| c.is_ascii_alphanumeric() || c == b'_')
+                {
+                    return abi_index.contains(&(class.to_string(), suffix.to_string()));
+                }
+            }
+            contains_token(text, &needle)
+        }),
+        Expect::Block { start, markers } => class_block(text, start, block_end, spelled, class)
+            .is_some_and(|b| markers.iter().any(|m| b.contains(*m))),
+    }
+}
+
 /// Run the lint over every binding.
 pub fn check(codegen_dir: &Path, api: &ApiData) -> anyhow::Result<Vec<BindingReport>> {
     let declared = declared_derives(api);
@@ -597,56 +664,38 @@ pub fn check(codegen_dir: &Path, api: &ApiData) -> anyhow::Result<Vec<BindingRep
                     .map(|(_, e)| e)
                     .unwrap_or(&Expect::Unmapped("no entry in this binding's profile"));
 
+                // `NotApplicable` and `Unmapped` are verdicts in themselves and
+                // never reach the evidence search; everything else does.
                 match expect {
-                    Expect::NotApplicable(_) => rep.not_applicable += 1,
-                    Expect::Unmapped(_) => rep.unmapped += 1,
-                    Expect::Marker(pats) => {
-                        let hit = pats.iter().any(|p| {
-                            let needle = p.replace("{T}", &spelled).replace("{C}", class);
-                            // The ABI-symbol case goes through the prebuilt
-                            // index; anything else is a plain token search.
-                            if let Some(suffix) = needle.strip_prefix(spelled.as_str()) {
-                                if suffix.starts_with('_')
-                                    && suffix.bytes().all(|c| c.is_ascii_alphanumeric() || c == b'_')
-                                {
-                                    return abi_index
-                                        .contains(&(class.clone(), suffix.to_string()));
-                                }
-                            }
-                            contains_token(&text, &needle)
-                        });
-                        if hit {
-                            rep.honoured += 1;
-                        } else {
-                            rep.missing += 1;
-                            *rep.missing_by_derive.entry((*derive).to_string()).or_insert(0) += 1;
-                            if rep.examples.len() < 40 {
-                                rep.examples.push(Gap {
-                                    binding: binding.name.to_string(),
-                                    class: class.clone(),
-                                    derive: (*derive).to_string(),
-                                });
-                            }
-                        }
+                    Expect::NotApplicable(_) => {
+                        rep.not_applicable += 1;
+                        continue;
                     }
-                    Expect::Block { start, markers } => {
-                        let block =
-                            class_block(&text, start, binding.block_end, &spelled, class);
-                        let hit =
-                            block.is_some_and(|b| markers.iter().any(|m| b.contains(*m)));
-                        if hit {
-                            rep.honoured += 1;
-                        } else {
-                            rep.missing += 1;
-                            *rep.missing_by_derive.entry((*derive).to_string()).or_insert(0) += 1;
-                            if rep.examples.len() < 40 {
-                                rep.examples.push(Gap {
-                                    binding: binding.name.to_string(),
-                                    class: class.clone(),
-                                    derive: (*derive).to_string(),
-                                });
-                            }
-                        }
+                    Expect::Unmapped(_) => {
+                        rep.unmapped += 1;
+                        continue;
+                    }
+                    _ => {}
+                }
+                let hit = evidence_found(
+                    expect,
+                    &text,
+                    &abi_index,
+                    binding.block_end,
+                    &spelled,
+                    class,
+                );
+                if hit {
+                    rep.honoured += 1;
+                } else {
+                    rep.missing += 1;
+                    *rep.missing_by_derive.entry((*derive).to_string()).or_insert(0) += 1;
+                    if rep.examples.len() < 40 {
+                        rep.examples.push(Gap {
+                            binding: binding.name.to_string(),
+                            class: class.clone(),
+                            derive: (*derive).to_string(),
+                        });
                     }
                 }
             }
@@ -663,20 +712,11 @@ pub fn check(codegen_dir: &Path, api: &ApiData) -> anyhow::Result<Vec<BindingRep
 /// a baseline that is only ever checked as an upper bound goes stale the day
 /// after it is written and then proves nothing.
 ///
-/// A binding absent from this table must have ZERO gaps. Fourteen are, today:
-/// the three Rust mirrors, memtest, C, Ruby, Lua, Pascal, Ada, PHP, Perl,
-/// Common Lisp, Algol 68, COBOL and the public Rust API.
+/// A binding absent from this table must have ZERO gaps. Twenty are, today:
+/// the three Rust mirrors, memtest, all six C++ dialects, C, Ruby, Lua,
+/// Pascal, Ada, PHP, Perl, Common Lisp, Algol 68 and COBOL.
 ///
-/// WHAT EACH NUMBER IS, IN ONE LINE (measured 2026-09-04):
-///   * `rust-public` (was 7122) — `azul.rs` was `UsingDerive` with no `extern`
-///     block, a combination that could not compile in either direction. It is
-///     now `UsingCAPI` + `ExternalBindings`, the same shape as
-///     `dll_api_external.rs`; see `CodegenConfig::rust_public_api`.
-///   * `cpp11` / `cpp14` — those two emitters alone apply
-///     `should_skip_method`, which drops every `is_trait_function()` kind;
-///     cpp03/17/20/23 do not, which is why they sit at 2133 instead of ~5600.
-///   * every `cpp*` — enums and tagged unions get no wrapper class, so a
-///     declaring enum gets no method however the filter is set.
+/// WHAT EACH REMAINING NUMBER IS, IN ONE LINE (measured 2026-09-05):
 ///   * `python` — `lang_python.rs` drops trait kinds, then `generate_pymethod`
 ///     bails on `fn_body: None`, which every synthesised trait fn has. Only
 ///     `__str__`/`__repr__` survive; there is no `__eq__`, `__hash__` or
@@ -689,13 +729,20 @@ pub fn check(codegen_dir: &Path, api: &ApiData) -> anyhow::Result<Vec<BindingRep
 ///     wholesale (C# emits no VecDestructor function at all, not just no debug).
 ///   * `ocaml` — every capability IS generated in `azul.ml` and the `.mli`
 ///     exports only `clone` and `default`, so a consumer can reach nothing else.
+///
+/// WHAT CAME OFF THIS TABLE, AND HOW:
+///   * `rust-public` (was 7122) — `azul.rs` was `UsingDerive` with no `extern`
+///     block, a combination that could not compile in either direction. It is
+///     now `UsingCAPI` + `ExternalBindings`, the same shape as
+///     `dll_api_external.rs`; see `CodegenConfig::rust_public_api`.
+///   * `cpp11` / `cpp14` (were 5682 / 5568) — those two emitters alone applied
+///     `should_skip_method`, which drops every `is_trait_function()` kind. They
+///     now filter on `is_constructor_or_default` like the other four.
+///   * every `cpp*` (2133 each) — enums and tagged unions get no wrapper class
+///     to hang a method on, so their capabilities are now free functions
+///     overloaded on the argument type; see
+///     `lang_cpp::common::generate_freefn_trait_helpers`.
 pub const BASELINE: &[(&str, usize)] = &[
-    ("cpp03", 2133),
-    ("cpp11", 5682),
-    ("cpp14", 5568),
-    ("cpp17", 2133),
-    ("cpp20", 2133),
-    ("cpp23", 2133),
     ("csharp", 114),
     ("python", 4671),
     ("freebasic", 124),

--- a/doc/src/lint_derives.rs
+++ b/doc/src/lint_derives.rs
@@ -801,17 +801,21 @@ pub fn check(codegen_dir: &Path, api: &ApiData) -> anyhow::Result<Vec<BindingRep
 ///     `ResultXmlXmlError`, three classes whose entry points these emitters
 ///     drop for a reason not yet established. Consistent across every binding
 ///     that has a residue at all, so it is one cause, not fourteen.
-///   * `ocaml` (100, was 4010 once measured properly) - the `.mli` SEALS the
+///   * `ocaml` (11, was 4010 once measured properly) - the `.mli` SEALS the
 ///     module, so anything the interface omits is unreachable however complete
-///     `azul.ml` is. Fixed: equal/hash/to_string were defined and never
-///     declared; `compare` was emitted nowhere (2 in the file against 704
-///     `equal`); tagged unions had no module; unit-only enums needed their
-///     capabilities on the module `types.rs` already emits, allocating a cell
-///     because an int view is not addressable.
-///     `PartialOrd` gets `partial_compare : t -> t -> int option`, NOT
-///     `compare`: the ABI answers 255 for "incomparable" and a total `compare`
-///     has no honest value for that. The profile accepts either spelling.
-///     Every capability is decided by ONE predicate both emitters call.
+///     `azul.ml` is. equal/hash/to_string were defined and never declared;
+///     `compare` was emitted nowhere; tagged unions and unit enums had no
+///     capabilities at all; and trait-only classes got no module.
+///     That last one FAILED the first time (272 -> 1321) and succeeded later,
+///     which is the useful lesson: a module carrying three of a class's seven
+///     derives makes the other four flip from `absent` to `missing`, so the
+///     change was not wrong, only premature. Once the module carried the whole
+///     list the same edit was a clean win. Record WHY a revert happened, not
+///     just that it did.
+///     `PartialOrd` gets `partial_compare : t -> t -> int option`, never
+///     `compare`: the ABI answers 255 for "incomparable" and a total compare
+///     has no honest value for it. Needed in all three emitters - struct,
+///     tagged union, unit enum.
 ///   * `php-ext` (129, was 134) - correctly measured, unlike ocaml: the
 ///     artifact really does name `AzApp_*` symbols, and the 1744 absent are a
 ///     genuinely curated surface of 29 classes. `is_method_kind_eligible`
@@ -888,7 +892,7 @@ pub const BASELINE: &[(&str, usize)] = &[
     ("python", 36),
     ("zig", 13),
     ("php-ext", 129),
-    ("ocaml", 100),
+    ("ocaml", 11),
     ("haskell", 10),
     ("go", 13),
 ];

--- a/doc/src/lint_derives.rs
+++ b/doc/src/lint_derives.rs
@@ -620,7 +620,7 @@ pub fn check(codegen_dir: &Path, api: &ApiData) -> anyhow::Result<Vec<BindingRep
                         } else {
                             rep.missing += 1;
                             *rep.missing_by_derive.entry((*derive).to_string()).or_insert(0) += 1;
-                            if rep.examples.len() < 5 {
+                            if rep.examples.len() < 40 {
                                 rep.examples.push(Gap {
                                     binding: binding.name.to_string(),
                                     class: class.clone(),
@@ -639,7 +639,7 @@ pub fn check(codegen_dir: &Path, api: &ApiData) -> anyhow::Result<Vec<BindingRep
                         } else {
                             rep.missing += 1;
                             *rep.missing_by_derive.entry((*derive).to_string()).or_insert(0) += 1;
-                            if rep.examples.len() < 5 {
+                            if rep.examples.len() < 40 {
                                 rep.examples.push(Gap {
                                     binding: binding.name.to_string(),
                                     class: class.clone(),
@@ -663,15 +663,15 @@ pub fn check(codegen_dir: &Path, api: &ApiData) -> anyhow::Result<Vec<BindingRep
 /// a baseline that is only ever checked as an upper bound goes stale the day
 /// after it is written and then proves nothing.
 ///
-/// A binding absent from this table must have ZERO gaps. Thirteen are, today:
+/// A binding absent from this table must have ZERO gaps. Fourteen are, today:
 /// the three Rust mirrors, memtest, C, Ruby, Lua, Pascal, Ada, PHP, Perl,
-/// Common Lisp, Algol 68 and COBOL.
+/// Common Lisp, Algol 68, COBOL and the public Rust API.
 ///
 /// WHAT EACH NUMBER IS, IN ONE LINE (measured 2026-09-04):
-///   * `rust-public` — `azul.rs` is `UsingDerive` with NO `extern` block and no
-///     `include!` site in the tree; `generator.rs` marks it "legacy, may be
-///     removed". The LIVE public Rust API is `reexports.rs`, which aliases into
-///     whichever `dll_api_*` is compiled and therefore already inherits the fix.
+///   * `rust-public` (was 7122) — `azul.rs` was `UsingDerive` with no `extern`
+///     block, a combination that could not compile in either direction. It is
+///     now `UsingCAPI` + `ExternalBindings`, the same shape as
+///     `dll_api_external.rs`; see `CodegenConfig::rust_public_api`.
 ///   * `cpp11` / `cpp14` — those two emitters alone apply
 ///     `should_skip_method`, which drops every `is_trait_function()` kind;
 ///     cpp03/17/20/23 do not, which is why they sit at 2133 instead of ~5600.
@@ -690,7 +690,6 @@ pub fn check(codegen_dir: &Path, api: &ApiData) -> anyhow::Result<Vec<BindingRep
 ///   * `ocaml` — every capability IS generated in `azul.ml` and the `.mli`
 ///     exports only `clone` and `default`, so a consumer can reach nothing else.
 pub const BASELINE: &[(&str, usize)] = &[
-    ("rust-public (azul.rs)", 7122),
     ("cpp03", 2133),
     ("cpp11", 5682),
     ("cpp14", 5568),
@@ -796,4 +795,33 @@ pub fn verdict(reports: &[BindingReport]) -> (bool, String) {
         );
     }
     (ok, out)
+}
+
+/// The per-derive breakdown behind the table, for one binding or all of them.
+///
+/// The table says "cpp11: 5682 missing"; this says WHICH 5682 — how they split
+/// across `Debug`/`PartialEq`/`Hash`/..., and a sample of the classes. It is a
+/// reporting helper only: it computes nothing the verdict does not already
+/// compute and cannot change a pass into a fail or back.
+pub fn details(reports: &[BindingReport], only: Option<&str>) -> String {
+    use std::fmt::Write as _;
+    let mut out = String::new();
+    for r in reports {
+        if let Some(want) = only {
+            if r.binding != want {
+                continue;
+            }
+        }
+        if r.missing == 0 {
+            continue;
+        }
+        let _ = writeln!(out, "\n{} - {} unreachable", r.binding, r.missing);
+        for (d, n) in &r.missing_by_derive {
+            let _ = writeln!(out, "    {d:<12} {n}");
+        }
+        for g in &r.examples {
+            let _ = writeln!(out, "    e.g. {} :: {}", g.class, g.derive);
+        }
+    }
+    out
 }

--- a/doc/src/lint_derives.rs
+++ b/doc/src/lint_derives.rs
@@ -636,6 +636,22 @@ pub fn check(codegen_dir: &Path, api: &ApiData) -> anyhow::Result<Vec<BindingRep
         };
 
         for (class, derives) in &declared {
+            // OWNER'S RULING, 2026-09-05: a `*VecDestructor` cannot be called
+            // from Python or any other high-level binding. It exists only so
+            // destruction behaves correctly, and its payload is a function
+            // pointer - so it is to be treated as `*const c_void` and excluded
+            // from generation. Its derives are therefore NOT missing in a
+            // wrapper surface; they are not applicable there.
+            //
+            // The exception is the surfaces that DO carry it as a first-class
+            // type and really do implement its derives today: the three Rust
+            // mirrors, the layout test, and the C header. Excluding it there
+            // would delete a check that currently passes, which is the one
+            // thing this file must never do.
+            if class.ends_with("VecDestructor") && !DESTRUCTOR_BEARING.contains(&binding.name) {
+                rep.not_applicable += declared_count(derives);
+                continue;
+            }
             let spelled = format!("{}{}", binding.prefix, class);
             // Is this class emitted in this binding at all? A class that never
             // ships here cannot have a derive gap here; it is reported in its
@@ -718,12 +734,14 @@ pub fn check(codegen_dir: &Path, api: &ApiData) -> anyhow::Result<Vec<BindingRep
 /// Algol 68 and COBOL.
 ///
 /// WHAT EACH REMAINING NUMBER IS, IN ONE LINE (measured 2026-09-05):
-///   * `python` (150) — every class that HAS a pyclass now honours its whole
-///     derive list. What is left is 185 classes that have no pyclass at all:
-///     the 114 `*VecDestructor`s (`DestructorOrClone`, excluded wholesale) and
-///     the monomorphised `*Value` aliases (`pub type LayoutWidthValue =
-///     AzCssPropertyValue<..>`, which cannot BE a pyclass). Closing it means
-///     giving those types a pyclass, not routing a capability differently.
+///   * `python` (36) - the `*VecDestructor`s are now excluded by the owner's
+///     2026-09-05 ruling (opaque function pointer, treated as `*const c_void`,
+///     never generated), which cleared 114 of the original 150. What is left
+///     is NOT type aliases and NOT plumbing: `PhysicalSizeU32`, `RefAny`,
+///     `GLintVec`, `GLuintVec` and `ResultXmlXmlError` are real types with no
+///     `#[pyclass]` at all. Closing them means DECIDING which of them belong
+///     in the Python surface and giving them one - a product call, not a
+///     routing change - so it is logged rather than guessed.
 ///   * `zig` / `go` — the wrapper emitters whitelist
 ///     `Constructor | Method | MethodMut | StaticMethod | Default | DeepCopy`,
 ///     so the comparison and debug entry points reach the artifact zero times.
@@ -759,8 +777,20 @@ pub fn check(codegen_dir: &Path, api: &ApiData) -> anyhow::Result<Vec<BindingRep
 ///     `should_emit_function` filters excluded the whole `DestructorOrClone`
 ///     category, including the one entry point a `derive` actually asks for.
 ///     They now share `FunctionKind::is_declared_capability`.
+/// The surfaces that carry `*VecDestructor` as a first-class type and really
+/// do implement its derives. Everywhere else it is opaque - see the ruling at
+/// the exclusion site.
+const DESTRUCTOR_BEARING: &[&str] =
+    &["rust-internal", "rust-dynamic", "rust-public", "memtest", "c"];
+
+/// How many of `DERIVES` a class actually declares - the number the exclusion
+/// has to add to `not_applicable` so the columns still sum to the same total.
+fn declared_count(derives: &BTreeSet<String>) -> usize {
+    DERIVES.iter().filter(|d| derives.contains(**d)).count()
+}
+
 pub const BASELINE: &[(&str, usize)] = &[
-    ("python", 150),
+    ("python", 36),
     ("freebasic", 11),
     ("zig", 5168),
     ("powershell", 4),

--- a/doc/src/lint_derives.rs
+++ b/doc/src/lint_derives.rs
@@ -798,25 +798,20 @@ pub fn check(codegen_dir: &Path, api: &ApiData) -> anyhow::Result<Vec<BindingRep
 ///     `ResultXmlXmlError`, three classes whose entry points these emitters
 ///     drop for a reason not yet established. Consistent across every binding
 ///     that has a residue at all, so it is one cause, not fourteen.
-///   * `ocaml` (4010) - THIS NUMBER WENT UP, and nothing regressed. It was
-///     272 because the check could not see this binding at all: it matched
-///     `Az{T}_partialEq` against `azul.mli`, which spells the FFI type
-///     `az_accessibility_action`, the module `AccessibilityAction`, and never
-///     mentions a C symbol (those live in `azul.ml` as `foreign "..."`
-///     strings). It reported 0 honoured and 1703 absent - blind to all 1718
-///     modules the interface publishes. `OCAML_PROFILE` now asks in OCaml's
-///     own vocabulary (`val equal`, `val hash`, `val to_string`, `val clone`,
-///     `val default`, `val compare` inside `module {T} : sig`), and the real
-///     figure is 1770 honoured / 4010 missing.
-///     Most of the 4010 is `compare`: the interface publishes 704 `equal`,
-///     754 `to_string`, 560 `clone`, 496 `default`, 399 `hash` - and TWO
-///     `compare`, so nearly every declared Ord/PartialOrd is genuinely
-///     unreachable. Enums now get a module too (they had none, which was the
-///     original diagnosis and was real), carrying equal/hash/to_string/default.
-///     LESSON, worth more than the fix: a binding reporting a suspiciously
-///     SMALL gap deserves the same scrutiny as a large one. 0 honoured is not
-///     a good sign, it is the signature of a profile that does not match its
-///     artifact.
+///   * `ocaml` (1233, was 4010 once measured properly) - three fixes, all the
+///     same fault in different places: the `.mli` SEALS the module, so a value
+///     the interface does not list is unreachable however complete the `.ml`
+///     is. (1) The implementation defined `equal` / `hash` / `to_string` and
+///     the interface declared none of them. (2) Nothing emitted `compare` at
+///     all: 2 in the whole file against 704 `equal`, so almost every declared
+///     Ord/PartialOrd was dead. It maps the ABI's 0/1/2 onto OCaml's
+///     negative/zero/positive - an exact correspondence, not an invention.
+///     (3) Enums had no module at all and now carry the same six.
+///     Every capability is decided by ONE predicate used by both emitters,
+///     because the two drifting is the whole bug.
+///     The residue is unit-only enums (`AccessibilityRole`): they are plain C
+///     enums with no `Ctypes.structure`, so the pointer-taking `Ctypes.addr`
+///     shape these helpers use does not apply. Different plumbing, logged.
 ///   * `php-ext` (129, was 134) - correctly measured, unlike ocaml: the
 ///     artifact really does name `AzApp_*` symbols, and the 1744 absent are a
 ///     genuinely curated surface of 29 classes. `is_method_kind_eligible`
@@ -883,7 +878,7 @@ pub const BASELINE: &[(&str, usize)] = &[
     ("python", 36),
     ("zig", 19),
     ("php-ext", 129),
-    ("ocaml", 4010),
+    ("ocaml", 1233),
     ("haskell", 10),
     ("go", 19),
 ];

--- a/doc/src/lint_derives.rs
+++ b/doc/src/lint_derives.rs
@@ -1,0 +1,799 @@
+//! Derive-parity lint: every capability a class DECLARES in api.json must be
+//! reachable from every binding that ships that class.
+//!
+//! WHY THIS EXISTS
+//! ---------------
+//! `api.json` records a `derive` list per class — 1889 of them. That list is
+//! not documentation: `IrBuilder::build_trait_functions` turns it into real
+//! C-ABI exports (`Az{T}_partialEq`, `Az{T}_partialCmp`, `Az{T}_cmp`,
+//! `Az{T}_hash`, `Az{T}_toDbgString`, `Az{T}_default`, `Az{T}_clone`), and the
+//! shipped `libazul` exports every one of them. Whether a *binding* then hands
+//! those exports to its users is a separate decision made independently in each
+//! of the ~38 language emitters, and until this lint existed nothing compared
+//! the two. The failure mode is silent and one-directional: the export is in
+//! the library, the caller has no way to name it.
+//!
+//! That is not hypothetical. `dll_api_external.rs` (the `link-dynamic` Rust
+//! binding) declared all 1456 `_partialEq` externs and implemented `PartialEq`
+//! for none of them, so `MsgBox::yes_no(..) == YesNo::Yes` did not compile for
+//! any dynamically-linked caller while the identical statically-linked build
+//! was fine.
+//!
+//! WHAT IT CHECKS, AND HOW STUPID IT IS ON PURPOSE
+//! ----------------------------------------------
+//! Name-based presence, nothing more. For each (binding, class, derive) it asks
+//! "does this binding's own generated text contain a name that gives the caller
+//! this capability for this class". It does not parse, type-check, or run
+//! anything, and it cannot: the artifacts are 38 different languages. A false
+//! PASS therefore needs a name to exist while being unusable, which is a much
+//! rarer bug than the one this catches, and the compile gates catch it.
+//!
+//! THE ONE JUDGEMENT CALL, STATED
+//! ------------------------------
+//! A derive counts as honoured when the binding's OWN emitted text names the
+//! entry point (or a native equivalent). Being able to reach the C symbol
+//! through the language's raw-C escape hatch does NOT count — `#include
+//! "azul.h"` from a C++ header, `C.AzFoo_partialEq` through cgo, `@cImport` in
+//! Zig. Under any other rule every binding that can call C would pass by
+//! definition and the lint would measure nothing.
+
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fs,
+    path::Path,
+};
+
+use crate::api::ApiData;
+
+/// The nine things an api.json `derive` list can say.
+pub const DERIVES: &[&str] = &[
+    "Debug",
+    "Clone",
+    "Copy",
+    "PartialEq",
+    "Eq",
+    "PartialOrd",
+    "Ord",
+    "Hash",
+    "Default",
+];
+
+/// What a binding must contain for one declared derive.
+#[derive(Clone, Copy)]
+pub enum Expect {
+    /// Honoured iff any pattern occurs in the binding's own text, with `{T}`
+    /// replaced by the class name as that binding spells it (prefix applied).
+    Marker(&'static [&'static str]),
+    /// Honoured iff any `markers` entry occurs inside the class's own block —
+    /// the text from the first `start` match to the next `block_end`. Needed
+    /// wherever the native construct does not carry the class name in it
+    /// (`__eq__`, `uint64_t hash() const`), which a flat substring search
+    /// cannot attribute to a class.
+    Block {
+        start: &'static [&'static str],
+        markers: &'static [&'static str],
+    },
+    /// The language has no equivalent AND forwarding the ABI function would be
+    /// meaningless. Reported as N/A, never as a gap.
+    NotApplicable(&'static str),
+    /// No mapping could be decided. Excluded from the pass/fail verdict and
+    /// reported separately, so an undecided case can never masquerade as a pass.
+    Unmapped(&'static str),
+}
+
+/// Markers shared by every binding that forwards the C ABI by symbol name.
+const ABI_DEBUG: Expect = Expect::Marker(&["{T}_toDbgString"]);
+const ABI_CLONE: Expect = Expect::Marker(&["{T}_clone"]);
+const ABI_PARTIAL_EQ: Expect = Expect::Marker(&["{T}_partialEq"]);
+const ABI_PARTIAL_ORD: Expect = Expect::Marker(&["{T}_partialCmp"]);
+const ABI_ORD: Expect = Expect::Marker(&["{T}_cmp"]);
+const ABI_HASH: Expect = Expect::Marker(&["{T}_hash"]);
+const ABI_DEFAULT: Expect = Expect::Marker(&["{T}_default"]);
+
+/// `Copy` is the one derive with no surface anywhere, by design.
+///
+/// It has no ABI entry point: `build_trait_functions` emits none, because a
+/// `Copy` value is copied by assignment in every target language and needs no
+/// call. In the Rust mirrors it is emitted as `#[derive(Copy)]` and is what
+/// makes the memtest size/alignment gate meaningful. Counting it as a gap in 38
+/// bindings would be noise, so it is N/A everywhere.
+const COPY_NA: Expect =
+    Expect::NotApplicable("no ABI entry point exists or is needed: Copy values are copied by assignment");
+
+/// `Eq` outside Rust.
+///
+/// `Eq` is a Rust marker trait asserting that `PartialEq` is reflexive. It has
+/// no runtime surface distinct from equality itself, and `build_trait_functions`
+/// emits no `Az{T}_eq`. The equality entry point is already accounted for under
+/// `PartialEq`, so counting `Eq` again would double-count one export.
+const EQ_NA: Expect = Expect::NotApplicable(
+    "Rust marker trait with no runtime surface of its own; the equality entry point is counted under PartialEq",
+);
+
+/// The profile used by every binding that forwards the C ABI by symbol name —
+/// which is most of them, because the generated FFI declarations spell the C
+/// name out.
+const ABI_PROFILE: &[(&str, Expect)] = &[
+    ("Debug", ABI_DEBUG),
+    ("Clone", ABI_CLONE),
+    ("Copy", COPY_NA),
+    ("PartialEq", ABI_PARTIAL_EQ),
+    ("Eq", EQ_NA),
+    ("PartialOrd", ABI_PARTIAL_ORD),
+    ("Ord", ABI_ORD),
+    ("Hash", ABI_HASH),
+    ("Default", ABI_DEFAULT),
+];
+
+/// The Rust mirrors (`dll_api_internal.rs`, `dll_api_external.rs`, `memtest.rs`).
+/// These do not merely declare the ABI, they must implement the trait, so the
+/// marker is the impl header — declaring `Az{T}_partialEq` and never writing
+/// `impl PartialEq` is exactly the bug this lint was written for.
+const RUST_MIRROR_PROFILE: &[(&str, Expect)] = &[
+    ("Debug", Expect::Marker(&["impl core::fmt::Debug for {T} {"])),
+    (
+        "Clone",
+        Expect::Marker(&["impl Clone for {T} {", "#[derive(Clone)]\n#[repr(C)]\npub struct {T} ", "#[derive(Clone)]\n#[repr(C)]\npub enum {T} "]),
+    ),
+    ("Copy", COPY_NA),
+    ("PartialEq", Expect::Marker(&["impl PartialEq for {T} {"])),
+    ("Eq", Expect::Marker(&["impl Eq for {T} {"])),
+    ("PartialOrd", Expect::Marker(&["impl PartialOrd for {T} {"])),
+    ("Ord", Expect::Marker(&["impl Ord for {T} {"])),
+    ("Hash", Expect::Marker(&["impl core::hash::Hash for {T} {"])),
+    ("Default", Expect::Marker(&["impl Default for {T} {"])),
+];
+
+/// The PyO3 extension. The Python-visible surface is the `#[pymethods]` block,
+/// not the Rust trait impls on the embedded mirror types: `python_api.rs`
+/// carries `impl PartialEq for AzStyleCursor` and `impl core::hash::Hash`, and
+/// neither is callable from Python without a `__eq__` / `__hash__`.
+const PYO3_PROFILE: &[(&str, Expect)] = &[
+    (
+        "Debug",
+        Expect::Block { start: PY_BLOCK, markers: &["fn __repr__", "fn __str__"] },
+    ),
+    (
+        "Clone",
+        Expect::Block { start: PY_BLOCK, markers: &["fn __copy__", "fn __deepcopy__", "fn clone("] },
+    ),
+    ("Copy", COPY_NA),
+    (
+        "PartialEq",
+        Expect::Block { start: PY_BLOCK, markers: &["fn __eq__", "fn __richcmp__"] },
+    ),
+    ("Eq", EQ_NA),
+    (
+        "PartialOrd",
+        Expect::Block { start: PY_BLOCK, markers: &["fn __lt__", "fn __richcmp__"] },
+    ),
+    (
+        "Ord",
+        Expect::Block { start: PY_BLOCK, markers: &["fn __lt__", "fn __richcmp__"] },
+    ),
+    ("Hash", Expect::Block { start: PY_BLOCK, markers: &["fn __hash__"] }),
+    ("Default", Expect::Block { start: PY_BLOCK, markers: &["fn default("] }),
+];
+
+const PY_BLOCK: &[&str] = &["#[pymethods]\nimpl {T} {"];
+
+/// C++ (`azul03.hpp` … `azul23.hpp`, `azul.cppm`).
+///
+/// The headers open with `extern "C" { #include "azul.h" }`, which under this
+/// lint's stated rule is the raw-C escape hatch and does not count. What counts
+/// is the wrapper class's own method — `bool partialEq(const MonitorId& b)
+/// const;`. Those methods carry the class name in their parameter for the
+/// comparisons, and not at all for `toDbgString`/`hash`, so the latter two are
+/// matched inside the wrapper class block.
+const CPP_BLOCK: &[&str] = &["class {C} {"];
+const CPP_PROFILE: &[(&str, Expect)] = &[
+    (
+        "Debug",
+        Expect::Block { start: CPP_BLOCK, markers: &["toDbgString() const", "operator<<"] },
+    ),
+    (
+        "Clone",
+        Expect::Block { start: CPP_BLOCK, markers: &["clone() const"] },
+    ),
+    ("Copy", COPY_NA),
+    (
+        "PartialEq",
+        Expect::Marker(&["partialEq(const {C}&", "operator==(const {C}&"]),
+    ),
+    ("Eq", EQ_NA),
+    (
+        "PartialOrd",
+        Expect::Marker(&["partialCmp(const {C}&", "operator<(const {C}&"]),
+    ),
+    (
+        "Ord",
+        Expect::Marker(&["cmp(const {C}&", "operator<=>(const {C}&"]),
+    ),
+    (
+        "Hash",
+        Expect::Block { start: CPP_BLOCK, markers: &["hash() const", "struct hash<"] },
+    ),
+    ("Default", Expect::Marker(&["static {C} default_()"])),
+];
+
+/// Go. cgo makes `C.Az{T}_partialEq` reachable, which does not count under this
+/// lint's rule; the binding has to emit a Go-level name.
+const GO_PROFILE: &[(&str, Expect)] = &[
+    ("Debug", Expect::Marker(&["{T}_toDbgString", "{T}) String()"])),
+    ("Clone", Expect::Marker(&["{T}_clone", "{T}) Clone()"])),
+    ("Copy", COPY_NA),
+    ("PartialEq", Expect::Marker(&["{T}_partialEq", "{T}) Equals("])),
+    ("Eq", EQ_NA),
+    ("PartialOrd", Expect::Marker(&["{T}_partialCmp", "{T}) PartialCmp("])),
+    ("Ord", Expect::Marker(&["{T}_cmp", "{T}) Cmp("])),
+    ("Hash", Expect::Marker(&["{T}_hash", "{T}) Hash()"])),
+    ("Default", Expect::Marker(&["{T}_default", "{T}Default()"])),
+];
+
+/// Zig. `@cImport` makes `C.Az{T}_partialEq` reachable, which does not count.
+const ZIG_PROFILE: &[(&str, Expect)] = &[
+    ("Debug", Expect::Marker(&["{T}_toDbgString"])),
+    ("Clone", Expect::Marker(&["{T}_clone"])),
+    ("Copy", COPY_NA),
+    ("PartialEq", Expect::Marker(&["{T}_partialEq"])),
+    ("Eq", EQ_NA),
+    ("PartialOrd", Expect::Marker(&["{T}_partialCmp"])),
+    ("Ord", Expect::Marker(&["{T}_cmp"])),
+    ("Hash", Expect::Marker(&["{T}_hash"])),
+    ("Default", Expect::Marker(&["{T}_default"])),
+];
+
+/// A binding: what it is called, which generated files are ITS text, how it
+/// spells a class name, and what each derive must look like in it.
+pub struct Binding {
+    pub name: &'static str,
+    /// Paths relative to `target/codegen`. A directory is walked recursively.
+    pub files: &'static [&'static str],
+    /// How this binding spells `StyleCursor` (`"Az"` for the prefixed ones).
+    pub prefix: &'static str,
+    /// Where a `Expect::Block` search stops. Empty means "scan 4 KiB forward".
+    pub block_end: &'static str,
+    /// `derive` -> what proves it. Every entry of [`DERIVES`] must be present.
+    pub expects: &'static [(&'static str, Expect)],
+    /// One line for the report: what shape this binding is.
+    pub note: &'static str,
+}
+
+/// Every binding `azul-doc codegen all` writes. The list is deliberately the
+/// full set of emitted artifacts, not the subset anyone remembers: a binding
+/// missing from here is a blind spot, which is the same failure this lint
+/// exists to prevent. The six C++ standards are separate entries because they
+/// do NOT agree — the C++11 and C++14 emitters filter trait functions out and
+/// the other four do not, and one merged "cpp" row would hide that.
+pub const BINDINGS: &[Binding] = &[
+    Binding { name: "rust-internal (static)", files: &["dll_api_internal.rs"], prefix: "Az", block_end: "", expects: RUST_MIRROR_PROFILE, note: "mirror types + impls delegating to the real crate" },
+    Binding { name: "rust-dynamic (dynamic)", files: &["dll_api_external.rs"], prefix: "Az", block_end: "", expects: RUST_MIRROR_PROFILE, note: "mirror types + extern decls; impls must call the ABI" },
+    Binding { name: "rust-public (azul.rs)", files: &["azul.rs"], prefix: "", block_end: "", expects: RUST_MIRROR_PROFILE, note: "standalone unprefixed Rust surface" },
+    Binding { name: "memtest", files: &["memtest.rs"], prefix: "Az", block_end: "", expects: RUST_MIRROR_PROFILE, note: "layout/size tests over the mirror types" },
+    Binding { name: "c", files: &["azul.h"], prefix: "Az", block_end: "", expects: ABI_PROFILE, note: "C header" },
+    Binding { name: "cpp03", files: &["azul03.hpp"], prefix: "Az", block_end: "\n};", expects: CPP_PROFILE, note: "C++03 wrapper classes" },
+    Binding { name: "cpp11", files: &["azul11.hpp"], prefix: "Az", block_end: "\n};", expects: CPP_PROFILE, note: "C++11 wrapper classes" },
+    Binding { name: "cpp14", files: &["azul14.hpp"], prefix: "Az", block_end: "\n};", expects: CPP_PROFILE, note: "C++14 wrapper classes" },
+    Binding { name: "cpp17", files: &["azul17.hpp"], prefix: "Az", block_end: "\n};", expects: CPP_PROFILE, note: "C++17 wrapper classes" },
+    Binding { name: "cpp20", files: &["azul20.hpp"], prefix: "Az", block_end: "\n};", expects: CPP_PROFILE, note: "C++20 wrapper classes" },
+    Binding { name: "cpp23", files: &["azul23.hpp"], prefix: "Az", block_end: "\n};", expects: CPP_PROFILE, note: "C++23 wrapper classes" },
+    Binding { name: "csharp", files: &["Azul.cs"], prefix: "Az", block_end: "", expects: ABI_PROFILE, note: "P/Invoke externs + wrapper classes" },
+    Binding { name: "python", files: &["python_api.rs"], prefix: "Az", block_end: "\n}\n", expects: PYO3_PROFILE, note: "PyO3 native extension" },
+    Binding { name: "ruby", files: &["azul.rb"], prefix: "Az", block_end: "", expects: ABI_PROFILE, note: "Fiddle/FFI attach_function" },
+    Binding { name: "lua", files: &["azul.lua"], prefix: "Az", block_end: "", expects: ABI_PROFILE, note: "LuaJIT ffi.cdef" },
+    Binding { name: "pascal", files: &["azul.pas"], prefix: "Az", block_end: "", expects: ABI_PROFILE, note: "external declarations" },
+    Binding { name: "ada", files: &["azul.ads", "azul.adb"], prefix: "Az", block_end: "", expects: ABI_PROFILE, note: "pragma Import (C, .., \"Az..\")" },
+    Binding { name: "freebasic", files: &["azul.bi"], prefix: "Az", block_end: "", expects: ABI_PROFILE, note: "Declare Function .. Alias" },
+    Binding { name: "zig", files: &["azul.zig"], prefix: "Az", block_end: "", expects: ZIG_PROFILE, note: "@cImport wrapper structs" },
+    Binding { name: "powershell", files: &["Azul.psm1"], prefix: "Az", block_end: "", expects: ABI_PROFILE, note: "Add-Type with the C# source embedded" },
+    Binding { name: "php", files: &["Azul.php"], prefix: "Az", block_end: "", expects: ABI_PROFILE, note: "FFI::cdef over the whole header" },
+    Binding { name: "php-ext", files: &["php_api.rs"], prefix: "Az", block_end: "", expects: ABI_PROFILE, note: "Zend native extension (curated 5-class surface)" },
+    Binding { name: "perl", files: &["Azul.pm"], prefix: "Az", block_end: "", expects: ABI_PROFILE, note: "FFI::Platypus attach" },
+    Binding { name: "ocaml", files: &["azul.mli"], prefix: "Az", block_end: "", expects: ABI_PROFILE, note: "the .mli SEALS the module - only what it lists is reachable" },
+    Binding { name: "haskell", files: &["haskell"], prefix: "Az", block_end: "", expects: ABI_PROFILE, note: "foreign import ccall + idiomatic instances" },
+    Binding { name: "java", files: &["java"], prefix: "Az", block_end: "", expects: ABI_PROFILE, note: "JNA/Panama" },
+    Binding { name: "kotlin", files: &["kotlin"], prefix: "Az", block_end: "", expects: ABI_PROFILE, note: "JNA" },
+    Binding { name: "fortran", files: &["azul.f90"], prefix: "Az", block_end: "", expects: ABI_PROFILE, note: "iso_c_binding interfaces" },
+    Binding { name: "go", files: &["go"], prefix: "Az", block_end: "", expects: GO_PROFILE, note: "cgo" },
+    Binding { name: "lisp", files: &["azul.lisp"], prefix: "Az", block_end: "", expects: ABI_PROFILE, note: "CFFI defcfun" },
+    Binding { name: "smalltalk", files: &["Azul.st", "BaselineOfAzul.st"], prefix: "Az", block_end: "", expects: ABI_PROFILE, note: "Pharo FFI" },
+    Binding { name: "algol68", files: &["azul.a68"], prefix: "Az", block_end: "", expects: ABI_PROFILE, note: "Algol 68 Genie" },
+    Binding { name: "cobol", files: &["azul.cpy"], prefix: "Az", block_end: "", expects: ABI_PROFILE, note: "GnuCOBOL copybook" },
+    Binding { name: "vb6", files: &["vb6"], prefix: "Az", block_end: "", expects: ABI_PROFILE, note: "Declare Function" },
+    Binding { name: "node", files: &["node"], prefix: "Az", block_end: "", expects: ABI_PROFILE, note: "koffi/ffi-napi" },
+    Binding { name: "crystal", files: &["azul.cr"], prefix: "Az", block_end: "", expects: ABI_PROFILE, note: "lib binding" },
+    Binding { name: "d", files: &["azul.d"], prefix: "Az", block_end: "", expects: ABI_PROFILE, note: "extern(C)" },
+    Binding { name: "julia", files: &["azul.jl"], prefix: "Az", block_end: "", expects: ABI_PROFILE, note: "ccall" },
+    Binding { name: "nim", files: &["azul.nim"], prefix: "Az", block_end: "", expects: ABI_PROFILE, note: "importc" },
+    Binding { name: "odin", files: &["azul.odin"], prefix: "Az", block_end: "", expects: ABI_PROFILE, note: "foreign import" },
+    Binding { name: "racket", files: &["azul.rkt"], prefix: "Az", block_end: "", expects: ABI_PROFILE, note: "ffi/unsafe" },
+    Binding { name: "red", files: &["azul.reds"], prefix: "Az", block_end: "", expects: ABI_PROFILE, note: "Red/System" },
+    Binding { name: "swift", files: &["azul.swift"], prefix: "Az", block_end: "", expects: ABI_PROFILE, note: "module map" },
+    Binding { name: "v", files: &["azul.v"], prefix: "Az", block_end: "", expects: ABI_PROFILE, note: "V C interop" },
+];
+
+/// One (binding, class, derive) that should have been reachable and is not.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Gap {
+    pub binding: String,
+    pub class: String,
+    pub derive: String,
+}
+
+/// Per-binding tally.
+#[derive(Clone, Debug, Default)]
+pub struct BindingReport {
+    pub binding: String,
+    pub note: String,
+    /// declared derive honoured by a name in this binding
+    pub honoured: usize,
+    /// declared derive with no name in this binding
+    pub missing: usize,
+    /// derive with no equivalent in this language, by construction
+    pub not_applicable: usize,
+    /// derive with no decided mapping; excluded from the verdict
+    pub unmapped: usize,
+    /// classes that carry a derive list but never appear in this binding at all
+    pub classes_absent: usize,
+    /// classes checked
+    pub classes_checked: usize,
+    /// per-derive missing counts, for the report
+    pub missing_by_derive: BTreeMap<String, usize>,
+    /// a few concrete examples, so a failure is actionable
+    pub examples: Vec<Gap>,
+}
+
+/// Read every file of a binding into one blob. A directory is walked.
+fn read_binding_text(codegen_dir: &Path, files: &[&str]) -> std::io::Result<String> {
+    fn push_file(out: &mut String, p: &Path) {
+        if let Ok(s) = fs::read_to_string(p) {
+            out.push_str(&s);
+            out.push('\n');
+        }
+    }
+    fn walk(out: &mut String, p: &Path) {
+        if p.is_dir() {
+            let mut entries: Vec<_> = match fs::read_dir(p) {
+                Ok(rd) => rd.filter_map(|e| e.ok()).map(|e| e.path()).collect(),
+                Err(_) => return,
+            };
+            entries.sort();
+            for e in entries {
+                walk(out, &e);
+            }
+        } else {
+            push_file(out, p);
+        }
+    }
+    let mut out = String::new();
+    for f in files {
+        walk(&mut out, &codegen_dir.join(f));
+    }
+    Ok(out)
+}
+
+/// Every `Az{Ident}_{suffix}` in the text, as a `(ident, suffix)` set.
+///
+/// One pass per suffix rather than 1889 x 9 substring searches over a 12 MB
+/// file, which is the difference between a lint that runs in `check` and one
+/// nobody runs.
+fn index_abi_symbols(text: &str, prefix: &str) -> BTreeSet<(String, String)> {
+    const SUFFIXES: &[&str] = &[
+        "_toDbgString",
+        "_clone",
+        "_partialEq",
+        "_partialCmp",
+        "_cmp",
+        "_hash",
+        "_default",
+    ];
+    let bytes = text.as_bytes();
+    let mut found = BTreeSet::new();
+    for suffix in SUFFIXES {
+        let mut from = 0usize;
+        while let Some(rel) = text[from..].find(suffix) {
+            let at = from + rel;
+            from = at + 1;
+            // The suffix must END the identifier.
+            let after = at + suffix.len();
+            if bytes
+                .get(after)
+                .is_some_and(|c| c.is_ascii_alphanumeric() || *c == b'_')
+            {
+                continue;
+            }
+            // Walk back over the identifier that carries it.
+            let mut start = at;
+            while start > 0 {
+                let c = bytes[start - 1];
+                if c.is_ascii_alphanumeric() || c == b'_' {
+                    start -= 1;
+                } else {
+                    break;
+                }
+            }
+            let ident = &text[start..at];
+            if let Some(class) = ident.strip_prefix(prefix) {
+                if !class.is_empty() {
+                    found.insert((class.to_string(), (*suffix).to_string()));
+                }
+            }
+        }
+    }
+    found
+}
+
+/// The text of one class's own block: from the first `start` match to the next
+/// `block_end` after it (or 4 KiB, when a binding declares no terminator).
+///
+/// This is what lets the lint attribute a construct that does NOT carry the
+/// class name — `fn __hash__`, `uint64_t hash() const` — to the right class,
+/// without parsing the language.
+fn class_block<'a>(
+    text: &'a str,
+    starts: &[&str],
+    block_end: &str,
+    spelled: &str,
+    bare: &str,
+) -> Option<&'a str> {
+    for pat in starts {
+        let needle = pat.replace("{T}", spelled).replace("{C}", bare);
+        if let Some(at) = text.find(&needle) {
+            let from = at + needle.len();
+            let rest = &text[from..];
+            let len = if block_end.is_empty() {
+                rest.len().min(4096)
+            } else {
+                rest.find(block_end).map(|e| e + block_end.len()).unwrap_or(rest.len().min(4096))
+            };
+            return Some(&rest[..len]);
+        }
+    }
+    None
+}
+
+/// Is this class named in this binding at all?
+///
+/// Looser than [`contains_token`] on the right-hand side only: a following `_`
+/// is accepted, because most bindings never write the bare type name — Ada
+/// writes `pragma Import (C, .., "AzStyleCursor_toDbgString")`, Pascal writes
+/// `PAzStyleCursor`. A following alphanumeric is still rejected, so
+/// `AzStyleCursorValue` never proves `StyleCursor` is here.
+fn class_is_named(text: &str, spelled: &str) -> bool {
+    let bytes = text.as_bytes();
+    let mut from = 0usize;
+    while let Some(rel) = text[from..].find(spelled) {
+        let at = from + rel;
+        from = at + 1;
+        let before_ok = at == 0 || {
+            let c = bytes[at - 1];
+            !(c.is_ascii_alphanumeric() || c == b'_')
+        };
+        let after = at + spelled.len();
+        let after_ok = bytes
+            .get(after)
+            .is_none_or(|c| !c.is_ascii_alphanumeric() || *c == b'_');
+        if before_ok && after_ok {
+            return true;
+        }
+    }
+    false
+}
+
+/// Does `text` contain `needle` as a standalone name (not glued to a longer
+/// identifier on either side)? Prevents `AzStyleCursor_hash` from being counted
+/// as evidence for `AzStyleCursorValue`.
+fn contains_token(text: &str, needle: &str) -> bool {
+    let bytes = text.as_bytes();
+    let nb = needle.as_bytes();
+    let mut from = 0usize;
+    while let Some(rel) = text[from..].find(needle) {
+        let at = from + rel;
+        from = at + 1;
+        let before_ok = at == 0 || {
+            let c = bytes[at - 1];
+            !(c.is_ascii_alphanumeric() || c == b'_')
+        };
+        let after = at + nb.len();
+        let last_is_ident = nb
+            .last()
+            .is_some_and(|c| c.is_ascii_alphanumeric() || *c == b'_');
+        let after_ok = !last_is_ident
+            || bytes
+                .get(after)
+                .is_none_or(|c| !(c.is_ascii_alphanumeric() || *c == b'_'));
+        if before_ok && after_ok {
+            return true;
+        }
+    }
+    false
+}
+
+/// Class name -> declared derives, from api.json.
+///
+/// GENERIC classes are excluded, because codegen itself excludes them:
+/// `IrBuilder::build_trait_functions` filters on `generic_params.is_empty()`,
+/// so `CssPropertyValue<T>`, `PhysicalSize<T>` and `PhysicalPosition<T>` never
+/// get a `Az..._partialEq` of their own — their monomorphised aliases
+/// (`AzStyleCursorValue`, …) carry their own api.json entries and ARE checked.
+/// Demanding a per-class entry point for a type that has no single ABI identity
+/// would be demanding something impossible.
+pub fn declared_derives(api: &ApiData) -> BTreeMap<String, BTreeSet<String>> {
+    let mut out: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+    for (_ver, vd) in &api.0 {
+        for (_module, md) in &vd.api {
+            for (class, cd) in &md.classes {
+                if cd
+                    .generic_params
+                    .as_ref()
+                    .is_some_and(|g| !g.is_empty())
+                {
+                    continue;
+                }
+                if let Some(d) = &cd.derive {
+                    out.entry(class.clone())
+                        .or_default()
+                        .extend(d.iter().cloned());
+                }
+            }
+        }
+    }
+    out
+}
+
+/// Run the lint over every binding.
+pub fn check(codegen_dir: &Path, api: &ApiData) -> anyhow::Result<Vec<BindingReport>> {
+    let declared = declared_derives(api);
+    if declared.is_empty() {
+        anyhow::bail!("api.json carries no `derive` lists at all - refusing to report a vacuous pass");
+    }
+    let mut reports = Vec::new();
+
+    for binding in BINDINGS {
+        let text = read_binding_text(codegen_dir, binding.files)?;
+        if text.is_empty() {
+            anyhow::bail!(
+                "binding `{}` has no generated text at {} ({:?}) - run `azul-doc codegen all` first",
+                binding.name,
+                codegen_dir.display(),
+                binding.files
+            );
+        }
+
+        let abi_index = index_abi_symbols(&text, binding.prefix);
+
+        let mut rep = BindingReport {
+            binding: binding.name.to_string(),
+            note: binding.note.to_string(),
+            ..Default::default()
+        };
+
+        for (class, derives) in &declared {
+            let spelled = format!("{}{}", binding.prefix, class);
+            // Is this class emitted in this binding at all? A class that never
+            // ships here cannot have a derive gap here; it is reported in its
+            // own column so the exclusion is never silent.
+            let present = class_is_named(&text, &spelled);
+            if !present {
+                rep.classes_absent += 1;
+                continue;
+            }
+            rep.classes_checked += 1;
+
+            for derive in DERIVES {
+                if !derives.contains(*derive) {
+                    continue;
+                }
+                // `Clone` on a `Copy` class has no `_clone` export by design
+                // (`needs_deep_copy` is `Clone && !Copy`); the value is copied.
+                if *derive == "Clone" && derives.contains("Copy") {
+                    rep.not_applicable += 1;
+                    continue;
+                }
+                let expect = binding
+                    .expects
+                    .iter()
+                    .find(|(d, _)| d == derive)
+                    .map(|(_, e)| e)
+                    .unwrap_or(&Expect::Unmapped("no entry in this binding's profile"));
+
+                match expect {
+                    Expect::NotApplicable(_) => rep.not_applicable += 1,
+                    Expect::Unmapped(_) => rep.unmapped += 1,
+                    Expect::Marker(pats) => {
+                        let hit = pats.iter().any(|p| {
+                            let needle = p.replace("{T}", &spelled).replace("{C}", class);
+                            // The ABI-symbol case goes through the prebuilt
+                            // index; anything else is a plain token search.
+                            if let Some(suffix) = needle.strip_prefix(spelled.as_str()) {
+                                if suffix.starts_with('_')
+                                    && suffix.bytes().all(|c| c.is_ascii_alphanumeric() || c == b'_')
+                                {
+                                    return abi_index
+                                        .contains(&(class.clone(), suffix.to_string()));
+                                }
+                            }
+                            contains_token(&text, &needle)
+                        });
+                        if hit {
+                            rep.honoured += 1;
+                        } else {
+                            rep.missing += 1;
+                            *rep.missing_by_derive.entry((*derive).to_string()).or_insert(0) += 1;
+                            if rep.examples.len() < 5 {
+                                rep.examples.push(Gap {
+                                    binding: binding.name.to_string(),
+                                    class: class.clone(),
+                                    derive: (*derive).to_string(),
+                                });
+                            }
+                        }
+                    }
+                    Expect::Block { start, markers } => {
+                        let block =
+                            class_block(&text, start, binding.block_end, &spelled, class);
+                        let hit =
+                            block.is_some_and(|b| markers.iter().any(|m| b.contains(*m)));
+                        if hit {
+                            rep.honoured += 1;
+                        } else {
+                            rep.missing += 1;
+                            *rep.missing_by_derive.entry((*derive).to_string()).or_insert(0) += 1;
+                            if rep.examples.len() < 5 {
+                                rep.examples.push(Gap {
+                                    binding: binding.name.to_string(),
+                                    class: class.clone(),
+                                    derive: (*derive).to_string(),
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        reports.push(rep);
+    }
+    Ok(reports)
+}
+
+/// The gaps this repo currently ships, per binding, as an EXACT number.
+///
+/// This is a ratchet, not an exemption list. It is compared for EQUALITY, so
+/// fixing a binding fails the lint until the number here comes down with it —
+/// a baseline that is only ever checked as an upper bound goes stale the day
+/// after it is written and then proves nothing.
+///
+/// A binding absent from this table must have ZERO gaps. Thirteen are, today:
+/// the three Rust mirrors, memtest, C, Ruby, Lua, Pascal, Ada, PHP, Perl,
+/// Common Lisp, Algol 68 and COBOL.
+///
+/// WHAT EACH NUMBER IS, IN ONE LINE (measured 2026-09-04):
+///   * `rust-public` — `azul.rs` is `UsingDerive` with NO `extern` block and no
+///     `include!` site in the tree; `generator.rs` marks it "legacy, may be
+///     removed". The LIVE public Rust API is `reexports.rs`, which aliases into
+///     whichever `dll_api_*` is compiled and therefore already inherits the fix.
+///   * `cpp11` / `cpp14` — those two emitters alone apply
+///     `should_skip_method`, which drops every `is_trait_function()` kind;
+///     cpp03/17/20/23 do not, which is why they sit at 2133 instead of ~5600.
+///   * every `cpp*` — enums and tagged unions get no wrapper class, so a
+///     declaring enum gets no method however the filter is set.
+///   * `python` — `lang_python.rs` drops trait kinds, then `generate_pymethod`
+///     bails on `fn_body: None`, which every synthesised trait fn has. Only
+///     `__str__`/`__repr__` survive; there is no `__eq__`, `__hash__` or
+///     `__lt__` in the whole extension.
+///   * `zig` / `go` — the wrapper emitters whitelist
+///     `Constructor | Method | MethodMut | StaticMethod | Default | DeepCopy`,
+///     so the comparison and debug entry points reach the artifact zero times.
+///   * `~114-134` in a dozen bindings — the `*VecDestructor` types. Their
+///     `_toDbgString` is exported from libazul and those emitters skip the type
+///     wholesale (C# emits no VecDestructor function at all, not just no debug).
+///   * `ocaml` — every capability IS generated in `azul.ml` and the `.mli`
+///     exports only `clone` and `default`, so a consumer can reach nothing else.
+pub const BASELINE: &[(&str, usize)] = &[
+    ("rust-public (azul.rs)", 7122),
+    ("cpp03", 2133),
+    ("cpp11", 5682),
+    ("cpp14", 5568),
+    ("cpp17", 2133),
+    ("cpp20", 2133),
+    ("cpp23", 2133),
+    ("csharp", 114),
+    ("python", 4671),
+    ("freebasic", 124),
+    ("zig", 5168),
+    ("powershell", 118),
+    ("php-ext", 134),
+    ("ocaml", 272),
+    ("haskell", 11),
+    ("java", 114),
+    ("kotlin", 114),
+    ("fortran", 134),
+    ("go", 5648),
+    ("smalltalk", 123),
+    ("vb6", 123),
+    ("node", 114),
+    ("crystal", 134),
+    ("d", 134),
+    ("julia", 134),
+    ("nim", 134),
+    ("odin", 134),
+    ("racket", 114),
+    ("red", 126),
+    ("swift", 4),
+    ("v", 134),
+];
+
+/// Compare against [`BASELINE`] and render the verdict.
+pub fn verdict(reports: &[BindingReport]) -> (bool, String) {
+    use std::fmt::Write as _;
+    let mut out = String::new();
+    let mut ok = true;
+
+    let _ = writeln!(
+        out,
+        "{:<28} {:>9} {:>8} {:>7} {:>8} {:>8}  {}",
+        "binding", "honoured", "missing", "n/a", "unmapped", "absent", "shape"
+    );
+    let _ = writeln!(out, "{}", "-".repeat(110));
+    for r in reports {
+        let _ = writeln!(
+            out,
+            "{:<28} {:>9} {:>8} {:>7} {:>8} {:>8}  {}",
+            r.binding, r.honoured, r.missing, r.not_applicable, r.unmapped, r.classes_absent, r.note
+        );
+    }
+    let _ = writeln!(out, "{}", "-".repeat(110));
+    let th: usize = reports.iter().map(|r| r.honoured).sum();
+    let tm: usize = reports.iter().map(|r| r.missing).sum();
+    let tn: usize = reports.iter().map(|r| r.not_applicable).sum();
+    let tu: usize = reports.iter().map(|r| r.unmapped).sum();
+    let _ = writeln!(
+        out,
+        "{:<28} {:>9} {:>8} {:>7} {:>8}",
+        "TOTAL", th, tm, tn, tu
+    );
+    let _ = writeln!(out);
+
+    for r in reports {
+        let expected = BASELINE
+            .iter()
+            .find(|(n, _)| *n == r.binding)
+            .map(|(_, c)| *c)
+            .unwrap_or(0);
+        if r.missing == expected {
+            continue;
+        }
+        ok = false;
+        if r.missing > expected {
+            let _ = writeln!(
+                out,
+                "[FAIL] {}: {} unreachable derive(s), baseline allows {}",
+                r.binding, r.missing, expected
+            );
+            for (d, n) in &r.missing_by_derive {
+                let _ = writeln!(out, "         {d}: {n}");
+            }
+            for g in r.examples.iter().take(3) {
+                let _ = writeln!(
+                    out,
+                    "         e.g. `{}` declares {} but nothing in this binding names it",
+                    g.class, g.derive
+                );
+            }
+        } else {
+            let _ = writeln!(
+                out,
+                "[FAIL] {}: improved to {} gap(s) but the baseline still says {} - lower it in \
+                 doc/src/lint_derives.rs::BASELINE",
+                r.binding, r.missing, expected
+            );
+        }
+    }
+    if ok {
+        let _ = writeln!(
+            out,
+            "[ok] every declared derive is reachable in every binding, or matches its recorded baseline"
+        );
+    }
+    (ok, out)
+}

--- a/doc/src/lint_derives.rs
+++ b/doc/src/lint_derives.rs
@@ -791,6 +791,20 @@ pub fn check(codegen_dir: &Path, api: &ApiData) -> anyhow::Result<Vec<BindingRep
 ///          and starts charging them for derives they still lack. Any fix here
 ///          must either carry the full list or avoid naming the class in prose
 ///          - and that fragility is worth knowing about the checker itself.
+///   * `haskell` (10) - the recursive-type carve-out moved it 11 -> 10, so its
+///     `_partialEq` / `_cmp` / `_hash` now reach the artifact. The remaining
+///     Debug / Clone / Default do NOT, for a different reason: Haskell routes
+///     Show and Eq through a per-struct `Az{T}_toDbgString_via` C SHIM, and
+///     the shim generator has its own filter (see the `*VecDestructor` note in
+///     `cshim.rs`). The four XML types are enums or excluded structs, so no
+///     shim is generated and the instance has nothing to call. Closing it
+///     means extending the shim generator, not the function filter.
+///   * `ocaml` enums - the interface loop iterates `ir.structs` only, so a
+///     tagged union like `AccessibilityAction` gets NO module at all. That is
+///     the whole of ocaml's 272, and it is the same shape C++, zig and go each
+///     had. It needs the module emitted in BOTH `azul.ml` and `azul.mli`
+///     carrying the full derive list at once - a partial module measures worse,
+///     see the two reverted attempts recorded above.
 ///   * `rust-public` (was 7122) — `azul.rs` was `UsingDerive` with no `extern`
 ///     block, a combination that could not compile in either direction. It is
 ///     now `UsingCAPI` + `ExternalBindings`, the same shape as

--- a/doc/src/main.rs
+++ b/doc/src/main.rs
@@ -227,7 +227,7 @@ fn main() -> anyhow::Result<()> {
             autofix::autofix_api(&api_data, &project_root, &output_dir, true)?;
             return Ok(());
         }
-        ["check", "derives"] => {
+        ["check", "derives", ..] => {
             // The derive-parity gate. api.json's `derive` list per class is what
             // `IrBuilder::build_trait_functions` turns into real C-ABI exports;
             // this asks whether each of the ~40 emitted bindings then gives its
@@ -238,6 +238,14 @@ fn main() -> anyhow::Result<()> {
             let reports = lint_derives::check(&codegen_dir, &api_data)?;
             let (ok, table) = lint_derives::verdict(&reports);
             print!("{table}");
+            // `--details [binding]` prints the per-derive breakdown and a
+            // sample of concrete gaps. Read-only: it changes no verdict, it
+            // only makes the numbers in the table above actionable without
+            // having to make the gate fail on purpose to see them.
+            if let Some(pos) = args.iter().position(|a| *a == "--details") {
+                let only = args.get(pos + 1).filter(|a| !a.starts_with("--"));
+                print!("{}", lint_derives::details(&reports, only.copied()));
+            }
             if !ok {
                 anyhow::bail!(
                     "azul-doc check derives failed: a declared derive is unreachable from a \

--- a/doc/src/main.rs
+++ b/doc/src/main.rs
@@ -17,6 +17,7 @@ pub mod doc_coverage;
 pub mod docgen;
 pub mod e2erun;
 pub mod gene2e;
+pub mod lint_derives;
 pub mod lint_examples;
 pub mod lint_links;
 pub mod lint_orphans;
@@ -224,6 +225,25 @@ fn main() -> anyhow::Result<()> {
             let output_dir = project_root.join("target").join("autofix");
             let api_data = load_api_json(&api_path)?;
             autofix::autofix_api(&api_data, &project_root, &output_dir, true)?;
+            return Ok(());
+        }
+        ["check", "derives"] => {
+            // The derive-parity gate. api.json's `derive` list per class is what
+            // `IrBuilder::build_trait_functions` turns into real C-ABI exports;
+            // this asks whether each of the ~40 emitted bindings then gives its
+            // users a name for them. See doc/src/lint_derives.rs for the rule
+            // it applies and the one judgement call it makes.
+            let api_data = load_api_json(&api_path)?;
+            let codegen_dir = project_root.join("target").join("codegen");
+            let reports = lint_derives::check(&codegen_dir, &api_data)?;
+            let (ok, table) = lint_derives::verdict(&reports);
+            print!("{table}");
+            if !ok {
+                anyhow::bail!(
+                    "azul-doc check derives failed: a declared derive is unreachable from a \
+                     binding, or a recorded baseline is stale"
+                );
+            }
             return Ok(());
         }
         ["check", "links"] => {

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -304,15 +304,30 @@ stage_check() {
 }
 
 stage_binding_syntax() {
-  # The derive-parity gate greps generated bindings for NAMES, so it reports
-  # green on code that does not compile - that is not hypothetical, it shipped
-  # three non-compiling PHP methods and a Zig parameter-shadowing error before
-  # anyone looked. Nothing else in this repo builds the non-Rust bindings, so
-  # these two cheap syntax checks are the only thing standing between a codegen
-  # change and a broken artifact.
+  # WHY THIS EXISTS
+  # ---------------
+  # `azul-doc check derives` proves a NAME is present in a generated binding.
+  # It cannot prove the binding compiles - it greps text, and a broken method
+  # still contains its name. Three non-compiling emissions shipped during the
+  # derive-parity work and none were visible to it. This stage is the other
+  # half: it asks each language's own compiler whether the derives actually
+  # materialised as valid native constructs.
   #
-  # Both are pure parsers: no libazul, no cgo, no linking. Skipped rather than
-  # failed when the toolchain is absent, so CI images without them stay green.
+  # THE PROBE RULE
+  # --------------
+  # Every checker is first run against a two-line known-good sample of its own
+  # language. A tool that cannot check `var x = 1;` is SKIPPED, not believed.
+  # Without this, adding checkers makes the gate less trustworthy: `node` is on
+  # PATH here and aborts with a missing dylib (exit 134), and `javac` is
+  # installed with no Java runtime. Both would otherwise be reported as "your
+  # generated code is broken".
+  #
+  # KNOWN_BROKEN
+  # ------------
+  # A binding whose artifact does not compile TODAY, for reasons that predate
+  # this gate. Recorded rather than silently skipped, and rather than blocking
+  # every other language behind it. Same ratchet idea as the derive baseline:
+  # the list may shrink, and anything NOT on it must pass.
   local gen="target/codegen"
   if [ ! -d "$gen" ]; then
     echo "  (skip: $gen missing - run 'cargo run --release -p azul-doc codegen all')"
@@ -320,32 +335,72 @@ stage_binding_syntax() {
   fi
 
   local rc=0
-  if command -v zig >/dev/null 2>&1; then
-    if zig ast-check "$gen/azul.zig"; then
-      echo "  zig ast-check: ok"
+  local tmp; tmp="$(mktemp -d)"
+
+  # label|probe command|real command
+  # KNOWN_BROKEN entries carry a trailing |broken plus a one-line reason.
+  local checks=(
+    "zig|zig ast-check $tmp/p.zig|zig ast-check $gen/azul.zig"
+    "go|gofmt -e $tmp/p.go|gofmt -e $gen/go"
+    "c|gcc -fsyntax-only -x c $tmp/p.c|gcc -fsyntax-only -x c $gen/azul.h"
+    "fortran|gfortran -fsyntax-only $tmp/p.f90|gfortran -fsyntax-only $gen/azul.f90"
+    "perl|perl -c $tmp/p.pm|perl -c $gen/Azul.pm"
+    "ruby|ruby -c $tmp/p.rb|ruby -c $gen/azul.rb"
+    "lua|luajit -bl $tmp/p.lua /dev/null|luajit -bl $gen/azul.lua /dev/null"
+    "php|php -l $tmp/p.php|php -l $gen/Azul.php"
+    "nim|nim check --hints:off $tmp/p.nim|nim check --hints:off $gen/azul.nim"
+    "crystal|crystal build --no-codegen $tmp/p.cr|crystal build --no-codegen $gen/azul.cr"
+    "odin|odin check $tmp/p.odin -file -no-entry-point|odin check $gen/azul.odin -file -no-entry-point"
+    "node|node --check $tmp/p.js|node --check $gen/node/azul.js"
+    "cpp|g++ -fsyntax-only -std=c++17 -x c++ $tmp/p.cpp|g++ -fsyntax-only -std=c++17 -x c++ $gen/azul17.hpp"
+  )
+
+  # Probe samples, one per language.
+  printf 'const x: u8 = 1;\n'                    > "$tmp/p.zig"
+  printf 'package p\nvar X = 1\n'                > "$tmp/p.go"
+  printf 'int x;\n'                              > "$tmp/p.c"
+  printf '#include <cstdint>\nint x;\n'          > "$tmp/p.cpp"
+  printf '      program p\n      end program p\n' > "$tmp/p.f90"
+  printf '1;\n'                                  > "$tmp/p.pm"
+  printf 'x = 1\n'                               > "$tmp/p.rb"
+  printf 'local x = 1\n'                         > "$tmp/p.lua"
+  printf '<?php $x = 1;\n'                       > "$tmp/p.php"
+  printf 'let x = 1\n'                           > "$tmp/p.nim"
+  printf 'x = 1\n'                               > "$tmp/p.cr"
+  printf 'package p\n'                           > "$tmp/p.odin"
+  printf 'var x = 1;\n'                          > "$tmp/p.js"
+  printf 'module main\nfn main() {}\n'            > "$tmp/p.v"
+
+  local entry label probe real out
+  for entry in "${checks[@]}"; do
+    label="${entry%%|*}"
+    probe="$(echo "$entry" | cut -d"|" -f2)"
+    real="$(echo "$entry" | cut -d"|" -f3)"
+    if ! eval "$probe" >/dev/null 2>&1; then
+      echo "  (skip $label: checker unavailable or not working here)"
+      continue
+    fi
+    if out="$(eval "$real" 2>&1)"; then
+      echo "  $label: ok"
     else
-      echo "  zig ast-check: FAILED" >&2
+      echo "  $label: FAILED" >&2
+      echo "$out" | head -15 >&2
       rc=1
     fi
-  else
-    echo "  (skip zig: not installed)"
-  fi
+  done
 
-  # OCaml gets a full TYPE check, not just a parse: `ocamlc -stop-after parsing`
-  # accepted a file that referenced `ffi_az_style_cursor_partial_eq` 42k lines
-  # before it was defined, and OCaml is order-sensitive. Only the type checker
-  # caught that, and a second error where a recursive element is an opaque
-  # pointer rather than a `Ctypes.structure`.
+  # OCaml gets a full TYPE check, not a parse: `ocamlc -stop-after parsing`
+  # accepted a file referencing a binding declared 42k lines later, and OCaml
+  # is order-sensitive. Only the type checker caught it.
   if command -v ocamlfind >/dev/null 2>&1 && ocamlfind query ctypes >/dev/null 2>&1; then
-    local omldir
-    omldir="$(mktemp -d)"
+    local omldir; omldir="$(mktemp -d)"
     cp "$gen/azul.mli" "$gen/azul.ml" "$omldir/" 2>/dev/null
     if (cd "$omldir" \
           && ocamlfind ocamlc -package ctypes,ctypes.foreign -c azul.mli \
           && ocamlfind ocamlc -package ctypes,ctypes.foreign -c azul.ml) >/dev/null 2>&1; then
-      echo "  ocaml typecheck: ok"
+      echo "  ocaml: ok"
     else
-      echo "  ocaml typecheck: FAILED" >&2
+      echo "  ocaml: FAILED" >&2
       (cd "$omldir" && ocamlfind ocamlc -package ctypes,ctypes.foreign -c azul.mli \
         && ocamlfind ocamlc -package ctypes,ctypes.foreign -c azul.ml) 2>&1 | head -20 >&2
       rc=1
@@ -355,59 +410,25 @@ stage_binding_syntax() {
     echo "  (skip ocaml: ocamlfind or ctypes not installed)"
   fi
 
-  # Every remaining checker follows one rule: PROBE it on a known-good sample
-  # before trusting its verdict. `command -v node` succeeds on this machine and
-  # then node aborts with a missing dylib - exit 134, which a naive gate would
-  # report as "your generated JavaScript is broken". A tool that cannot check
-  # its own trivial sample gets skipped, not believed.
-  probe_and_check() {
-    local label="$1" probe_cmd="$2" real_cmd="$3"
-    if ! eval "$probe_cmd" >/dev/null 2>&1; then
-      echo "  (skip $label: checker unavailable or not working here)"
-      return 0
-    fi
-    local out
-    if out="$(eval "$real_cmd" 2>&1)"; then
-      echo "  $label: ok"
-    else
-      echo "  $label: FAILED" >&2
-      echo "$out" | head -20 >&2
+  # KNOWN_BROKEN: v. `v -check target/codegen/azul.v` reports ~200 errors of
+  # the form "field name `Alias` cannot contain uppercase letters, use
+  # snake_case instead". V enforces snake_case field names as a LANGUAGE rule,
+  # and the emitter carries the api.json spelling through unchanged. It
+  # predates this gate - v has reported 0 unreachable derives throughout,
+  # which is precisely the blind spot this stage exists to expose: every name
+  # is present and the file has never compiled. Fixing it is an emitter change
+  # (snake_case the field names, keep the C ABI spelling for the extern side),
+  # not a gate change, so it is recorded here rather than silently skipped.
+  if command -v v >/dev/null 2>&1 && v -check "$tmp/p.v" >/dev/null 2>&1; then
+    if v -check "$gen/azul.v" >/dev/null 2>&1; then
+      echo "  v: ok (KNOWN_BROKEN entry is stale - remove it)"
       rc=1
+    else
+      echo "  v: KNOWN_BROKEN (uppercase field names; see the comment above)"
     fi
-  }
-
-  local tmp; tmp="$(mktemp -d)"
-  printf 'x = 1\n'        > "$tmp/probe.rb"
-  printf 'local x = 1\n'  > "$tmp/probe.lua"
-  printf '<?php $x = 1;\n' > "$tmp/probe.php"
-  printf 'var x = 1;\n'   > "$tmp/probe.js"
-
-  probe_and_check "ruby -c"   "ruby -c '$tmp/probe.rb'"       "ruby -c '$gen/azul.rb'"
-  probe_and_check "luajit"    "luajit -bl '$tmp/probe.lua' /dev/null" \
-                              "luajit -bl '$gen/azul.lua' /dev/null"
-  probe_and_check "php -l"    "php -l '$tmp/probe.php'"       "php -l '$gen/Azul.php'"
-  if [ -f "$gen/node/azul.js" ]; then
-    probe_and_check "node --check" "node --check '$tmp/probe.js'" \
-                                   "node --check '$gen/node/azul.js'"
   fi
+
   rm -rf "$tmp"
-
-  if command -v gofmt >/dev/null 2>&1; then
-    # `gofmt -e` prints syntax errors; formatting differences go to stdout as
-    # filenames, which is why the error stream is what decides the verdict.
-    local goerr
-    goerr="$(gofmt -e "$gen/go" 2>&1 >/dev/null)"
-    if [ -z "$goerr" ]; then
-      echo "  gofmt -e: ok"
-    else
-      echo "  gofmt -e: FAILED" >&2
-      echo "$goerr" >&2
-      rc=1
-    fi
-  else
-    echo "  (skip go: gofmt not installed)"
-  fi
-
   return $rc
 }
 

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -331,6 +331,30 @@ stage_binding_syntax() {
     echo "  (skip zig: not installed)"
   fi
 
+  # OCaml gets a full TYPE check, not just a parse: `ocamlc -stop-after parsing`
+  # accepted a file that referenced `ffi_az_style_cursor_partial_eq` 42k lines
+  # before it was defined, and OCaml is order-sensitive. Only the type checker
+  # caught that, and a second error where a recursive element is an opaque
+  # pointer rather than a `Ctypes.structure`.
+  if command -v ocamlfind >/dev/null 2>&1 && ocamlfind query ctypes >/dev/null 2>&1; then
+    local omldir
+    omldir="$(mktemp -d)"
+    cp "$gen/azul.mli" "$gen/azul.ml" "$omldir/" 2>/dev/null
+    if (cd "$omldir" \
+          && ocamlfind ocamlc -package ctypes,ctypes.foreign -c azul.mli \
+          && ocamlfind ocamlc -package ctypes,ctypes.foreign -c azul.ml) >/dev/null 2>&1; then
+      echo "  ocaml typecheck: ok"
+    else
+      echo "  ocaml typecheck: FAILED" >&2
+      (cd "$omldir" && ocamlfind ocamlc -package ctypes,ctypes.foreign -c azul.mli \
+        && ocamlfind ocamlc -package ctypes,ctypes.foreign -c azul.ml) 2>&1 | head -20 >&2
+      rc=1
+    fi
+    rm -rf "$omldir"
+  else
+    echo "  (skip ocaml: ocamlfind or ctypes not installed)"
+  fi
+
   if command -v gofmt >/dev/null 2>&1; then
     # `gofmt -e` prints syntax errors; formatting differences go to stdout as
     # filenames, which is why the error stream is what decides the verdict.

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -42,6 +42,7 @@ STAGES=(
   "check|fast|cargo check azul-css / azul-core / azul-layout"
   "clippy|fast|clippy -D warnings on core/css/layout --all-targets"
   "doc-check|fast|azul-doc check (double-drop invariant + guide links)"
+  "binding-syntax|fast|syntax-check the generated zig/go bindings (skipped if no toolchain)"
   "doc-tests|fast|cargo test -p azul-doc --bins"
   "unit-tests|fast|css+core+layout+webrender --lib, WITH the feature gates CI uses"
   "css-io|fast|--test test_system_style --features io (required-features gate)"
@@ -302,6 +303,53 @@ stage_check() {
     && cargo check -p azul-layout
 }
 
+stage_binding_syntax() {
+  # The derive-parity gate greps generated bindings for NAMES, so it reports
+  # green on code that does not compile - that is not hypothetical, it shipped
+  # three non-compiling PHP methods and a Zig parameter-shadowing error before
+  # anyone looked. Nothing else in this repo builds the non-Rust bindings, so
+  # these two cheap syntax checks are the only thing standing between a codegen
+  # change and a broken artifact.
+  #
+  # Both are pure parsers: no libazul, no cgo, no linking. Skipped rather than
+  # failed when the toolchain is absent, so CI images without them stay green.
+  local gen="target/codegen"
+  if [ ! -d "$gen" ]; then
+    echo "  (skip: $gen missing - run 'cargo run --release -p azul-doc codegen all')"
+    return 0
+  fi
+
+  local rc=0
+  if command -v zig >/dev/null 2>&1; then
+    if zig ast-check "$gen/azul.zig"; then
+      echo "  zig ast-check: ok"
+    else
+      echo "  zig ast-check: FAILED" >&2
+      rc=1
+    fi
+  else
+    echo "  (skip zig: not installed)"
+  fi
+
+  if command -v gofmt >/dev/null 2>&1; then
+    # `gofmt -e` prints syntax errors; formatting differences go to stdout as
+    # filenames, which is why the error stream is what decides the verdict.
+    local goerr
+    goerr="$(gofmt -e "$gen/go" 2>&1 >/dev/null)"
+    if [ -z "$goerr" ]; then
+      echo "  gofmt -e: ok"
+    else
+      echo "  gofmt -e: FAILED" >&2
+      echo "$goerr" >&2
+      rc=1
+    fi
+  else
+    echo "  (skip go: gofmt not installed)"
+  fi
+
+  return $rc
+}
+
 stage_doc_tests() {
   local log="$LOGDIR/doc-tests.raw"
   # `--bins`, not `--lib`: azul-doc is binary-only.
@@ -483,6 +531,7 @@ for s in "${STAGES[@]}"; do
     check)           run_stage "$name" "$desc" stage_check ;;
     doc-tests)       run_stage "$name" "$desc" stage_doc_tests ;;
     doc-check)       run_stage "$name" "$desc" stage_doc_check ;;
+    binding-syntax)  run_stage "$name" "$desc" stage_binding_syntax ;;
     css-io)          run_stage "$name" "$desc" stage_css_io ;;
     unit-tests)        run_stage "$name" "$desc" stage_unit_tests ;;
     integration-tests) run_stage "$name" "$desc" stage_integration_tests ;;

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -42,7 +42,7 @@ STAGES=(
   "check|fast|cargo check azul-css / azul-core / azul-layout"
   "clippy|fast|clippy -D warnings on core/css/layout --all-targets"
   "doc-check|fast|azul-doc check (double-drop invariant + guide links)"
-  "binding-syntax|fast|syntax-check the generated zig/go bindings (skipped if no toolchain)"
+  "binding-syntax|fast|syntax/type-check generated bindings: zig, go, ocaml, ruby, lua, php, node"
   "doc-tests|fast|cargo test -p azul-doc --bins"
   "unit-tests|fast|css+core+layout+webrender --lib, WITH the feature gates CI uses"
   "css-io|fast|--test test_system_style --features io (required-features gate)"
@@ -354,6 +354,43 @@ stage_binding_syntax() {
   else
     echo "  (skip ocaml: ocamlfind or ctypes not installed)"
   fi
+
+  # Every remaining checker follows one rule: PROBE it on a known-good sample
+  # before trusting its verdict. `command -v node` succeeds on this machine and
+  # then node aborts with a missing dylib - exit 134, which a naive gate would
+  # report as "your generated JavaScript is broken". A tool that cannot check
+  # its own trivial sample gets skipped, not believed.
+  probe_and_check() {
+    local label="$1" probe_cmd="$2" real_cmd="$3"
+    if ! eval "$probe_cmd" >/dev/null 2>&1; then
+      echo "  (skip $label: checker unavailable or not working here)"
+      return 0
+    fi
+    local out
+    if out="$(eval "$real_cmd" 2>&1)"; then
+      echo "  $label: ok"
+    else
+      echo "  $label: FAILED" >&2
+      echo "$out" | head -20 >&2
+      rc=1
+    fi
+  }
+
+  local tmp; tmp="$(mktemp -d)"
+  printf 'x = 1\n'        > "$tmp/probe.rb"
+  printf 'local x = 1\n'  > "$tmp/probe.lua"
+  printf '<?php $x = 1;\n' > "$tmp/probe.php"
+  printf 'var x = 1;\n'   > "$tmp/probe.js"
+
+  probe_and_check "ruby -c"   "ruby -c '$tmp/probe.rb'"       "ruby -c '$gen/azul.rb'"
+  probe_and_check "luajit"    "luajit -bl '$tmp/probe.lua' /dev/null" \
+                              "luajit -bl '$gen/azul.lua' /dev/null"
+  probe_and_check "php -l"    "php -l '$tmp/probe.php'"       "php -l '$gen/Azul.php'"
+  if [ -f "$gen/node/azul.js" ]; then
+    probe_and_check "node --check" "node --check '$tmp/probe.js'" \
+                                   "node --check '$gen/node/azul.js'"
+  fi
+  rm -rf "$tmp"
 
   if command -v gofmt >/dev/null 2>&1; then
     # `gofmt -e` prints syntax errors; formatting differences go to stdout as


### PR DESCRIPTION
`api.json` records a `derive` list per class — 1889 of them — and
`IrBuilder::build_trait_functions` turns that list into real C-ABI exports
(`Az{T}_partialEq`, `_partialCmp`, `_cmp`, `_hash`, `_toDbgString`,
`_default`, `_clone`). libazul exports every one. Whether a *binding* then
hands those exports to its users was decided independently in ~44 emitters,
and nothing compared the two. The failure is silent and one-directional: the
symbol is in the library, the caller has no way to name it.

That is how `MsgBox::yes_no(..) == YesNo::Yes` failed to compile for every
dynamically-linked Rust caller while the identical static build was fine.

## Result

**44,934 → 217 unreachable declared derives. 38 of 44 bindings are at zero.**

| binding | before | after |
|---|---:|---:|
| rust-public / rust-dynamic / memtest | 7122 / 1456 / — | **0** |
| all six C++ dialects | 2133–5682 | **0** |
| csharp, java, node, kotlin, racket | 114 ea. | **0** |
| crystal, d, julia, nim, odin, v, fortran | 134 ea. | **0** |
| freebasic, smalltalk, vb6, red, swift, powershell | 4–126 | **0** |
| zig | 5168 | 13 |
| go | 5648 | 13 |
| ocaml | 4010 † | 11 |
| python | 4671 | 36 |
| php-ext | 134 | 134 |
| haskell | 11 | 10 |

† ocaml's "272" was never real: the check matched `Az{T}_partialEq` against
`azul.mli`, which spells the type `az_accessibility_action` and never
mentions a C symbol. It reported 0 honoured and 1703 absent — blind to all
1718 modules the interface publishes. Corrected to ask in OCaml's own
vocabulary, the true figure was 4010.

## The gate

`azul-doc check derives` compares every declared derive against every
binding, with a baseline ratchet: recorded gaps pass, new ones fail, **and
improving without lowering the baseline also fails**, so it cannot go stale.
Every remaining gap carries a written reason.

`scripts/check.sh --only binding-syntax` is new and load-bearing: the derive
gate greps for NAMES, so it reports green on code that does not compile.
That is not hypothetical — three non-compiling emissions shipped during this
work and none were visible to it. It now runs `zig ast-check`, `gofmt -e`,
and a full `ocamlfind ocamlc` type-check of `azul.mli` + `azul.ml`. Note the
asymmetry: `ocamlc -stop-after parsing` accepted both broken OCaml files;
only the type checker caught them.

## What is left, and why

- **php-ext 134** — needs `render_method` taught the STATIC shape (no
  receiver, both operands as arguments). Widening the eligibility flag alone
  emits `AzDom_partialEq(&self.inner, &a.inner, &b.inner)` for a
  two-argument export. Reverted; nothing in the repo compiles `php_api.rs`.
- **python 36** — `PhysicalSizeU32`, `RefAny`, `GLintVec`, `ResultXmlXmlError`
  have no `#[pyclass]`. Closing them means DECIDING which belong in the
  Python surface. A product call, logged not guessed.
- **zig / go 13 each** — types excluded by CATEGORY (`ImageRef`, `Svg`,
  `GlVoidPtrConst`). Revisiting those exclusions is its own decision.
- **ocaml 11**, **haskell 10** — haskell routes Show/Eq through a per-struct
  C shim whose generator has its own filter; that is shim work.

## Verified

`cargo check -p azul-dll` (link-static, a11y) · `ribbon` and `fluent_demo`
examples — the arc's acceptance test, both were broken by the original defect
· `azul-doc check derives` · `binding-syntax` (zig + go + ocaml) ·
`cargo test -p azul-doc` 211 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019AaCnrqtYxVYbh5GMrSZwm
