### PR TITLE
fix(ci): the binding gate's three CI-only failures were the gate's own bugs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -290,11 +290,16 @@ jobs:
         # cannot be checked on the maintainer's machine - node has a broken
         # dylib, javac has no JRE, g++ cannot find <cstdint>. CI is where those
         # actually get covered.
+        #
+        # `libffi-platypus-perl` is not incidental: Azul.pm loads FFI::Platypus
+        # at compile time, so `perl -c` cannot parse it without the module and
+        # reports a MISSING DEPENDENCY as broken generated code. The probe now
+        # loads the same module, so a runner without it skips perl instead.
         shell: bash
         run: |
           sudo apt-get update -qq || true
           sudo apt-get install -y -qq \
-            gfortran php-cli luajit ruby perl \
+            gfortran php-cli luajit ruby perl libffi-platypus-perl \
             ocaml libctypes-ocaml-dev golang-go || true
           for t in gcc g++ gfortran perl ruby luajit php node javac go gofmt ocamlfind; do
             printf '%-10s %s\n' "$t" "$(command -v $t || echo MISSING)"

--- a/doc/src/codegen/v2/lang_fortran/mod.rs
+++ b/doc/src/codegen/v2/lang_fortran/mod.rs
@@ -191,8 +191,15 @@ fn emit_header(builder: &mut CodeBuilder) {
     builder.line("! gfortran >= 4.6 and Intel Fortran (ifort/ifx) >= 14.");
     builder.line("!");
     builder.line("! Build:");
-    builder.line("!   gfortran -c azul.f90");
-    builder.line("!   gfortran main.f90 azul.o -L. -lazul -o main");
+    builder.line("!   gfortran -ffree-line-length-none -c azul.f90");
+    builder.line("!   gfortran -ffree-line-length-none main.f90 azul.o -L. -lazul -o main");
+    builder.line("!");
+    builder.line("! `-ffree-line-length-none` is not optional. Free-form Fortran capped");
+    builder.line("! lines at 132 columns until F2023 lifted it, and the C ABI names here");
+    builder.line("! are long enough that ~1500 declarations run past that. gfortran >= 14");
+    builder.line("! defaults to no limit and accepts the file bare; every older gfortran");
+    builder.line("! truncates the line and then errors on the half-statement that is left.");
+    builder.line("! The generated Makefile already carries the flag in FFLAGS.");
     builder.line("! ============================================================================");
     builder.blank();
 }

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -338,12 +338,13 @@ stage_binding_syntax() {
   local tmp; tmp="$(mktemp -d)"
 
   # label|probe command|real command
-  # KNOWN_BROKEN entries carry a trailing |broken plus a one-line reason.
+  # Exactly three fields. A binding that cannot pass yet is handled below the
+  # loop instead (see the `v` KNOWN_BROKEN block), so it can carry its reason.
   local checks=(
     "zig|zig ast-check $tmp/p.zig|zig ast-check $gen/azul.zig"
     "go|gofmt -e $tmp/p.go|gofmt -e $gen/go"
     "c|gcc -fsyntax-only -x c $tmp/p.c|gcc -fsyntax-only -x c $gen/azul.h"
-    "fortran|gfortran -fsyntax-only $tmp/p.f90|gfortran -fsyntax-only $gen/azul.f90"
+    "fortran|gfortran -fsyntax-only -ffree-line-length-none -J$tmp $tmp/p.f90|gfortran -fsyntax-only -ffree-line-length-none -J$tmp $gen/azul.f90"
     "perl|perl -c $tmp/p.pm|perl -c $gen/Azul.pm"
     "ruby|ruby -c $tmp/p.rb|ruby -c $gen/azul.rb"
     "lua|luajit -bl $tmp/p.lua /dev/null|luajit -bl $gen/azul.lua /dev/null"
@@ -355,13 +356,18 @@ stage_binding_syntax() {
     "cpp|g++ -fsyntax-only -std=c++17 -x c++ $tmp/p.cpp|g++ -fsyntax-only -std=c++17 -x c++ $gen/azul17.hpp"
   )
 
+  # `-J$tmp` on gfortran: `-fsyntax-only` still WRITES a `.mod` file for every
+  # module it sees, into the current directory. Without it this stage drops
+  # `azul.mod` in the repo root, which then trips the "tree is dirty" guard on
+  # the next run - a gate that dirties the tree it is checking.
+  #
   # Probe samples, one per language.
   printf 'const x: u8 = 1;\n'                    > "$tmp/p.zig"
   printf 'package p\nvar X = 1\n'                > "$tmp/p.go"
   printf 'int x;\n'                              > "$tmp/p.c"
   printf '#include <cstdint>\nint x;\n'          > "$tmp/p.cpp"
   printf '      program p\n      end program p\n' > "$tmp/p.f90"
-  printf '1;\n'                                  > "$tmp/p.pm"
+  printf 'use FFI::Platypus;\n1;\n'             > "$tmp/p.pm"
   printf 'x = 1\n'                               > "$tmp/p.rb"
   printf 'local x = 1\n'                         > "$tmp/p.lua"
   printf '<?php $x = 1;\n'                       > "$tmp/p.php"
@@ -374,8 +380,9 @@ stage_binding_syntax() {
   local entry label probe real out
   for entry in "${checks[@]}"; do
     label="${entry%%|*}"
-    probe="$(echo "$entry" | cut -d"|" -f2)"
-    real="$(echo "$entry" | cut -d"|" -f3)"
+    local rest="${entry#*|}"
+    probe="${rest%%|*}"
+    real="${rest#*|}"
     if ! eval "$probe" >/dev/null 2>&1; then
       echo "  (skip $label: checker unavailable or not working here)"
       continue
@@ -384,7 +391,7 @@ stage_binding_syntax() {
       echo "  $label: ok"
     else
       echo "  $label: FAILED" >&2
-      echo "$out" | head -15 >&2
+      echo "$out" | awk 'NR<=15' >&2
       rc=1
     fi
   done


### PR DESCRIPTION
Follow-up to #462. `Generate bindings (Linux)` is red on master, and all three reasons are the gate's own bugs rather than anything wrong with the generated bindings.

### fortran

Free-form Fortran capped lines at 132 columns until F2023 lifted it, and ~1500 generated declarations run past that because the C ABI names are long:

```
procedure(AzCssPropertyWithConditionsVecDestructorType_iface), pointer :: AzCssPropertyWithConditionsVecDestructorType_default => null()
```

gfortran >= 14 defaults to no limit and accepts the file bare; Ubuntu's older gfortran truncates the line and then errors on the half-statement left behind. That is the whole "green locally, red on CI" gap — and it also explains the second error, `Error in pointer initialization`, which is just the truncated `=>` with its target chopped off.

The generated Makefile has carried `-ffree-line-length-none` in `FFLAGS` all along, so the **shipped build path was always correct**; only this check omitted the flag. The emitted header's hand-written build example did contradict the Makefile beside it, so that is corrected too.

### perl

`Can't locate FFI/Platypus.pm in @INC` — `Azul.pm` loads FFI::Platypus at compile time, so `perl -c` cannot parse it without the module, and a **missing dependency was reported as broken generated code**.

The probe was `1;`, valid in any perl, so it claimed the checker worked when it could not check anything. It now loads the same module the real file needs — which is the entire point of probing — and CI installs `libffi-platypus-perl` so perl is genuinely covered rather than skipped.

### broken pipe

`echo "$out" | head -15` takes EPIPE once `head` has its 15 lines, so the stage printed `write error: Broken pipe` over its own diagnostics. Reading the fields with `echo | cut` had the same hazard. Both are now pipe-free.

### also carried over

`-J$tmp` on gfortran: `-fsyntax-only` still writes a `.mod` per module into the current directory, so the stage was dropping `azul.mod` in the repo root — a gate that dirties the tree it is checking.

### verification

`scripts/check.sh --only binding-syntax` is GREEN locally on this branch and leaves the tree clean.

One thing worth keeping from the failing run: **node and cpp PASS on CI.** Those are two of the three that cannot be checked on the maintainer's machine (node has a broken libllhttp dylib, g++ cannot find `<cstdint>`), and covering them was the reason for wiring this into CI in the first place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019AaCnrqtYxVYbh5GMrSZwm
