### PR TITLE
fix(layout): mint markers deterministically, and drop uuid from every target

### DIFF
--- a/layout/Cargo.toml
+++ b/layout/Cargo.toml
@@ -71,8 +71,6 @@ zune-jpeg               = { version = "0.5", default-features = false, features 
 rust-fontconfig = { version = ">=4.6, <4.7", default-features = false, optional = true }
 libc                    = { version = "0.2", default-features = false, optional = true }
 serde                   = { version = "1.0", features = ["derive"] }
-short-uuid              = { version = "0.2" }
-uuid                    = { version = "1.7", default-features = false, features = ["v4"] }
 brotli-decompressor     = { version = "5", default-features = false, features = ["std"], optional = true }
 accesskit               = { version = "0.24", default-features = false, optional = true }
 tinyvec                 = { version = "1.9.0", default-features = false, optional = true  }
@@ -533,15 +531,6 @@ path = "tests/virtualview_hit_matches_render.rs"
 # Dev-only: JSON fixture deserialization for the e2e_json harness. Dev-deps are
 # never shipped and never affect the published dependency graph, so this does
 # NOT rely on the optional `json` crate feature.
-# `short-uuid` pulls `uuid`, which on wasm32-unknown-unknown has no source of
-# randomness and REFUSES TO COMPILE without one being named ("specify a source
-# of randomness using one of the `js`, `rng-getrandom`, or `rng-rand`
-# features"). `js` routes it through the browser's crypto, which is the only
-# one of the three that exists in a browser. Feature-unified into short-uuid's
-# copy; azul-layout does not use `uuid` directly.
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-uuid = { version = "1", default-features = false, features = ["js"] }
-
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 ureq = { version = "3.3", default-features = false, features = ["rustls-no-provider", "rustls-webpki-roots"], optional = true }
 rustls = { version = "0.23", default-features = false, features = ["std", "tls12", "logging"], optional = true }

--- a/layout/src/managers/changeset.rs
+++ b/layout/src/managers/changeset.rs
@@ -566,6 +566,12 @@ impl TextChangeset {
 /// `DocumentOperation` themselves; it is the built-in "apply this changeset to
 /// a plain `Dom`" helper that disappears.
 #[cfg(feature = "xml")]
+/// Gated exactly like [`crate::document_edit`], the module this reaches into:
+/// `text_layout` alone (printpdf's reduced build) compiles the changeset types
+/// but not `document_edit`, and an ungated method referring to it fails to
+/// resolve. Same class as the `cpurender` gaps on `tray_icon` and
+/// `rasterize_svg_clip_to_r8`.
+#[cfg(all(feature = "text_layout", feature = "xml"))]
 impl DocumentChangeset {
     /// Apply this changeset to an app-model [`Dom`](azul_core::dom::Dom) -
     /// the Path-2 helper [`crate::document_edit::apply_document_operation`]

--- a/layout/src/uuid.rs
+++ b/layout/src/uuid.rs
@@ -15,8 +15,60 @@
 //! [`Uuid::v4`] returns the canonical hyphenated form (36 chars);
 //! [`Uuid::short`] returns the same 128 bits as a 22-char flickrBase58 string
 //! (the `short-uuid` encoding) - shorter, no hyphens, URL/log friendly.
+//!
+//! # These ids are DETERMINISTIC, not random
+//!
+//! Every id is a pure function of a process-local counter, so run the same
+//! program twice and you get the same sequence of ids. That is all a marker
+//! needs - it has to be unique among the strings alive in ONE process, and it
+//! is: the mixing function is a bijection, so 2^63 mints collide zero times,
+//! exactly rather than probabilistically.
+//!
+//! What it is NOT: unpredictable, or unique across processes and machines. Do
+//! not use these to identify a client to a server, as a security token, or as
+//! a database key that two processes might mint independently. The crate
+//! carries no randomness source on purpose - `uuid`'s `v4` needs one, and on
+//! `wasm32-unknown-unknown` there isn't one without pulling in `getrandom`'s
+//! JS shim, which broke every wasm consumer of azul-layout 0.0.15.
+
+use core::sync::atomic::{AtomicU64, Ordering};
 
 use azul_css::AzString;
+
+/// flickrBase58 — base58 without the look-alikes `0`, `O`, `I` and `l`.
+const BASE58: &[u8; 58] = b"123456789abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ";
+
+/// Mint tick. Every id is a pure function of its tick, so the sequence is the
+/// same on every run — deterministic, not random.
+static TICK: AtomicU64 = AtomicU64::new(0);
+
+/// The splitmix64 finalizer. Every step (xor-shift-right, multiply by an odd
+/// constant) is invertible, so the whole function is a BIJECTION on `u64`:
+/// distinct ticks give distinct outputs, which is what makes the no-collision
+/// guarantee below exact rather than probabilistic.
+const fn mix64(mut z: u64) -> u64 {
+    z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+    z ^ (z >> 31)
+}
+
+/// 128 fresh bits: one tick spread over two disjoint `mix64` inputs.
+///
+/// `hi` alone is `mix64` of an injective function of the tick, so two mints
+/// can only repeat once the tick wraps at 2^63.
+fn next_bits() -> [u8; 16] {
+    let tick = TICK.fetch_add(1, Ordering::Relaxed);
+    let hi = mix64(tick.wrapping_mul(2));
+    let lo = mix64(tick.wrapping_mul(2).wrapping_add(1));
+    let mut out = [0u8; 16];
+    out[..8].copy_from_slice(&hi.to_be_bytes());
+    out[8..].copy_from_slice(&lo.to_be_bytes());
+    // RFC 4122: version 4 in the high nibble of byte 6, variant 0b10 in the
+    // top two bits of byte 8. Stamped after the mix so the shape is exact.
+    out[6] = (out[6] & 0x0F) | 0x40;
+    out[8] = (out[8] & 0x3F) | 0x80;
+    out
+}
 
 /// Static-method namespace for UUID string generation ([`Uuid::v4`],
 /// [`Uuid::short`]). The struct only exists so the FFI layer can hang static
@@ -42,20 +94,47 @@ impl Uuid {
         Self { _reserved: 0 }
     }
 
-    /// A fresh random (version 4) UUID in canonical hyphenated lowercase form,
+    /// A fresh version-4-shaped UUID in canonical hyphenated lowercase form,
     /// e.g. `"550e8400-e29b-41d4-a716-446655440000"` (36 characters).
+    ///
+    /// Deterministic, not random - the value depends only on how many ids this
+    /// process has already minted. See the module docs before using one as
+    /// anything but a marker.
     #[must_use]
     pub fn v4() -> AzString {
-        ::uuid::Uuid::new_v4().to_string().into()
+        const HEX: &[u8; 16] = b"0123456789abcdef";
+        let b = next_bits();
+        let mut out = String::with_capacity(36);
+        for (i, byte) in b.iter().enumerate() {
+            // 4-2-2-2-6 bytes, so the hyphens fall after bytes 4, 6, 8 and 10.
+            if matches!(i, 4 | 6 | 8 | 10) {
+                out.push('-');
+            }
+            out.push(HEX[usize::from(byte >> 4)] as char);
+            out.push(HEX[usize::from(byte & 0x0F)] as char);
+        }
+        out.into()
     }
 
-    /// A fresh random (version 4) UUID as a 22-character flickrBase58 string,
-    /// e.g. `"mhvXdrZT4jP5T8vBxuvm75"` - the `short-uuid` encoding of the same
-    /// 128 bits `v4` would print. The compact spelling for markers, log lines
-    /// and URLs.
+    /// A fresh version-4-shaped UUID as a 22-character flickrBase58 string,
+    /// e.g. `"mhvXdrZT4jP5T8vBxuvm75"` - the same encoding `short-uuid` used to
+    /// print. The compact spelling for markers, log lines and URLs.
+    ///
+    /// Deterministic, not random - see [`Uuid::v4`] and the module docs.
     #[must_use]
     pub fn short() -> AzString {
-        short_uuid::ShortUuid::generate().to_string().into()
+        // Big-endian base58 of the same 128 bits, left-padded to the fixed 22
+        // characters `short-uuid` emits (a value with leading zero bytes still
+        // has to spell 22 characters or the width stops being a contract).
+        let mut n = u128::from_be_bytes(next_bits());
+        let mut buf = [BASE58[0]; 22];
+        let mut i = 22;
+        while n > 0 && i > 0 {
+            i -= 1;
+            buf[i] = BASE58[(n % 58) as usize];
+            n /= 58;
+        }
+        String::from_utf8_lossy(&buf).into_owned().into()
     }
 }
 


### PR DESCRIPTION
Found by printpdf's CI matrix against the published `azul-layout` — printpdf is the only consumer that builds azul-layout **without `cpurender` and without `xml`**, and it checks all three wasm targets, so it reaches configurations nothing else in the matrix compiles.

## 1. `uuid` on wasm

`Uuid::v4` / `Uuid::short` exist to mint DOM marker strings — ids that must not collide with anything else alive in **one** process. They don't need randomness, and paying for it cost two dependencies plus a target-specific workaround: `uuid` refuses to compile on `wasm32-unknown-unknown` without a randomness source, so master names `js` to route through the browser's crypto.

That block is `cfg(target_arch = "wasm32")`, which is **also `wasm32-wasip1` and `wasm32-wasip2`** — WASI targets that have their own getrandom backend and no browser crypto to reach.

This mints from a process-local counter through the splitmix64 finalizer instead. Every step of that function (xor-shift-right, multiply by an odd constant) is invertible, so it's a **bijection on `u64`**: distinct ticks give distinct ids, which makes the no-collision property *exact* rather than probabilistic, for 2^63 mints. `uuid`, `short-uuid` and the wasm32 block all go away — one code path on every target.

The v4 shape (version nibble, variant bits, 36 chars) and the 22-character flickrBase58 short form are unchanged; **the module's existing tests pass untouched.**

### The one real behaviour change
The ids are no longer unpredictable, and the docs now say so plainly instead of calling them random. Nothing depended on it — telemetry's `new_client_id`, the one identifier whose documented contract is unlinkability, has always had its own `fill_random` and never went through this module.

## 2. `DocumentChangeset::apply_to_dom` was ungated

It calls into `crate::document_edit`, a module behind `all(text_layout, xml)`, from an ungated impl block. `--no-default-features --features text_layout` fails with `E0433: could not find document_edit in the crate root`. Same class as the `cpurender` gaps on `tray_icon` and `rasterize_svg_clip_to_r8` fixed in #457.

## Verified
- `azul-layout` builds for `wasm32-unknown-unknown` with default features.
- Builds under both of printpdf's feature sets: `std,text_layout,font_loading` and that plus `xml,pdf,text_layout_hyphenation`.
- `uuid_tests` 4/4 under default features; a 10k-mint sweep is distinct and well-formed.

## Note on the released crates
Both defects shipped in `azul-layout 0.0.15` (published today from #457, which branched before master's `js` workaround). They are already fixed in **0.0.16**, published from #457's branch, which printpdf 0.12.8 pins. This PR carries the same two fixes to master, where the ungated `apply_to_dom` and the WASI-target gap both still exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzMoAeNs1A5P6PEA4fbVRx