### PR TITLE
ci(bindings): actually check the perl binding — install FFI::Platypus 2.x, and make the probe ask for it

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -316,6 +316,16 @@ jobs:
           sudo cpanm --notest --quiet FFI::Platypus || true
           perl -e 'eval { require FFI::Platypus; 1 } or do { print "FFI::Platypus: ABSENT\n"; exit };
                    printf "FFI::Platypus: %s\n", $FFI::Platypus::VERSION' || true
+          # Run the binding-syntax stage's OWN perl probe here and say what it
+          # decided. `check.sh` prints "perl: ok" / "(skip perl: ...)" on
+          # stdout, which the stage runner only surfaces when the stage FAILS -
+          # so on a green run there is no way to tell a real check from a
+          # silent skip, and a skip is exactly what this job used to do wrong.
+          if perl -e 'use FFI::Platypus 2.00; 1' 2>/dev/null; then
+            echo "perl probe: OK - the generated Azul.pm WILL be syntax-checked"
+          else
+            echo "perl probe: FAILS - perl will be SKIPPED (Platypus 2.x missing)"
+          fi
           for t in gcc g++ gfortran perl ruby luajit php node javac go gofmt ocamlfind; do
             printf '%-10s %s\n' "$t" "$(command -v $t || echo MISSING)"
           done

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -294,13 +294,28 @@ jobs:
         # `libffi-platypus-perl` is not incidental: Azul.pm loads FFI::Platypus
         # at compile time, so `perl -c` cannot parse it without the module and
         # reports a MISSING DEPENDENCY as broken generated code. The probe now
-        # loads the same module, so a runner without it skips perl instead.
+        # loads the same module AT THE SAME VERSION, so a runner that cannot
+        # satisfy it skips perl instead.
+        #
+        # And it CAN be satisfied here: the distro package is FFI::Platypus
+        # 1.56, while the generated `Azul.pm` opens with `use FFI::Platypus
+        # 2.00;` (2.x is where `$ffi->closure` and `record_layout_1` live), so
+        # the apt package alone left the perl binding permanently unchecked.
+        # cpanm installs 2.x into /usr/local/..., which precedes the distro
+        # directories in @INC, so it wins. `--notest` because we want the
+        # module, not its test suite; `libffi-dev` because the XS build needs
+        # it. If the install fails the probe skips perl exactly as before -
+        # this can only turn a skipped check into a real one.
         shell: bash
         run: |
           sudo apt-get update -qq || true
           sudo apt-get install -y -qq \
             gfortran php-cli luajit ruby perl libffi-platypus-perl \
+            cpanminus libffi-dev \
             ocaml libctypes-ocaml-dev golang-go || true
+          sudo cpanm --notest --quiet FFI::Platypus || true
+          perl -e 'eval { require FFI::Platypus; 1 } or do { print "FFI::Platypus: ABSENT\n"; exit };
+                   printf "FFI::Platypus: %s\n", $FFI::Platypus::VERSION' || true
           for t in gcc g++ gfortran perl ruby luajit php node javac go gofmt ocamlfind; do
             printf '%-10s %s\n' "$t" "$(command -v $t || echo MISSING)"
           done

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -620,7 +620,14 @@ jobs:
           toolchain: 1.90.0
 
       - name: Install dependencies (Ubuntu)
-        run: sudo apt-get update && sudo apt-get install -y libv4l-dev
+        # `fonts-dejavu-core`: AzWriter's pagination tests MEASURE text - a
+        # 40-paragraph document spans two pages only if the glyphs have real
+        # metrics. On a runner with no fonts installed they all fit on one and
+        # five tests fail with "need multiple pages, got 1". The same package is
+        # already installed for the native-e2e job below, and fonts-noto-core for
+        # another; this job just never got one. Locally (fonts present) all 44
+        # AzWriter tests pass.
+        run: sudo apt-get update && sudo apt-get install -y libv4l-dev fonts-dejavu-core
 
       - name: Download generated bindings (built once by codegen_linux)
         uses: actions/download-artifact@v8

--- a/examples/azul-paint/src/lib.rs
+++ b/examples/azul-paint/src/lib.rs
@@ -1884,8 +1884,24 @@ mod tests {
             a: 255,
         };
         let (w, h) = (100u32, 60u32);
-        let alone = render_metaballs(&[black_dab(30.0, 30.0)], w, h, bg, None);
-        let pair = render_metaballs(
+        // `render_metaballs` became `metaball_image` in 7ec9b564e (incremental
+        // metaball field): same trailing arguments, plus the `MetaballField`
+        // cache it now paints into. The test was never updated, so this crate's
+        // lib test has not COMPILED since - and the CI job that would have said
+        // so sits behind a `needs: [clippy]` that has been failing, so nobody
+        // saw it. A FRESH field per call is what the old function did
+        // internally, which keeps the two renders independent exactly as the
+        // assertions below assume.
+        let alone = metaball_image(
+            &mut MetaballField::default(),
+            &[black_dab(30.0, 30.0)],
+            w,
+            h,
+            bg,
+            None,
+        );
+        let pair = metaball_image(
+            &mut MetaballField::default(),
             &[black_dab(30.0, 30.0), black_dab(60.0, 30.0)],
             w,
             h,

--- a/examples/rust/Cargo.toml
+++ b/examples/rust/Cargo.toml
@@ -92,10 +92,16 @@ name = "icu_demo"
 path = "src/icu_demo.rs"
 required-features = ["icu", "link-static"]
 
+# Needs `link-static` for the same reason as `http_zip_demo` below: it reaches
+# into `azul::desktop::fluent` and `azul::desktop::zip`, which live behind
+# `cabi_internal` and therefore do not exist in a `link-dynamic` build. Without
+# it the lean build fails with "could not find `desktop` in `azul`" - which it
+# has been doing, unseen, because that job sits behind a `needs: [clippy]` that
+# was failing and skipped it.
 [[example]]
 name = "fluent_demo"
 path = "src/fluent_demo.rs"
-required-features = ["fluent", "icu"]
+required-features = ["fluent", "icu", "link-static"]
 
 # Also needs `link-static`: this demo drives the desktop ZIP helpers
 # (`zip_create_from_files` / `zip_extract_all` / `zip_list_contents`), which

--- a/layout/src/window.rs
+++ b/layout/src/window.rs
@@ -5546,7 +5546,7 @@ impl LayoutWindow {
             // just before handing `styled_dom` over. Dump what THIS function sees so
             // we can tell whether the by-value StyledDom move corrupted it.
             unsafe {
-                crate::az_mark(0x40610, compact_cache_ref.is_some() as u32);
+                crate::az_mark(0x40610, u32::from(compact_cache_ref.is_some()));
                 if let Some(cc) = compact_cache_ref {
                     crate::az_mark(0x40614, cc.prev_font_hashes.len() as u32);
                     crate::az_mark(0x40618, cc.prev_font_hashes.as_ptr() as usize as u32);

--- a/scripts/PHYSICAL_TESTING_WAYLAND_2026_09_05.md
+++ b/scripts/PHYSICAL_TESTING_WAYLAND_2026_09_05.md
@@ -721,6 +721,13 @@ this work; none was caused by the #463 / #466 merges:
 | `AZ_E2E rust / c-cpp / scripting-a / -b` | **PRE-EXISTING, NOT FIXED.** `hello_world_counter.json` step 6 (the third click): "could not resolve the click target". Bisected: built libazul + the hello-world example from **pre-merge master `0d3b63eb5`** and got the IDENTICAL failure, so it is not a merge regression. The engine's own in-process `E2E Headless (e2e/*.json)` PASSES the same scenarios - only the shipped-binding lane fails |
 | `Autofix + normalize (api.json drift)` | **PARKED.** Ran CI's exact chain and audited the result: a clean relocation of 14 public classes (`XmlTagName` dom->xml, `NativeGestureEvent` dom->gesture, the font types css->font), 2251 classes in and out, none lost or gained, no `external` key dropped. Reverted rather than committed: it changes public MODULE PATHS, which is what documentation references, and the user is writing documentation |
 
+**Round two: two more jobs surfaced once the lean build was fixed.**
+
+| failure | verdict |
+|---|---|
+| `DLL tests + feature check` (still) | **FIXED (CI env).** Not AzPaint any more - five AzWriter PAGINATION tests: "need multiple pages, got 1". `paginate` MEASURES text, so a 40-paragraph document spans two pages only if the glyphs have real metrics; the job installs `libv4l-dev` and no fonts at all. Locally, with fonts, all 44 AzWriter tests pass. Added `fonts-dejavu-core` - the same package the native-e2e job already installs, and another job installs `fonts-noto-core`. The assertions are untouched; they simply get the environment they always assumed |
+| `Build Binaries (ubuntu, macos)` | **PRE-EXISTING, NOT FIXED - needs a decision.** The release gate "exports only the azul C API + allowed residuals" fails: `libazul.so` and `azul.so` export `Median_init/step/finalize`, `PercentileCont_*`, `PercentileDisc_*`. Those are SQLite AGGREGATE functions from **turso**, pulled in by `db-sqlite` - the same turso 0.7 upgrade (`b26c376d5`, 2026-08-31) that brought the `turso_sdk_kit` windres break. Fixing it means either widening the gate's allowlist for known third-party residuals or hiding the symbols at link time (version script / visibility), and that is a release-artifact policy call, not a CI-plumbing one |
+
 **And the libazul clobber trap reproduced deterministically** while doing this:
 `cargo build -p azul-examples --example hello-world --no-default-features
 --features link-dynamic` truncates `target/release/libazul.so` to **0 bytes**,

--- a/scripts/PHYSICAL_TESTING_WAYLAND_2026_09_05.md
+++ b/scripts/PHYSICAL_TESTING_WAYLAND_2026_09_05.md
@@ -702,6 +702,32 @@ the blink still moves exactly 19 px in a 1x19 box and nothing else.
 Branch is now 41 ahead / **0 behind** master; PR #463 retargeted from the
 merged `fix/x11-desktop-integration` to `master` and reports MERGEABLE.
 
+## The CI gate was hiding four failures, and one is still open
+
+Fixing Clippy had a side effect worth recording: a whole tier of jobs sits
+behind `needs: [..., clippy, ...]`, so while Clippy was red they were SKIPPED,
+not run. Across the **last eight master runs** `Build lean libazul` was skipped
+every time and `AZ_E2E rust` never appeared at all. Master's green/red signal
+was therefore structurally misleading - "two jobs red" was itself an artifact of
+the gating.
+
+With Clippy green, the tier ran and four failures surfaced. All four PREDATE
+this work; none was caused by the #463 / #466 merges:
+
+| failure | verdict |
+|---|---|
+| `Build lean libazul` (3 OSes) | **FIXED.** `fluent_demo` uses `azul::desktop::fluent` / `::zip`, behind `cabi_internal`, absent in a `link-dynamic` build - its `required-features` never said `link-static`. Its sibling `http_zip_demo` already carries it, with a comment describing this exact failure. RED reproduced locally with the lean feature set, then green |
+| `DLL tests + feature check` | **FIXED.** AzPaint's lib test called `render_metaballs`, which `7ec9b564e` replaced with `metaball_image` - so that crate's tests had not COMPILED since. Call sites adapted, assertions untouched, 7/7 pass |
+| `AZ_E2E rust / c-cpp / scripting-a / -b` | **PRE-EXISTING, NOT FIXED.** `hello_world_counter.json` step 6 (the third click): "could not resolve the click target". Bisected: built libazul + the hello-world example from **pre-merge master `0d3b63eb5`** and got the IDENTICAL failure, so it is not a merge regression. The engine's own in-process `E2E Headless (e2e/*.json)` PASSES the same scenarios - only the shipped-binding lane fails |
+| `Autofix + normalize (api.json drift)` | **PARKED.** Ran CI's exact chain and audited the result: a clean relocation of 14 public classes (`XmlTagName` dom->xml, `NativeGestureEvent` dom->gesture, the font types css->font), 2251 classes in and out, none lost or gained, no `external` key dropped. Reverted rather than committed: it changes public MODULE PATHS, which is what documentation references, and the user is writing documentation |
+
+**And the libazul clobber trap reproduced deterministically** while doing this:
+`cargo build -p azul-examples --example hello-world --no-default-features
+--features link-dynamic` truncates `target/release/libazul.so` to **0 bytes**,
+which then fails the NEXT link with `undefined symbol: AzRefCount_delete`. Keep
+a copy and restore it after any link-dynamic example build - that is what the
+"build libazul LAST" rule is protecting against, seen directly.
+
 ## Traps found
 
 1. **`build-dll` and `link-dynamic` fight over `target/release/libazul.so`, in

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -367,7 +367,16 @@ stage_binding_syntax() {
   printf 'int x;\n'                              > "$tmp/p.c"
   printf '#include <cstdint>\nint x;\n'          > "$tmp/p.cpp"
   printf '      program p\n      end program p\n' > "$tmp/p.f90"
-  printf 'use FFI::Platypus;\n1;\n'             > "$tmp/p.pm"
+  # WITH THE VERSION, because that is what the artifact asks for. `Azul.pm`
+  # opens with `use FFI::Platypus 2.00;`, so a runner carrying the DISTRO
+  # package (Ubuntu ships 1.56) passed a bare `use FFI::Platypus;` probe, went
+  # on to check the real file, and reported
+  #   FFI::Platypus version 2 required--this is only version 1.56
+  # as broken generated code. That is the exact failure this probe exists to
+  # prevent: it is a missing dependency, not a bad binding, and such a runner
+  # must SKIP perl like one with no Platypus at all. Keep the version in step
+  # with `doc/src/codegen/v2/lang_perl/mod.rs`, which emits it.
+  printf 'use FFI::Platypus 2.00;\n1;\n'        > "$tmp/p.pm"
   printf 'x = 1\n'                               > "$tmp/p.rb"
   printf 'local x = 1\n'                         > "$tmp/p.lua"
   printf '<?php $x = 1;\n'                       > "$tmp/p.php"


### PR DESCRIPTION
`Generate bindings (Linux)` has been red on **master** (not just on PRs):

```
perl: FAILED
FFI::Platypus version 2 required--this is only version 1.56 at target/codegen/Azul.pm line 13
```

The generated `Azul.pm` opens with `use FFI::Platypus 2.00;` — 2.x is where `$ffi->closure` and `record_layout_1` live, so the generator is right to ask. The runner installs the **distro** package `libffi-platypus-perl`, which on Ubuntu is **1.56**.

Two things were wrong, and this PR fixes both.

## 1. The guard asked the wrong question

The binding-syntax stage probes each language before trusting its checker, precisely so a missing dependency isn't reported as broken generated code. The perl probe was `use FFI::Platypus;` — **no version** — so it passed on 1.56, the checker went on to the real file, and CI went red for a reason that had nothing to do with the binding.

The probe now asks for `2.00`, the same as the artifact. Proved with a stub `FFI/Platypus.pm` on `-I`, since no machine here can hold both versions at once:

| installed | old probe | new probe |
|---|---|---|
| 1.56 | PASS → perl checked → **red** | fail → perl **skipped** |
| 2.08 | PASS | PASS → still really checks |

## 2. …but skipping perl is a silent hole

The probe fix alone would leave the perl binding permanently unchecked, since the runner would never have 2.x. So the job now installs the version the artifact needs:

```
sudo apt-get install ... cpanminus libffi-dev
sudo cpanm --notest --quiet FFI::Platypus
```

cpanm puts 2.x under `/usr/local/...`, which precedes the distro directories in `@INC`, so it wins over the 1.56 package. The step also prints the resolved version, so a future disagreement shows up in the log instead of being inferred from a failure.

**Belt and braces on purpose:** if the CPAN install ever fails — network, a broken XS build, a runner without a compiler — the versioned probe skips perl exactly as before. Together the two changes can only turn a *skipped* check into a *real* one, never a real one into a red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KxSkFd1PPsSmDq9taAP5YL